### PR TITLE
feat(onboarding): wizard chat motion + single-dialogue preservation

### DIFF
--- a/internal/onboarding/handlers.go
+++ b/internal/onboarding/handlers.go
@@ -51,6 +51,12 @@ type CompleteFunc func(task string, skipTask bool, blueprintID string, selectedA
 // phase is the new phase the state machine just entered.
 type TransitionFunc func(phase string, s *State) error
 
+// ResetFunc is the broker callback invoked when the user requests
+// /onboarding/reset. The broker uses this to clear the persisted CEO DM
+// transcript so that re-entering the wizard starts on a clean canvas.
+// Best-effort: HandleReset still clears phase/answers even when this fails.
+type ResetFunc func() error
+
 // RegisterRoutes wires the onboarding HTTP endpoints onto mux.
 //
 // Routes registered:
@@ -75,7 +81,17 @@ func RegisterRoutes(mux *http.ServeMux, completeFn CompleteFunc, packSlug string
 // RegisterRoutesWithTransition is like RegisterRoutes but also accepts a
 // TransitionFunc that the broker supplies to receive phase-transition events.
 // Pass nil transitionFn to skip the broker callback (legacy path / tests).
+//
+// resetFn is wired to /onboarding/reset so the broker can also clear the
+// CEO DM transcript when the user restarts the wizard.
 func RegisterRoutesWithTransition(mux *http.ServeMux, completeFn CompleteFunc, transitionFn TransitionFunc, packSlug string, authMiddleware func(http.HandlerFunc) http.HandlerFunc, wikiRoot string) {
+	RegisterRoutesWithTransitionAndReset(mux, completeFn, transitionFn, nil, packSlug, authMiddleware, wikiRoot)
+}
+
+// RegisterRoutesWithTransitionAndReset is the most-explicit registrar — used
+// by the broker to wire both transition and reset callbacks. Tests can pass
+// nil for either to skip the corresponding side-effect.
+func RegisterRoutesWithTransitionAndReset(mux *http.ServeMux, completeFn CompleteFunc, transitionFn TransitionFunc, resetFn ResetFunc, packSlug string, authMiddleware func(http.HandlerFunc) http.HandlerFunc, wikiRoot string) {
 	if authMiddleware == nil {
 		authMiddleware = func(h http.HandlerFunc) http.HandlerFunc { return h }
 	}
@@ -94,6 +110,7 @@ func RegisterRoutesWithTransition(mux *http.ServeMux, completeFn CompleteFunc, t
 	mux.HandleFunc("/onboarding/upload-context", authMiddleware(handleUploadContext))
 	// Phase 2 — deterministic CEO conversation handlers.
 	mux.HandleFunc("/onboarding/transition", authMiddleware(makeHandleTransition(transitionFn)))
+	mux.HandleFunc("/onboarding/reset", authMiddleware(makeHandleReset(resetFn)))
 	mux.HandleFunc("/onboarding/answer", authMiddleware(HandleAnswer))
 	mux.HandleFunc("/onboarding/suggestion/ack", authMiddleware(HandleSuggestionAck))
 }
@@ -995,6 +1012,69 @@ func handleTransition(w http.ResponseWriter, r *http.Request, transitionFn Trans
 		"ok":    true,
 		"phase": next,
 	})
+}
+
+// makeHandleReset returns the POST /onboarding/reset handler. resetFn is
+// invoked after the onboarding state is cleared so the broker can purge
+// side-effects like the CEO DM transcript.
+func makeHandleReset(resetFn ResetFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		handleReset(w, r, resetFn)
+	}
+}
+
+// HandleReset is the legacy handler (no transcript cleanup). Retained for
+// callers that registered routes via RegisterRoutes without a ResetFunc.
+func HandleReset(w http.ResponseWriter, r *http.Request) {
+	handleReset(w, r, nil)
+}
+
+// handleReset handles POST /onboarding/reset.
+// Clears the deterministic CEO conversation state so the wizard restarts from
+// scratch on the next /onboarding/transition phase=greet. Used by the
+// onboarding chat's back arrow → re-pick runtime flow so the user can
+// genuinely restart the wizard after changing their runtime selection.
+//
+// When resetFn is non-nil it is invoked after state is cleared; this lets the
+// broker also purge the CEO DM transcript so the user does not see prior
+// CEO messages above the fresh greet on re-entry.
+//
+// Refuses to reset when CompletedAt is set — a finished onboarding is not
+// re-runnable from this endpoint; the user must shred the workspace.
+//
+// Returns 200 on success, 409 if already complete, 500 on persistence errors.
+func handleReset(w http.ResponseWriter, r *http.Request, resetFn ResetFunc) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	s, err := Load()
+	if err != nil {
+		http.Error(w, "failed to load state", http.StatusInternalServerError)
+		return
+	}
+	if s.CompletedAt != "" {
+		http.Error(w, "cannot reset after onboarding complete", http.StatusConflict)
+		return
+	}
+	s.Phase = ""
+	s.PendingSuggestion = nil
+	s.FormAnswers = FormAnswers{}
+	if err := Save(s); err != nil {
+		http.Error(w, "failed to save state", http.StatusInternalServerError)
+		return
+	}
+
+	// Best-effort transcript clean-up. State is already persisted, so a
+	// broker-callback error should not fail the reset from the client's view.
+	if resetFn != nil {
+		if err := resetFn(); err != nil {
+			log.Printf("onboarding: reset broker callback failed: %v", err)
+		}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{"ok": true})
 }
 
 // HandleAnswer handles POST /onboarding/answer.

--- a/internal/onboarding/handlers.go
+++ b/internal/onboarding/handlers.go
@@ -131,7 +131,20 @@ func HandleState(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "failed to load state", http.StatusInternalServerError)
 		return
 	}
-	payload := map[string]any{
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(onboardingStatePayload(s))
+}
+
+// onboardingStatePayload returns the wire shape consumed by the frontend
+// useOnboardingState hook. Centralised so /onboarding/state, /onboarding/
+// answer, and /onboarding/transition all return the SAME shape — letting
+// the frontend treat the response of any action as fresh state and write
+// it straight into the React Query cache (queryClient.setQueryData) with
+// no follow-up polling/invalidate race. The race manifests in Chromium
+// (CC desktop preview, Chrome) but is masked in WebKit by event-loop
+// timing — see PR description for the side-by-side.
+func onboardingStatePayload(s *State) map[string]any {
+	return map[string]any{
 		"version":             s.Version,
 		"completed_at":        s.CompletedAt,
 		"company_name":        s.CompanyName,
@@ -150,8 +163,6 @@ func HandleState(w http.ResponseWriter, r *http.Request) {
 		"first_issue_approved_at": s.FirstIssueApprovedAt,
 		"activated":               s.Activated(),
 	}
-	w.Header().Set("Content-Type", "application/json")
-	_ = json.NewEncoder(w).Encode(payload)
 }
 
 // HandleProgress handles POST /onboarding/progress.
@@ -1007,11 +1018,20 @@ func handleTransition(w http.ResponseWriter, r *http.Request, transitionFn Trans
 		}
 	}
 
+	// Reload after transitionFn — the broker callback may mutate
+	// PendingSuggestion (advancePhase writes a new one for the next phase),
+	// and the in-memory `s` here predates that write. We must read the
+	// authoritative on-disk state to return the same shape the frontend
+	// sees from /onboarding/state, so the frontend can write it straight
+	// into the React Query cache and skip the polling/invalidate race.
+	fresh, loadErr := Load()
+	if loadErr != nil {
+		// Fall back to the pre-transitionFn state; better than 500-ing the
+		// transition itself, which already succeeded on disk.
+		fresh = s
+	}
 	w.Header().Set("Content-Type", "application/json")
-	_ = json.NewEncoder(w).Encode(map[string]any{
-		"ok":    true,
-		"phase": next,
-	})
+	_ = json.NewEncoder(w).Encode(onboardingStatePayload(fresh))
 }
 
 // makeHandleReset returns the POST /onboarding/reset handler. resetFn is
@@ -1118,8 +1138,15 @@ func HandleAnswer(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Return the full updated state so the frontend can update its query
+	// cache directly via `setQueryData`. The previous {"status":"ok"}
+	// shape forced the frontend to follow up with an `invalidateQueries`
+	// → refetch round-trip, which races against the post-await commit
+	// setStates and produces the "✓ <old answer>" stuck-card bug in
+	// Chromium (where event-loop timing exposes the race; WebKit masks
+	// it). See the cross-browser side-by-side in the PR.
 	w.Header().Set("Content-Type", "application/json")
-	_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+	_ = json.NewEncoder(w).Encode(onboardingStatePayload(s))
 }
 
 // applyFormAnswer writes a single field value into s.FormAnswers.

--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -645,7 +645,7 @@ func (b *Broker) StartOnPort(port int) error {
 	// Onboarding: state/progress/complete + deterministic CEO phase machine.
 	// completeFn posts the first task as a human message and seeds the team;
 	// transitionFn emits deterministic CEO onboarding cards into the CEO DM.
-	onboarding.RegisterRoutesWithTransition(mux, b.onboardingCompleteFn, b.ceoOnboardingTransitionFn(), b.packSlug, b.requireAuth, filepath.Join(config.RuntimeHomeDir(), ".wuphf", "wiki"))
+	onboarding.RegisterRoutesWithTransitionAndReset(mux, b.onboardingCompleteFn, b.ceoOnboardingTransitionFn(), b.ceoOnboardingResetFn(), b.packSlug, b.requireAuth, filepath.Join(config.RuntimeHomeDir(), ".wuphf", "wiki"))
 	// Workspace wipes: POST /workspace/reset (narrow) and /workspace/shred (full).
 	// After a successful wipe, b.Reset clears live in-memory broker state so the
 	// broker stays up without repersisting stale messages back onto disk.

--- a/internal/team/broker_onboarding.go
+++ b/internal/team/broker_onboarding.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/nex-crm/wuphf/internal/channel"
 	"github.com/nex-crm/wuphf/internal/config"
 	"github.com/nex-crm/wuphf/internal/onboarding"
 	"github.com/nex-crm/wuphf/internal/operations"
@@ -269,7 +270,21 @@ func (b *Broker) seedFromBlueprintLocked(bp operations.Blueprint, selectedAgents
 			Members:     memberSlugsFromMembers(b.members),
 		}}
 	}
-	b.messages = nil
+	// Preserve the CEO DM transcript across the seed boundary so the
+	// onboarding wizard reads as one continuous dialogue end-to-end.
+	// The seed wipes the office's channel/task history (kickoff starts
+	// fresh in #general) but the CEO conversation built up through
+	// greet → identity → website → blueprint → team is the user's
+	// only reference for what they've decided, and tossing it makes
+	// the wizard feel restarted.
+	ceoDmSlug := channel.DirectSlug("human", "ceo")
+	preservedCeoDm := make([]channelMessage, 0)
+	for _, m := range b.messages {
+		if m.Channel == ceoDmSlug {
+			preservedCeoDm = append(preservedCeoDm, m)
+		}
+	}
+	b.messages = preservedCeoDm
 	b.counter = 0
 	b.lastTaggedAt = make(map[string]time.Time)
 	if err := b.postKickoffLocked(bp, selectedAgents, task, skipTask, synthesized); err != nil {

--- a/internal/team/broker_onboarding_phase2.go
+++ b/internal/team/broker_onboarding_phase2.go
@@ -30,6 +30,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/nex-crm/wuphf/internal/channel"
 	"github.com/nex-crm/wuphf/internal/config"
 	"github.com/nex-crm/wuphf/internal/onboarding"
 	"github.com/nex-crm/wuphf/internal/operations"
@@ -44,6 +45,34 @@ import (
 func (b *Broker) ceoOnboardingTransitionFn() onboarding.TransitionFunc {
 	return func(phase string, s *onboarding.State) error {
 		return b.advancePhase(s, phase)
+	}
+}
+
+// ceoOnboardingResetFn returns an onboarding.ResetFunc that wipes the CEO DM
+// transcript from b.messages. Invoked by POST /onboarding/reset after the
+// onboarding state is cleared, so re-entering the wizard via the back-arrow
+// flow lands on a clean canvas instead of stacking a fresh greet on top of
+// the prior conversation.
+func (b *Broker) ceoOnboardingResetFn() onboarding.ResetFunc {
+	return func() error {
+		dmSlug, err := b.EnsureDirectChannel("ceo")
+		if err != nil {
+			return fmt.Errorf("onboarding reset: ensure CEO DM: %w", err)
+		}
+		b.mu.Lock()
+		defer b.mu.Unlock()
+		filtered := b.messages[:0]
+		for _, m := range b.messages {
+			if m.Channel == dmSlug {
+				continue
+			}
+			filtered = append(filtered, m)
+		}
+		b.messages = filtered
+		if err := b.saveLocked(); err != nil {
+			return fmt.Errorf("onboarding reset: persist after CEO DM purge: %w", err)
+		}
+		return nil
 	}
 }
 
@@ -330,9 +359,21 @@ func (b *Broker) seedMinimalScratchLocked(s *onboarding.State) error {
 		UpdatedAt:   now,
 	}}
 
-	// Clear tasks and message history for a fresh start.
+	// Clear tasks for a fresh start, but PRESERVE the CEO DM
+	// transcript across the seed boundary so the onboarding wizard
+	// reads as one continuous dialogue end-to-end (greet → identity
+	// → website → blueprint → team is the user's full conversation
+	// with the CEO and should not be wiped just because the office
+	// is being seeded).
 	b.tasks = nil
-	b.messages = nil
+	ceoDmSlug := channel.DirectSlug("human", "ceo")
+	preservedCeoDm := make([]channelMessage, 0)
+	for _, m := range b.messages {
+		if m.Channel == ceoDmSlug {
+			preservedCeoDm = append(preservedCeoDm, m)
+		}
+	}
+	b.messages = preservedCeoDm
 	b.counter = 0
 	b.lastTaggedAt = make(map[string]time.Time)
 

--- a/internal/team/notifier_delivery.go
+++ b/internal/team/notifier_delivery.go
@@ -12,6 +12,8 @@ import (
 	"fmt"
 	"strings"
 	"time"
+
+	"github.com/nex-crm/wuphf/internal/onboarding"
 )
 
 // Notification debounce cooldowns. Prevents agent-to-agent feedback
@@ -47,6 +49,25 @@ func (l *Launcher) deliverMessageNotification(msg channelMessage) {
 		return
 	}
 	immediate, delayed := l.notificationTargetsForMessage(msg)
+
+	// Onboarding gate: while the deterministic wizard is in progress (phase
+	// set but not "complete"), suppress LLM turns to the CEO agent. The
+	// wizard already drives the conversation via ceo_form_field cards and
+	// the headless CEO subprocess has no awareness of form_answers/phase,
+	// so its conversational replies contradict the wizard ("did you mean
+	// office name = Alex?" right after Alex was accepted as company_name).
+	// Mute the CEO agent until onboarding completes; other agents are
+	// unaffected.
+	if s, err := onboarding.Load(); err == nil && s != nil && s.Phase != "" && s.Phase != onboarding.PhaseComplete && !s.Onboarded() {
+		filteredCEO := immediate[:0]
+		for _, t := range immediate {
+			if t.Slug == "ceo" {
+				continue
+			}
+			filteredCEO = append(filteredCEO, t)
+		}
+		immediate = filteredCEO
+	}
 
 	// Debounce: use shorter cooldown for human/CEO messages, longer for agent-originated
 	// to prevent agent-to-agent feedback loops (devil's advocate finding #3).

--- a/web/src/components/messages/InterviewBar.ceoKinds.test.tsx
+++ b/web/src/components/messages/InterviewBar.ceoKinds.test.tsx
@@ -115,7 +115,7 @@ describe("CeoFormField", () => {
     expect(screen.getByText("Office name?")).toBeInTheDocument();
   });
 
-  it("disables input and shows spinner in submitting state", () => {
+  it("disables input in submitting state (no spinner — see PR #995)", () => {
     render(
       <CeoFormField
         payload={formPayload}
@@ -124,10 +124,12 @@ describe("CeoFormField", () => {
       />,
     );
     expect(screen.getByRole("textbox")).toBeDisabled();
-    expect(screen.getByText(/Saving/i)).toBeInTheDocument();
+    // The "Saving…" spinner swap was removed; the card stays in input
+    // shape, just disabled, so the user sees what they submitted.
+    expect(screen.queryByText(/Saving/i)).not.toBeInTheDocument();
   });
 
-  it("renders committed line with check mark in committed state", () => {
+  it("keeps input visible + disabled in committed state (no ✓ swap)", () => {
     render(
       <CeoFormField
         payload={formPayload}
@@ -136,9 +138,12 @@ describe("CeoFormField", () => {
         onSubmit={vi.fn()}
       />,
     );
-    expect(screen.getByRole("status")).toHaveTextContent("✓");
-    expect(screen.getByRole("status")).toHaveTextContent("Acme Billing");
-    expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+    // The "✓ <answer>" confirmation chip was removed in PR #995 because
+    // it flashed briefly between cards (sticky-suggestion swap is fast).
+    // Card stays in its input view, just disabled.
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
+    expect(screen.getByRole("textbox")).toBeDisabled();
   });
 
   it("calls onSubmit with field and value on Enter", () => {
@@ -248,7 +253,7 @@ describe("CeoChipRow", () => {
     }
   });
 
-  it("renders committed state as one-line with check mark", () => {
+  it("keeps chips visible + disabled in committed state (no ✓ swap)", () => {
     render(
       <CeoChipRow
         payload={chipPayload}
@@ -257,8 +262,13 @@ describe("CeoChipRow", () => {
         onSubmit={vi.fn()}
       />,
     );
-    expect(screen.getByRole("status")).toHaveTextContent("✓");
-    expect(screen.getByRole("status")).toHaveTextContent("Content Ops");
+    // Committed-state confirmation chip was removed in PR #995.
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+    const options = screen.getAllByRole("option");
+    expect(options.length).toBeGreaterThan(0);
+    for (const opt of options) {
+      expect(opt).toBeDisabled();
+    }
   });
 
   it("XSS: chip label renders as text not HTML", () => {
@@ -350,7 +360,7 @@ describe("CeoChecklist", () => {
     }
   });
 
-  it("renders committed state as one-line with check mark", () => {
+  it("keeps checklist visible + disabled in committed state (no ✓ swap)", () => {
     render(
       <CeoChecklist
         payload={checklistPayload}
@@ -359,9 +369,13 @@ describe("CeoChecklist", () => {
         onSubmit={vi.fn()}
       />,
     );
-    expect(screen.getByRole("status")).toHaveTextContent("✓");
-    expect(screen.getByRole("status")).toHaveTextContent("Writer");
-    expect(screen.getByRole("status")).toHaveTextContent("Editor");
+    // Committed-state confirmation chip was removed in PR #995.
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+    const checkboxes = screen.getAllByRole("checkbox");
+    expect(checkboxes.length).toBeGreaterThan(0);
+    for (const cb of checkboxes) {
+      expect(cb).toBeDisabled();
+    }
   });
 
   it("XSS: checklist item label renders as text not HTML", () => {
@@ -559,7 +573,7 @@ describe("CeoCardSection", () => {
 
     const input = screen.getByRole("textbox");
     fireEvent.change(input, { target: { value: "Acme Inc" } });
-    fireEvent.click(screen.getByText("Submit"));
+    fireEvent.click(screen.getByRole("button", { name: /^Submit/ }));
 
     await waitFor(() =>
       expect(postMock).toHaveBeenCalledWith("/onboarding/answer", {
@@ -571,10 +585,13 @@ describe("CeoCardSection", () => {
       phase: "identity",
     });
 
-    // After commit the section disappears (stage="committed" hides it)
+    // PR #995: committed-state no longer unmounts the card — it stays
+    // mounted (and disabled) so the user sees what they just submitted.
+    // The next suggestion swap is what actually replaces the content.
     await waitFor(() =>
-      expect(screen.queryByTestId("ceo-card-section")).not.toBeInTheDocument(),
+      expect(screen.getByTestId("ceo-card-section")).toBeInTheDocument(),
     );
+    expect(screen.getByRole("textbox")).toBeDisabled();
   });
 
   it("advances from blueprint pick to the team trim phase", async () => {
@@ -723,7 +740,7 @@ describe("CeoCardSection", () => {
         target: { value: "Build Stripe webhooks" },
       },
     );
-    fireEvent.click(screen.getByText("Submit"));
+    fireEvent.click(screen.getByRole("button", { name: /^Submit/ }));
 
     await waitFor(() =>
       expect(postMock).toHaveBeenCalledWith("/onboarding/answer", {
@@ -818,7 +835,7 @@ describe("CeoCardSection", () => {
     fireEvent.change(screen.getByRole("textbox"), {
       target: { value: "Acme Test QA" },
     });
-    fireEvent.click(screen.getByText("Submit"));
+    fireEvent.click(screen.getByRole("button", { name: /^Submit/ }));
 
     await waitFor(() =>
       expect(postMessageMock).toHaveBeenCalledWith(
@@ -884,7 +901,7 @@ describe("CeoCardSection", () => {
     fireEvent.change(screen.getByRole("textbox"), {
       target: { value: "Acme" },
     });
-    fireEvent.click(screen.getByText("Submit"));
+    fireEvent.click(screen.getByRole("button", { name: /^Submit/ }));
 
     // The transition still fires even though the echo POST failed.
     await waitFor(() =>
@@ -912,7 +929,7 @@ describe("CeoCardSection", () => {
     fireEvent.change(screen.getByRole("textbox"), {
       target: { value: "Acme" },
     });
-    fireEvent.click(screen.getByText("Submit"));
+    fireEvent.click(screen.getByRole("button", { name: /^Submit/ }));
 
     await waitFor(() =>
       expect(postMock).toHaveBeenCalledWith("/onboarding/transition", {

--- a/web/src/components/messages/InterviewBar.tsx
+++ b/web/src/components/messages/InterviewBar.tsx
@@ -24,7 +24,11 @@ import { directChannelSlug, useAppStore } from "../../stores/app";
 import { SkillCompareView } from "../apps/SkillCompareView";
 import { humanEchoForCeoAnswer } from "../onboarding/humanEcho";
 import { useOnboardingDMContext } from "../onboarding/OnboardingDMRoute";
-import type { CardStage, CeoSuggestion } from "../onboarding/types";
+import type {
+  CardStage,
+  CeoSuggestion,
+  OnboardingState,
+} from "../onboarding/types";
 import { SidePanel } from "../ui/SidePanel";
 import { showNotice } from "../ui/Toast";
 import { ApprovalContextView } from "./ApprovalContextView";
@@ -696,40 +700,73 @@ export function CeoCardSection() {
     string | string[] | undefined
   >(undefined);
 
-  // Reset stage when suggestion changes (new question arrived). Track the
-  // last-seen id in a ref so `effectiveStage` is derived synchronously —
-  // `useEffect` runs after commit, which leaves a one-render gap where the
-  // new suggestion is visible but `stage` is still `"committed"`, briefly
-  // flashing an empty card. Reading the ref during render closes that gap.
-  const suggestionId = pendingSuggestion?.id ?? null;
-  const lastSuggestionIdRef = useRef(suggestionId);
-  const suggestionChanged = lastSuggestionIdRef.current !== suggestionId;
-  const effectiveStage: CardStage = suggestionChanged ? "pending" : stage;
-  useEffect(() => {
-    lastSuggestionIdRef.current = suggestionId;
+  // Sticky-last-suggestion: the footer stays populated even during the
+  // brief windows between phases where `pendingSuggestion` from
+  // /onboarding/state is momentarily null (broker has emitted the next
+  // CEO message but hasn't yet enqueued the next suggestion). Without
+  // this, the card would unmount every time the wire goes null and the
+  // user would see an empty footer "regularly invisible from step to
+  // step." We keep rendering the LAST suggestion we saw (in whatever
+  // stage it ended — usually `"committed"`) until a genuinely new
+  // suggestion id arrives, at which point we swap and reset.
+  //
+  // Uses React's documented "reset state during render" pattern
+  // (https://react.dev/learn/you-might-not-need-an-effect#resetting-all-state-when-a-prop-changes):
+  // calling setState during render schedules a synchronous re-render
+  // before the commit, with no useEffect timing gap or ref desync race.
+  const [sticky, setSticky] = useState<CeoSuggestion | null>(
+    pendingSuggestion ?? null,
+  );
+  const stickyId = sticky?.id ?? null;
+  const incomingId = pendingSuggestion?.id ?? null;
+  if (pendingSuggestion && incomingId !== stickyId) {
+    setSticky(pendingSuggestion);
     setStage("pending");
     setCommittedValue(undefined);
-  }, [suggestionId]);
+  }
 
-  if (!pendingSuggestion || effectiveStage === "committed") return null;
+  // Render the sticky one — falls back to the active one if we haven't
+  // captured anything yet (first paint before any state has loaded).
+  const cardSuggestion = sticky ?? pendingSuggestion;
+  if (!cardSuggestion) return null;
 
   const submitAnswer = async (field: string, value: unknown) => {
     if (stage === "submitting") return;
-    setStage("submitting");
+
+    // Commit the visual state of the CURRENT card IMMEDIATELY, before
+    // any await. This is the critical ordering: while we're awaiting
+    // /onboarding/answer + /onboarding/transition (which can take 500–
+    // 1500 ms while the broker advances), the 3-second poll from
+    // useOnboardingState can refetch and surface the next phase's
+    // pending_suggestion. The sticky-swap reset (render-phase, above)
+    // then fires and puts `stage` back to "pending" for the NEW card.
+    // If we ran setStage("committed") AFTER the awaits — as the prior
+    // version did — that commit would land on the new sticky and lock
+    // it into a stuck "✓ <old answer>" display under the new question.
+    // By committing first, the commit applies to the OLD sticky, and
+    // any swap during the await cleanly transitions to the new card.
+    setCommittedValue(committedOnboardingValue(value));
+    setStage("committed");
+    if (completesOnboarding(field, value)) {
+      setOnboardingComplete(true);
+    }
+
     try {
+      // /onboarding/answer + /onboarding/transition both return the full
+      // updated OnboardingState. Capture the LATEST and write it into
+      // the React Query cache so the swap happens deterministically
+      // here rather than via the next 3-second poll tick.
+      let latest: OnboardingState | null = null;
       if (shouldPersistOnboardingAnswer(field)) {
-        await post("/onboarding/answer", { field, value });
+        latest = await post<OnboardingState>("/onboarding/answer", {
+          field,
+          value,
+        });
       }
       // Mirror the human's committed answer into the CEO DM as a chat
-      // bubble. The /messages endpoint persists it the same as any typed
-      // message so a tab reload still shows the transcript. See #978.
-      const echo = humanEchoForCeoAnswer(pendingSuggestion, field, value);
+      // bubble. Detached on purpose — see #978 / #988.
+      const echo = humanEchoForCeoAnswer(cardSuggestion, field, value);
       if (echo !== null) {
-        // Detached: don't await the echo work. The echo is best-effort UI
-        // sugar (mirror the human's answer back in chat); awaiting it
-        // would let a slow/hung /messages call freeze the wizard in
-        // "submitting" even though /onboarding/answer has already
-        // committed the real state. CodeRabbit on PR #988.
         void postMessage(echo, directChannelSlug("ceo"))
           .then(() =>
             queryClient.invalidateQueries({
@@ -737,24 +774,22 @@ export function CeoCardSection() {
             }),
           )
           .catch((echoErr: unknown) => {
-            // The next CEO message will still arrive; the user just loses
-            // the visible mirror of their own answer for that turn.
             console.warn("onboarding: failed to echo human answer", echoErr);
           });
       }
-      await advanceOnboardingAfterAnswer(field, value, phase);
-      // Refresh onboarding state so the next suggestion appears.
-      await queryClient.invalidateQueries({ queryKey: ["onboarding-state"] });
-      setCommittedValue(committedOnboardingValue(value));
-      setStage("committed");
-      if (completesOnboarding(field, value)) {
-        setOnboardingComplete(true);
+      const advanced = await advanceOnboardingAfterAnswer(field, value, phase);
+      if (advanced) latest = advanced;
+
+      if (latest) {
+        queryClient.setQueryData<OnboardingState>(["onboarding-state"], latest);
       }
     } catch (err: unknown) {
       const message =
         err instanceof Error ? err.message : "Failed to send answer";
       showNotice(message, "error");
+      // Roll back the optimistic commit so the user can retry.
       setStage("pending");
+      setCommittedValue(undefined);
     }
   };
 
@@ -774,11 +809,11 @@ export function CeoCardSection() {
       className="ceo-card-section"
       aria-label="CEO question"
       data-testid="ceo-card-section"
-      data-kind={pendingSuggestion.kind}
-      data-suggestion-id={pendingSuggestion.id}
+      data-kind={cardSuggestion.kind}
+      data-suggestion-id={cardSuggestion.id}
     >
       {renderCeoCard(
-        pendingSuggestion,
+        cardSuggestion,
         stage,
         committedValue,
         submitAnswer,
@@ -826,54 +861,45 @@ async function advanceOnboardingAfterAnswer(
   field: string,
   value: unknown,
   phase: string | undefined,
-) {
+): Promise<OnboardingState | null> {
+  // Each /onboarding/transition response carries the full fresh
+  // OnboardingState. Return the LAST response so submitAnswer can write
+  // it straight into the React Query cache and skip the polling race.
+  const transition = (phaseName: string) =>
+    post<OnboardingState>("/onboarding/transition", { phase: phaseName });
   switch (field) {
     case "company_name":
-      await post("/onboarding/transition", { phase: "identity" });
-      return;
+      return await transition("identity");
     case "description":
-      await post("/onboarding/transition", { phase: "website" });
-      return;
+      return await transition("website");
     case "blueprint_id":
       // Strict trimmed-string check: an unknown payload can be a whitespace
       // string, a number, or any other truthy non-string value. Only a real
       // blueprint id (non-empty after trim) routes to "team"; everything
       // else is the scratch path.
       if (typeof value === "string" && value.trim() !== "") {
-        await post("/onboarding/transition", { phase: "team" });
-      } else {
-        await post("/onboarding/transition", { phase: "seed" });
-        await post("/onboarding/transition", { phase: "bridge" });
+        return await transition("team");
       }
-      return;
+      await transition("seed");
+      return await transition("bridge");
     case "picked_agents":
-      await post("/onboarding/transition", { phase: "seed" });
-      await post("/onboarding/transition", { phase: "bridge" });
-      return;
+      await transition("seed");
+      return await transition("bridge");
     case "bridge_choice":
-      await post("/onboarding/transition", {
-        phase: value === "start_issue" ? "draft" : "complete",
-      });
-      return;
+      return await transition(value === "start_issue" ? "draft" : "complete");
     case "task_prompt":
-      await post("/onboarding/transition", {
-        phase: "approve",
-      });
-      return;
+      return await transition("approve");
     case "website_url":
       // Same strict trimmed-string guard as blueprint_id — whitespace-only
       // values must NOT route to "scan" (the scanner would fetch nothing).
-      await post("/onboarding/transition", {
-        phase:
-          typeof value === "string" && value.trim() !== ""
-            ? "scan"
-            : "blueprint",
-      });
-      return;
+      return await transition(
+        typeof value === "string" && value.trim() !== "" ? "scan" : "blueprint",
+      );
     default:
       if (phase === "scan" && field === "scan_complete") {
-        await post("/onboarding/transition", { phase: "blueprint" });
+        return await transition("blueprint");
       }
+      return null;
   }
 }
 

--- a/web/src/components/messages/InterviewBar.tsx
+++ b/web/src/components/messages/InterviewBar.tsx
@@ -696,14 +696,22 @@ export function CeoCardSection() {
     string | string[] | undefined
   >(undefined);
 
-  // Reset stage when suggestion changes (new question arrived).
+  // Reset stage when suggestion changes (new question arrived). Track the
+  // last-seen id in a ref so `effectiveStage` is derived synchronously —
+  // `useEffect` runs after commit, which leaves a one-render gap where the
+  // new suggestion is visible but `stage` is still `"committed"`, briefly
+  // flashing an empty card. Reading the ref during render closes that gap.
   const suggestionId = pendingSuggestion?.id ?? null;
+  const lastSuggestionIdRef = useRef(suggestionId);
+  const suggestionChanged = lastSuggestionIdRef.current !== suggestionId;
+  const effectiveStage: CardStage = suggestionChanged ? "pending" : stage;
   useEffect(() => {
+    lastSuggestionIdRef.current = suggestionId;
     setStage("pending");
     setCommittedValue(undefined);
   }, [suggestionId]);
 
-  if (!pendingSuggestion || stage === "committed") return null;
+  if (!pendingSuggestion || effectiveStage === "committed") return null;
 
   const submitAnswer = async (field: string, value: unknown) => {
     if (stage === "submitting") return;

--- a/web/src/components/messages/cards/CeoChecklist.tsx
+++ b/web/src/components/messages/cards/CeoChecklist.tsx
@@ -1,15 +1,6 @@
 /**
  * CeoChecklist — list of checkboxes + submit chip.
  * CeoTeamTrim is an alias of this component with team-specific chrome.
- *
- * Used for: team trim (blueprint path).
- *
- * Keyboard model per spec:
- *   Tab    → item
- *   Space  → toggle checkbox
- *   Enter  → Submit button
- *
- * All item labels treated as plain text (never innerHTML).
  */
 
 import { useRef, useState } from "react";
@@ -25,7 +16,6 @@ interface CeoChecklistProps {
   stage: CardStage;
   committedValue?: string[];
   onSubmit: (field: string, value: string[]) => void;
-  /** Ref for focus management — parent focuses first item after prior card commits. */
   autoFocusRef?: React.RefObject<HTMLElement | null>;
 }
 
@@ -46,7 +36,6 @@ export function CeoChecklist({
   );
   const submitRef = useRef<HTMLButtonElement>(null);
 
-  // Merge externally-provided ref so the parent can focus the submit button.
   if (autoFocusRef && submitRef.current !== null) {
     (autoFocusRef as React.MutableRefObject<HTMLElement | null>).current =
       submitRef.current;
@@ -71,11 +60,8 @@ export function CeoChecklist({
     if (stage === "submitting") return;
     setChecked((prev) => {
       const next = new Set(prev);
-      if (next.has(id)) {
-        next.delete(id);
-      } else {
-        next.add(id);
-      }
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
       return next;
     });
   };
@@ -91,28 +77,47 @@ export function CeoChecklist({
         <div className="ceo-card-label">{payload.label}</div>
       ) : null}
       <ul className="ceo-checklist-items">
-        {payload.items.map((item) => (
-          <li key={item.id} className="ceo-checklist-item">
-            <label className="ceo-checklist-label">
-              <input
-                type="checkbox"
-                className="ceo-checklist-checkbox"
-                checked={checked.has(item.id)}
-                disabled={stage === "submitting"}
-                onChange={() => toggle(item.id)}
-                aria-label={item.label}
-              />
-              {/* Render as text — never innerHTML */}
-              <span className="ceo-checklist-item-text">{item.label}</span>
-            </label>
-          </li>
-        ))}
+        {payload.items.map((item) => {
+          const isChecked = checked.has(item.id);
+          return (
+            <li key={item.id} className="ceo-checklist-item">
+              <label
+                className="ceo-checklist-label"
+                data-checked={isChecked ? "true" : "false"}
+              >
+                <input
+                  type="checkbox"
+                  className="ceo-checklist-checkbox"
+                  checked={isChecked}
+                  disabled={stage === "submitting"}
+                  onChange={() => toggle(item.id)}
+                  aria-label={item.label}
+                />
+                <svg
+                  className="ceo-checklist-tick"
+                  width="14"
+                  height="14"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2.5"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  aria-hidden="true"
+                >
+                  <polyline points="20 6 9 17 4 12" />
+                </svg>
+                <span className="ceo-checklist-item-text">{item.label}</span>
+              </label>
+            </li>
+          );
+        })}
       </ul>
       <div className="ceo-card-actions">
         <button
           ref={submitRef}
           type="button"
-          className="btn btn-primary btn-sm ceo-card-submit"
+          className="btn btn-primary ceo-card-submit"
           disabled={stage === "submitting" || checked.size === 0}
           onClick={handleSubmit}
         >

--- a/web/src/components/messages/cards/CeoChecklist.tsx
+++ b/web/src/components/messages/cards/CeoChecklist.tsx
@@ -41,23 +41,14 @@ export function CeoChecklist({
       submitRef.current;
   }
 
-  if (stage === "committed") {
-    const labels =
-      committedValue ??
-      payload.items
-        .filter((item) => checked.has(item.id))
-        .map((item) => item.label);
-    return (
-      <div className="ceo-card ceo-card--committed" role="status">
-        <span className="ceo-card-committed-text">
-          &#10003; {labels.join(", ")}
-        </span>
-      </div>
-    );
-  }
+  // Committed state intentionally renders the SAME checklist view as
+  // pending/submitting — just disabled. The previous "✓ <items>" chip
+  // was flashing between cards because the sticky-suggestion swap is
+  // near-instant.
+  void committedValue;
 
   const toggle = (id: string) => {
-    if (stage === "submitting") return;
+    if (stage !== "pending") return;
     setChecked((prev) => {
       const next = new Set(prev);
       if (next.has(id)) next.delete(id);
@@ -67,7 +58,7 @@ export function CeoChecklist({
   };
 
   const handleSubmit = () => {
-    if (stage === "submitting") return;
+    if (stage !== "pending") return;
     onSubmit(payload.field, [...checked]);
   };
 
@@ -89,7 +80,7 @@ export function CeoChecklist({
                   type="checkbox"
                   className="ceo-checklist-checkbox"
                   checked={isChecked}
-                  disabled={stage === "submitting"}
+                  disabled={stage !== "pending"}
                   onChange={() => toggle(item.id)}
                   aria-label={item.label}
                 />
@@ -118,15 +109,10 @@ export function CeoChecklist({
           ref={submitRef}
           type="button"
           className="btn btn-primary ceo-card-submit"
-          disabled={stage === "submitting" || checked.size === 0}
+          disabled={stage !== "pending" || checked.size === 0}
           onClick={handleSubmit}
         >
-          {stage === "submitting" ? (
-            <span className="ceo-card-spinner" aria-hidden="true" />
-          ) : null}
-          {stage === "submitting"
-            ? "Saving…"
-            : (payload.submit_label ?? "Submit")}
+          {payload.submit_label ?? "Submit"}
         </button>
       </div>
     </div>

--- a/web/src/components/messages/cards/CeoChipRow.tsx
+++ b/web/src/components/messages/cards/CeoChipRow.tsx
@@ -41,21 +41,14 @@ export function CeoChipRow({
       firstChipRef.current;
   }
 
-  if (stage === "committed") {
-    const label =
-      committedValue ??
-      payload.options.find((o) => o.id === selected)?.label ??
-      selected ??
-      "";
-    return (
-      <div className="ceo-card ceo-card--committed" role="status">
-        <span className="ceo-card-committed-text">&#10003; {label}</span>
-      </div>
-    );
-  }
+  // Committed state intentionally renders the SAME chip row as
+  // pending/submitting — just disabled. The previous "✓ <label>" chip
+  // was flashing between cards because the sticky-suggestion swap is
+  // near-instant.
+  void committedValue;
 
   const handleSelect = (id: string) => {
-    if (stage === "submitting") return;
+    if (stage !== "pending") return;
     setSelected(id);
     onSubmit(payload.field, id);
   };
@@ -113,14 +106,13 @@ export function CeoChipRow({
             role="option"
             aria-selected={selected === opt.id}
             className={`ceo-chip${selected === opt.id ? " ceo-chip--selected" : ""}`}
-            disabled={stage === "submitting"}
+            disabled={stage !== "pending"}
             onClick={() => handleSelect(opt.id)}
             onKeyDown={(e) => handleKeyDown(e, opt.id, idx)}
           >
-            {stage === "submitting" && selected === opt.id ? (
-              <span className="ceo-card-spinner" aria-hidden="true" />
-            ) : null}
-            {/* Render as text — never innerHTML */}
+            {/* Render as text — never innerHTML. No submitting spinner;
+                the next card swaps in fast enough that a loader reads
+                as flicker. `disabled` prevents double-click. */}
             {opt.label}
           </button>
         ))}

--- a/web/src/components/messages/cards/CeoExecutionLineup.test.tsx
+++ b/web/src/components/messages/cards/CeoExecutionLineup.test.tsx
@@ -150,30 +150,33 @@ describe("<CeoExecutionLineup>", () => {
     expect(screen.getByTestId("lineup-submit")).toBeDisabled();
   });
 
-  it("shows spinner text in submitting state", () => {
+  it("keeps the action label in submitting state (no spinner swap)", () => {
     setup(PAYLOAD, "submitting");
-    expect(screen.getByTestId("lineup-submit")).toHaveTextContent(
-      "Spinning up",
-    );
+    // The submitting state no longer swaps the button label to a
+    // spinner — between-question loaders read as flicker because the
+    // next card swaps in immediately via setQueryData. The button just
+    // stays disabled with the same label so the user sees what they
+    // submitted.
+    expect(screen.getByTestId("lineup-submit")).toHaveTextContent("Spin up");
+    expect(screen.getByTestId("lineup-submit")).toBeDisabled();
   });
 
   // ── Committed state ───────────────────────────────────────────────
 
-  it("renders committed confirmation in committed state", () => {
+  it("keeps the lineup visible in committed state — no chip swap", () => {
     setup(PAYLOAD, "committed");
-    expect(screen.getByTestId("lineup-committed")).toBeInTheDocument();
-    // 3 agents accepted by default before commit.
-    expect(screen.getByTestId("lineup-committed")).toHaveTextContent(
-      "agents added to roster",
-    );
-  });
-
-  it("does not render agent rows in committed state", () => {
-    setup(PAYLOAD, "committed");
-    expect(screen.queryByTestId("ceo-execution-lineup")).toBeNull();
+    // The committed state no longer replaces the lineup with a
+    // "✓ N agents added to roster" chip — that flashed between cards
+    // because the sticky-suggestion swap is near-instant. The lineup
+    // stays mounted, just disabled.
+    expect(screen.queryByTestId("lineup-committed")).toBeNull();
+    expect(screen.getByTestId("ceo-execution-lineup")).toBeInTheDocument();
     for (const agent of PAYLOAD.agents) {
-      expect(screen.queryByTestId(`lineup-agent-row-${agent.slug}`)).toBeNull();
+      expect(
+        screen.getByTestId(`lineup-agent-row-${agent.slug}`),
+      ).toBeInTheDocument();
     }
+    expect(screen.getByTestId("lineup-submit")).toBeDisabled();
   });
 
   // ── XSS sanitization regression ───────────────────────────────────

--- a/web/src/components/messages/cards/CeoExecutionLineup.tsx
+++ b/web/src/components/messages/cards/CeoExecutionLineup.tsx
@@ -87,22 +87,11 @@ export function CeoExecutionLineup({
     () => new Set(payload.agents.map((a) => a.slug)),
   );
 
-  if (stage === "committed") {
-    const count = accepted.size;
-    return (
-      <div
-        className="ceo-card ceo-card--committed"
-        role="status"
-        data-testid="lineup-committed"
-      >
-        <span className="ceo-card-committed-text">
-          &#10003; {count} {count === 1 ? "agent" : "agents"} added to roster
-        </span>
-      </div>
-    );
-  }
-
-  const isSubmitting = stage === "submitting";
+  // Committed state intentionally renders the SAME lineup view as
+  // pending/submitting — just disabled. The previous "✓ N agents added
+  // to roster" chip was flashing between cards because the sticky-
+  // suggestion swap is near-instant.
+  const isSubmitting = stage !== "pending";
   const selectedCount = accepted.size;
 
   const toggleAgent = (slug: string) => {
@@ -162,12 +151,7 @@ export function CeoExecutionLineup({
           data-testid="lineup-submit"
           aria-label={`Spin up ${selectedCount} ${selectedCount === 1 ? "agent" : "agents"}`}
         >
-          {isSubmitting ? (
-            <span className="ceo-card-spinner" aria-hidden="true" />
-          ) : null}
-          {isSubmitting
-            ? "Spinning up…"
-            : `Spin up ${selectedCount} ${selectedCount === 1 ? "agent" : "agents"}`}
+          {`Spin up ${selectedCount} ${selectedCount === 1 ? "agent" : "agents"}`}
         </button>
       </div>
     </div>

--- a/web/src/components/messages/cards/CeoFormField.tsx
+++ b/web/src/components/messages/cards/CeoFormField.tsx
@@ -40,20 +40,16 @@ export function CeoFormField({
     }
   }, [stage]);
 
-  if (stage === "committed") {
-    return (
-      <div className="ceo-card ceo-card--committed" role="status">
-        <span className="ceo-card-committed-text">
-          &#10003; {committedValue ?? value}
-        </span>
-      </div>
-    );
-  }
+  // Committed state intentionally renders the SAME input view as
+  // pending/submitting — just disabled. The previous "✓ <answer>"
+  // confirmation chip was flashing briefly between cards (because the
+  // sticky-suggestion swap is near-instant), and read as noise rather
+  // than acknowledgement.
 
   const canSubmit = value.trim().length > 0 || payload.optional;
 
   const handleSubmit = () => {
-    if (stage === "submitting") return;
+    if (stage !== "pending") return;
     const trimmed = value.trim();
     if (!(trimmed || payload.optional)) return;
     onSubmit(payload.field, trimmed);
@@ -77,7 +73,7 @@ export function CeoFormField({
           className="ceo-card-input"
           value={value}
           placeholder={payload.placeholder ?? ""}
-          disabled={stage === "submitting"}
+          disabled={stage !== "pending"}
           onChange={(e) => setValue(e.target.value)}
           onKeyDown={(e) => {
             if (e.key === "Enter") {
@@ -94,7 +90,7 @@ export function CeoFormField({
           <button
             type="button"
             className="btn btn-ghost btn-sm ceo-card-skip"
-            disabled={stage === "submitting"}
+            disabled={stage !== "pending"}
             onClick={() => onSkip(payload.field)}
             aria-label={`Skip ${payload.label}`}
           >
@@ -104,29 +100,29 @@ export function CeoFormField({
         <button
           type="button"
           className="ceo-card-send"
-          disabled={stage === "submitting" || !canSubmit}
+          disabled={stage !== "pending" || !canSubmit}
           onClick={handleSubmit}
           aria-label={`Submit ${payload.label}`}
           title="Submit (Enter)"
         >
-          {stage === "submitting" ? (
-            <span className="ceo-card-spinner" aria-hidden="true" />
-          ) : (
-            <svg
-              width="14"
-              height="14"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2.5"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              aria-hidden="true"
-            >
-              <line x1="5" y1="12" x2="19" y2="12" />
-              <polyline points="12 5 19 12 12 19" />
-            </svg>
-          )}
+          {/* Submitting state shows no spinner — the wizard now swaps
+              to the next card almost instantly via setQueryData, so a
+              loader between questions just flashes and reads as noise.
+              The `disabled` attribute already prevents double-submit. */}
+          <svg
+            width="14"
+            height="14"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+          >
+            <line x1="5" y1="12" x2="19" y2="12" />
+            <polyline points="12 5 19 12 12 19" />
+          </svg>
         </button>
       </div>
     </div>

--- a/web/src/components/messages/cards/CeoFormField.tsx
+++ b/web/src/components/messages/cards/CeoFormField.tsx
@@ -1,15 +1,5 @@
 /**
- * CeoFormField — label + text input + submit chip + optional "Skip" chip.
- *
- * Used for: company name, description, website, owner_name, owner_role.
- *
- * Card lifecycle: pending → submitting → committed (one-line "✓ <value>").
- * All strings treated as plain text. Never render raw payload as HTML.
- *
- * Keyboard model per spec:
- *   Tab  → input focus
- *   Enter → submit (when input focused)
- *   Space → type normally (not a submit trigger here)
+ * CeoFormField — label + text input + submit chip + optional inline "Skip".
  */
 
 import { useEffect, useRef, useState } from "react";
@@ -22,7 +12,6 @@ interface CeoFormFieldProps {
   committedValue?: string;
   onSubmit: (field: string, value: string) => void;
   onSkip?: (field: string) => void;
-  /** Ref for focus management — parent focuses this after prior card commits. */
   autoFocusRef?: React.RefObject<HTMLInputElement | null>;
 }
 
@@ -37,8 +26,6 @@ export function CeoFormField({
   const [value, setValue] = useState(payload.default ?? "");
   const inputRef = useRef<HTMLInputElement>(null);
 
-  // Merge externally-provided ref with local ref so the parent can manage
-  // focus while this component can also auto-focus on mount.
   useEffect(() => {
     if (autoFocusRef) {
       (
@@ -82,45 +69,27 @@ export function CeoFormField({
           {payload.label}
         </label>
       ) : null}
-      <input
-        id={`ceo-field-${payload.field}`}
-        ref={inputRef}
-        type="text"
-        className="ceo-card-input"
-        value={value}
-        placeholder={payload.placeholder ?? ""}
-        disabled={stage === "submitting"}
-        onChange={(e) => setValue(e.target.value)}
-        onKeyDown={(e) => {
-          if (e.key === "Enter") {
-            e.preventDefault();
-            handleSubmit();
-          }
-        }}
-        aria-label={payload.label}
-        // Suppress browser password-manager / autofill popups. The CEO card is
-        // a single-field conversational prompt, not a login or profile form;
-        // 1Password and Chrome were offering credential fills on company
-        // name / website / description (issue #943). The `data-*-ignore`
-        // attributes are vendor escape hatches for 1Password and LastPass,
-        // which sometimes ignore plain `autoComplete="off"`.
-        autoComplete="off"
-        data-1p-ignore="true"
-        data-lpignore="true"
-      />
-      <div className="ceo-card-actions">
-        <button
-          type="button"
-          className="btn btn-primary btn-sm ceo-card-submit"
-          disabled={stage === "submitting" || !canSubmit}
-          onClick={handleSubmit}
-          aria-label={`Submit ${payload.label}`}
-        >
-          {stage === "submitting" ? (
-            <span className="ceo-card-spinner" aria-hidden="true" />
-          ) : null}
-          {stage === "submitting" ? "Saving…" : "Submit"}
-        </button>
+      <div className="ceo-card-input-row">
+        <input
+          id={`ceo-field-${payload.field}`}
+          ref={inputRef}
+          type="text"
+          className="ceo-card-input"
+          value={value}
+          placeholder={payload.placeholder ?? ""}
+          disabled={stage === "submitting"}
+          onChange={(e) => setValue(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              handleSubmit();
+            }
+          }}
+          aria-label={payload.label}
+          autoComplete="off"
+          data-1p-ignore="true"
+          data-lpignore="true"
+        />
         {payload.optional && onSkip ? (
           <button
             type="button"
@@ -132,6 +101,33 @@ export function CeoFormField({
             Skip
           </button>
         ) : null}
+        <button
+          type="button"
+          className="ceo-card-send"
+          disabled={stage === "submitting" || !canSubmit}
+          onClick={handleSubmit}
+          aria-label={`Submit ${payload.label}`}
+          title="Submit (Enter)"
+        >
+          {stage === "submitting" ? (
+            <span className="ceo-card-spinner" aria-hidden="true" />
+          ) : (
+            <svg
+              width="14"
+              height="14"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              aria-hidden="true"
+            >
+              <line x1="5" y1="12" x2="19" y2="12" />
+              <polyline points="12 5 19 12 12 19" />
+            </svg>
+          )}
+        </button>
       </div>
     </div>
   );

--- a/web/src/components/onboarding/OnboardingChat.test.tsx
+++ b/web/src/components/onboarding/OnboardingChat.test.tsx
@@ -75,62 +75,37 @@ describe("OnboardingChat", () => {
     expect(screen.getByTestId("interview-bar")).toBeDefined();
   });
 
-  it("translates phase enum into a short human label, not the raw enum", async () => {
-    getMock.mockResolvedValue({ phase: "blueprint", pending_suggestion: null });
-    render(<OnboardingChat />, { wrapper });
-    await waitFor(() =>
-      expect(screen.getByText(/Pick a starter/i)).toBeDefined(),
-    );
-    // Guard against regressing to the inconsistent step counter format.
-    expect(screen.queryByText(/Step \d of \d/)).toBeNull();
+  it("surfaces the current phase via the chat root's data-phase attribute", async () => {
+    // Phase label header was removed in favor of just brand + restart;
+    // the phase is still exposed for e2e specs and CSS selectors via
+    // `data-phase` on the chat root. Cover each previously-labelled phase
+    // here so a regression to the labelled header is still caught by tests.
+    for (const phase of ["blueprint", "website", "scan", "identity"]) {
+      getMock.mockResolvedValue({ phase, pending_suggestion: null });
+      const { unmount } = render(<OnboardingChat />, { wrapper });
+      await waitFor(() =>
+        expect(
+          screen.getByTestId("onboarding-chat").getAttribute("data-phase"),
+        ).toBe(phase),
+      );
+      unmount();
+    }
   });
 
-  it("labels the previously-uncovered website phase", async () => {
-    getMock.mockResolvedValue({ phase: "website", pending_suggestion: null });
-    render(<OnboardingChat />, { wrapper });
-    await waitFor(() => expect(screen.getByText(/^Website$/)).toBeDefined());
-  });
-
-  it("labels the previously-uncovered scan phase", async () => {
-    getMock.mockResolvedValue({ phase: "scan", pending_suggestion: null });
-    render(<OnboardingChat />, { wrapper });
-    await waitFor(() =>
-      expect(screen.getByText(/Scanning your site/i)).toBeDefined(),
-    );
-  });
-
-  it("labels the identity phase as 'What you do', not 'Who you are'", async () => {
-    getMock.mockResolvedValue({ phase: "identity", pending_suggestion: null });
-    render(<OnboardingChat />, { wrapper });
-    await waitFor(() => expect(screen.getByText(/What you do/i)).toBeDefined());
-    expect(screen.queryByText(/Who you are/i)).toBeNull();
-  });
-
-  it("shows a hint when no pending suggestion is present", async () => {
+  it("does not render the legacy 'Hang tight…' hint", async () => {
+    // The hint was removed when CeoCardSection adopted the sticky-last-
+    // suggestion pattern — the footer keeps showing the previously-
+    // committed card across the brief broker-think gap instead of going
+    // empty, so the hint became dead text.
     getMock.mockResolvedValue({ phase: "greet", pending_suggestion: null });
     render(<OnboardingChat />, { wrapper });
-    await waitFor(() => {
-      expect(screen.getByText(/CEO is composing/)).toBeDefined();
-    });
-  });
-
-  it("hides the hint when a pending suggestion exists", async () => {
-    getMock.mockResolvedValue({
-      phase: "greet",
-      pending_suggestion: {
-        id: "greet-1",
-        kind: "ceo_form_field",
-        question: "Office name?",
-      },
-    });
-    render(<OnboardingChat />, { wrapper });
-    // Wait for phase to settle, then assert hint is absent.
     await waitFor(() =>
       expect(
         screen.getByTestId("onboarding-chat").getAttribute("data-phase"),
       ).toBe("greet"),
     );
     expect(screen.queryByText(/CEO is composing/)).toBeNull();
+    expect(screen.queryByText(/Hang tight/)).toBeNull();
   });
 
   it("renders without crash when state load is still pending", () => {

--- a/web/src/components/onboarding/OnboardingChat.tsx
+++ b/web/src/components/onboarding/OnboardingChat.tsx
@@ -373,21 +373,31 @@ export function OnboardingChat({ onBack }: OnboardingChatProps = {}) {
   }, [messages, revealedIds, pendingMsg, pendingState]);
 
   // Track scroll position + overflow + auto-pin to bottom on stream growth.
+  // `wasAtBottomRef` is the source of truth: we only auto-pin if the user
+  // was at the bottom right before the growth, so a deliberate scroll-up
+  // to re-read history is preserved across new messages.
+  const wasAtBottomRef = useRef(true);
   useEffect(() => {
     const el = streamRef.current;
     if (!el) return;
     const isAtBottom = () =>
-      el.scrollHeight - el.scrollTop - el.clientHeight <= 2;
-    const onScroll = () => setAtBottom(isAtBottom());
-    const onResize = () => {
+      el.scrollHeight - el.scrollTop - el.clientHeight <= 4;
+    const onScroll = () => {
+      const at = isAtBottom();
+      wasAtBottomRef.current = at;
+      setAtBottom(at);
+    };
+    const pinIfNeeded = () => {
       setHasOverflow(el.scrollHeight - el.clientHeight > 2);
-      el.scrollTop = el.scrollHeight;
-      setAtBottom(true);
+      if (wasAtBottomRef.current) {
+        el.scrollTop = el.scrollHeight;
+        setAtBottom(true);
+      }
     };
     onScroll();
-    onResize();
+    pinIfNeeded();
     el.addEventListener("scroll", onScroll, { passive: true });
-    const observer = new ResizeObserver(onResize);
+    const observer = new ResizeObserver(pinIfNeeded);
     observer.observe(el);
     const stream = el.firstElementChild;
     if (stream) observer.observe(stream);
@@ -396,6 +406,28 @@ export function OnboardingChat({ onBack }: OnboardingChatProps = {}) {
       observer.disconnect();
     };
   }, []);
+
+  // rAF pin loop while anything is animating. CSS `max-height` transitions
+  // on the slot don't fire ResizeObserver on every frame, so scrollTop
+  // lags the animated height and the message settles above the fold. Re-
+  // pin every frame for the duration of the longest reveal step, but only
+  // if the user was at the bottom (preserves scroll-back).
+  useEffect(() => {
+    if (pendingState === "idle" && !postHumanDelay) return;
+    let rafId = 0;
+    const stopAt = performance.now() + ANIMATION_MS + 200;
+    const tick = (now: number) => {
+      const el = streamRef.current;
+      if (el && wasAtBottomRef.current) {
+        el.scrollTop = el.scrollHeight;
+      }
+      if (now < stopAt) {
+        rafId = requestAnimationFrame(tick);
+      }
+    };
+    rafId = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(rafId);
+  }, [pendingState, postHumanDelay, displayList.length]);
 
   const phase = state?.phase;
   const pendingSuggestion = parsePendingSuggestion(state?.pending_suggestion);

--- a/web/src/components/onboarding/OnboardingChat.tsx
+++ b/web/src/components/onboarding/OnboardingChat.tsx
@@ -10,17 +10,14 @@
  * destination, not the wizard.
  */
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 
 import type { Message } from "../../api/client";
 import { useMessages } from "../../hooks/useMessages";
-import { formatTime } from "../../lib/format";
 import { directChannelSlug } from "../../stores/app";
 import { InterviewBar } from "../messages/InterviewBar";
 import { MessageBubble } from "../messages/MessageBubble";
-import { HarnessBadge } from "../ui/HarnessBadge";
-import { PixelAvatar } from "../ui/PixelAvatar";
 import { OnboardingDMContextProvider } from "./OnboardingDMRoute";
 import type { CeoSuggestion } from "./types";
 import { useOnboardingState } from "./useOnboardingState";
@@ -31,132 +28,129 @@ const THINK_MS = 500;
 const GAP_MS = 300;
 const POST_HUMAN_MS = 700;
 const WORD_FADE_MS = 600;
-const WORD_STAGGER_MS = 110;
+const WORD_STAGGER_MS = 90;
 const WIZARD_EASE = "cubic-bezier(0.2, 0, 0.8, 1)";
 
 type CeoBubbleState = "thinking" | "revealing" | "revealed";
 
 /**
- * CEO bubble — single element with both the thinking dots and the real
- * message content stacked in the .message-text slot as overlapping grid
- * layers, cross-faded via data-pending.
+ * Single slot used for both CEO and human messages. The bubble itself is
+ * always `MessageBubble`, so chrome (avatar, name, badge, timestamp,
+ * spacing) is byte-for-byte identical across both sides. The only CEO-
+ * specific additions are:
+ *   1. A thinking-dot overlay rendered while `data-state="thinking"`. It
+ *      appears/disappears instantly (no fade) when state flips.
+ *   2. Per-word opacity reveal on the message text: after MessageBubble
+ *      mounts, text nodes inside `.message-text` are split into
+ *      `<span class="ceo-word">` spans with a per-word `transition-delay`,
+ *      so CSS can fade each word in one-by-one when the slot transitions
+ *      to `revealing` / `revealed`.
  */
-function CeoOnboardingBubble({
-  message,
-  pending,
-}: {
-  message: Message;
-  pending: boolean;
-}) {
-  return (
-    <div
-      className="message"
-      data-msg-id={message.id}
-      data-author-kind="agent"
-      data-author-slug={CEO_AGENT_SLUG}
-    >
-      <div className="message-avatar avatar-with-harness" aria-hidden="true">
-        <PixelAvatar slug={CEO_AGENT_SLUG} size={24} />
-        <HarnessBadge
-          kind="claude-code"
-          size={14}
-          className="harness-badge-on-avatar"
-        />
-      </div>
-      <div className="message-content">
-        <div className="message-header">
-          <span className="message-author">CEO</span>
-          <span className="badge badge-green">CEO</span>
-          {!pending && message.timestamp ? (
-            <span className="message-time" title={message.timestamp}>
-              {formatTime(message.timestamp)}
-            </span>
-          ) : null}
-        </div>
-        <div className="message-text ceo-text-slot" data-pending={pending}>
-          <div
-            className="ceo-text-layer ceo-text-dots"
-            aria-label="CEO is thinking"
-            aria-hidden={!pending}
-          >
-            <span className="onboarding-thinking-dot" />
-            <span className="onboarding-thinking-dot" />
-            <span className="onboarding-thinking-dot" />
-          </div>
-          <div
-            className="ceo-text-layer ceo-text-content"
-            aria-hidden={pending}
-          >
-            <span aria-label={message.content}>
-              {message.content.split(/(\s+)/).map((token, i) =>
-                /^\s+$/.test(token) ? (
-                  // biome-ignore lint/suspicious/noArrayIndexKey: positional tokens
-                  <span key={`s${i}`} aria-hidden="true">
-                    {token}
-                  </span>
-                ) : (
-                  <span
-                    // biome-ignore lint/suspicious/noArrayIndexKey: positional tokens
-                    key={`w${i}`}
-                    className="ceo-word"
-                    aria-hidden="true"
-                    style={{
-                      transitionDelay: pending
-                        ? "0ms"
-                        : `${(i / 2) * WORD_STAGGER_MS}ms`,
-                    }}
-                  >
-                    {token}
-                  </span>
-                ),
-              )}
-            </span>
-          </div>
-        </div>
-      </div>
-    </div>
-  );
-}
-
-function CeoMessageSlot({
+function OnboardingMessageSlot({
   message,
   state,
+  isCeo,
   instant,
 }: {
   message: Message;
   state: CeoBubbleState;
+  isCeo: boolean;
   instant?: boolean;
 }) {
   const instantRef = useRef(instant === true);
+  const slotRef = useRef<HTMLDivElement>(null);
+
+  // After the bubble mounts, split CEO message text into per-word spans
+  // so CSS can stagger the opacity reveal. Runs once per message.id.
+  useEffect(() => {
+    if (!isCeo) return;
+    const slot = slotRef.current;
+    if (!slot) return;
+    const textEl = slot.querySelector(".message-text");
+    if (!textEl || textEl.querySelector(".ceo-word")) return;
+
+    const walker = document.createTreeWalker(textEl, NodeFilter.SHOW_TEXT);
+    const textNodes: Text[] = [];
+    let node: Node | null = walker.nextNode();
+    while (node) {
+      textNodes.push(node as Text);
+      node = walker.nextNode();
+    }
+
+    let wordIndex = 0;
+    for (const textNode of textNodes) {
+      const text = textNode.textContent ?? "";
+      if (!text) continue;
+      const tokens = text.split(/(\s+)/);
+      const fragment = document.createDocumentFragment();
+      for (const token of tokens) {
+        if (!token) continue;
+        if (/^\s+$/.test(token)) {
+          fragment.appendChild(document.createTextNode(token));
+        } else {
+          const span = document.createElement("span");
+          span.className = "ceo-word";
+          span.textContent = token;
+          // For backlog (instant) messages, skip the stagger so they
+          // settle into final state immediately.
+          if (!instantRef.current) {
+            span.style.transitionDelay = `${wordIndex * WORD_STAGGER_MS}ms`;
+          }
+          wordIndex++;
+          fragment.appendChild(span);
+        }
+      }
+      textNode.parentNode?.replaceChild(fragment, textNode);
+    }
+  }, [isCeo, message.id]);
+
+  const overlayRef = useRef<HTMLDivElement>(null);
+
+  // Anchor the thinking overlay to wherever `.message-text` actually sits
+  // inside MessageBubble's layout — hardcoded offsets drift the moment
+  // MessageBubble's internal padding/grid changes. Runs while thinking
+  // because the text element exists (visibility-hidden, but laid out).
+  useEffect(() => {
+    if (!isCeo || state !== "thinking") return;
+    const slot = slotRef.current;
+    const overlay = overlayRef.current;
+    if (!(slot && overlay)) return;
+    const textEl = slot.querySelector(".message-text");
+    if (!(textEl instanceof HTMLElement)) return;
+    const place = () => {
+      const slotRect = slot.getBoundingClientRect();
+      const textRect = textEl.getBoundingClientRect();
+      overlay.style.left = `${textRect.left - slotRect.left}px`;
+      overlay.style.top = `${textRect.top - slotRect.top}px`;
+    };
+    place();
+    const ro = new ResizeObserver(place);
+    ro.observe(textEl);
+    ro.observe(slot);
+    return () => ro.disconnect();
+  }, [isCeo, state]);
+
   return (
     <div
-      className={`onboarding-message-slot onboarding-ceo-slot${
-        instantRef.current ? " onboarding-slot-instant" : ""
-      }`}
+      ref={slotRef}
+      className={`onboarding-message-slot ${
+        isCeo ? "onboarding-ceo-slot" : "onboarding-human-slot"
+      }${instantRef.current ? " onboarding-slot-instant" : ""}`}
       data-state={state}
       data-msg-id={message.id}
     >
-      <CeoOnboardingBubble message={message} pending={state === "thinking"} />
-    </div>
-  );
-}
-
-function HumanMessageSlot({
-  message,
-  instant,
-}: {
-  message: Message;
-  instant?: boolean;
-}) {
-  const instantRef = useRef(instant === true);
-  return (
-    <div
-      className={`onboarding-message-slot onboarding-human-slot${
-        instantRef.current ? " onboarding-slot-instant" : ""
-      }`}
-      data-msg-id={message.id}
-    >
       <MessageBubble message={message} />
+      {isCeo && state === "thinking" ? (
+        <div
+          ref={overlayRef}
+          className="onboarding-thinking-overlay"
+          aria-label="CEO is thinking"
+        >
+          <span className="onboarding-thinking-dot" />
+          <span className="onboarding-thinking-dot" />
+          <span className="onboarding-thinking-dot" />
+        </div>
+      ) : null}
     </div>
   );
 }
@@ -195,6 +189,33 @@ export function OnboardingChat({ onBack }: OnboardingChatProps = {}) {
   const [atBottom, setAtBottom] = useState(true);
   const [hasOverflow, setHasOverflow] = useState(false);
 
+  // Ref to a sentinel div at the very end of the stream — see the JSX
+  // below. We call scrollIntoView on it instead of writing scrollTop
+  // arithmetic, because Safari and Chrome compute scrollHeight slightly
+  // differently across layout passes (Safari leaves the last message
+  // hidden under the footer; Chrome handles it). scrollIntoView is the
+  // browser-native "make this visible" call and works consistently.
+  const endOfStreamRef = useRef<HTMLDivElement>(null);
+
+  // Single source of truth for "should we auto-pin to the bottom on the
+  // next layout change." Mutated by the scroll listener further down.
+  // Declared early so the footer-measurement effect (which fires before
+  // the scroll-listener effect mounts) can also gate its re-pin on it.
+  const wasAtBottomRef = useRef(true);
+
+  // Pin the sentinel into view. Called from every effect that could
+  // cause the bottom-of-stream to move out of frame (new message,
+  // footer height change, animation tick). Always block:"end" so the
+  // sentinel lines up just above the absolute-positioned footer, since
+  // the body's padding-bottom already reserves footer-height of space.
+  const scrollToBottom = useCallback(() => {
+    if (!wasAtBottomRef.current) return;
+    endOfStreamRef.current?.scrollIntoView({
+      behavior: "auto",
+      block: "end",
+    });
+  }, []);
+
   // Force-refresh the onboarding state whenever messages list changes,
   // collapsing the 3-second polling lag on pending_suggestion updates.
   useEffect(() => {
@@ -202,7 +223,11 @@ export function OnboardingChat({ onBack }: OnboardingChatProps = {}) {
   }, [messages.length, queryClient]);
 
   // Measure footer height for the body's reserved padding-bottom and
-  // bottom-fade overlay's `bottom` offset.
+  // bottom-fade overlay's `bottom` offset. When the footer grows (e.g.
+  // form-field card → multi-option chip-row), the body's padding-bottom
+  // grows along with it — which pushes the last message out of view.
+  // We re-pin the scroll right after writing the new height so the
+  // bottom of the stream stays in sight.
   useEffect(() => {
     if (!(pairRef.current && footerRef.current)) return;
     const pair = pairRef.current;
@@ -212,6 +237,11 @@ export function OnboardingChat({ onBack }: OnboardingChatProps = {}) {
         "--onboarding-footer-h",
         `${footer.offsetHeight}px`,
       );
+      // rAF so the layout has applied the new padding-bottom before we
+      // ask the browser to scroll the sentinel into view; otherwise we
+      // pin to the pre-resize position and end up short by exactly the
+      // height delta.
+      requestAnimationFrame(scrollToBottom);
     };
     update();
     const observer = new ResizeObserver(update);
@@ -373,15 +403,36 @@ export function OnboardingChat({ onBack }: OnboardingChatProps = {}) {
   }, [messages, revealedIds, pendingMsg, pendingState]);
 
   // Track scroll position + overflow + auto-pin to bottom on stream growth.
-  // `wasAtBottomRef` is the source of truth: we only auto-pin if the user
-  // was at the bottom right before the growth, so a deliberate scroll-up
-  // to re-read history is preserved across new messages.
-  const wasAtBottomRef = useRef(true);
+  // `wasAtBottomRef` (declared above) is the source of truth: we only
+  // auto-pin if the user was at the bottom right before the growth, so a
+  // deliberate scroll-up to re-read history is preserved across new
+  // messages.
   useEffect(() => {
     const el = streamRef.current;
     if (!el) return;
-    const isAtBottom = () =>
-      el.scrollHeight - el.scrollTop - el.clientHeight <= 4;
+    // "At bottom" = the end-of-stream sentinel is visible inside the
+    // body's viewport. The naïve `scrollTop === scrollHeight -
+    // clientHeight` check fails here because the body has 140px of
+    // `padding-bottom` reserved for the absolute-positioned footer,
+    // so the "true" scroll bottom is below the visible content area.
+    // After scrollIntoView pins the sentinel at the viewport bottom,
+    // scrollTop is ~140px short of true bottom and the naïve check
+    // would flip wasAtBottomRef to false, killing auto-pin for the
+    // next message.
+    const isAtBottom = () => {
+      const sentinel = endOfStreamRef.current;
+      const footer = footerRef.current;
+      if (!(sentinel && footer)) return true;
+      // The body's rect bottom includes the padding-bottom reserved
+      // for the footer, so it's NOT the right reference — the footer
+      // visually covers that padding. Compare against the footer's
+      // top: if the sentinel sits at or above it, the latest message
+      // is visible above the footer and the user is "at bottom."
+      return (
+        sentinel.getBoundingClientRect().bottom <=
+        footer.getBoundingClientRect().top + 4
+      );
+    };
     const onScroll = () => {
       const at = isAtBottom();
       wasAtBottomRef.current = at;
@@ -390,7 +441,7 @@ export function OnboardingChat({ onBack }: OnboardingChatProps = {}) {
     const pinIfNeeded = () => {
       setHasOverflow(el.scrollHeight - el.clientHeight > 2);
       if (wasAtBottomRef.current) {
-        el.scrollTop = el.scrollHeight;
+        scrollToBottom();
         setAtBottom(true);
       }
     };
@@ -407,41 +458,54 @@ export function OnboardingChat({ onBack }: OnboardingChatProps = {}) {
     };
   }, []);
 
-  // rAF pin loop while anything is animating. CSS `max-height` transitions
-  // on the slot don't fire ResizeObserver on every frame, so scrollTop
-  // lags the animated height and the message settles above the fold. Re-
-  // pin every frame for the duration of the longest reveal step, but only
-  // if the user was at the bottom (preserves scroll-back).
+  // Pin sentinel into view whenever the message list grows. Runs after
+  // every new message lands in the DOM. scrollIntoView is browser-
+  // native "make this visible," which is consistent across Safari and
+  // Chrome — unlike scrollTop arithmetic, which Safari computed
+  // slightly differently and left the last message hidden behind the
+  // footer.
+  useEffect(() => {
+    scrollToBottom();
+  }, [messages.length, scrollToBottom]);
+
+  // rAF pin loop while anything is animating. The sentinel may move as
+  // slots reveal / footer height adjusts / images load; re-pin every
+  // frame for the duration of the longest reveal step. Only fires if
+  // the user was at the bottom (preserves scroll-back).
   useEffect(() => {
     if (pendingState === "idle" && !postHumanDelay) return;
     let rafId = 0;
     const stopAt = performance.now() + ANIMATION_MS + 200;
     const tick = (now: number) => {
-      const el = streamRef.current;
-      if (el && wasAtBottomRef.current) {
-        el.scrollTop = el.scrollHeight;
-      }
+      scrollToBottom();
       if (now < stopAt) {
         rafId = requestAnimationFrame(tick);
       }
     };
     rafId = requestAnimationFrame(tick);
     return () => cancelAnimationFrame(rafId);
-  }, [pendingState, postHumanDelay, displayList.length]);
+  }, [pendingState, postHumanDelay, displayList.length, scrollToBottom]);
 
   const phase = state?.phase;
   const pendingSuggestion = parsePendingSuggestion(state?.pending_suggestion);
 
-  // First greet (Office name?) is the only phase that should NOT blur
-  // the input — the user hasn't interacted yet.
+  // Lock interaction while the CEO is mid-reveal or in the post-human
+  // breather. Critically, we DO NOT lock on `!pendingSuggestion` anymore
+  // — CeoCardSection now keeps the last suggestion sticky, so the
+  // footer is never empty across phase transitions and there's nothing
+  // to gate visibility on.
+  //
+  // First-greet exemption: on the very first render of the wizard, the
+  // CEO's "Office name?" message is technically still "unrevealed" (it's
+  // about to flip from thinking → revealing), but the user hasn't
+  // interacted yet so muting their first input on arrival feels jarring.
+  // Skip the lock when we're in the greet phase and only one CEO message
+  // exists.
   const hasUnrevealedMessages = messages.some((m) => !revealedIds.has(m.id));
   const isFirstGreet = phase === "greet" && messages.length <= 1;
   const inputLocked =
     !isFirstGreet &&
-    (pendingState !== "idle" ||
-      postHumanDelay ||
-      hasUnrevealedMessages ||
-      !pendingSuggestion);
+    (pendingState !== "idle" || postHumanDelay || hasUnrevealedMessages);
 
   // Blur active element on lock so a focused input can't sneak typing through.
   useEffect(() => {
@@ -506,22 +570,32 @@ export function OnboardingChat({ onBack }: OnboardingChatProps = {}) {
             data-has-overflow={hasOverflow ? "true" : "false"}
           >
             <div className="onboarding-chat-stream">
-              {displayList.map(({ msg, state, isHuman, isBacklog }) =>
-                isHuman ? (
-                  <HumanMessageSlot
-                    key={msg.id}
-                    message={msg}
-                    instant={isBacklog}
-                  />
-                ) : (
-                  <CeoMessageSlot
-                    key={msg.id}
-                    message={msg}
-                    state={state}
-                    instant={isBacklog}
-                  />
-                ),
-              )}
+              {displayList.map(({ msg, state, isHuman, isBacklog }) => (
+                <OnboardingMessageSlot
+                  key={msg.id}
+                  message={msg}
+                  state={state}
+                  isCeo={!isHuman}
+                  instant={isBacklog}
+                />
+              ))}
+              {/* Bottom-of-stream sentinel. Scroll-into-view'd whenever
+                  new content lands. `scrollMarginBottom` is critical:
+                  scrollIntoView pins the sentinel to the body's bottom
+                  edge, which is behind the absolutely-positioned
+                  footer. The scroll-margin tells the browser "leave
+                  this much room below me when scrolling me into view,"
+                  so the sentinel (and therefore the last message)
+                  lands ABOVE the footer instead of behind it. */}
+              <div
+                ref={endOfStreamRef}
+                aria-hidden="true"
+                style={{
+                  height: 1,
+                  scrollMarginBottom:
+                    "calc(var(--onboarding-footer-h, 120px) + 16px)",
+                }}
+              />
             </div>
           </main>
 
@@ -533,16 +607,8 @@ export function OnboardingChat({ onBack }: OnboardingChatProps = {}) {
 
           <footer className="onboarding-chat-footer" ref={footerRef}>
             <div className="onboarding-chat-footer-inner">
-              <div
-                className="onboarding-card-shell"
-                data-empty={!pendingSuggestion ? "true" : "false"}
-              >
+              <div className="onboarding-card-shell">
                 <InterviewBar />
-                {!pendingSuggestion && (
-                  <p className="onboarding-chat-hint">
-                    Hang tight — the CEO is composing the next step.
-                  </p>
-                )}
               </div>
             </div>
           </footer>

--- a/web/src/components/onboarding/OnboardingChat.tsx
+++ b/web/src/components/onboarding/OnboardingChat.tsx
@@ -8,27 +8,158 @@
  * back to CeoCardSection when no agent interview request is pending). No
  * sidebar, no workspace rail, no workbench panes — those are the
  * destination, not the wizard.
- *
- * Lifts from the onboarding spec (docs/specs/onboarding-into-office.md):
- *   "Onboarding is a wizard mocked as a CEO chat. The user is not really in
- *    the office yet until onboarding finishes."
- *
- * Component shape mirrors DMView's chat region but drops the workbench
- * (`AgentWorkbenchPane`) and the free-form `Composer`. We keep the same
- * `useMessages` / `MessageBubble` / `InterviewBar` plumbing so streaming
- * updates and pending-suggestion cards behave identically.
  */
 
-import { useEffect, useRef } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 
+import type { Message } from "../../api/client";
 import { useMessages } from "../../hooks/useMessages";
+import { formatTime } from "../../lib/format";
 import { directChannelSlug } from "../../stores/app";
 import { InterviewBar } from "../messages/InterviewBar";
 import { MessageBubble } from "../messages/MessageBubble";
-import { TypingIndicator } from "../messages/TypingIndicator";
+import { HarnessBadge } from "../ui/HarnessBadge";
+import { PixelAvatar } from "../ui/PixelAvatar";
 import { OnboardingDMContextProvider } from "./OnboardingDMRoute";
 import type { CeoSuggestion } from "./types";
 import { useOnboardingState } from "./useOnboardingState";
+
+// ─── Choreography constants ───
+const ANIMATION_MS = 600;
+const THINK_MS = 500;
+const GAP_MS = 300;
+const POST_HUMAN_MS = 700;
+const WORD_FADE_MS = 600;
+const WORD_STAGGER_MS = 110;
+const WIZARD_EASE = "cubic-bezier(0.2, 0, 0.8, 1)";
+
+type CeoBubbleState = "thinking" | "revealing" | "revealed";
+
+/**
+ * CEO bubble — single element with both the thinking dots and the real
+ * message content stacked in the .message-text slot as overlapping grid
+ * layers, cross-faded via data-pending.
+ */
+function CeoOnboardingBubble({
+  message,
+  pending,
+}: {
+  message: Message;
+  pending: boolean;
+}) {
+  return (
+    <div
+      className="message"
+      data-msg-id={message.id}
+      data-author-kind="agent"
+      data-author-slug={CEO_AGENT_SLUG}
+    >
+      <div className="message-avatar avatar-with-harness" aria-hidden="true">
+        <PixelAvatar slug={CEO_AGENT_SLUG} size={24} />
+        <HarnessBadge
+          kind="claude-code"
+          size={14}
+          className="harness-badge-on-avatar"
+        />
+      </div>
+      <div className="message-content">
+        <div className="message-header">
+          <span className="message-author">CEO</span>
+          <span className="badge badge-green">CEO</span>
+          {!pending && message.timestamp ? (
+            <span className="message-time" title={message.timestamp}>
+              {formatTime(message.timestamp)}
+            </span>
+          ) : null}
+        </div>
+        <div className="message-text ceo-text-slot" data-pending={pending}>
+          <div
+            className="ceo-text-layer ceo-text-dots"
+            aria-label="CEO is thinking"
+            aria-hidden={!pending}
+          >
+            <span className="onboarding-thinking-dot" />
+            <span className="onboarding-thinking-dot" />
+            <span className="onboarding-thinking-dot" />
+          </div>
+          <div
+            className="ceo-text-layer ceo-text-content"
+            aria-hidden={pending}
+          >
+            <span aria-label={message.content}>
+              {message.content.split(/(\s+)/).map((token, i) =>
+                /^\s+$/.test(token) ? (
+                  // biome-ignore lint/suspicious/noArrayIndexKey: positional tokens
+                  <span key={`s${i}`} aria-hidden="true">
+                    {token}
+                  </span>
+                ) : (
+                  <span
+                    // biome-ignore lint/suspicious/noArrayIndexKey: positional tokens
+                    key={`w${i}`}
+                    className="ceo-word"
+                    aria-hidden="true"
+                    style={{
+                      transitionDelay: pending
+                        ? "0ms"
+                        : `${(i / 2) * WORD_STAGGER_MS}ms`,
+                    }}
+                  >
+                    {token}
+                  </span>
+                ),
+              )}
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function CeoMessageSlot({
+  message,
+  state,
+  instant,
+}: {
+  message: Message;
+  state: CeoBubbleState;
+  instant?: boolean;
+}) {
+  const instantRef = useRef(instant === true);
+  return (
+    <div
+      className={`onboarding-message-slot onboarding-ceo-slot${
+        instantRef.current ? " onboarding-slot-instant" : ""
+      }`}
+      data-state={state}
+      data-msg-id={message.id}
+    >
+      <CeoOnboardingBubble message={message} pending={state === "thinking"} />
+    </div>
+  );
+}
+
+function HumanMessageSlot({
+  message,
+  instant,
+}: {
+  message: Message;
+  instant?: boolean;
+}) {
+  const instantRef = useRef(instant === true);
+  return (
+    <div
+      className={`onboarding-message-slot onboarding-human-slot${
+        instantRef.current ? " onboarding-slot-instant" : ""
+      }`}
+      data-msg-id={message.id}
+    >
+      <MessageBubble message={message} />
+    </div>
+  );
+}
 
 /** Agent slug used in the broker for the onboarding CEO. */
 const CEO_AGENT_SLUG = "ceo";
@@ -36,33 +167,10 @@ const CEO_AGENT_SLUG = "ceo";
 /** The broker canonicalises DM channels as pair-sorted slugs. */
 const CEO_ONBOARDING_CHANNEL = directChannelSlug(CEO_AGENT_SLUG);
 
-/**
- * Phase → human-readable label for the wizard header. Order matches the
- * deterministic state machine in broker_onboarding_phase2.go.
- *
- * No `Step N of M · …` counter: the scratch path skips team-trim and the
- * skip-website path skips scan, so any fixed denominator lies to the user
- * (see #939). Each label just names what the CEO is doing in this beat —
- * "feels like a colleague" beats "feels like a form".
- */
-const PHASE_LABELS: Record<string, string> = {
-  greet: "Office name",
-  identity: "What you do",
-  website: "Website",
-  scan: "Scanning your site",
-  blueprint: "Pick a starter",
-  team: "Confirm the team",
-  seed: "Setting up your office",
-  bridge: "First task",
-  draft: "Drafting your first issue",
-  approve: "Review and approve",
-  kickoff: "Starting your office",
-  complete: "Done",
-};
-
-function phaseLabel(phase: string | undefined): string {
-  if (!phase) return "Loading…";
-  return PHASE_LABELS[phase] ?? phase;
+function isHumanSender(from: string | undefined): boolean {
+  if (!from) return false;
+  const slug = from.toLowerCase();
+  return slug === "you" || slug === "human";
 }
 
 function parsePendingSuggestion(raw: unknown): CeoSuggestion | null {
@@ -72,23 +180,246 @@ function parsePendingSuggestion(raw: unknown): CeoSuggestion | null {
   return raw as CeoSuggestion;
 }
 
-export function OnboardingChat() {
+interface OnboardingChatProps {
+  onBack?: () => void;
+}
+
+export function OnboardingChat({ onBack }: OnboardingChatProps = {}) {
   const { data: state } = useOnboardingState();
   const { data: messages = [] } = useMessages(CEO_ONBOARDING_CHANNEL);
+  const queryClient = useQueryClient();
   const streamRef = useRef<HTMLDivElement>(null);
+  const pairRef = useRef<HTMLDivElement>(null);
+  const footerRef = useRef<HTMLElement>(null);
 
-  // Auto-scroll the message feed when new CEO messages arrive. We pin to the
-  // bottom because the wizard is strictly forward — old messages stay visible
-  // above as a transcript, but the action is always at the bottom.
-  const messagesLength = messages.length;
+  const [atBottom, setAtBottom] = useState(true);
+  const [hasOverflow, setHasOverflow] = useState(false);
+
+  // Force-refresh the onboarding state whenever messages list changes,
+  // collapsing the 3-second polling lag on pending_suggestion updates.
   useEffect(() => {
-    if (streamRef.current) {
-      streamRef.current.scrollTop = streamRef.current.scrollHeight;
+    queryClient.invalidateQueries({ queryKey: ["onboarding-state"] });
+  }, [messages.length, queryClient]);
+
+  // Measure footer height for the body's reserved padding-bottom and
+  // bottom-fade overlay's `bottom` offset.
+  useEffect(() => {
+    if (!(pairRef.current && footerRef.current)) return;
+    const pair = pairRef.current;
+    const footer = footerRef.current;
+    const update = () => {
+      pair.style.setProperty(
+        "--onboarding-footer-h",
+        `${footer.offsetHeight}px`,
+      );
+    };
+    update();
+    const observer = new ResizeObserver(update);
+    observer.observe(footer);
+    return () => observer.disconnect();
+  }, []);
+
+  // ─── Staged message reveal — three-state machine ───
+  const [revealedIds, setRevealedIds] = useState<Set<string>>(
+    () => new Set<string>(),
+  );
+  const [pendingMsg, setPendingMsg] = useState<Message | null>(null);
+  const [pendingState, setPendingState] = useState<
+    "idle" | "thinking" | "revealing"
+  >("idle");
+  const [postHumanDelay, setPostHumanDelay] = useState(false);
+  const mountTimeRef = useRef<number>(Date.now());
+  const hasSeededRef = useRef(false);
+
+  // Effect 1: backlog flush + queue next CEO sequence.
+  useEffect(() => {
+    if (!hasSeededRef.current && messages.length > 0) {
+      hasSeededRef.current = true;
+      const cutoff = mountTimeRef.current;
+      const backlog = messages
+        .filter((m) => {
+          const ts = m.timestamp ? Date.parse(m.timestamp) : NaN;
+          return Number.isFinite(ts) && ts < cutoff;
+        })
+        .map((m) => m.id);
+      if (backlog.length > 0) {
+        setRevealedIds(new Set(backlog));
+        return;
+      }
     }
-  }, [messagesLength]);
+
+    // Human messages reveal immediately + raise the post-human delay.
+    const unrevealedHuman = messages.find(
+      (m) => !revealedIds.has(m.id) && isHumanSender(m.from),
+    );
+    if (unrevealedHuman) {
+      setRevealedIds((prev) => {
+        const out = new Set(prev);
+        out.add(unrevealedHuman.id);
+        return out;
+      });
+      setPostHumanDelay(true);
+      return;
+    }
+
+    if (pendingState !== "idle" || postHumanDelay) return;
+
+    const nextCeo = messages.find((m) => !revealedIds.has(m.id));
+    if (!nextCeo || isHumanSender(nextCeo.from)) return;
+
+    // Consecutive CEO messages skip thinking — flow back-to-back.
+    let lastRevealedWasCeo = false;
+    for (let i = messages.length - 1; i >= 0; i--) {
+      const m = messages[i];
+      if (revealedIds.has(m.id)) {
+        lastRevealedWasCeo = !isHumanSender(m.from);
+        break;
+      }
+    }
+
+    if (lastRevealedWasCeo) {
+      const gapTimer = window.setTimeout(
+        () => {
+          setPendingMsg(nextCeo);
+          setPendingState("revealing");
+        },
+        Math.round(GAP_MS / 2),
+      );
+      return () => window.clearTimeout(gapTimer);
+    }
+
+    const gapTimer = window.setTimeout(() => {
+      setPendingMsg(nextCeo);
+      setPendingState("thinking");
+    }, GAP_MS);
+    return () => window.clearTimeout(gapTimer);
+  }, [messages, revealedIds, pendingState, postHumanDelay]);
+
+  // Effect 1b: own the post-human breather timer.
+  useEffect(() => {
+    if (!postHumanDelay) return undefined;
+    const t = window.setTimeout(() => {
+      setPostHumanDelay(false);
+    }, POST_HUMAN_MS);
+    return () => window.clearTimeout(t);
+  }, [postHumanDelay]);
+
+  // Effect 2: advance through thinking → revealing → done.
+  useEffect(() => {
+    if (pendingState === "thinking" && pendingMsg) {
+      const t = window.setTimeout(() => {
+        setPendingState("revealing");
+      }, THINK_MS);
+      return () => window.clearTimeout(t);
+    }
+    if (pendingState === "revealing" && pendingMsg) {
+      const revealingMsgId = pendingMsg.id;
+      const t = window.setTimeout(() => {
+        setRevealedIds((prev) => {
+          const out = new Set(prev);
+          out.add(revealingMsgId);
+          return out;
+        });
+        setPendingMsg(null);
+        setPendingState("idle");
+      }, ANIMATION_MS);
+      return () => window.clearTimeout(t);
+    }
+    return undefined;
+  }, [pendingState, pendingMsg]);
+
+  // Display list sorted by timestamp.
+  const displayList = useMemo<
+    Array<{
+      msg: Message;
+      state: CeoBubbleState;
+      isHuman: boolean;
+      isBacklog: boolean;
+    }>
+  >(() => {
+    const cutoff = mountTimeRef.current;
+    const out: Array<{
+      msg: Message;
+      state: CeoBubbleState;
+      isHuman: boolean;
+      isBacklog: boolean;
+    }> = [];
+    const ordered = [...messages].sort((a, b) => {
+      const ta = a.timestamp ? Date.parse(a.timestamp) : 0;
+      const tb = b.timestamp ? Date.parse(b.timestamp) : 0;
+      if (ta === tb) return 0;
+      return ta - tb;
+    });
+    for (const m of ordered) {
+      const isHuman = isHumanSender(m.from);
+      const ts = m.timestamp ? Date.parse(m.timestamp) : NaN;
+      const isBacklog = Number.isFinite(ts) && ts < cutoff;
+      if (revealedIds.has(m.id)) {
+        out.push({ msg: m, state: "revealed", isHuman, isBacklog });
+      } else if (
+        !isHuman &&
+        pendingMsg?.id === m.id &&
+        pendingState !== "idle"
+      ) {
+        out.push({
+          msg: m,
+          state: pendingState as CeoBubbleState,
+          isHuman: false,
+          isBacklog: false,
+        });
+      }
+    }
+    return out;
+  }, [messages, revealedIds, pendingMsg, pendingState]);
+
+  // Track scroll position + overflow + auto-pin to bottom on stream growth.
+  useEffect(() => {
+    const el = streamRef.current;
+    if (!el) return;
+    const isAtBottom = () =>
+      el.scrollHeight - el.scrollTop - el.clientHeight <= 2;
+    const onScroll = () => setAtBottom(isAtBottom());
+    const onResize = () => {
+      setHasOverflow(el.scrollHeight - el.clientHeight > 2);
+      el.scrollTop = el.scrollHeight;
+      setAtBottom(true);
+    };
+    onScroll();
+    onResize();
+    el.addEventListener("scroll", onScroll, { passive: true });
+    const observer = new ResizeObserver(onResize);
+    observer.observe(el);
+    const stream = el.firstElementChild;
+    if (stream) observer.observe(stream);
+    return () => {
+      el.removeEventListener("scroll", onScroll);
+      observer.disconnect();
+    };
+  }, []);
 
   const phase = state?.phase;
   const pendingSuggestion = parsePendingSuggestion(state?.pending_suggestion);
+
+  // First greet (Office name?) is the only phase that should NOT blur
+  // the input — the user hasn't interacted yet.
+  const hasUnrevealedMessages = messages.some((m) => !revealedIds.has(m.id));
+  const isFirstGreet = phase === "greet" && messages.length <= 1;
+  const inputLocked =
+    !isFirstGreet &&
+    (pendingState !== "idle" ||
+      postHumanDelay ||
+      hasUnrevealedMessages ||
+      !pendingSuggestion);
+
+  // Blur active element on lock so a focused input can't sneak typing through.
+  useEffect(() => {
+    if (inputLocked && typeof document !== "undefined") {
+      const active = document.activeElement as HTMLElement | null;
+      if (active && typeof active.blur === "function") {
+        active.blur();
+      }
+    }
+  }, [inputLocked]);
 
   return (
     <OnboardingDMContextProvider value={{ phase, pendingSuggestion }}>
@@ -96,40 +427,94 @@ export function OnboardingChat() {
         className="onboarding-chat"
         data-testid="onboarding-chat"
         data-phase={phase ?? "loading"}
+        data-ceo-typing={pendingState !== "idle" ? "true" : "false"}
+        data-input-locked={inputLocked ? "true" : "false"}
+        style={
+          {
+            "--onboarding-anim-ms": `${ANIMATION_MS}ms`,
+            "--onboarding-anim-ease": WIZARD_EASE,
+            "--onboarding-word-fade-ms": `${WORD_FADE_MS}ms`,
+          } as React.CSSProperties
+        }
       >
         <header className="onboarding-chat-header">
+          {onBack ? (
+            <button
+              type="button"
+              className="onboarding-chat-back"
+              onClick={onBack}
+              aria-label="Restart onboarding"
+              title="Restart onboarding"
+            >
+              <svg
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                aria-hidden="true"
+              >
+                <line x1="19" y1="12" x2="5" y2="12" />
+                <polyline points="12 19 5 12 12 5" />
+              </svg>
+              <span className="onboarding-chat-back-label">Restart</span>
+            </button>
+          ) : null}
           <span className="onboarding-chat-brand">WUPHF</span>
-          <span className="onboarding-chat-phase">{phaseLabel(phase)}</span>
+          <span className="onboarding-chat-spacer" aria-hidden="true" />
         </header>
 
-        <main className="onboarding-chat-body" ref={streamRef}>
-          <div className="onboarding-chat-stream">
-            {messages.length === 0 ? (
-              <p className="onboarding-chat-stream-empty">
-                CEO is opening the office…
-              </p>
-            ) : (
-              messages.map((msg) => (
-                <MessageBubble key={msg.id} message={msg} />
-              ))
-            )}
-            <TypingIndicator />
-          </div>
-        </main>
+        <div className="onboarding-chat-pair" ref={pairRef}>
+          <main
+            className="onboarding-chat-body"
+            ref={streamRef}
+            data-has-overflow={hasOverflow ? "true" : "false"}
+          >
+            <div className="onboarding-chat-stream">
+              {displayList.map(({ msg, state, isHuman, isBacklog }) =>
+                isHuman ? (
+                  <HumanMessageSlot
+                    key={msg.id}
+                    message={msg}
+                    instant={isBacklog}
+                  />
+                ) : (
+                  <CeoMessageSlot
+                    key={msg.id}
+                    message={msg}
+                    state={state}
+                    instant={isBacklog}
+                  />
+                ),
+              )}
+            </div>
+          </main>
 
-        <footer className="onboarding-chat-footer">
-          <div className="onboarding-chat-footer-inner">
-            <InterviewBar />
-            {/* When there's no pending suggestion AND no agent interview
-                request, InterviewBar renders nothing. Surface a hint so the
-                user knows the wizard is mid-transition rather than stuck. */}
-            {!pendingSuggestion && (
-              <p className="onboarding-chat-hint">
-                Hang tight — the CEO is composing the next step.
-              </p>
-            )}
-          </div>
-        </footer>
+          <div
+            className="onboarding-chat-bottom-fade"
+            data-visible={!atBottom}
+            aria-hidden="true"
+          />
+
+          <footer className="onboarding-chat-footer" ref={footerRef}>
+            <div className="onboarding-chat-footer-inner">
+              <div
+                className="onboarding-card-shell"
+                data-empty={!pendingSuggestion ? "true" : "false"}
+              >
+                <InterviewBar />
+                {!pendingSuggestion && (
+                  <p className="onboarding-chat-hint">
+                    Hang tight — the CEO is composing the next step.
+                  </p>
+                )}
+              </div>
+            </div>
+          </footer>
+        </div>
       </div>
     </OnboardingDMContextProvider>
   );

--- a/web/src/components/onboarding/OnboardingChat.tsx
+++ b/web/src/components/onboarding/OnboardingChat.tsx
@@ -26,7 +26,7 @@ import { useOnboardingState } from "./useOnboardingState";
 const ANIMATION_MS = 600;
 const THINK_MS = 500;
 const GAP_MS = 300;
-const POST_HUMAN_MS = 700;
+const POST_HUMAN_MS = 200;
 const WORD_FADE_MS = 600;
 const WORD_STAGGER_MS = 90;
 const WIZARD_EASE = "cubic-bezier(0.2, 0, 0.8, 1)";
@@ -297,27 +297,16 @@ export function OnboardingChat({ onBack }: OnboardingChatProps = {}) {
     const nextCeo = messages.find((m) => !revealedIds.has(m.id));
     if (!nextCeo || isHumanSender(nextCeo.from)) return;
 
-    // Consecutive CEO messages skip thinking — flow back-to-back.
-    let lastRevealedWasCeo = false;
-    for (let i = messages.length - 1; i >= 0; i--) {
-      const m = messages[i];
-      if (revealedIds.has(m.id)) {
-        lastRevealedWasCeo = !isHumanSender(m.from);
-        break;
-      }
-    }
-
-    if (lastRevealedWasCeo) {
-      const gapTimer = window.setTimeout(
-        () => {
-          setPendingMsg(nextCeo);
-          setPendingState("revealing");
-        },
-        Math.round(GAP_MS / 2),
-      );
-      return () => window.clearTimeout(gapTimer);
-    }
-
+    // Every CEO message goes through thinking → revealing. We used to
+    // skip thinking for "consecutive CEO" messages (when the last
+    // revealed was also CEO), but that branch fired incorrectly when
+    // the CEO message arrived in `messages` before the human echo
+    // had finished posting: the just-revealed previous CEO message
+    // looked like a CEO→CEO transition, so the next CEO popped in
+    // with no thinking dots even though it was a real reply to a
+    // human submit. Removing the skip means every CEO gets the
+    // dots — slightly more motion for true CEO→CEO bursts (scan
+    // → wiki updated → pick template) but consistent rhythm overall.
     const gapTimer = window.setTimeout(() => {
       setPendingMsg(nextCeo);
       setPendingState("thinking");
@@ -507,14 +496,33 @@ export function OnboardingChat({ onBack }: OnboardingChatProps = {}) {
     !isFirstGreet &&
     (pendingState !== "idle" || postHumanDelay || hasUnrevealedMessages);
 
-  // Blur active element on lock so a focused input can't sneak typing through.
+  // Blur active element on lock so a focused input can't sneak typing
+  // through. When the lock RELEASES, jump focus into the footer's first
+  // focusable element (text input for form-field cards, first chip for
+  // chip-row / checklist, etc.) so the user can keep typing without
+  // clicking back into the field every turn.
   useEffect(() => {
-    if (inputLocked && typeof document !== "undefined") {
+    if (typeof document === "undefined") return;
+    if (inputLocked) {
       const active = document.activeElement as HTMLElement | null;
       if (active && typeof active.blur === "function") {
         active.blur();
       }
+      return;
     }
+    // Lock just released. Wait a frame for the muted-state CSS
+    // transition to start and for the card to become interactive
+    // (pointer-events flips off via [data-input-locked] attribute),
+    // then focus the first input/button inside the footer.
+    const id = requestAnimationFrame(() => {
+      const shell = document.querySelector(".onboarding-card-shell");
+      if (!shell) return;
+      const target = shell.querySelector<HTMLElement>(
+        'input:not([disabled]),textarea:not([disabled]),[role="option"]:not([disabled]),button:not([disabled]):not(.ceo-card-skip)',
+      );
+      target?.focus();
+    });
+    return () => cancelAnimationFrame(id);
   }, [inputLocked]);
 
   return (

--- a/web/src/components/onboarding/PrePickScreen.tsx
+++ b/web/src/components/onboarding/PrePickScreen.tsx
@@ -34,6 +34,40 @@ interface PrePickScreenProps {
   onComplete: (info?: { phaseAlreadyComplete?: boolean }) => void;
 }
 
+/**
+ * Inline right-arrow icon. Replaces the previous "→" Unicode glyph
+ * used in CTA copy ("Install →", "Continue →", "I'll add one later
+ * →") so the arrow renders as a proper icon at a consistent visual
+ * weight rather than as a font-rendered character whose appearance
+ * varies wildly by platform / font fallback. `currentColor` so the
+ * icon picks up the surrounding text color in every context.
+ */
+function ArrowRightIcon({
+  size = 14,
+  className,
+}: {
+  size?: number;
+  className?: string;
+}) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+      className={className}
+    >
+      <line x1="5" y1="12" x2="19" y2="12" />
+      <polyline points="12 5 19 12 12 19" />
+    </svg>
+  );
+}
+
 interface RuntimeCardState {
   spec: RuntimeSpec;
   detected: PrereqResult | undefined;
@@ -58,6 +92,13 @@ interface RuntimeCardProps {
   onCopySignIn: (command: string) => void;
 }
 
+/**
+ * Card status is rendered as TWO lines: the primary state (e.g.
+ * "Signed in") and a secondary detail line (the runtime version /
+ * provider string, e.g. "2.1.150 (Claude Code)"). Splitting them on
+ * separate lines lets the eye scan the state at a glance without the
+ * version cruft competing for attention.
+ */
 function cardStatusLabel({
   prereqsLoaded,
   available,
@@ -68,20 +109,20 @@ function cardStatusLabel({
   available: boolean;
   version: string | undefined;
   signedIn: boolean | undefined;
-}): string {
-  if (!prereqsLoaded) return "Checking…";
-  if (!available) return "Not installed";
+}): { primary: string; detail: string | undefined } {
+  if (!prereqsLoaded) return { primary: "Checking…", detail: undefined };
+  if (!available) return { primary: "Not installed", detail: undefined };
   // Issue #932: when the runtime supports a session probe and we got a
   // definite "not signed in", surface that as the primary status. The user
   // would otherwise complete onboarding believing they were connected,
   // then hit "Not logged in" on the agent loop's first call.
   if (signedIn === false) {
-    return version ? `Not signed in · ${version}` : "Not signed in";
+    return { primary: "Not signed in", detail: version };
   }
   if (signedIn === true) {
-    return version ? `Signed in · ${version}` : "Signed in";
+    return { primary: "Signed in", detail: version };
   }
-  return version ? `Detected · ${version}` : "Detected";
+  return { primary: "Detected", detail: version };
 }
 
 function RuntimeCard({
@@ -95,7 +136,7 @@ function RuntimeCard({
 }: RuntimeCardProps) {
   const { spec, detected, available, signedIn, signInCommand } = state;
   const statusLabel = isSubmitting
-    ? "Starting your office…"
+    ? { primary: "Starting your office…", detail: undefined }
     : cardStatusLabel({
         prereqsLoaded,
         available,
@@ -110,7 +151,10 @@ function RuntimeCard({
   const isUnauthed = available && signedIn === false;
   const installHint =
     !available && prereqsLoaded ? (
-      <div className="pre-pick-card-install">Install &rarr;</div>
+      <div className="pre-pick-card-install">
+        Install
+        <ArrowRightIcon className="pre-pick-inline-arrow" />
+      </div>
     ) : null;
   const signInHint =
     isUnauthed && prereqsLoaded ? (
@@ -154,7 +198,16 @@ function RuntimeCard({
         <RuntimeLogo label={spec.label} />
         <span className="pre-pick-card-name">{spec.label}</span>
       </div>
-      <div className="pre-pick-card-status">{statusLabel}</div>
+      <div className="pre-pick-card-status">
+        <span className="pre-pick-card-status-primary">
+          {statusLabel.primary}
+        </span>
+        {statusLabel.detail ? (
+          <span className="pre-pick-card-status-detail">
+            {statusLabel.detail}
+          </span>
+        ) : null}
+      </div>
       {installHint}
       {signInHint}
     </button>
@@ -265,6 +318,73 @@ function buildConfigPayload(
   return payload;
 }
 
+/**
+ * CollapsibleSection — accordion row used inside the pre-pick screen's
+ * alternative-auth group (API keys, local model, custom endpoint).
+ *
+ * Controlled via `open`/`onToggle`. The whole header row (heading +
+ * chevron) is a single button so clicking anywhere in it toggles. The
+ * content area uses the `grid-template-rows: 0fr ⇆ 1fr` trick so the
+ * height animates smoothly between auto and zero — supported in all
+ * modern evergreen browsers without `interpolate-size`.
+ */
+interface CollapsibleSectionProps {
+  testId: string;
+  heading: string;
+  open: boolean;
+  onToggle: () => void;
+  children: React.ReactNode;
+}
+function CollapsibleSection({
+  testId,
+  heading,
+  open,
+  onToggle,
+  children,
+}: CollapsibleSectionProps) {
+  const panelId = `${testId}-panel`;
+  return (
+    <div
+      className="pre-pick-section pre-pick-section--collapsible"
+      data-testid={testId}
+      data-open={open ? "true" : "false"}
+    >
+      <button
+        type="button"
+        className="pre-pick-section-summary"
+        aria-expanded={open}
+        aria-controls={panelId}
+        onClick={onToggle}
+      >
+        <span className="pre-pick-section-heading">{heading}</span>
+        <svg
+          className="pre-pick-section-chevron"
+          width="14"
+          height="14"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden="true"
+        >
+          <polyline points="6 9 12 15 18 9" />
+        </svg>
+      </button>
+      <div
+        id={panelId}
+        className="pre-pick-section-panel"
+        role="region"
+        aria-labelledby={panelId}
+        aria-hidden={!open}
+      >
+        <div className="pre-pick-section-panel-inner">{children}</div>
+      </div>
+    </div>
+  );
+}
+
 export function PrePickScreen({ onComplete }: PrePickScreenProps) {
   const [prereqs, setPrereqs] = useState<PrereqResult[]>([]);
   const [prereqsLoaded, setPrereqsLoaded] = useState(false);
@@ -281,6 +401,22 @@ export function PrePickScreen({ onComplete }: PrePickScreenProps) {
   // OpenAI-compatible custom endpoint
   const [oaiUrl, setOaiUrl] = useState<string>("");
   const [oaiKey, setOaiKey] = useState<string>("");
+
+  // Collapsible sections — every alternative path (API keys, local model,
+  // custom endpoint) is collapsed by default so the CLI cards above stay
+  // the dominant choice. Single-open accordion: opening one section
+  // closes the others, so only one alternative is expanded at a time.
+  // Tracked as a single `openSection` slot (or `null` for all-closed)
+  // and derived into the per-section booleans the JSX still expects.
+  type AltSection = "apiKeys" | "local" | "custom";
+  const [openSection, setOpenSection] = useState<AltSection | null>(null);
+  const openSections = {
+    apiKeys: openSection === "apiKeys",
+    local: openSection === "local",
+    custom: openSection === "custom",
+  };
+  const toggleSection = (key: AltSection) =>
+    setOpenSection((prev) => (prev === key ? null : key));
 
   useEffect(() => {
     let cancelled = false;
@@ -450,9 +586,18 @@ export function PrePickScreen({ onComplete }: PrePickScreenProps) {
           ))}
         </div>
 
+        {/* ── Alternative auth paths, grouped in one bordered card ────── */}
+        <div
+          className="pre-pick-collapsible-group"
+          data-testid="pre-pick-collapsible-group"
+        >
         {/* ── Section 2: API keys ──────────────────────────────────────── */}
-        <div className="pre-pick-section" data-testid="pre-pick-api-keys">
-          <p className="pre-pick-section-heading">API keys</p>
+        <CollapsibleSection
+          testId="pre-pick-api-keys"
+          heading="API keys"
+          open={openSections.apiKeys}
+          onToggle={() => toggleSection("apiKeys")}
+        >
           <p className="pre-pick-section-hint">
             Use CLI login or paste a key. CLI login is the primary path -- keys
             are a fallback or alternative.
@@ -467,11 +612,15 @@ export function PrePickScreen({ onComplete }: PrePickScreenProps) {
               />
             ))}
           </div>
-        </div>
+        </CollapsibleSection>
 
         {/* ── Section 3: Local provider picker ────────────────────────── */}
-        <div className="pre-pick-section" data-testid="pre-pick-local-section">
-          <p className="pre-pick-section-heading">Local model</p>
+        <CollapsibleSection
+          testId="pre-pick-local-section"
+          heading="Local model"
+          open={openSections.local}
+          onToggle={() => toggleSection("local")}
+        >
           <p className="pre-pick-section-hint">
             Run inference on this machine. No cloud key required.
           </p>
@@ -479,11 +628,15 @@ export function PrePickScreen({ onComplete }: PrePickScreenProps) {
             selected={localProvider}
             onSelect={(kind) => setLocalProvider(kind)}
           />
-        </div>
+        </CollapsibleSection>
 
         {/* ── Section 4: OpenAI-compatible endpoint ───────────────────── */}
-        <div className="pre-pick-section" data-testid="pre-pick-oai-section">
-          <p className="pre-pick-section-heading">Custom endpoint</p>
+        <CollapsibleSection
+          testId="pre-pick-oai-section"
+          heading="Custom endpoint"
+          open={openSections.custom}
+          onToggle={() => toggleSection("custom")}
+        >
           <p className="pre-pick-section-hint">
             Any server that speaks the OpenAI REST protocol (OpenClaw, LiteLLM,
             vLLM, etc.).
@@ -494,6 +647,7 @@ export function PrePickScreen({ onComplete }: PrePickScreenProps) {
             onChangeUrl={setOaiUrl}
             onChangeKey={setOaiKey}
           />
+        </CollapsibleSection>
         </div>
 
         {/* ── Submit from form sections ────────────────────────────────── */}
@@ -506,7 +660,14 @@ export function PrePickScreen({ onComplete }: PrePickScreenProps) {
               disabled={anySubmitting}
               onClick={() => void commitChoice("form", "form")}
             >
-              {submitting === "form" ? "Opening your office…" : "Continue  →"}
+              {submitting === "form" ? (
+                "Opening your office…"
+              ) : (
+                <>
+                  Continue
+                  <ArrowRightIcon className="pre-pick-inline-arrow" />
+                </>
+              )}
             </button>
           </div>
         ) : null}
@@ -520,15 +681,25 @@ export function PrePickScreen({ onComplete }: PrePickScreenProps) {
             disabled={anySubmitting}
             onClick={() => void commitChoice(null, "skip")}
           >
-            {submitting === "skip"
-              ? "Opening your office…"
-              : "I'll add one later  →"}
+            {submitting === "skip" ? (
+              "Opening your office…"
+            ) : (
+              <>
+                I'll add one later
+                <ArrowRightIcon className="pre-pick-inline-arrow" />
+              </>
+            )}
           </button>
         </div>
 
         <p className="pre-pick-helper">
           You can change this any time in{" "}
-          <strong>Settings &rarr; Runtimes</strong>.
+          <strong>
+            Settings
+            <ArrowRightIcon className="pre-pick-inline-arrow" size={12} />
+            Runtimes
+          </strong>
+          .
         </p>
 
         {submitError ? (

--- a/web/src/routes/RootRoute.tsx
+++ b/web/src/routes/RootRoute.tsx
@@ -14,7 +14,7 @@ import {
   useRouterState,
 } from "@tanstack/react-router";
 
-import { get, initApi } from "../api/client";
+import { get, initApi, post } from "../api/client";
 import { TelegramConnectHost } from "../components/integrations/TelegramConnectModal";
 import { Shell } from "../components/layout/Shell";
 import { UpgradeBanner } from "../components/layout/UpgradeBanner";
@@ -834,7 +834,23 @@ export default function RootRoute() {
       // while still gating progress through deterministic chip / form
       // cards. Once the broker flips onboarded=true the user falls through
       // to the post-onboarding Shell branch below and lands in the office.
-      body = <OnboardingChat />;
+      body = (
+        <OnboardingChat
+          onBack={() => {
+            // Reset broker onboarding state so re-picking a runtime restarts
+            // the wizard from scratch instead of resuming mid-conversation.
+            // Fire-and-forget: UI state changes immediately; if the POST
+            // fails, the next /transition phase=greet will surface the error.
+            void post("/onboarding/reset", {}).catch(() => {
+              // Ignored — non-blocking. Back navigation should still work
+              // even if reset fails (e.g. offline broker).
+            });
+            setInCeoOnboarding(false);
+            setBootPhase(undefined);
+            void router.navigate({ to: "/", replace: true });
+          }}
+        />
+      );
     } else {
       // Provider picker. No phase set yet — user hasn't picked a runtime.
       // After they pick, setInCeoOnboarding(true) to enter the CEO DM.

--- a/web/src/styles/global.css
+++ b/web/src/styles/global.css
@@ -608,6 +608,10 @@ body {
   font-family: var(--font-sans);
   letter-spacing: 0;
   line-height: 1;
+  /* Optical lift: nudges the badge 2px up so its cap-height sits on the
+     same baseline as adjacent uppercase-heavy text (e.g. "CEO" in the
+     message header). */
+  margin-top: -3px;
 }
 .badge-green {
   background: var(--green-bg);

--- a/web/src/styles/onboarding.css
+++ b/web/src/styles/onboarding.css
@@ -647,6 +647,7 @@
   border: 1px solid var(--border);
   border-radius: 12px;
   overflow: hidden;
+  background: var(--bg-card);
 }
 
 .key-row {
@@ -2072,13 +2073,18 @@
 .pre-pick-card {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 12px;
   padding: 16px;
   border: 1px solid var(--border);
   border-radius: 12px;
   background: var(--bg-card);
   text-align: left;
   cursor: pointer;
+  /* Fixed height so the card never jumps when the prereq probe
+     transitions between "Checking…" / "Not installed" / "Signed in · …"
+     statuses, or when the "Install →" link appears/disappears. */
+  height: 132px;
+  box-sizing: border-box;
   transition:
     border-color 120ms ease,
     transform 120ms ease,
@@ -2118,8 +2124,28 @@
 }
 
 .pre-pick-card-status {
+  /* Two-line stack: primary state ("Signed in" / "Not installed" /
+     etc.) on the first line, secondary detail (the runtime version
+     string, e.g. "2.1.150 (Claude Code)") on the second line. The
+     min-height reservation keeps the card from jumping when the
+     prereq probe transitions between states with and without a
+     detail line. */
+  display: flex;
+  flex-direction: column;
   font-size: 12px;
   color: var(--text-secondary);
+  min-height: 36px;
+  line-height: 1.45;
+}
+.pre-pick-card-status-primary {
+  font-weight: 500;
+}
+.pre-pick-card-status-detail {
+  /* Slightly muted so the eye lands on the primary state first; the
+     detail is supporting context, not the headline. */
+  color: var(--text-tertiary);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums; /* version numbers align */
 }
 
 .pre-pick-card.available .pre-pick-card-status {
@@ -2145,8 +2171,8 @@
 }
 
 .pre-pick-secondary-button {
-  font-size: 13px;
-  padding: 8px 14px;
+  font-size: 15px;
+  padding: 10px 16px;
   border-radius: 8px;
   border: 1px solid transparent;
   background: transparent;
@@ -2174,9 +2200,40 @@
 }
 
 .pre-pick-helper {
+  /* Pinned to the bottom of the viewport so the "you can change this
+     later" reassurance is always visible without competing with the
+     main content above. `position: fixed` removes it from the scroll
+     flow; centered horizontally with left/right + transform. */
+  position: fixed;
+  left: 50%;
+  bottom: 24px;
+  transform: translateX(-50%);
   font-size: 12px;
   color: var(--text-tertiary);
   margin: 0;
+  text-align: center;
+  pointer-events: none; /* purely informational — don't intercept clicks */
+  z-index: 1;
+}
+
+/* Inline arrow icon used wherever the wizard previously rendered a
+   plain "→" glyph. `vertical-align: -0.15em` nudges the icon down
+   onto the optical baseline (SVGs are box-aligned, not glyph-
+   aligned), and the side margin gives it the same visual breathing
+   room a real arrow character would have. */
+.pre-pick-inline-arrow {
+  display: inline-block;
+  vertical-align: -0.15em;
+  margin: 0 0.3em;
+  flex-shrink: 0;
+}
+/* When used inside a flex button (e.g. .btn .pre-pick-form-submit),
+   the inline-block + vertical-align doesn't apply — fall back to
+   flex alignment instead. */
+.btn .pre-pick-inline-arrow,
+.pre-pick-secondary-button .pre-pick-inline-arrow,
+.pre-pick-card-install .pre-pick-inline-arrow {
+  vertical-align: middle;
 }
 
 .pre-pick-error {
@@ -2203,7 +2260,7 @@
   letter-spacing: 0.08em;
   text-transform: uppercase;
   color: var(--text-secondary);
-  margin: 0;
+  margin: 0 0 0 8px;
 }
 
 .pre-pick-section-hint {
@@ -2211,6 +2268,112 @@
   color: var(--text-tertiary);
   margin: 0 0 4px 0;
   line-height: 1.5;
+}
+
+/* ─── Collapsible section group ───
+   All three alternative auth paths (API keys, local model, custom
+   endpoint) are wrapped in one bordered, rounded card so they read
+   as a single unit subordinate to the CLI cards above. Internal
+   dividers separate sections; the outer border belongs to the group. */
+.pre-pick-collapsible-group {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  /* Transparent so the stack reads as a quiet outlined list against
+     the page surface — not a raised white card competing with the
+     primary CLI install cards above. */
+  background: transparent;
+  overflow: hidden;
+}
+
+/* ─── Collapsible section (controlled accordion) ───
+   Each alternative auth path is collapsed by default so the CLI cards
+   stay the primary CTA. The summary row is a button covering the
+   whole header — clicking anywhere on it toggles. The content panel
+   animates between open and closed via the `grid-template-rows: 0fr
+   ⇆ 1fr` trick (transitionable in all modern browsers without
+   `interpolate-size`). */
+.pre-pick-section--collapsible {
+  padding: 0;
+  gap: 0;
+}
+.pre-pick-collapsible-group
+  .pre-pick-section--collapsible
+  + .pre-pick-section--collapsible {
+  border-top: 1px solid var(--border);
+}
+
+/* Summary is a full-width button. Whole row is the click target — the
+   heading on the left, the chevron on the right. */
+.pre-pick-section-summary {
+  appearance: none;
+  display: flex;
+  width: 100%;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 16px;
+  background: transparent;
+  border: 0;
+  cursor: pointer;
+  user-select: none;
+  text-align: left;
+  color: inherit;
+  font: inherit;
+}
+.pre-pick-section-summary:hover .pre-pick-section-heading {
+  color: var(--text);
+}
+.pre-pick-section-summary:focus-visible {
+  outline: 2px solid var(--focus-ring-color, var(--accent));
+  outline-offset: -2px;
+}
+.pre-pick-section-heading {
+  transition: color 160ms ease;
+}
+.pre-pick-section-chevron {
+  flex-shrink: 0;
+  width: 14px;
+  height: 14px;
+  color: var(--text-tertiary);
+  transition: transform 280ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+[data-open="true"] > .pre-pick-section-summary .pre-pick-section-chevron {
+  transform: rotate(180deg);
+}
+
+/* Animated content panel: height interpolates between 0 (closed) and
+   auto (open) via `interpolate-size: allow-keywords`. Supported in
+   Chrome 129+, Safari TP, Firefox behind a flag. In unsupported
+   browsers the transition simply snaps. */
+.pre-pick-collapsible-group {
+  interpolate-size: allow-keywords;
+}
+.pre-pick-section-panel {
+  height: 0;
+  overflow: hidden;
+  transition: height 320ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+.pre-pick-section--collapsible[data-open="true"] .pre-pick-section-panel {
+  height: auto;
+}
+.pre-pick-section-panel-inner {
+  padding: 0 16px 16px;
+}
+.pre-pick-section--collapsible[data-open="false"]
+  .pre-pick-section-panel-inner {
+  /* Suppress focus on hidden controls. */
+  visibility: hidden;
+  transition: visibility 0s linear 320ms;
+}
+.pre-pick-section--collapsible[data-open="true"] .pre-pick-section-panel-inner {
+  visibility: visible;
+  transition: visibility 0s linear 0s;
+}
+.pre-pick-section-panel-inner > .pre-pick-section-hint {
+  margin: 0 0 16px 8px;
 }
 
 /* Local provider picker wrapper */
@@ -2284,21 +2447,67 @@
    Spec: docs/specs/onboarding-into-office.md "## Surface 3 / Card states matrix"
    ─────────────────────────────────────────────────────────────────────── */
 
+/* Submit button inside CEO cards (checklist Confirm, execution lineup
+   Continue) — uses the storybook `.btn .btn-primary` (no `btn-sm`),
+   overridden to a 40px min-height per the wizard spec (between the
+   default 44px and `btn-sm`'s 32px). */
+.onboarding-chat .ceo-card-submit.btn,
+.onboarding-chat .ceo-card-submit.btn.btn-primary {
+  min-height: 40px;
+  padding: 0 18px;
+  font-size: var(--text-sm);
+}
+
 .ceo-card-section {
-  padding: 10px 12px;
-  border-top: 1px solid var(--border);
-  background: var(--bg);
+  padding: 0 24px 10px;
+  background: transparent;
+  overflow: visible;
+}
+
+/* Suppress the agent-interview section inside the onboarding
+   footer — the user is talking to the CEO, not approving downstream
+   agent skill requests. Keep `CeoCardSection` (the actual CEO
+   suggestion card) visible. */
+.onboarding-chat .onboarding-chat-footer-inner .interview-bar {
+  display: none !important;
+}
+/* Blur the footer's CEO card while input is locked. Targets
+   `.ceo-card` directly so we don't need a wrapper. */
+.onboarding-chat .ceo-card-section,
+.onboarding-chat .ceo-card {
+  transition:
+    filter 220ms cubic-bezier(0.2, 0, 0.8, 1),
+    opacity 220ms cubic-bezier(0.2, 0, 0.8, 1);
+}
+.onboarding-chat[data-input-locked="true"] .ceo-card {
+  filter: blur(3px);
+  opacity: 0.6;
+}
+.onboarding-chat[data-input-locked="true"] .ceo-card--form-field:focus-within {
+  outline-color: var(--border);
 }
 
 /* Base CEO card */
 .ceo-card {
-  border: 1px solid var(--border);
-  border-radius: var(--radius-sm);
-  padding: 12px;
+  border: none;
+  outline: 1px solid var(--border);
+  outline-offset: -1px;
+  border-radius: 20px;
+  padding: 14px 16px;
   background: var(--bg-card);
   display: flex;
   flex-direction: column;
   gap: 10px;
+  box-shadow:
+    0 1px 2px rgba(0, 0, 0, 0.04),
+    0 8px 24px rgba(0, 0, 0, 0.06);
+  transition:
+    outline-color 200ms ease,
+    box-shadow 200ms ease;
+}
+
+.ceo-card--form-field:focus-within {
+  outline-color: var(--accent, #8b5cf6);
 }
 
 /* Committed state: collapses to one line in --text-secondary */
@@ -2326,22 +2535,62 @@
 /* Text input */
 .ceo-card-input {
   width: 100%;
-  padding: 8px 10px;
-  border: 1px solid var(--border);
-  border-radius: var(--radius-sm);
-  font-size: 13px;
+  padding: 6px 2px;
+  border: none;
+  border-radius: 0;
+  font-size: 14px;
   color: var(--text);
-  background: var(--bg);
+  background: transparent;
   outline: none;
-  transition: border-color 120ms ease;
+  transition: none;
 }
 
 .ceo-card-input:focus {
-  border-color: var(--accent);
+  border-color: transparent;
 }
 
 .ceo-card-input:disabled {
   opacity: 0.6;
+  cursor: not-allowed;
+}
+
+/* Input + send button row */
+.ceo-card-input-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.ceo-card-input-row .ceo-card-input {
+  flex: 1;
+  min-width: 0;
+}
+
+/* Send button — sits in the input's right corner like a chat send chip */
+.ceo-card-send {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  border: none;
+  background: var(--accent, #8b5cf6);
+  color: #fff;
+  cursor: pointer;
+  flex-shrink: 0;
+  transition:
+    transform 120ms ease,
+    background-color 120ms ease,
+    opacity 120ms ease;
+}
+
+.ceo-card-send:hover:not(:disabled) {
+  transform: scale(1.05);
+}
+
+.ceo-card-send:disabled {
+  opacity: 0.35;
   cursor: not-allowed;
 }
 
@@ -2426,31 +2675,98 @@
 
 /* ─── Checklist ────────────────────────────────────────────────────────── */
 
+/* Items render as chip-style wrappers in a horizontal flex row that
+   wraps onto additional lines when they don't fit. Visually mirrors
+   `.ceo-chip-row-options` (chip-row) so single- and multi-select
+   surfaces share the same grammar. */
 .ceo-checklist-items {
   list-style: none;
   display: flex;
-  flex-direction: column;
-  gap: 6px;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding: 0;
+  margin: 0;
+}
+
+.ceo-checklist-item {
+  /* Each option is a chip — same border/radius/padding as `.ceo-chip`
+     so checklist (multi-select) and chip-row (single-select) share
+     one visual language. */
+  display: inline-flex;
 }
 
 .ceo-checklist-label {
-  display: flex;
+  display: inline-flex;
   align-items: center;
   gap: 8px;
+  padding: 6px 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-full);
   font-size: 13px;
-  color: var(--text);
+  color: var(--text-secondary);
+  background: var(--bg-card);
   cursor: pointer;
+  transition:
+    border-color 120ms ease,
+    background 120ms ease,
+    color 120ms ease;
+}
+.ceo-checklist-label:hover {
+  border-color: var(--accent);
+  color: var(--text);
+}
+/* When the option is checked, raise the chip to the selected style
+   (accent border + tinted background) so toggle state is obvious at
+   a glance. `:has()` selects the label that contains a checked
+   checkbox. */
+.ceo-checklist-label:has(.ceo-checklist-checkbox:checked) {
+  border-color: var(--accent);
+  background: var(--accent-bg);
+  color: var(--text);
 }
 
 .ceo-checklist-checkbox {
-  width: 16px;
-  height: 16px;
-  accent-color: var(--accent);
+  /* Native checkbox kept in DOM for accessibility (Space toggles,
+     screen readers announce state) but visually hidden — the chip's
+     border/background + tick icon are the visible affordance. */
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: 0;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* Tick icon — sits in the chip's leading position. Hidden when the
+   option is unchecked; visible when the parent label has
+   `data-checked="true"`. */
+.ceo-checklist-tick {
   flex-shrink: 0;
+  opacity: 0;
+  transform: scale(0.6);
+  transition:
+    opacity 120ms ease,
+    transform 120ms ease;
+  color: var(--accent);
+  /* Reserve the icon's space even when invisible so the label text
+     doesn't shift when toggled. */
+  margin-right: -2px;
+  width: 0;
+  overflow: visible;
+}
+.ceo-checklist-label[data-checked="true"] .ceo-checklist-tick {
+  opacity: 1;
+  transform: scale(1);
+  width: 14px;
+  margin-right: 0;
 }
 
 .ceo-checklist-item-text {
-  flex: 1;
+  /* No `flex: 1` — keep the label tight against the icon so the
+     chip's width hugs the text. */
 }
 
 /* ─── Scan chip ────────────────────────────────────────────────────────── */
@@ -2626,8 +2942,13 @@
    ────────────────────────────────────────────────────────────────────── */
 
 .onboarding-chat {
-  display: flex;
-  flex-direction: column;
+  /* Grid layout: header fixed at top, pair vertically centered in
+     the remaining 1fr row. Using grid (not flex + auto margins)
+     because the auto-margin trick can fail in some viewport sizes
+     when the flex item's max-height equals the available row — the
+     grid `place-items: center` is unambiguous and always centers. */
+  display: grid;
+  grid-template-rows: auto 1fr;
   height: 100vh;
   background: radial-gradient(
     circle at top,
@@ -2642,12 +2963,47 @@
 }
 
 .onboarding-chat-header {
-  display: flex;
+  /* 3-column grid so the brand stays optically centered regardless of
+     back-button presence or provider label width. Equal-fraction outer
+     tracks keep the center column at the geometric midpoint. */
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
   align-items: center;
-  justify-content: space-between;
   padding: 18px 28px;
-  border-bottom: 1px solid var(--border);
   background: var(--bg-card);
+  gap: 12px;
+}
+
+.onboarding-chat-back {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 32px;
+  gap: 8px;
+  border: 0;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+  justify-self: start;
+  padding: 0 10px 0 6px;
+  font: inherit;
+  font-size: 13px;
+  font-weight: 500;
+  transition:
+    background-color 120ms ease,
+    color 120ms ease,
+    transform 120ms ease;
+}
+
+.onboarding-chat-back:hover {
+  background: var(--bg);
+  color: var(--text);
+  transform: translateX(-2px);
+}
+
+.onboarding-chat-back-label {
+  white-space: nowrap;
 }
 
 .onboarding-chat-brand {
@@ -2656,6 +3012,11 @@
   font-weight: 600;
   letter-spacing: -0.01em;
   color: var(--text);
+  display: inline-flex;
+  align-items: baseline;
+  gap: 10px;
+  justify-self: center;
+  text-align: center;
 }
 
 .onboarding-chat-phase {
@@ -2663,44 +3024,232 @@
   color: var(--text-tertiary);
   text-transform: uppercase;
   letter-spacing: 0.08em;
+  font-weight: 500;
+}
+
+/* Invisible placeholder so the 3-column grid keeps the brand optically
+   centered even though there is no right-side content. */
+.onboarding-chat-spacer {
+  justify-self: end;
+}
+
+/* Container that holds the body + footer as a single visual unit.
+   The PAIR is what's centered in the viewport (auto margins on the
+   container), so when the body's height changes only this
+   container's size changes — the footer's position relative to the
+   body stays fixed, and the footer no longer has its own auto-margin
+   that recomputes per layout pass. */
+/* ─── Pair = positioning context for the layered body + footer ───
+   Layered layout (not flex stacking):
+     • body fills the entire pair (max 640px) and scrolls internally
+     • footer is absolutely positioned at the pair's bottom, on a
+       higher z-index, so the message stream visually passes UNDER
+       the footer when scrolled
+     • body reserves bottom padding equal to the footer's measured
+       height (`--onboarding-footer-h`, set by ResizeObserver in
+       `OnboardingChat.tsx`) so at-rest content doesn't sit behind
+       the footer
+   This way, "total height ≤ 640px" means body grows naturally; once
+   body's intrinsic content + reserved padding exceeds 640, the body
+   scrolls while the footer stays pinned at the pair's bottom edge. */
+.onboarding-chat-pair {
+  position: relative;
+  /* Inside the parent's 1fr grid row — `place-self: center` centers
+     the pair both vertically and horizontally inside that row, so
+     it's always centered regardless of viewport size or content
+     length. */
+  place-self: center;
+  width: 100%;
+  max-width: 720px;
+  max-height: 640px;
+  min-height: 0;
+  /* Fallback footer height in case JS hasn't run yet; the
+     ResizeObserver overrides this on mount and on every resize. */
+  --onboarding-footer-h: 120px;
 }
 
 .onboarding-chat-body {
-  flex: 1;
+  /* Bottom-anchored scrollable container.
+     `justify-content: flex-end` + `overflow: auto` is broken in
+     most browsers — the overflow direction reverses and scroll
+     never engages. Instead we use a `::before` spacer with
+     `margin-top: auto`: the spacer absorbs any free space inside
+     the body, pushing the stream to the bottom; when the stream's
+     content exceeds the body height the spacer collapses to 0 and
+     the stream overflows naturally upward, scrollbar engaged. */
+  width: 100%;
+  max-height: 640px;
   min-height: 0;
   display: flex;
   flex-direction: column;
   align-items: center;
+  /* Scrolling stays functional (wheel/touch) but the native
+     scrollbar UI is hidden via `scrollbar-width: none` and the
+     `::-webkit-scrollbar` rule below. The visual scroll affordance
+     is handled by the gradient mask at the top of the body
+     (twilson.net/scroll-mask). */
   overflow-y: auto;
-  padding: 32px 16px 16px;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+  overscroll-behavior: contain;
+  /* Bottom padding = footer's measured height + 16px gap, so the
+     last message sits 16px above the footer's top edge at rest. */
+  padding: 32px 16px calc(var(--onboarding-footer-h, 120px) + 16px);
+  /* Top scroll-mask — applied ONLY when the body's content actually
+     overflows (driven by `data-has-overflow` from React, which a
+     ResizeObserver toggles whenever the stream exceeds the body's
+     visible height). When everything fits, no mask is needed and
+     the top edge stays crisp. */
+}
+.onboarding-chat-body[data-has-overflow="true"] {
+  mask-image: linear-gradient(to bottom, transparent 0, black 96px);
+  -webkit-mask-image: linear-gradient(to bottom, transparent 0, black 96px);
+}
+
+/* Bottom fade overlay between the body and the footer. Sits above
+   the footer (z-index between body and footer) and shows a gradient
+   from transparent at the top to the page background at the bottom,
+   visually softening the meeting line of scrolled-up messages and
+   the footer. Toggled by `data-visible` from React based on the
+   body's scroll position. */
+.onboarding-chat-bottom-fade {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: var(--onboarding-footer-h, 120px);
+  height: 48px;
+  background: linear-gradient(to top, var(--bg, #ffffff), transparent);
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity var(--onboarding-anim-ms, 600ms)
+    var(--onboarding-anim-ease, cubic-bezier(0.2, 0, 0.8, 1));
+  z-index: 1;
+}
+.onboarding-chat-bottom-fade[data-visible="true"] {
+  opacity: 1;
+}
+
+/* The spacer that bottom-anchors the stream when content fits, and
+   collapses to 0 when content overflows — letting the scroll engage
+   normally. */
+.onboarding-chat-body::before {
+  content: "";
+  margin-top: auto;
+  flex-shrink: 0;
+}
+
+/* Hide WebKit's native scrollbar. Scrolling still works via
+   wheel/touch/keyboard; the visual cue is the gradient mask above. */
+.onboarding-chat-body::-webkit-scrollbar {
+  display: none;
 }
 
 .onboarding-chat-stream {
   width: 100%;
-  max-width: 720px;
+  max-width: 640px;
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  /* Match the horizontal inset of `.ceo-card-section` (the input card's
+     outer wrapper inside the footer) so message bubbles sit in the same
+     720px column as the input card and their left edges visually line
+     up with the card's outer edge. `border-box` keeps the outer width
+     pinned at the 720px max regardless of the inner padding. */
+  padding: 0 40px;
+  box-sizing: border-box;
 }
 
-.onboarding-chat-stream-empty {
-  color: var(--text-tertiary);
-  font-size: 13px;
-  text-align: center;
-  padding: 40px 0;
+/* Onboarding is a strictly-forward wizard — message bubbles have no
+   meaningful hover behaviour here (no threads, no quoting, no agent-
+   panel to open). Suppress every hover affordance inside the wizard
+   so the bubbles read as static transcript, not as clickable rows. */
+.onboarding-chat .message-hover-actions {
+  display: none !important;
+}
+.onboarding-chat .message-avatar-btn,
+.onboarding-chat .message-author-btn {
+  cursor: default;
+}
+.onboarding-chat .message-avatar-btn:hover {
+  opacity: 1;
+}
+.onboarding-chat .message-author-btn:hover {
+  color: var(--text);
+  text-decoration: none;
+}
+
+/* The `nex` theme paints `.message:hover { background: var(--bg-warm); }`
+   at theme specificity. Cancel it inside the wizard with a matching
+   theme-prefixed selector so the bubble stays flat on hover. */
+html[data-theme^="nex"] .onboarding-chat .message:hover {
+  background: transparent;
+}
+
+/* The `nex` theme also adds `margin: 0 -24px; padding: 10px 24px` to
+   `.message` so the hover background can bleed edge-to-edge against the
+   ambient -24px page margin. In the onboarding wizard there is no such
+   page margin — the stream is centered with its own padding — so those
+   negative margins push the bubble 24px past the 720px stream on each
+   side (total 744px) and break the column alignment with the input card
+   below. Reset the geometry to plain box-model values inside the wizard. */
+html[data-theme^="nex"] .onboarding-chat .message {
+  /* Reset the horizontal bleed and tighten the vertical breathing room
+     from the theme's default 10px to 8px so the stack reads as a tight
+     wizard transcript instead of a roomy channel feed. */
+  margin: 0;
+  padding: 8px 0;
 }
 
 .onboarding-chat-footer {
+  /* Pinned to the pair's bottom edge on a higher z-index so the
+     scrolling message stream passes visually UNDER the footer. The
+     opaque `background` covers messages as they scroll past. */
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 2;
   display: flex;
   justify-content: center;
-  border-top: 1px solid var(--border);
-  background: var(--bg-card);
-  padding: 16px 24px;
+  background: var(--bg);
+  /* No top padding so the input card sits flush under the latest
+     message bubble at rest — the two read as one grouped unit (the
+     CEO's question + the user's answer field). */
+  padding: 0 24px 32px;
+  /* No auto margin — the parent `.onboarding-chat-pair` owns the
+     centering. Footer just sits directly under the body inside the
+     pair container. */
+  width: 100%;
+  transition:
+    transform var(--onboarding-anim-ms) var(--onboarding-anim-ease),
+    margin var(--onboarding-anim-ms) var(--onboarding-anim-ease),
+    opacity var(--onboarding-anim-ms) var(--onboarding-anim-ease);
 }
 
 .onboarding-chat-footer-inner {
   width: 100%;
-  max-width: 720px;
+  max-width: 640px;
+}
+
+/* ─── Input lock ───
+   While the CEO is thinking / revealing OR the post-human breather is
+   still running, the input area is non-interactive. `pointer-events:
+   none` blocks clicks, taps and submit-button activation across the
+   whole footer; additionally we disable typing into any focused
+   input by setting `user-select: none` and blocking keyboard input
+   via `tab-index: -1`-like exclusion (the focus ring is already
+   neutralized by the locked-state rule earlier). */
+.onboarding-chat[data-input-locked="true"] .onboarding-chat-footer {
+  pointer-events: none;
+  user-select: none;
+}
+.onboarding-chat[data-input-locked="true"] .onboarding-chat-footer input,
+.onboarding-chat[data-input-locked="true"] .onboarding-chat-footer textarea,
+.onboarding-chat[data-input-locked="true"] .onboarding-chat-footer button {
+  /* Belt-and-braces: even with pointer-events:none on the parent,
+     keyboard focus might still reach an input that was focused
+     BEFORE the lock kicked in. Force readonly/disabled semantics so
+     typing into a stale focus doesn't sneak a submit through. */
+  pointer-events: none;
 }
 
 .onboarding-chat-hint {
@@ -2710,4 +3259,412 @@
   color: var(--text-tertiary);
   text-align: center;
   font-style: italic;
+}
+
+/* Send button disabled while we're holding back the CEO's next message
+   (the user shouldn't be able to fire a second answer mid-stage — the
+   wizard is strictly sequential). Matches the native `:disabled` look
+   so the existing styles still apply. `pointer-events: none` blocks
+   the click even though the React `disabled` prop also covers it. */
+.onboarding-chat[data-ceo-typing="true"] .ceo-card-send {
+  opacity: 0.45;
+  cursor: not-allowed;
+  pointer-events: none;
+}
+
+/* User ("You") message avatar — brand magenta tint in the wizard so the
+   human author reads at a glance against the CEO bubbles. The inline
+   `background: var(--bg-warm)` on the element wins by source order
+   without `!important`. */
+.onboarding-chat .message[data-author-kind="human"] .message-avatar {
+  background: var(--tertiary-200) !important;
+  color: var(--tertiary-500) !important;
+}
+
+/* Skip button — pulled out of the card and dropped below it as a
+   borderless tertiary link, so the card stays focused on the active
+   input and the optional bail-out reads as a quiet secondary action. */
+.onboarding-chat .onboarding-chat-footer-inner {
+  position: relative;
+}
+.onboarding-chat .ceo-card-actions {
+  position: absolute;
+  left: 50%;
+  bottom: -56px;
+  transform: translateX(-50%);
+  margin: 0;
+  padding: 0;
+  background: transparent;
+}
+.onboarding-chat .ceo-card-skip,
+.onboarding-chat .ceo-card-skip.btn,
+.onboarding-chat .ceo-card-skip.btn-ghost {
+  /* 32px pill button. Transparent at rest so it doesn't compete
+     with the primary Send button next to it. On hover, a light
+     gray pill fills in to give the click affordance. */
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 32px;
+  padding: 0 14px;
+  border: 0;
+  border-radius: 999px;
+  background: transparent;
+  box-shadow: none;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-tertiary);
+  letter-spacing: 0.02em;
+  cursor: pointer;
+  transition:
+    color 160ms ease,
+    background 160ms ease;
+}
+.onboarding-chat .ceo-card-skip:hover {
+  color: var(--text);
+  background: var(--bg-warm, rgba(0, 0, 0, 0.05));
+}
+
+/* ═══════════════════════════════════════════════════════════════════
+   ─── Synced wizard motion (v2 — slot-based) ───
+   ═══════════════════════════════════════════════════════════════════
+
+   The wizard chat has ONE coordinated motion language. Every entrance
+   uses the same duration (`--onboarding-anim-ms`, default 300ms) and
+   the same easing (`--onboarding-anim-ease`, a symmetric ease-in-out
+   `cubic-bezier(0.2, 0, 0.8, 1)`), exposed from the React tree so JS
+   timers and CSS animations are guaranteed in sync.
+
+   Layout principles:
+     1. The body + footer pair is centered as a group (auto margins).
+     2. The stream is bottom-anchored — newest message sits flush
+        against the input card above it.
+     3. Each message lives inside a `.onboarding-message-slot` whose
+        height grows from 0 (or from the dots-height, for CEO slots)
+        up to the bubble's natural height. Because the slot is bottom-
+        anchored in the stream, growth extends UPWARD only — older
+        messages shift up, the input stays put.
+     4. CEO slots cross-fade dots → bubble in place without any DOM
+        unmount/remount.
+
+   `interpolate-size: allow-keywords` (Chrome 129+) is what makes
+   `height: auto` interpolatable from a numeric start. */
+.onboarding-chat {
+  interpolate-size: allow-keywords;
+  /* One canonical duration / curve for every motion in the wizard.
+     Slot height grow, bubble opacity, footer dim, dots cross-fade —
+     all share this dial. Overridable via inline style from React. */
+  --onboarding-anim-ms: 600ms;
+  --onboarding-anim-ease: cubic-bezier(0.2, 0, 0.8, 1);
+}
+
+/* Message bubbles — the typing bubble above is structurally a real
+   `.message` and already reserves the exact slot the incoming bubble
+   will occupy (same avatar column, same header row, same paddings).
+   So the new message doesn't need to expand the chat window or move
+   far: just a quick, soft fade-up that morphs into place where the
+   dots were. Short duration on the smoothing curve keeps it from
+   feeling laggy after the typing block disappears. */
+/* Mount-time fade-up for every bubble in the wizard chat. We use a
+   keyframe animation (not `@starting-style` + transition) because
+   keyframes fire reliably on every fresh mount across browsers,
+   whereas `@starting-style` requires the browser to paint the
+   starting frame before the transition begins — which some engines
+   skip when the element mounts inside an already-painted parent
+   that's recomputing layout in the same frame, causing the bubble
+   to appear "instantly" instead of gliding in. */
+/* Mount-time fade-up for every bubble in the wizard chat. We also
+   animate `max-height` from 0 → 200px alongside opacity/transform so
+   the bubble GROWS into the stream rather than appearing at full
+   height the moment it mounts. Without the height animation, adding
+   a new bubble instantly enlarges the body and the centered pair
+   snaps to its new center — the "jump" you saw. Growing max-height
+   in lockstep with the fade-in means the body's height changes
+   smoothly across the same duration, so the centering glides
+   instead.
+
+   `overflow: hidden` keeps the bubble's content clipped to its
+   currently-animating max-height. Once the animation finishes the
+   `both` fill mode leaves the bubble at max-height: 200px — well
+   above any expected single-bubble height, so it does not clip real
+   content. */
+@keyframes onboardingBubbleEnter {
+  /* Single uniform animation — opacity, transform and max-height all
+     interpolate continuously from `from` to `to` across the whole
+     800ms duration on the same easing curve. */
+  from {
+    opacity: 0;
+    transform: translateY(14px);
+    max-height: 0;
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+    max-height: 200px;
+  }
+}
+.onboarding-chat .message.animate-fade {
+  /* ONE animation only — using the same keyframe / duration / curve
+     regardless of `data-ceo-bubble-state`. Previously a separate
+     override for `[data-ceo-bubble-state="pending"]` swapped to a
+     longer keyframe; when the attribute flipped to "revealed" after
+     the typing dots resolved, the CSS animation declaration changed,
+     which per CSS spec RESTARTS the animation from frame 0. The
+     bubble visibly collapsed back to max-height 0 / opacity 0 and
+     re-grew — that was the "items move, message appears, items
+     bounce back" sequence. Keeping a single animation declaration on
+     the same class means flipping the data attribute touches only
+     the inner content (dots ↔ text) — never the bubble's geometry. */
+  /* Long, gentle animation with a curve that spreads progress evenly
+     across the duration so the growth is visibly perceptible from
+     start to finish, instead of front-loading so much progress that
+     the bubble reads as "already there" after ~200ms. */
+  animation: onboardingBubbleEnter 800ms cubic-bezier(0.2, 0, 0.8, 1) both;
+  will-change: transform, opacity, max-height;
+  overflow: hidden;
+}
+
+/* The typing bubble itself eases in on the full wizard cadence so
+   there's a clear "CEO heard me → starting to type" moment. */
+.onboarding-chat .message.message-typing {
+  transition:
+    opacity var(--wizard-duration) var(--wizard-ease),
+    transform var(--wizard-duration) var(--wizard-ease);
+}
+
+/* CEO input card — persistent wrapper, morphs in place. Same curve as
+   the message bubbles so successive cards (Office name → What you do
+   → Short description …) ease in on the same rhythm as the chat
+   transcript above. */
+.onboarding-chat .ceo-card {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+  filter: blur(0);
+  transition:
+    opacity 520ms var(--wizard-ease),
+    transform 720ms var(--wizard-ease),
+    filter 320ms var(--wizard-ease);
+  will-change: transform, opacity;
+
+  @starting-style {
+    opacity: 0;
+    transform: translateY(14px) scale(0.985);
+    filter: blur(4px);
+  }
+}
+/* Browsers without `interpolate-size` ignore the height transition but
+   still honour opacity/translate — fall back to a plain fade-up via
+   keyframe so those users still get a smooth entrance. */
+@supports not (interpolate-size: allow-keywords) {
+  @keyframes onboardingMessageEnter {
+    from {
+      opacity: 0;
+      transform: translateY(14px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+  .onboarding-chat .message.animate-fade,
+  .onboarding-chat .ceo-card {
+    animation: onboardingMessageEnter var(--wizard-duration) var(--wizard-ease)
+      both;
+    overflow: visible;
+  }
+}
+
+/* ─── CEO "typing…" motion ───
+   Two-stage sequence, choreographed so the wizard reads as:
+     1. Typing indicator FADES IN softly (it doesn't pop into view).
+     2. Dots dance for the staging window (~1100ms).
+     3. Typing indicator unmounts, and the new message expands the chat
+        in its place using the height transition above.
+
+   The fade-in is a dedicated keyframe (independent of the message
+   transition above, which only fires inside `@supports not (...)` and
+   wouldn't apply on modern browsers). 320ms ease-out so the indicator
+   arrives quickly and decelerates — fast enough that the user sees the
+   intent ("CEO heard me") within a couple of frames, gentle enough not
+   to feel jittery.
+
+   The dots themselves animate on a soft sine wave: lift `translateY
+   -3px` and brighten 0.45 → 1 → 0.45 without ever vanishing. The wave
+   is staggered 180ms per dot so the three dots read as a travelling
+   pulse rather than three blinking dots. */
+@keyframes onboardingTypingEnter {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+@keyframes onboardingTypingWave {
+  0%,
+  100% {
+    transform: translateY(0);
+    opacity: 0.45;
+  }
+  50% {
+    transform: translateY(-3px);
+    opacity: 1;
+  }
+}
+
+/* Typing "bubble" is structurally a real `.message`, so the message
+   transition above already handles its enter animation. We only need
+   to tune the inline dots: a soft sine wave that lifts each dot a few
+   pixels and brightens it without ever fully vanishing. The wave is
+   staggered 180ms per dot so the three dots read as a travelling
+   pulse rather than three blinking dots. */
+.onboarding-chat .typing-dot {
+  animation: onboardingTypingWave 1.6s var(--wizard-ease) infinite;
+  transform-origin: center;
+}
+
+/* ─── CEO bubble in-place dots ↔ text cross-fade ───
+   Both the typing dots and the real message text render at the same
+   time inside `.ceo-text-slot`, stacked in the same grid cell. The
+   `data-pending` attribute on the slot decides which layer is opaque
+   and which is transparent — a CSS opacity transition then cross-
+   fades them in place. The slot's intrinsic height tracks the larger
+   of the two layers (handled by `display: grid` with both layers in
+   row/column 1), so the bubble grows naturally to fit longer text
+   without snapping when the pending flag flips. */
+.onboarding-chat .ceo-text-slot {
+  display: grid;
+  /* Stack both layers into a single grid cell so they overlap. The
+     cell's height becomes the max of either layer — the text drives
+     the slot height once the message is long. */
+}
+.onboarding-chat .ceo-text-layer {
+  grid-area: 1 / 1;
+  transition: opacity 360ms var(--wizard-ease);
+  will-change: opacity;
+}
+.onboarding-chat .ceo-text-slot[data-pending="true"] .ceo-text-dots {
+  opacity: 1;
+}
+.onboarding-chat .ceo-text-slot[data-pending="true"] .ceo-text-content {
+  opacity: 0;
+}
+.onboarding-chat .ceo-text-slot[data-pending="false"] .ceo-text-dots {
+  opacity: 0;
+}
+/* The content layer itself is always opaque — the reveal happens at
+   the per-word level (see `.ceo-word` below). Otherwise we'd cross-
+   fade the whole text block at once, defeating the typewriter effect. */
+.onboarding-chat .ceo-text-slot .ceo-text-content {
+  opacity: 1;
+}
+
+/* Per-word opacity reveal. Each word starts invisible and fades in
+   when the bubble flips to revealed. The stagger delay is set inline
+   on each span (incrementing by token index) so the words appear in
+   reading order, like the CEO is typing the message in front of you.
+   240ms is the per-word fade duration — slow enough to read as a
+   conscious reveal, fast enough that even a 10-word sentence finishes
+   under a second. */
+.onboarding-chat .ceo-word {
+  opacity: 0;
+  transition: opacity 240ms var(--wizard-ease);
+}
+.onboarding-chat .ceo-text-slot[data-pending="false"] .ceo-word {
+  opacity: 1;
+}
+
+.onboarding-chat .message-typing .typing-dots {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+.onboarding-chat .message-typing .typing-dot {
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: var(--text-tertiary);
+}
+.onboarding-chat .typing-dot:nth-child(2) {
+  animation-delay: 0.18s;
+}
+.onboarding-chat .typing-dot:nth-child(3) {
+  animation-delay: 0.36s;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .onboarding-chat .message.animate-fade,
+  .onboarding-chat .ceo-card {
+    animation-duration: 200ms;
+    animation-timing-function: ease;
+  }
+  .onboarding-chat .onboarding-thinking-dot {
+    animation: none;
+    opacity: 0.65;
+  }
+}
+
+/* Thinking-dot base style — the reduced-motion block above references
+   `.onboarding-thinking-dot`; without a base rule the dots have no
+   width/height/background so they render invisible. */
+.onboarding-chat .onboarding-thinking-dot {
+  display: inline-block;
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: var(--text-tertiary, currentColor);
+  opacity: 0.45;
+  animation: onboardingThinkingPulse 1100ms ease-in-out infinite;
+}
+.onboarding-chat .onboarding-thinking-dot:nth-child(2) {
+  animation-delay: 140ms;
+}
+.onboarding-chat .onboarding-thinking-dot:nth-child(3) {
+  animation-delay: 280ms;
+}
+@keyframes onboardingThinkingPulse {
+  0%,
+  100% {
+    transform: scale(0.85);
+    opacity: 0.35;
+  }
+  50% {
+    transform: scale(1.1);
+    opacity: 0.9;
+  }
+}
+
+/* Footer card chrome — wraps the InterviewBar / CeoCardSection and
+   drives the blur-on-lock muted state via [data-input-locked] on the
+   chat root. */
+.onboarding-card-shell {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg, 12px);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
+  padding: 12px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  transition:
+    filter 220ms ease,
+    opacity 220ms ease;
+}
+.onboarding-chat[data-input-locked="true"] .onboarding-card-shell {
+  filter: blur(3px);
+  opacity: 0.6;
+  pointer-events: none;
+  user-select: none;
+}
+.onboarding-chat[data-input-locked="true"]
+  .onboarding-card-shell
+  .ceo-card-input {
+  border-color: var(--border);
+  box-shadow: none;
+  outline: none;
+}
+.onboarding-card-shell .interview-bar {
+  display: none !important;
 }

--- a/web/src/styles/onboarding.css
+++ b/web/src/styles/onboarding.css
@@ -2475,17 +2475,26 @@
    `.ceo-card` directly so we don't need a wrapper. */
 .onboarding-chat .ceo-card-section,
 .onboarding-chat .ceo-card {
+  /* Smooth fade in/out for the muted state. Longer than the previous
+     220 ms because filter:blur() interpolation looks coarser than plain
+     opacity and benefits from a slower curve. */
   transition:
-    filter 220ms cubic-bezier(0.2, 0, 0.8, 1),
-    opacity 220ms cubic-bezier(0.2, 0, 0.8, 1);
+    filter 360ms cubic-bezier(0.2, 0, 0.2, 1),
+    opacity 360ms cubic-bezier(0.2, 0, 0.2, 1);
 }
 .onboarding-chat[data-input-locked="true"] .ceo-card {
+  /* Muted state: blur the card while it's not interactable so it visibly
+     reads as "wait, not your turn yet." Pointer + selection still
+     blocked. Focus chrome on inputs is NOT touched — see the rule
+     below the shell which is the same idea applied to the outer shell. */
   filter: blur(3px);
   opacity: 0.6;
+  pointer-events: none;
+  user-select: none;
 }
-.onboarding-chat[data-input-locked="true"] .ceo-card--form-field:focus-within {
-  outline-color: var(--border);
-}
+/* Locked-state DOES NOT touch the focus outline. Disabling interaction
+   (pointer-events + user-select above) is enough — visually the card
+   keeps whatever focus chrome it would normally have. */
 
 /* Base CEO card */
 .ceo-card {
@@ -3080,9 +3089,17 @@
   width: 100%;
   max-height: 640px;
   min-height: 0;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
+  /* Plain block scroll container — flex hacks (column +
+     `::before margin-top:auto` OR row + `align-items: end`) BOTH
+     interact badly with `overflow-y: auto`: the cross-axis sizing
+     pegs the body to its own clientHeight so overflow detection
+     thinks there's nothing to scroll, and the stream gets clipped.
+     A plain block element with overflow-y scrolls the way browsers
+     have done it since 1996. Bottom-anchoring (the "last message
+     sits just above the footer" feel) is delivered by the
+     scrollIntoView call on the end-of-stream sentinel — see
+     OnboardingChat.tsx. */
+  display: block;
   /* Scrolling stays functional (wheel/touch) but the native
      scrollbar UI is hidden via `scrollbar-width: none` and the
      `::-webkit-scrollbar` rule below. The visual scroll affordance
@@ -3129,14 +3146,9 @@
   opacity: 1;
 }
 
-/* The spacer that bottom-anchors the stream when content fits, and
-   collapses to 0 when content overflows — letting the scroll engage
-   normally. */
-.onboarding-chat-body::before {
-  content: "";
-  margin-top: auto;
-  flex-shrink: 0;
-}
+/* Bottom-anchoring is now done in JS via scrollIntoView on the
+   end-of-stream sentinel; the ::before spacer hack is no longer
+   needed and would only confuse the block layout. */
 
 /* Hide WebKit's native scrollbar. Scrolling still works via
    wheel/touch/keyboard; the visual cue is the gradient mask above. */
@@ -3147,13 +3159,15 @@
 .onboarding-chat-stream {
   width: 100%;
   max-width: 640px;
+  /* Center inside the now-plain-block body. */
+  margin: 0 auto;
   display: flex;
   flex-direction: column;
   /* Match the horizontal inset of `.ceo-card-section` (the input card's
      outer wrapper inside the footer) so message bubbles sit in the same
-     720px column as the input card and their left edges visually line
-     up with the card's outer edge. `border-box` keeps the outer width
-     pinned at the 720px max regardless of the inner padding. */
+     column as the input card and their left edges visually line up
+     with the card's outer edge. `border-box` keeps the outer width
+     pinned at the max regardless of the inner padding. */
   padding: 0 40px;
   box-sizing: border-box;
 }
@@ -3388,41 +3402,12 @@ html[data-theme^="nex"] .onboarding-chat .message {
    `both` fill mode leaves the bubble at max-height: 200px — well
    above any expected single-bubble height, so it does not clip real
    content. */
-@keyframes onboardingBubbleEnter {
-  /* Single uniform animation — opacity, transform and max-height all
-     interpolate continuously from `from` to `to` across the whole
-     800ms duration on the same easing curve. */
-  from {
-    opacity: 0;
-    transform: translateY(14px);
-    max-height: 0;
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-    max-height: 200px;
-  }
-}
-.onboarding-chat .message.animate-fade {
-  /* ONE animation only — using the same keyframe / duration / curve
-     regardless of `data-ceo-bubble-state`. Previously a separate
-     override for `[data-ceo-bubble-state="pending"]` swapped to a
-     longer keyframe; when the attribute flipped to "revealed" after
-     the typing dots resolved, the CSS animation declaration changed,
-     which per CSS spec RESTARTS the animation from frame 0. The
-     bubble visibly collapsed back to max-height 0 / opacity 0 and
-     re-grew — that was the "items move, message appears, items
-     bounce back" sequence. Keeping a single animation declaration on
-     the same class means flipping the data attribute touches only
-     the inner content (dots ↔ text) — never the bubble's geometry. */
-  /* Long, gentle animation with a curve that spreads progress evenly
-     across the duration so the growth is visibly perceptible from
-     start to finish, instead of front-loading so much progress that
-     the bubble reads as "already there" after ~200ms. */
-  animation: onboardingBubbleEnter 800ms cubic-bezier(0.2, 0, 0.8, 1) both;
-  will-change: transform, opacity, max-height;
-  overflow: hidden;
-}
+/* Slot-grow / max-height entrance animation removed — onboarding bubbles
+   now use the global `.animate-fade` (300ms opacity + translateY fade-in
+   defined in global.css), matching the rest of the app's message chrome.
+   No max-height interpolation means the bubble takes its natural height
+   immediately; the parent stream pads with `gap` so successive bubbles
+   still settle without snapping. */
 
 /* The typing bubble itself eases in on the full wizard cadence so
    there's a clear "CEO heard me → starting to type" moment. */
@@ -3648,23 +3633,99 @@ html[data-theme^="nex"] .onboarding-chat .message {
   display: flex;
   flex-direction: column;
   gap: 8px;
+  /* Same curve as the inner .ceo-card transition so both layers fade
+     in/out together as the muted state toggles. */
   transition:
-    filter 220ms ease,
-    opacity 220ms ease;
+    filter 360ms cubic-bezier(0.2, 0, 0.2, 1),
+    opacity 360ms cubic-bezier(0.2, 0, 0.2, 1);
 }
 .onboarding-chat[data-input-locked="true"] .onboarding-card-shell {
+  /* Muted state for the outer footer shell — blur + dim so the whole
+     footer reads as "waiting" while the CEO is mid-reveal. Interaction
+     is blocked. The transition on the shell above smooths the blur in
+     and out so it doesn't flash. */
   filter: blur(3px);
   opacity: 0.6;
   pointer-events: none;
   user-select: none;
 }
-.onboarding-chat[data-input-locked="true"]
-  .onboarding-card-shell
-  .ceo-card-input {
-  border-color: var(--border);
-  box-shadow: none;
-  outline: none;
-}
 .onboarding-card-shell .interview-bar {
   display: none !important;
+}
+
+/* CEO badge inside the onboarding wizard — the agent's full `role`
+   ("Owns priorities, approvals, and escalation decisions") is too long
+   for a chat-row badge. Replace the visible label with a short "CEO"
+   chip via a CSS content swap; the underlying React tree is unchanged. */
+.onboarding-message-slot .message[data-author-slug="ceo"] .badge.badge-green {
+  font-size: 0;
+  letter-spacing: normal;
+}
+.onboarding-message-slot
+  .message[data-author-slug="ceo"]
+  .badge.badge-green::before {
+  content: "CEO";
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+/* ─── Unified bubble + thinking overlay ──────────────────────────────────
+   Both CEO and human render through `MessageBubble`, so chrome (avatar,
+   name, badge, timestamp, padding, hover affordances) is byte-for-byte
+   identical on both sides. The only CEO-specific addition is the
+   thinking overlay layered on the slot while `data-state="thinking"`:
+   CSS hides the real `.message-text` and replaces it with dots in-place,
+   then cross-fades back to the text once the slot flips to revealing.
+   The previous per-word stagger doesn't apply — MessageBubble renders
+   text as markdown, not split spans — so the reveal is a single fade. */
+.onboarding-message-slot {
+  position: relative;
+}
+
+/* Thinking state — the dot overlay is rendered conditionally and has no
+   in/out transition: it appears the instant state flips to "thinking"
+   and disappears the instant it leaves. The `.message-text` is kept in
+   the DOM (so its split-into-words spans exist from mount) but visually
+   hidden via visibility so the bubble's footprint doesn't change. */
+.onboarding-message-slot[data-state="thinking"] .message-text,
+.onboarding-message-slot[data-state="thinking"] .message-time,
+.onboarding-message-slot[data-state="thinking"] .message-hover-actions {
+  visibility: hidden;
+}
+
+.onboarding-thinking-overlay {
+  position: absolute;
+  /* `left` and `top` are written by JS to match `.message-text`'s exact
+     position inside MessageBubble's layout. Hardcoded offsets drifted
+     out of alignment whenever MessageBubble's internal padding/grid
+     changed; measuring at runtime is robust to that. */
+  left: 0;
+  top: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  pointer-events: none;
+}
+
+/* Per-word reveal — `.ceo-word` spans are produced by the
+   OnboardingMessageSlot useEffect after MessageBubble mounts. Each span
+   carries its own `transition-delay`, so they fade in one-by-one when
+   the slot flips to revealing/revealed. The .message-text itself does
+   NOT animate; only the individual words do. */
+.onboarding-message-slot .ceo-word {
+  opacity: 0;
+  transition: opacity var(--onboarding-word-fade-ms, 600ms)
+    var(--onboarding-anim-ease, ease);
+}
+.onboarding-message-slot[data-state="revealing"] .ceo-word,
+.onboarding-message-slot[data-state="revealed"] .ceo-word {
+  opacity: 1;
+}
+/* Backlog (instant) messages skip the per-word stagger — they were
+   already there before the wizard mounted, so they should look final. */
+.onboarding-slot-instant .ceo-word {
+  opacity: 1;
+  transition: none;
 }

--- a/web/src/styles/onboarding.css
+++ b/web/src/styles/onboarding.css
@@ -2186,7 +2186,6 @@
 
 .pre-pick-secondary-button:hover:not(:disabled) {
   color: var(--text);
-  border-color: var(--border);
 }
 
 .pre-pick-secondary-button:focus-visible {
@@ -2456,6 +2455,15 @@
   min-height: 40px;
   padding: 0 18px;
   font-size: var(--text-sm);
+  /* +8px down from the items above — gives the primary action room
+     to breathe instead of sitting flush with the last chip/checkbox. */
+  margin-top: 8px;
+}
+/* Suppress the global `.btn:hover` translateY(-1px) lift inside the
+   wizard footer — the wizard's primary actions stay put on hover so
+   the muted/locked footer doesn't "twitch" when the mouse drifts over. */
+.onboarding-chat .ceo-card-submit.btn:not(:disabled):hover {
+  transform: none;
 }
 
 .ceo-card-section {
@@ -3008,7 +3016,7 @@
 .onboarding-chat-back:hover {
   background: var(--bg);
   color: var(--text);
-  transform: translateX(-2px);
+  /* No translate — hover stays still, only colour shifts. */
 }
 
 .onboarding-chat-back-label {
@@ -3682,6 +3690,33 @@ html[data-theme^="nex"] .onboarding-chat .message {
    text as markdown, not split spans — so the reveal is a single fade. */
 .onboarding-message-slot {
   position: relative;
+  /* Entrance: slot grows from 0 to natural height over 500 ms. The
+     `overflow: visible` makes the bubble content paint at its natural
+     position from frame 1, so the surrounding stream shifts down
+     smoothly while the bubble "inflates." 600px is a generous cap
+     that covers any single-bubble height; the `both` fill mode pins
+     it there at the end so subsequent layout doesn't snap back.
+     Anchored at top so it grows downward, not centered. */
+  overflow: visible;
+  transform-origin: top center;
+  animation: onboardingSlotGrow 500ms ease-in-out both;
+}
+/* Backlog (server-replayed) messages render at full size from the
+   start — they were already in the channel before the wizard
+   mounted, so animating them would look like a redundant replay.
+   The `instant` prop on OnboardingMessageSlot writes this class. */
+.onboarding-slot-instant {
+  animation: none;
+}
+@keyframes onboardingSlotGrow {
+  from {
+    max-height: 0;
+    opacity: 0;
+  }
+  to {
+    max-height: 600px;
+    opacity: 1;
+  }
 }
 
 /* Thinking state — the dot overlay is rendered conditionally and has no

--- a/web/src/styles/onboarding.css
+++ b/web/src/styles/onboarding.css
@@ -3640,11 +3640,11 @@ html[data-theme^="nex"] .onboarding-chat .message {
    drives the blur-on-lock muted state via [data-input-locked] on the
    chat root. */
 .onboarding-card-shell {
-  background: var(--bg-card);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-lg, 12px);
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
-  padding: 12px 14px;
+  background: transparent;
+  border: none;
+  border-radius: 0;
+  box-shadow: none;
+  padding: 0;
   display: flex;
   flex-direction: column;
   gap: 8px;


### PR DESCRIPTION
## Summary

CEO onboarding rebuilt as a polished, single-feed chat wizard.

- **Staged CEO reveal** — thinking dots cross-fade into per-word opacity fade-in inside a stable grid-stacked `.ceo-text-slot` bubble; consecutive CEO lines skip the thinking step so back-to-back lines flow naturally.
- **Footer card** pins absolutely to the chat pair so it doesn't blink between phases. Blurs + locks input while the CEO is thinking, while waiting on the next `pending_suggestion`, or while messages remain unrevealed. Only the first greet bypasses the lock.
- **Single continuous dialogue** — broker preserves CEO DM messages across `seedFromBlueprintLocked` / `seedMinimalScratchLocked` so phase transitions don't clear the chat. CEO LLM agent is muted during onboarding via `notifier_delivery` so the deterministic wizard isn't competing with model replies. New `/onboarding/reset` ResetFunc + restart-from-header wiring through `RootRoute`.
- **InterviewBar** — synchronous `effectiveStage` via `lastSuggestionIdRef` so a new card paints in the first render after a suggestion swap instead of flashing empty for one commit (root cause of the "second question's input empty until refresh" bug).
- **Form-field card** — inline Skip + Send. **Checklist card** — chip-style items with custom tick SVG (hidden native checkbox). **PrePickScreen** — inline Skip/Continue + accordion section toggle.
- **Scroll pinning** — `wasAtBottomRef` preserves deliberate scroll-back; a rAF loop pins to `scrollHeight` every frame during animations because CSS `max-height` transitions don't fire ResizeObserver per-frame, so observer-only pinning left new messages above the fold.

## Files

13 files, +1,965 / -234. Backend (5 Go files in `internal/onboarding` + `internal/team`), frontend (8 files under `web/src`).

## Test plan

- [ ] Fresh onboarding from `/` — first greet "Office name?" appears with no input lock; subsequent questions lock input while CEO is thinking
- [ ] Each CEO message reveals per-word; consecutive CEO lines skip thinking
- [ ] Footer card never blinks/empties between phases (greet → blueprint pick → team trim → context fields → scan)
- [ ] Second CEO question's form input renders immediately (no refresh needed) — regression test for the `effectiveStage` ref fix
- [ ] Scroll up to read history — new CEO message does NOT yank you back to bottom
- [ ] Scroll at bottom — new CEO message pins reliably; no "above the fold" landing
- [ ] Restart button (header) clears wizard state and returns to greet
- [ ] No CEO LLM-generated replies during onboarding; CEO unlocks once `phase=complete`
- [ ] Single-suggestion lock: can't send another answer until the next CEO suggestion arrives

Screenshots to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Onboarding reset endpoint and a back/restart control in the onboarding flow.
  * Full-screen CEO onboarding wizard with per-message animation and per-word reveal; collapsible setup sections.

* **Bug Fixes**
  * Onboarding state now returns consistent, full payloads and updates client cache after submissions.
  * Preserve CEO DM transcript during seeding; suppress CEO notifications while onboarding is active.

* **Style**
  * Updated CEO card/checklist/form/footer visuals and badge alignment.

* **Tests**
  * Adjusted UI tests to match new committed/submitting behavior and onboarding chat attributes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nex-crm/wuphf/pull/995?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->