### PR TITLE
feat(skill): held-out validation gate for new/enhance proposals (#1004)

### DIFF
--- a/internal/team/skill_compile.go
+++ b/internal/team/skill_compile.go
@@ -91,6 +91,12 @@ type SkillCompileMetrics struct {
 	// SkillEnhancementsTotal counts proposals that enhanced an existing
 	// skill instead of being discarded or created as new.
 	SkillEnhancementsTotal int64
+	// ValidationGateRejections counts Stage B proposals rejected by the
+	// held-out fixture validation gate (regression or no improvement found).
+	ValidationGateRejections int64
+	// ValidationGateNoFixtures counts Stage B proposals where the gate was
+	// called but no fixture file existed (gate skipped — graceful degradation).
+	ValidationGateNoFixtures int64
 }
 
 // snapshotSkillCompileMetrics returns a copy of m suitable for serialization.
@@ -118,6 +124,8 @@ func snapshotSkillCompileMetrics(m *SkillCompileMetrics) SkillCompileMetrics {
 		EmbeddingCostUsdBits:          atomic.LoadUint64(&m.EmbeddingCostUsdBits),
 		SemanticDedupHitsTotal:        atomic.LoadInt64(&m.SemanticDedupHitsTotal),
 		SkillEnhancementsTotal:        atomic.LoadInt64(&m.SkillEnhancementsTotal),
+		ValidationGateRejections:      atomic.LoadInt64(&m.ValidationGateRejections),
+		ValidationGateNoFixtures:      atomic.LoadInt64(&m.ValidationGateNoFixtures),
 	}
 }
 

--- a/internal/team/skill_synthesizer.go
+++ b/internal/team/skill_synthesizer.go
@@ -44,13 +44,14 @@ type SynthError struct {
 // StageBSynthResult is the JSON-serializable summary of a single synth pass.
 // Counts mirror ScanResult so callers can fold them into Stage A telemetry.
 type StageBSynthResult struct {
-	CandidatesScanned int          `json:"candidates_scanned"`
-	Synthesized       int          `json:"synthesized"`
-	Deduped           int          `json:"deduped"`
-	RejectedByGuard   int          `json:"rejected_by_guard"`
-	Errors            []SynthError `json:"errors,omitempty"`
-	DurationMs        int64        `json:"duration_ms"`
-	Trigger           string       `json:"trigger"`
+	CandidatesScanned    int          `json:"candidates_scanned"`
+	Synthesized          int          `json:"synthesized"`
+	Deduped              int          `json:"deduped"`
+	RejectedByGuard      int          `json:"rejected_by_guard"`
+	RejectedByValidation int          `json:"rejected_by_validation"`
+	Errors               []SynthError `json:"errors,omitempty"`
+	DurationMs           int64        `json:"duration_ms"`
+	Trigger              string       `json:"trigger"`
 }
 
 // stageBCandidateSource is the small interface SkillSynthesizer reads
@@ -69,6 +70,7 @@ type SkillSynthesizer struct {
 	broker        *Broker
 	aggregator    stageBCandidateSource
 	provider      stageBLLMProvider
+	gate          skillValidationGate // nil when WUPHF_SKILL_VALIDATION_GATE_DISABLED=true
 	budgetPerPass int
 }
 
@@ -77,9 +79,14 @@ type SkillSynthesizer struct {
 // candidates); the provider is set separately by the caller so tests can
 // inject fakes.
 func NewSkillSynthesizer(b *Broker, agg stageBCandidateSource) *SkillSynthesizer {
+	var gate skillValidationGate
+	if strings.TrimSpace(os.Getenv("WUPHF_SKILL_VALIDATION_GATE_DISABLED")) != "true" {
+		gate = newDefaultSkillValidationGate()
+	}
 	return &SkillSynthesizer{
 		broker:        b,
 		aggregator:    agg,
+		gate:          gate,
 		budgetPerPass: stageBSynthBudgetFromEnv(),
 	}
 }
@@ -142,6 +149,7 @@ func (s *SkillSynthesizer) SynthesizeOnce(ctx context.Context, trigger string) (
 		"synthesized", res.Synthesized,
 		"deduped", res.Deduped,
 		"rejected_by_guard", res.RejectedByGuard,
+		"rejected_by_validation", res.RejectedByValidation,
 		"errors", len(res.Errors),
 		"duration_ms", res.DurationMs,
 	)
@@ -203,6 +211,42 @@ func (s *SkillSynthesizer) runPass(ctx context.Context, trigger string, start ti
 				Reason:        "synth: empty name from llm",
 			})
 			continue
+		}
+
+		// --- Validation gate ---
+		// LLM-as-judge: candidate must strictly improve on held-out task
+		// fixtures versus the baseline (empty for new skills, existing body
+		// for enhance). Skipped when no fixture file exists for the slug
+		// (graceful degradation — common before teams author fixture sets).
+		if s.gate != nil {
+			gateSlug := fm.Name
+			baselineBody := ""
+			if decision.Enhance != "" {
+				gateSlug = decision.Enhance
+				s.broker.mu.Lock()
+				if ex := s.broker.findSkillByNameLocked(decision.Enhance); ex != nil {
+					baselineBody = ex.Content
+				}
+				s.broker.mu.Unlock()
+			}
+			hasFixtures, gateErr := s.gate.Validate(ctx, gateSlug, body, baselineBody, wikiRoot)
+			if !hasFixtures {
+				atomic.AddInt64(&s.broker.skillCompileMetrics.ValidationGateNoFixtures, 1)
+			}
+			if gateErr != nil {
+				res.RejectedByValidation++
+				atomic.AddInt64(&s.broker.skillCompileMetrics.ValidationGateRejections, 1)
+				slog.Info("stage_b_synth_validation_gate_rejected",
+					"source", string(cand.Source),
+					"slug", gateSlug,
+					"reason", gateErr.Error(),
+				)
+				res.Errors = append(res.Errors, SynthError{
+					CandidateName: fm.Name,
+					Reason:        "validation_gate: " + gateErr.Error(),
+				})
+				continue
+			}
 		}
 
 		// --- Enhance / rename path ---

--- a/internal/team/skill_validation_gate.go
+++ b/internal/team/skill_validation_gate.go
@@ -1,0 +1,432 @@
+package team
+
+// skill_validation_gate.go implements the held-out validation gate for Stage B
+// skill synthesis (issue #1004). Before accepting any NEW or ENHANCE proposal,
+// the gate:
+//
+//  1. Loads representative task fixtures from the workspace wiki under
+//     team/skills/.fixtures/<slug>.md.
+//  2. Asks an LLM-as-judge to compare the candidate body against the baseline
+//     (empty for new skills, existing body for enhance) on each fixture.
+//  3. Accepts only when the candidate strictly improves: zero regressions and
+//     at least one win across all fixtures.
+//  4. Degrades gracefully when no fixture file exists for the slug — the common
+//     case before teams have authored their fixture sets.
+//
+// The gate is disabled entirely via WUPHF_SKILL_VALIDATION_GATE_DISABLED=true.
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/nex-crm/wuphf/internal/config"
+)
+
+// skillValidationGate is the interface SkillSynthesizer calls before accepting
+// any NEW or ENHANCE proposal. Defined where consumed per the "accept interfaces,
+// return structs" convention already used by stageBLLMProvider.
+//
+// Validate returns (hasFixtures bool, err error):
+//   - (false, nil): no fixture file found; gate skipped. Caller increments
+//     ValidationGateNoFixtures.
+//   - (true, nil): gate passed; candidate strictly improves on fixtures.
+//   - (true, err): gate rejected; err describes why.
+type skillValidationGate interface {
+	Validate(ctx context.Context, slug, candidateBody, baselineBody, wikiRoot string) (bool, error)
+}
+
+// fixtureVerdict is the LLM judge's per-fixture decision.
+type fixtureVerdict string
+
+const (
+	verdictBetter     fixtureVerdict = "better"
+	verdictEquivalent fixtureVerdict = "equivalent"
+	verdictWorse      fixtureVerdict = "worse"
+)
+
+// loadFixturesForSlug reads <wikiRoot>/team/skills/.fixtures/<slug>.md and
+// returns individual fixture strings split on "\n---\n". Returns nil, nil when
+// the file does not exist (graceful degradation — callers treat this as "skip
+// gate"). Returns a non-nil error for unexpected read failures other than ENOENT.
+//
+// The slug is checked for path separators as defense-in-depth; slugs are already
+// validated to ^[a-z0-9][a-z0-9-]*$ by the synth provider upstream.
+func loadFixturesForSlug(wikiRoot, slug string) ([]string, error) {
+	if wikiRoot == "" || slug == "" {
+		return nil, nil
+	}
+	if strings.ContainsRune(slug, filepath.Separator) {
+		return nil, nil
+	}
+	fixturePath := filepath.Join(wikiRoot, "team", "skills", ".fixtures", slug+".md")
+	raw, err := os.ReadFile(fixturePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("skill_validation_gate: read fixture for %q: %w", slug, err)
+	}
+	return splitFixtures(string(raw)), nil
+}
+
+// splitFixtures splits raw fixture content on "\n---\n", trims each section,
+// and discards empty sections. A file containing only whitespace returns nil.
+func splitFixtures(raw string) []string {
+	parts := strings.Split(raw, "\n---\n")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// validationCacheKey returns a deterministic SHA-256 cache key for a
+// (fixture, candidateBody, baselineBody) triple. NUL bytes separate the
+// fields so a body containing the separator string cannot forge a collision.
+func validationCacheKey(fixture, candidateBody, baselineBody string) string {
+	h := sha256.New()
+	h.Write([]byte(fixture))
+	h.Write([]byte{0})
+	h.Write([]byte(candidateBody))
+	h.Write([]byte{0})
+	h.Write([]byte(baselineBody))
+	return fmt.Sprintf("%x", h.Sum(nil))
+}
+
+// defaultSkillValidationGate is the production implementation of
+// skillValidationGate. It loads fixtures from the wiki, calls an LLM-as-judge
+// (Anthropic preferred, OpenAI fallback — same credential resolution as the
+// synth provider), and applies the strict-improvement rule before returning.
+type defaultSkillValidationGate struct {
+	httpClient *http.Client
+
+	cacheMu sync.Mutex
+	cache   map[string]fixtureVerdict // keyed by validationCacheKey(...)
+
+	missingKeyWarned sync.Once
+}
+
+// newDefaultSkillValidationGate constructs a gate with its own HTTP client.
+// The timeout mirrors the synth provider via stageBSynthTimeoutFromEnv.
+func newDefaultSkillValidationGate() *defaultSkillValidationGate {
+	return &defaultSkillValidationGate{
+		httpClient: &http.Client{Timeout: stageBSynthTimeoutFromEnv()},
+		cache:      make(map[string]fixtureVerdict),
+	}
+}
+
+// Validate implements skillValidationGate.
+//
+//  1. Load fixtures for slug from wikiRoot. Return (false, nil) when none exist.
+//  2. Judge each fixture (cache-first, then LLM). A judge failure degrades to
+//     verdictEquivalent so a single failing call does not block the gate.
+//  3. Count wins (better) and losses (worse). Ties are neutral.
+//  4. Reject if losses > 0 or wins == 0.
+func (g *defaultSkillValidationGate) Validate(
+	ctx context.Context,
+	slug, candidateBody, baselineBody, wikiRoot string,
+) (bool, error) {
+	fixtures, err := loadFixturesForSlug(wikiRoot, slug)
+	if err != nil {
+		// Unexpected read error: log and skip the gate rather than blocking synthesis.
+		slog.Warn("skill_validation_gate: fixture load error; gate skipped",
+			"slug", slug, "err", err)
+		return false, nil
+	}
+	if len(fixtures) == 0 {
+		slog.Debug("skill_validation_gate: no fixtures for slug; gate skipped",
+			"slug", slug)
+		return false, nil
+	}
+
+	wins := 0
+	losses := 0
+	for _, fixture := range fixtures {
+		switch g.judgeFixture(ctx, fixture, candidateBody, baselineBody) {
+		case verdictBetter:
+			wins++
+		case verdictWorse:
+			losses++
+		}
+	}
+
+	if losses > 0 {
+		return true, fmt.Errorf(
+			"skill_validation_gate: candidate regresses on %d/%d fixture(s) for %q (strict improvement requires zero regressions)",
+			losses, len(fixtures), slug,
+		)
+	}
+	if wins == 0 {
+		return true, fmt.Errorf(
+			"skill_validation_gate: candidate shows no improvement on any of %d fixture(s) for %q (at least one improvement required)",
+			len(fixtures), slug,
+		)
+	}
+	slog.Debug("skill_validation_gate: candidate passed",
+		"slug", slug, "wins", wins, "total_fixtures", len(fixtures))
+	return true, nil
+}
+
+// judgeFixture returns the verdict for one (fixture, candidate, baseline) triple.
+// The in-memory cache is checked first; on a miss the LLM is called and the
+// result stored. If the LLM call or response parsing fails, verdictEquivalent
+// is returned so a single failing judge does not block the entire gate.
+func (g *defaultSkillValidationGate) judgeFixture(
+	ctx context.Context,
+	fixture, candidateBody, baselineBody string,
+) fixtureVerdict {
+	key := validationCacheKey(fixture, candidateBody, baselineBody)
+
+	g.cacheMu.Lock()
+	if v, ok := g.cache[key]; ok {
+		g.cacheMu.Unlock()
+		return v
+	}
+	g.cacheMu.Unlock()
+
+	v := g.callJudge(ctx, fixture, candidateBody, baselineBody)
+
+	g.cacheMu.Lock()
+	g.cache[key] = v
+	g.cacheMu.Unlock()
+	return v
+}
+
+// callJudge calls the LLM-as-judge and returns the parsed verdict. It follows
+// the identical Anthropic → OpenAI fallback as callLLM in skill_synth_provider.go.
+// On any error, it returns verdictEquivalent (degraded grading, not a gate failure).
+func (g *defaultSkillValidationGate) callJudge(
+	ctx context.Context,
+	fixture, candidateBody, baselineBody string,
+) fixtureVerdict {
+	anthroKey := strings.TrimSpace(config.ResolveAnthropicAPIKey())
+	openaiKey := strings.TrimSpace(config.ResolveOpenAIAPIKey())
+	if anthroKey == "" && openaiKey == "" {
+		g.missingKeyWarned.Do(func() {
+			slog.Warn("skill_validation_gate: no API key configured; judge disabled, fixtures treated as equivalent")
+		})
+		return verdictEquivalent
+	}
+
+	systemPrompt := validationJudgeSystemPrompt()
+	userPrompt := validationJudgeUserPrompt(fixture, candidateBody, baselineBody)
+
+	var raw string
+	var callErr error
+	if anthroKey != "" {
+		raw, callErr = callAnthropicJudge(ctx, g.httpClient, anthroKey, systemPrompt, userPrompt)
+	} else {
+		raw, callErr = callOpenAIJudge(ctx, g.httpClient, openaiKey, systemPrompt, userPrompt)
+	}
+	if callErr != nil {
+		slog.Debug("skill_validation_gate: judge call failed; treating as equivalent",
+			"err", callErr)
+		return verdictEquivalent
+	}
+
+	verdict, parseErr := parseJudgeResponse(raw)
+	if parseErr != nil {
+		slog.Debug("skill_validation_gate: judge parse failed; treating as equivalent",
+			"err", parseErr,
+			"raw", truncateForPrompt(raw, 120),
+		)
+		return verdictEquivalent
+	}
+	return verdict
+}
+
+// skillValidationJudgeMaxTokens is the token budget for judge responses.
+// Small because the response is a single JSON object, not a full skill body.
+const skillValidationJudgeMaxTokens = 256
+
+// callAnthropicJudge posts to /v1/messages and returns the text content.
+// Mirrors callAnthropic in skill_synth_provider.go but uses a smaller token
+// budget appropriate for the compact JSON judge response.
+func callAnthropicJudge(ctx context.Context, client *http.Client, key, systemPrompt, userPrompt string) (string, error) {
+	const endpoint = "https://api.anthropic.com/v1/messages"
+	model := resolveStageBSynthModel(stageBDefaultAnthropicModel)
+
+	payload := map[string]any{
+		"model":      model,
+		"max_tokens": skillValidationJudgeMaxTokens,
+		"system":     systemPrompt,
+		"messages": []map[string]string{
+			{"role": "user", "content": userPrompt},
+		},
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return "", fmt.Errorf("anthropic_judge: marshal payload: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return "", fmt.Errorf("anthropic_judge: build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("x-api-key", key)
+	req.Header.Set("anthropic-version", "2023-06-01")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("anthropic_judge: do: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return "", fmt.Errorf("anthropic_judge: read body: %w", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return "", fmt.Errorf("anthropic_judge: status %d: %s",
+			resp.StatusCode, truncateForPrompt(string(respBody), 240))
+	}
+
+	var parsed struct {
+		Content []struct {
+			Type string `json:"type"`
+			Text string `json:"text"`
+		} `json:"content"`
+	}
+	if err := json.Unmarshal(respBody, &parsed); err != nil {
+		return "", fmt.Errorf("anthropic_judge: decode response: %w", err)
+	}
+	var out strings.Builder
+	for _, c := range parsed.Content {
+		if c.Type == "text" {
+			out.WriteString(c.Text)
+		}
+	}
+	return out.String(), nil
+}
+
+// callOpenAIJudge posts to /v1/chat/completions and returns the assistant content.
+// Mirrors callOpenAI in skill_synth_provider.go but uses a smaller token budget
+// appropriate for the compact JSON judge response.
+func callOpenAIJudge(ctx context.Context, client *http.Client, key, systemPrompt, userPrompt string) (string, error) {
+	const endpoint = "https://api.openai.com/v1/chat/completions"
+	model := resolveStageBSynthModel(stageBDefaultOpenAIModel)
+
+	payload := map[string]any{
+		"model":      model,
+		"max_tokens": skillValidationJudgeMaxTokens,
+		"messages": []map[string]string{
+			{"role": "system", "content": systemPrompt},
+			{"role": "user", "content": userPrompt},
+		},
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return "", fmt.Errorf("openai_judge: marshal payload: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return "", fmt.Errorf("openai_judge: build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+key)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("openai_judge: do: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return "", fmt.Errorf("openai_judge: read body: %w", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return "", fmt.Errorf("openai_judge: status %d: %s",
+			resp.StatusCode, truncateForPrompt(string(respBody), 240))
+	}
+
+	var parsed struct {
+		Choices []struct {
+			Message struct {
+				Content string `json:"content"`
+			} `json:"message"`
+		} `json:"choices"`
+	}
+	if err := json.Unmarshal(respBody, &parsed); err != nil {
+		return "", fmt.Errorf("openai_judge: decode response: %w", err)
+	}
+	if len(parsed.Choices) == 0 {
+		return "", fmt.Errorf("openai_judge: empty choices")
+	}
+	return parsed.Choices[0].Message.Content, nil
+}
+
+// validationJudgeSystemPrompt returns the system prompt for the LLM judge.
+func validationJudgeSystemPrompt() string {
+	return `You are an impartial evaluator comparing two AI agent skill documents.
+Your job: decide whether a CANDIDATE SKILL helps an agent complete a TASK better than a BASELINE SKILL.
+
+Rules:
+- "better": the candidate clearly provides more actionable, precise, or correct guidance for this task.
+- "equivalent": both are equally useful (or equally unhelpful) for this task.
+- "worse": the baseline is more useful than the candidate for this task.
+- If the baseline is empty, compare the candidate against having no skill at all.
+
+Respond ONLY with valid JSON: {"verdict":"better"|"equivalent"|"worse","reasoning":"<one sentence>"}.
+Do not include any other text.`
+}
+
+// validationJudgeUserPrompt assembles the user turn for the LLM judge.
+func validationJudgeUserPrompt(taskDescription, candidateBody, baselineBody string) string {
+	var b strings.Builder
+	b.WriteString("TASK:\n")
+	b.WriteString(strings.TrimSpace(taskDescription))
+	b.WriteString("\n\nBASELINE SKILL:\n")
+	if strings.TrimSpace(baselineBody) == "" {
+		b.WriteString("(none — this is a new skill with no existing baseline)\n")
+	} else {
+		b.WriteString(strings.TrimSpace(baselineBody))
+		b.WriteString("\n")
+	}
+	b.WriteString("\nCANDIDATE SKILL:\n")
+	b.WriteString(strings.TrimSpace(candidateBody))
+	b.WriteString("\n\nRespond with JSON only.")
+	return b.String()
+}
+
+// parseJudgeResponse extracts the verdict from the judge's JSON response.
+// Tolerates ```json fences and leading prose via the package-level
+// stripJSONNoise helper already used by parseStageBSynthResponse.
+func parseJudgeResponse(raw string) (fixtureVerdict, error) {
+	cleaned := stripJSONNoise(raw)
+	if cleaned == "" {
+		return verdictEquivalent, fmt.Errorf("skill_validation_gate: empty judge response")
+	}
+	var parsed struct {
+		Verdict   string `json:"verdict"`
+		Reasoning string `json:"reasoning"`
+	}
+	if err := json.Unmarshal([]byte(cleaned), &parsed); err != nil {
+		return verdictEquivalent, fmt.Errorf("skill_validation_gate: decode judge json: %w", err)
+	}
+	switch fixtureVerdict(strings.TrimSpace(parsed.Verdict)) {
+	case verdictBetter:
+		return verdictBetter, nil
+	case verdictWorse:
+		return verdictWorse, nil
+	case verdictEquivalent:
+		return verdictEquivalent, nil
+	default:
+		return verdictEquivalent, fmt.Errorf("skill_validation_gate: unknown verdict %q", parsed.Verdict)
+	}
+}

--- a/internal/team/skill_validation_gate_e2e_test.go
+++ b/internal/team/skill_validation_gate_e2e_test.go
@@ -1,0 +1,1089 @@
+package team
+
+// skill_validation_gate_e2e_test.go exercises the defaultSkillValidationGate
+// end-to-end with:
+//
+//  1. The real fixture files under /Users/belovetech/.wuphf/wiki (or skipped
+//     when that path does not exist, so CI is not broken by a missing wiki).
+//  2. A fake Anthropic HTTP server wired through rewriteTransport — no live
+//     API key required; all judge calls are intercepted locally.
+//  3. Synthesizer-level integration via a wikiRootOverrideGate wrapper that
+//     threads a known wikiRoot into the gate when resolveWikiRoot() returns ""
+//     (the no-wiki-worker case that applies to all newTestBroker tests).
+//
+// Bugs this suite is designed to catch:
+//   - Fixture format mismatch: real files use \n\n---\n\n; splitFixtures must
+//     still split correctly (covered by TestE2E_RealFixtures_SplitCorrectly).
+//   - wikiRoot="" silent skip: when wikiRoot is empty the gate returns (false,nil)
+//     and increments ValidationGateNoFixtures rather than blocking the proposal.
+//   - Enhance-path baseline: the gate reads the existing skill body before making
+//     the LLM call; the enhance path must pass the right baselineBody.
+//   - Context cancellation: a cancelled context degrades all fixtures to
+//     equivalent, which then triggers the "no improvement" rejection.
+//   - Cache hit: two identical judge calls must only hit the HTTP server once.
+//   - Judge response parsing: fenced JSON, extra whitespace, unknown verdict.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// realWikiFixturesDir returns the path to the live fixture directory.
+// Returns "" when the directory does not exist (CI / fresh clone).
+func realWikiFixturesDir() string {
+	const wikiRoot = "/Users/belovetech/.wuphf/wiki"
+	dir := filepath.Join(wikiRoot, "team", "skills", ".fixtures")
+	if _, err := os.Stat(dir); err != nil {
+		return ""
+	}
+	return wikiRoot
+}
+
+// readCurrentSkillBody reads a skill file from the wiki and returns only the
+// body — everything after the closing YAML frontmatter delimiter (---).
+// Returns "" when the file is missing or has no frontmatter.
+func readCurrentSkillBody(t *testing.T, wikiRoot, slug string) string {
+	t.Helper()
+	path := filepath.Join(wikiRoot, "team", "skills", slug+".md")
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Logf("readCurrentSkillBody: %v", err)
+		return ""
+	}
+	content := string(raw)
+	// Strip YAML frontmatter: find the second "---" delimiter.
+	const delim = "---"
+	first := strings.Index(content, delim)
+	if first == -1 {
+		return content
+	}
+	second := strings.Index(content[first+len(delim):], "\n"+delim)
+	if second == -1 {
+		return content
+	}
+	body := content[first+len(delim)+second+1+len(delim):]
+	return strings.TrimSpace(body)
+}
+
+// fakeAnthropicServer builds an httptest.Server that returns a single
+// repeating verdict for every /v1/messages call.
+func fakeAnthropicServer(t *testing.T, verdict fixtureVerdict) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		payload := map[string]any{
+			"content": []map[string]any{
+				{
+					"type": "text",
+					"text": fmt.Sprintf(`{"verdict":%q,"reasoning":"e2e stub"}`, verdict),
+				},
+			},
+		}
+		b, _ := json.Marshal(payload)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(b)
+	}))
+}
+
+// fakeAnthropicServerSequence serves verdicts from a slice in order.
+// Once exhausted, every subsequent call returns the last verdict.
+func fakeAnthropicServerSequence(t *testing.T, verdicts []fixtureVerdict) (srv *httptest.Server, callCount *atomic.Int64) {
+	t.Helper()
+	var n atomic.Int64
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		idx := int(n.Add(1) - 1)
+		v := verdicts[len(verdicts)-1]
+		if idx < len(verdicts) {
+			v = verdicts[idx]
+		}
+		payload := map[string]any{
+			"content": []map[string]any{
+				{"type": "text", "text": fmt.Sprintf(`{"verdict":%q,"reasoning":"seq stub"}`, v)},
+			},
+		}
+		b, _ := json.Marshal(payload)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(b)
+	}))
+	return srv, &n
+}
+
+// gateWithFakeServer returns a defaultSkillValidationGate whose HTTP client
+// routes all calls through the given fake server.
+func gateWithFakeServer(t *testing.T, srv *httptest.Server) *defaultSkillValidationGate {
+	t.Helper()
+	t.Setenv("ANTHROPIC_API_KEY", "test-e2e-key")
+	g := newDefaultSkillValidationGate()
+	g.httpClient = &http.Client{Transport: rewriteTransport{target: srv.URL}}
+	return g
+}
+
+// ---------------------------------------------------------------------------
+// Bug 1 — Fixture format: real files use \n\n---\n\n — must parse to 5 sections
+// ---------------------------------------------------------------------------
+
+func TestE2E_RealFixtures_SplitCorrectly(t *testing.T) {
+	wikiRoot := realWikiFixturesDir()
+	if wikiRoot == "" {
+		t.Skip("real wiki fixture directory not present; skipping")
+	}
+	slugs := []string{
+		"explore-data-layer",
+		"explore-frontend-layer",
+		"map-service-architecture",
+		"orchestrate-codebase-exploration",
+		"trace-call-graph",
+		"review-codebase-exploration-findings",
+	}
+	for _, slug := range slugs {
+		t.Run(slug, func(t *testing.T) {
+			fixtures, err := loadFixturesForSlug(wikiRoot, slug)
+			if err != nil {
+				t.Fatalf("loadFixturesForSlug: %v", err)
+			}
+			if len(fixtures) != 5 {
+				t.Fatalf("expected 5 fixtures, got %d", len(fixtures))
+			}
+			for i, f := range fixtures {
+				if strings.TrimSpace(f) == "" {
+					t.Fatalf("fixture %d is empty after trimming", i)
+				}
+				// Each fixture should be a non-trivial task description.
+				if len(f) < 30 {
+					t.Fatalf("fixture %d too short (%d chars): %q", i, len(f), f)
+				}
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Bug 2 — Gate reads real fixtures + fake judge: acceptance path
+// ---------------------------------------------------------------------------
+
+func TestE2E_Gate_AcceptsWhenBetterOnRealFixtures(t *testing.T) {
+	wikiRoot := realWikiFixturesDir()
+	if wikiRoot == "" {
+		t.Skip("real wiki fixture directory not present; skipping")
+	}
+	srv := fakeAnthropicServer(t, verdictBetter)
+	defer srv.Close()
+	gate := gateWithFakeServer(t, srv)
+
+	// A rich candidate body for explore-data-layer.
+	candidate := "## Steps\n" +
+		"1. Search for *.sql, sqlc.yaml, *.atlas.hcl.\n" +
+		"2. Read the base DDL and identify tables, FKs, JSONB columns.\n" +
+		"3. Read SQLC query files for CRUD vs append-only patterns.\n" +
+		"4. Scan migration history for schema evolution clues.\n" +
+		"5. Map Kafka event types to tables or projections they write to.\n" +
+		"6. Write notebook entry: storage engine, schema overview, query patterns, event schema, surprises, open questions.\n" +
+		"7. Broadcast team summary under 10 lines.\n" +
+		"8. Complete or submit the task.\n"
+
+	hasFixtures, err := gate.Validate(context.Background(), "explore-data-layer", candidate, "", wikiRoot)
+	if !hasFixtures {
+		t.Fatal("expected hasFixtures=true (real fixture file exists)")
+	}
+	if err != nil {
+		t.Fatalf("expected acceptance, got rejection: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Bug 3 — Gate reads real fixtures + fake judge: regression rejection path
+// ---------------------------------------------------------------------------
+
+func TestE2E_Gate_RejectsOnRegressionWithRealFixtures(t *testing.T) {
+	wikiRoot := realWikiFixturesDir()
+	if wikiRoot == "" {
+		t.Skip("real wiki fixture directory not present; skipping")
+	}
+	srv := fakeAnthropicServer(t, verdictWorse)
+	defer srv.Close()
+	gate := gateWithFakeServer(t, srv)
+
+	hasFixtures, err := gate.Validate(context.Background(), "trace-call-graph", "step 1. do the thing.", "", wikiRoot)
+	if !hasFixtures {
+		t.Fatal("expected hasFixtures=true")
+	}
+	if err == nil {
+		t.Fatal("expected rejection for all-worse verdict, got nil")
+	}
+	if !containsStr(err.Error(), "regresses") {
+		t.Fatalf("expected 'regresses' in error, got: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Bug 4 — All-equivalent rejection with real fixtures
+// ---------------------------------------------------------------------------
+
+func TestE2E_Gate_RejectsAllEquivalentWithRealFixtures(t *testing.T) {
+	wikiRoot := realWikiFixturesDir()
+	if wikiRoot == "" {
+		t.Skip("real wiki fixture directory not present; skipping")
+	}
+	srv := fakeAnthropicServer(t, verdictEquivalent)
+	defer srv.Close()
+	gate := gateWithFakeServer(t, srv)
+
+	hasFixtures, err := gate.Validate(context.Background(), "map-service-architecture", "do the thing", "", wikiRoot)
+	if !hasFixtures {
+		t.Fatal("expected hasFixtures=true")
+	}
+	if err == nil {
+		t.Fatal("expected 'no improvement' rejection, got nil")
+	}
+	if !containsStr(err.Error(), "no improvement") {
+		t.Fatalf("expected 'no improvement' in error, got: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Bug 5 — Exactly one win wins the gate (even with many equivalents)
+// ---------------------------------------------------------------------------
+
+func TestE2E_Gate_OneWinAmongEquivalentsAccepts(t *testing.T) {
+	wikiRoot := realWikiFixturesDir()
+	if wikiRoot == "" {
+		t.Skip("real wiki fixture directory not present; skipping")
+	}
+	// Return "better" only for fixture 1; the remaining 4 return "equivalent".
+	verdicts := []fixtureVerdict{verdictBetter, verdictEquivalent, verdictEquivalent, verdictEquivalent, verdictEquivalent}
+	srv, callCount := fakeAnthropicServerSequence(t, verdicts)
+	defer srv.Close()
+	gate := gateWithFakeServer(t, srv)
+
+	candidate := "## Steps\n" +
+		"1. Scope check — confirm the repo path.\n" +
+		"2. Spin up OFFICE-36 reviewer gate.\n" +
+		"3. Create 5 parallel exploration Issues.\n" +
+		"4. Tag specialists in kickoff broadcast.\n" +
+		"5. Wait for notifications — do NOT poll.\n"
+
+	hasFixtures, err := gate.Validate(context.Background(), "orchestrate-codebase-exploration", candidate, "", wikiRoot)
+	if !hasFixtures {
+		t.Fatal("expected hasFixtures=true")
+	}
+	if err != nil {
+		t.Fatalf("expected acceptance with 1 win / 0 losses, got: %v", err)
+	}
+	// All 5 fixtures should have been judged.
+	if callCount.Load() != 5 {
+		t.Fatalf("expected 5 HTTP calls (one per fixture), got %d", callCount.Load())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Bug 6 — Cache: identical call pair must hit the server only once
+// ---------------------------------------------------------------------------
+
+func TestE2E_Gate_CacheDeduplicatesIdenticalCalls(t *testing.T) {
+	wikiRoot := realWikiFixturesDir()
+	if wikiRoot == "" {
+		t.Skip("real wiki fixture directory not present; skipping")
+	}
+	srv, callCount := fakeAnthropicServerSequence(t,
+		// Five fixtures, all "better".
+		[]fixtureVerdict{verdictBetter, verdictBetter, verdictBetter, verdictBetter, verdictBetter},
+	)
+	defer srv.Close()
+	gate := gateWithFakeServer(t, srv)
+
+	cand := "same-candidate-body"
+	base := ""
+
+	// First call: 5 LLM round-trips.
+	_, _ = gate.Validate(context.Background(), "explore-data-layer", cand, base, wikiRoot)
+	firstCount := callCount.Load()
+
+	// Second call with identical inputs: all 5 results should be cache hits.
+	_, _ = gate.Validate(context.Background(), "explore-data-layer", cand, base, wikiRoot)
+	secondCount := callCount.Load()
+
+	if secondCount != firstCount {
+		t.Fatalf("second call made %d extra HTTP calls (want 0 — all cache hits)",
+			secondCount-firstCount)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Bug 7 — wikiRoot="" graceful skip (no wiki worker in test broker)
+// ---------------------------------------------------------------------------
+
+func TestE2E_Gate_EmptyWikiRootSkipsGracefully(t *testing.T) {
+	srv := fakeAnthropicServer(t, verdictBetter) // would be called if wiki existed
+	defer srv.Close()
+	gate := gateWithFakeServer(t, srv)
+
+	// Pass wikiRoot="" — simulates resolveWikiRoot() returning "" when
+	// broker.wikiWorker is nil (the standard newTestBroker condition).
+	hasFixtures, err := gate.Validate(context.Background(), "explore-data-layer", "anything", "", "")
+	if err != nil {
+		t.Fatalf("expected nil error for empty wikiRoot, got: %v", err)
+	}
+	if hasFixtures {
+		t.Fatal("expected hasFixtures=false for empty wikiRoot")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Bug 8 — Context cancellation degrades all fixtures to equivalent → rejection
+// ---------------------------------------------------------------------------
+
+func TestE2E_Gate_CancelledContextRejectsWithNoImprovement(t *testing.T) {
+	wikiRoot := realWikiFixturesDir()
+	if wikiRoot == "" {
+		t.Skip("real wiki fixture directory not present; skipping")
+	}
+
+	// Slow server: 200ms per call. Context is cancelled after 50ms.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Read the body to avoid broken-pipe on the client side.
+		_, _ = io.ReadAll(r.Body)
+		time.Sleep(200 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"content":[{"type":"text","text":"{\"verdict\":\"better\",\"reasoning\":\"ok\"}"}]}`))
+	}))
+	defer srv.Close()
+
+	gate := gateWithFakeServer(t, srv)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	hasFixtures, err := gate.Validate(ctx, "explore-data-layer", "candidate body", "", wikiRoot)
+	if !hasFixtures {
+		t.Fatal("expected hasFixtures=true (fixture file exists)")
+	}
+	// All judge calls fail due to context deadline → all equivalent → no improvement.
+	if err == nil {
+		t.Fatal("expected 'no improvement' rejection when context cancelled, got nil")
+	}
+	if !containsStr(err.Error(), "no improvement") {
+		t.Fatalf("expected 'no improvement' in error, got: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Bug 9 — HTTP 500 from judge degrades, does not panic
+// ---------------------------------------------------------------------------
+
+func TestE2E_Gate_HTTP500DegradesCleanly(t *testing.T) {
+	wikiRoot := realWikiFixturesDir()
+	if wikiRoot == "" {
+		t.Skip("real wiki fixture directory not present; skipping")
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":"overloaded"}`))
+	}))
+	defer srv.Close()
+	gate := gateWithFakeServer(t, srv)
+
+	hasFixtures, err := gate.Validate(context.Background(), "trace-call-graph", "candidate", "", wikiRoot)
+	if !hasFixtures {
+		t.Fatal("expected hasFixtures=true")
+	}
+	// All 5 calls fail → all equivalent → 0 wins, 0 losses → "no improvement".
+	if err == nil {
+		t.Fatal("expected rejection when all judges return HTTP 500, got nil")
+	}
+	if !containsStr(err.Error(), "no improvement") {
+		t.Fatalf("expected 'no improvement', got: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Bug 10 — Malformed JSON response from judge degrades cleanly
+// ---------------------------------------------------------------------------
+
+func TestE2E_Gate_MalformedJSONDegrades(t *testing.T) {
+	wikiRoot := realWikiFixturesDir()
+	if wikiRoot == "" {
+		t.Skip("real wiki fixture directory not present; skipping")
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		payload := map[string]any{
+			"content": []map[string]any{
+				{"type": "text", "text": "Sure! I think the candidate is better. (not valid JSON)"},
+			},
+		}
+		b, _ := json.Marshal(payload)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(b)
+	}))
+	defer srv.Close()
+	gate := gateWithFakeServer(t, srv)
+
+	hasFixtures, err := gate.Validate(context.Background(), "explore-data-layer", "candidate", "", wikiRoot)
+	if !hasFixtures {
+		t.Fatal("expected hasFixtures=true")
+	}
+	// Unparseable verdict → equivalent for each fixture → no improvement.
+	if err == nil {
+		t.Fatal("expected rejection when all verdicts are unparseable, got nil")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Bug 11 — Synthesizer: real gate + no wiki worker → ValidationGateNoFixtures
+// ---------------------------------------------------------------------------
+
+func TestE2E_Synthesizer_RealGate_NoWikiWorker_AlwaysSkips(t *testing.T) {
+	// When resolveWikiRoot() returns "" (no wiki worker, which is always the
+	// case for newTestBroker), the real gate must skip and increment the
+	// ValidationGateNoFixtures metric — it must NOT block the proposal.
+	t.Setenv("ANTHROPIC_API_KEY", "test-e2e-key")
+
+	b := newTestBroker(t)
+	prov := &stubLLMProvider{
+		queue: []stubLLMResponse{{
+			fm:   SkillFrontmatter{Name: "data-layer-audit", Description: "Audit the data layer."},
+			body: goodSynthBody(),
+		}},
+	}
+	cands := []SkillCandidate{newCandidateForGateTests("data-layer-audit")}
+	synth := newSynthWithCandidates(t, b, prov, cands)
+
+	// Inject the real gate (not a stub). It will call loadFixturesForSlug with
+	// wikiRoot="" because resolveWikiRoot() returns "" for a broker with no
+	// wiki worker.
+	synth.gate = newDefaultSkillValidationGate()
+
+	res, err := synth.SynthesizeOnce(context.Background(), "manual")
+	if err != nil {
+		t.Fatalf("SynthesizeOnce: %v", err)
+	}
+	if res.Synthesized != 1 {
+		t.Fatalf("Synthesized: got %d want 1 (gate must not block when wikiRoot empty; errors: %+v)",
+			res.Synthesized, res.Errors)
+	}
+	if res.RejectedByValidation != 0 {
+		t.Fatalf("RejectedByValidation: got %d want 0", res.RejectedByValidation)
+	}
+	// The metric IS incremented even when the skip reason is "no wikiRoot".
+	// This is the expected (if slightly imprecise) telemetry behaviour.
+	if atomic.LoadInt64(&b.skillCompileMetrics.ValidationGateNoFixtures) != 1 {
+		t.Fatalf("ValidationGateNoFixtures: got %d want 1",
+			atomic.LoadInt64(&b.skillCompileMetrics.ValidationGateNoFixtures))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Bug 12 — wikiRootOverrideGate: synthesizer integration with real fixtures
+// ---------------------------------------------------------------------------
+
+// wikiRootOverrideGate wraps the real gate but substitutes a known wikiRoot
+// so tests can exercise the full fixture-loading + judging path without
+// needing a live wiki worker wired into the broker.
+type wikiRootOverrideGate struct {
+	real     *defaultSkillValidationGate
+	wikiRoot string
+}
+
+func (g *wikiRootOverrideGate) Validate(ctx context.Context, slug, candidate, baseline, _ string) (bool, error) {
+	return g.real.Validate(ctx, slug, candidate, baseline, g.wikiRoot)
+}
+
+func TestE2E_Synthesizer_RealFixtures_GateAccepts(t *testing.T) {
+	wikiRoot := realWikiFixturesDir()
+	if wikiRoot == "" {
+		t.Skip("real wiki fixture directory not present; skipping")
+	}
+
+	srv := fakeAnthropicServer(t, verdictBetter)
+	defer srv.Close()
+
+	b := newTestBroker(t)
+	prov := &stubLLMProvider{
+		queue: []stubLLMResponse{{
+			fm:   SkillFrontmatter{Name: "explore-data-layer", Description: "Explore the data layer."},
+			body: goodSynthBody(),
+		}},
+	}
+	cands := []SkillCandidate{newCandidateForGateTests("explore-data-layer")}
+	synth := newSynthWithCandidates(t, b, prov, cands)
+
+	realGate := gateWithFakeServer(t, srv)
+	synth.gate = &wikiRootOverrideGate{real: realGate, wikiRoot: wikiRoot}
+
+	res, err := synth.SynthesizeOnce(context.Background(), "manual")
+	if err != nil {
+		t.Fatalf("SynthesizeOnce: %v", err)
+	}
+	if res.Synthesized != 1 {
+		t.Fatalf("Synthesized: got %d want 1; errors: %+v", res.Synthesized, res.Errors)
+	}
+	if res.RejectedByValidation != 0 {
+		t.Fatalf("RejectedByValidation: got %d want 0", res.RejectedByValidation)
+	}
+}
+
+func TestE2E_Synthesizer_RealFixtures_GateRejects(t *testing.T) {
+	wikiRoot := realWikiFixturesDir()
+	if wikiRoot == "" {
+		t.Skip("real wiki fixture directory not present; skipping")
+	}
+
+	srv := fakeAnthropicServer(t, verdictWorse)
+	defer srv.Close()
+
+	b := newTestBroker(t)
+	prov := &stubLLMProvider{
+		queue: []stubLLMResponse{{
+			fm:   SkillFrontmatter{Name: "explore-data-layer", Description: "Explore the data layer."},
+			body: goodSynthBody(),
+		}},
+	}
+	cands := []SkillCandidate{newCandidateForGateTests("explore-data-layer")}
+	synth := newSynthWithCandidates(t, b, prov, cands)
+
+	realGate := gateWithFakeServer(t, srv)
+	synth.gate = &wikiRootOverrideGate{real: realGate, wikiRoot: wikiRoot}
+
+	res, err := synth.SynthesizeOnce(context.Background(), "manual")
+	if err != nil {
+		t.Fatalf("SynthesizeOnce: %v", err)
+	}
+	if res.Synthesized != 0 {
+		t.Fatalf("Synthesized: got %d want 0 (gate must reject)", res.Synthesized)
+	}
+	if res.RejectedByValidation != 1 {
+		t.Fatalf("RejectedByValidation: got %d want 1", res.RejectedByValidation)
+	}
+	if atomic.LoadInt64(&b.skillCompileMetrics.ValidationGateRejections) != 1 {
+		t.Fatalf("ValidationGateRejections metric: got %d want 1",
+			atomic.LoadInt64(&b.skillCompileMetrics.ValidationGateRejections))
+	}
+	// Rejection error should be captured in the errors slice.
+	if len(res.Errors) == 0 {
+		t.Fatal("expected at least one SynthError for rejected proposal, got none")
+	}
+	if !containsStr(res.Errors[0].Reason, "validation_gate") {
+		t.Fatalf("error reason should contain 'validation_gate', got: %q", res.Errors[0].Reason)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Bug 13 — Enhance path: gate uses enhance slug and existing body as baseline
+// ---------------------------------------------------------------------------
+
+func TestE2E_Synthesizer_EnhancePath_BaselineBodyPassedToGate(t *testing.T) {
+	wikiRoot := realWikiFixturesDir()
+	if wikiRoot == "" {
+		t.Skip("real wiki fixture directory not present; skipping")
+	}
+
+	// Capture what the gate receives.
+	// Use a gate that records inputs but always accepts.
+	capture := &capturingGate{wikiRoot: wikiRoot}
+
+	b := newTestBroker(t)
+	const existingContent = "## Steps\n1. Find schema files.\n2. Read the DDL.\n3. Write a notebook entry.\n"
+	b.mu.Lock()
+	b.skills = append(b.skills, teamSkill{
+		Name:      "explore-data-layer",
+		Title:     "Explore Data Layer",
+		Content:   existingContent,
+		Status:    "active",
+		CreatedBy: "scanner",
+	})
+	b.mu.Unlock()
+
+	prov := &stubLLMProvider{
+		queue: []stubLLMResponse{{
+			fm:      SkillFrontmatter{Name: "explore-data-layer", Description: "Enhanced."},
+			body:    goodSynthBody(),
+			enhance: "explore-data-layer",
+		}},
+	}
+	cands := []SkillCandidate{newCandidateForGateTests("new-data-signal")}
+	synth := newSynthWithCandidates(t, b, prov, cands)
+	synth.gate = capture
+
+	_, err := synth.SynthesizeOnce(context.Background(), "manual")
+	if err != nil {
+		t.Fatalf("SynthesizeOnce: %v", err)
+	}
+
+	if capture.lastSlug != "explore-data-layer" {
+		t.Fatalf("gate called with slug %q, want %q", capture.lastSlug, "explore-data-layer")
+	}
+	if capture.lastBaseline != existingContent {
+		t.Fatalf("gate called with baseline %q, want %q", capture.lastBaseline, existingContent)
+	}
+}
+
+// capturingGate records the last Validate call's slug and baseline for
+// assertion. It always accepts — the test only cares what was passed in.
+type capturingGate struct {
+	wikiRoot     string
+	lastSlug     string
+	lastBaseline string
+}
+
+func (g *capturingGate) Validate(_ context.Context, slug, _, baseline, _ string) (bool, error) {
+	g.lastSlug = slug
+	g.lastBaseline = baseline
+	return true, nil
+}
+
+// ---------------------------------------------------------------------------
+// Bug 14 — No-API-key path: gate warns once and treats all as equivalent
+// ---------------------------------------------------------------------------
+
+func TestE2E_Gate_NoAPIKey_TreatsAllAsEquivalent(t *testing.T) {
+	wikiRoot := realWikiFixturesDir()
+	if wikiRoot == "" {
+		t.Skip("real wiki fixture directory not present; skipping")
+	}
+	// Unset any API key so the gate cannot call the LLM.
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	t.Setenv("WUPHF_ANTHROPIC_API_KEY", "")
+	t.Setenv("OPENAI_API_KEY", "")
+	t.Setenv("WUPHF_OPENAI_API_KEY", "")
+
+	gate := newDefaultSkillValidationGate()
+
+	// When no API key is configured, all fixtures return verdictEquivalent.
+	// 0 wins, 0 losses → "no improvement" rejection.
+	hasFixtures, err := gate.Validate(context.Background(), "explore-data-layer", "candidate body", "", wikiRoot)
+	if !hasFixtures {
+		t.Fatal("expected hasFixtures=true (fixture file exists)")
+	}
+	if err == nil {
+		t.Fatal("expected rejection (all-equivalent → no improvement) when no API key, got nil")
+	}
+	if !containsStr(err.Error(), "no improvement") {
+		t.Fatalf("expected 'no improvement', got: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Bug 15 — Unknown skill slug: gate skips gracefully (no fixture file)
+// ---------------------------------------------------------------------------
+
+func TestE2E_Gate_UnknownSlug_SkipsGracefully(t *testing.T) {
+	wikiRoot := realWikiFixturesDir()
+	if wikiRoot == "" {
+		t.Skip("real wiki fixture directory not present; skipping")
+	}
+	t.Setenv("ANTHROPIC_API_KEY", "test-key")
+	gate := newDefaultSkillValidationGate()
+
+	hasFixtures, err := gate.Validate(context.Background(), "slug-with-no-fixture-file", "candidate", "", wikiRoot)
+	if err != nil {
+		t.Fatalf("expected nil error for unknown slug, got: %v", err)
+	}
+	if hasFixtures {
+		t.Fatal("expected hasFixtures=false for slug with no fixture file")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Bug 16 — Request body is valid Anthropic payload shape
+// ---------------------------------------------------------------------------
+
+func TestE2E_Gate_AnthropicRequestShape(t *testing.T) {
+	wikiRoot := realWikiFixturesDir()
+	if wikiRoot == "" {
+		t.Skip("real wiki fixture directory not present; skipping")
+	}
+
+	type anthropicMsg struct {
+		Role    string `json:"role"`
+		Content string `json:"content"`
+	}
+	type anthropicPayload struct {
+		Model     string         `json:"model"`
+		MaxTokens int            `json:"max_tokens"`
+		System    string         `json:"system"`
+		Messages  []anthropicMsg `json:"messages"`
+	}
+
+	var capturedPayload anthropicPayload
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rawBody, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(rawBody, &capturedPayload)
+
+		payload := map[string]any{
+			"content": []map[string]any{
+				{"type": "text", "text": `{"verdict":"better","reasoning":"ok"}`},
+			},
+		}
+		b, _ := json.Marshal(payload)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(b)
+	}))
+	defer srv.Close()
+	gate := gateWithFakeServer(t, srv)
+
+	// Run with one fixture (only one call will be captured).
+	dir := t.TempDir()
+	writeFixtureFile(t, dir, "test-skill", []string{"Deploy to production safely."})
+	_, _ = gate.Validate(context.Background(), "test-skill", "candidate body", "baseline body", dir)
+
+	// Verify required Anthropic fields.
+	if capturedPayload.Model == "" {
+		t.Fatal("model field missing from Anthropic request")
+	}
+	if capturedPayload.MaxTokens != skillValidationJudgeMaxTokens {
+		t.Fatalf("max_tokens: got %d want %d", capturedPayload.MaxTokens, skillValidationJudgeMaxTokens)
+	}
+	if capturedPayload.System == "" {
+		t.Fatal("system field missing from Anthropic request")
+	}
+	if len(capturedPayload.Messages) != 1 || capturedPayload.Messages[0].Role != "user" {
+		t.Fatalf("unexpected messages shape: %+v", capturedPayload.Messages)
+	}
+	// User prompt must mention the task fixture and both skill bodies.
+	userContent := capturedPayload.Messages[0].Content
+	if !containsStr(userContent, "TASK:") {
+		t.Fatalf("user prompt missing 'TASK:' section; got:\n%s", userContent)
+	}
+	if !containsStr(userContent, "BASELINE SKILL:") {
+		t.Fatalf("user prompt missing 'BASELINE SKILL:' section")
+	}
+	if !containsStr(userContent, "CANDIDATE SKILL:") {
+		t.Fatalf("user prompt missing 'CANDIDATE SKILL:' section")
+	}
+	// The fixture content should appear verbatim.
+	if !containsStr(userContent, "Deploy to production safely.") {
+		t.Fatalf("user prompt missing fixture content")
+	}
+	// Baseline body should appear verbatim.
+	if !containsStr(userContent, "baseline body") {
+		t.Fatalf("user prompt missing baseline body content")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Real current + candidate skill body pairs
+//
+// These tests close the gap identified in the review: all previous E2E tests
+// used baselineBody="" (new-skill path). The tests below pair the actual
+// current wiki skill body as baseline against a realistic candidate — the
+// scenario that fires on every ENHANCE proposal in production.
+// ---------------------------------------------------------------------------
+
+// betterExploreDataLayerCandidate is an enhanced version of explore-data-layer
+// that adds two specific improvements over the current body:
+//  1. Step 1 now also checks for missing index coverage on frequently queried columns.
+//  2. Step 7 notebook requires a "Query cost estimate" section (10× load projection).
+//  3. Step 3 flags raw pgx usage outside SQLC as a maintenance risk, not just a signal.
+const betterExploreDataLayerCandidate = `## Steps
+
+1. **Locate the schema files.**
+   - Search for ` + "`" + `*.sql` + "`" + `, ` + "`" + `schema.go` + "`" + `, ` + "`" + `*.atlas.hcl` + "`" + `, or migration directories (e.g. ` + "`" + `db/migrations/` + "`" + `, ` + "`" + `internal/db/` + "`" + `).
+   - Also check for SQLC config (` + "`" + `sqlc.yaml` + "`" + `) to find generated query directories.
+   - Note the storage engine (PostgreSQL, SQLite, in-memory) — this affects everything downstream.
+   - **Check for missing indexes**: for every column used in a WHERE clause in the query layer, confirm an index exists. Flag any gap as a performance risk.
+
+2. **Read the base schema.**
+   - Open the primary DDL file (schema.sql or Atlas HCL).
+   - Identify: table names, primary keys, foreign keys, JSONB/EAV columns, and any ` + "`" + `NOT NULL` + "`" + ` surprises.
+   - Flag any unexpected design choices (e.g. no SQL DB — in-memory store, event-sourced projections only, flat-file receipts).
+
+3. **Read the query layer.**
+   - Open SQLC-generated files or hand-written query files.
+   - Note which tables have full CRUD vs. append-only vs. read-only patterns.
+   - **Flag raw ` + "`" + `database/sql` + "`" + ` or ` + "`" + `pgx` + "`" + ` usage outside SQLC as a maintenance risk** — it bypasses type safety and query auditing, not just custom logic.
+
+4. **Read the migration history (if any).**
+   - Scan migration files chronologically for schema evolution clues (dropped columns, renamed tables, added indexes).
+   - Note the migration tool in use (Atlas, goose, flyway, raw SQL).
+
+5. **Read the event/message schemas.**
+   - Locate Protobuf or Avro definitions for Kafka/gRPC event types relevant to the data layer.
+   - Map each event type to the table or projection it writes to.
+
+6. **Check the projections / read models.**
+   - Find any in-memory or derived state (e.g. approvals projector, thread payload assembler).
+   - Note what raw events they consume and what query-ready shape they produce.
+
+7. **Write the notebook entry.**
+   - Path: ` + "`" + `agents/data-analyst/notebook/{issue-id}-data-layer.md` + "`" + `
+   - Frontmatter: ` + "`" + `scratch: true` + "`" + ` (until promoted).
+   - Required sections:
+     - **Storage engine** (one line)
+     - **Schema overview** (table list with one-line purpose each)
+     - **Query patterns** (CRUD breakdown, notable hand-rolled queries)
+     - **Event schema** (event types → projections map)
+     - **Query cost estimate** (for the top 3 queries by frequency, estimate row count and latency at 10× current load)
+     - **Surprises / design flags** (anything the team should know that they might not expect)
+     - **Open questions** (gaps that need owner clarification)
+
+8. **Post the team summary.**
+   - Call ` + "`" + `team_broadcast` + "`" + ` with a tight summary: storage engine, schema shape, one or two key surprises.
+   - Keep it under 10 lines — details live in the notebook.
+
+9. **Complete or submit the task.**
+   - If the issue needs reviewer sign-off: call ` + "`" + `team_task action=submit_for_review` + "`" + `.
+   - If it is self-contained exploration: call ` + "`" + `team_task action=complete` + "`" + `.
+   - Drop a one-line ` + "`" + `@ceo` + "`" + ` note in the channel if the exploration revealed something that should change the task graph.
+`
+
+// worseExploreDataLayerCandidate strips the current body down to vague steps
+// that lose all the specific guidance agents actually need.
+const worseExploreDataLayerCandidate = `## Steps
+
+1. Find the database files.
+2. Read the schema.
+3. Check the queries.
+4. Write a notebook entry with what you found.
+5. Tell the team.
+`
+
+// betterTraceCallGraphCandidate adds two precise improvements to the current body:
+//  1. Step 3 adds: flag any function that holds a mutex while making an external call.
+//  2. Step 4 adds: flag context.Background() usage instead of the incoming ctx (span loss).
+const betterTraceCallGraphCandidate = `**Input:** one entrypoint — a gRPC method name, HTTP route path, or Kafka topic+handler.
+
+### Steps
+
+1. **Locate the entrypoint definition**
+   - For gRPC: find the ` + "`" + `.proto` + "`" + ` file, read the method signature and request/response types.
+   - For HTTP: find the router registration (` + "`" + `mux.Handle` + "`" + `, ` + "`" + `r.POST` + "`" + `, etc.) and the handler function.
+   - For Kafka: find the consumer group registration and the handler function.
+   - Note the file path and line number.
+
+2. **Read the handler implementation** (depth 0)
+   - Read the full handler body.
+   - List every function call made, with package + function name.
+   - Note any domain model types created, read, or mutated.
+   - Note any cross-cutting calls (auth middleware, logger, tracer, metrics).
+
+3. **Trace one hop at a time** (depth 1 → max 3)
+   - For each non-stdlib call at the current depth, read its implementation.
+   - Stop descending into: standard library, generated code (protoc/sqlc), vendor/, and pure utility functions (string/time helpers).
+   - At each hop record: package, function, domain models touched, storage calls (DB/cache/queue), external RPC calls.
+   - **Flag any function that holds a mutex while making an external call** (DB, RPC, HTTP) — this is a deadlock risk if the external call blocks.
+   - **Flag any use of ` + "`" + `context.Background()` + "`" + ` instead of the incoming ctx** — it breaks tracing span propagation and cancellation.
+
+4. **Identify cross-cutting concerns**
+   - Auth: where is identity asserted or passed? Which middleware or function enforces it?
+   - Observability: where are spans started/ended, metrics incremented, structured logs emitted?
+   - Error handling: what error types are returned upward? Where are errors wrapped vs. swallowed?
+
+5. **Write a structured notebook entry** at ` + "`" + `agents/arch-analyst/notebook/{ISSUE-ID}-call-graph-{entrypoint}.md` + "`" + `
+
+6. **Post a team summary** via ` + "`" + `team_broadcast` + "`" + `
+`
+
+func TestE2E_Gate_CurrentVsEnhancedCandidate_Accepted(t *testing.T) {
+	wikiRoot := realWikiFixturesDir()
+	if wikiRoot == "" {
+		t.Skip("real wiki fixture directory not present; skipping")
+	}
+	currentBody := readCurrentSkillBody(t, wikiRoot, "explore-data-layer")
+	if currentBody == "" {
+		t.Skip("could not read current explore-data-layer skill body")
+	}
+
+	srv := fakeAnthropicServer(t, verdictBetter)
+	defer srv.Close()
+	gate := gateWithFakeServer(t, srv)
+
+	// baseline = current wiki body, candidate = enhanced version with index check + cost section.
+	hasFixtures, err := gate.Validate(
+		context.Background(),
+		"explore-data-layer",
+		betterExploreDataLayerCandidate,
+		currentBody,
+		wikiRoot,
+	)
+	if !hasFixtures {
+		t.Fatal("expected hasFixtures=true")
+	}
+	if err != nil {
+		t.Fatalf("expected enhanced candidate to be accepted, got: %v", err)
+	}
+}
+
+func TestE2E_Gate_CurrentVsDegradedCandidate_Rejected(t *testing.T) {
+	wikiRoot := realWikiFixturesDir()
+	if wikiRoot == "" {
+		t.Skip("real wiki fixture directory not present; skipping")
+	}
+	currentBody := readCurrentSkillBody(t, wikiRoot, "explore-data-layer")
+	if currentBody == "" {
+		t.Skip("could not read current explore-data-layer skill body")
+	}
+
+	srv := fakeAnthropicServer(t, verdictWorse)
+	defer srv.Close()
+	gate := gateWithFakeServer(t, srv)
+
+	// baseline = current wiki body, candidate = stripped vague version.
+	hasFixtures, err := gate.Validate(
+		context.Background(),
+		"explore-data-layer",
+		worseExploreDataLayerCandidate,
+		currentBody,
+		wikiRoot,
+	)
+	if !hasFixtures {
+		t.Fatal("expected hasFixtures=true")
+	}
+	if err == nil {
+		t.Fatal("expected degraded candidate to be rejected, got nil")
+	}
+	if !containsStr(err.Error(), "regresses") {
+		t.Fatalf("expected 'regresses' in rejection reason, got: %v", err)
+	}
+}
+
+func TestE2E_Gate_CurrentVsIdenticalCandidate_NoImprovement(t *testing.T) {
+	wikiRoot := realWikiFixturesDir()
+	if wikiRoot == "" {
+		t.Skip("real wiki fixture directory not present; skipping")
+	}
+	currentBody := readCurrentSkillBody(t, wikiRoot, "trace-call-graph")
+	if currentBody == "" {
+		t.Skip("could not read current trace-call-graph skill body")
+	}
+
+	// When candidate == baseline the judge returns "equivalent" — the gate
+	// must reject with "no improvement". This is the exact check that prevents
+	// a no-op enhance from being accepted.
+	srv := fakeAnthropicServer(t, verdictEquivalent)
+	defer srv.Close()
+	gate := gateWithFakeServer(t, srv)
+
+	hasFixtures, err := gate.Validate(
+		context.Background(),
+		"trace-call-graph",
+		currentBody, // candidate is identical to baseline
+		currentBody,
+		wikiRoot,
+	)
+	if !hasFixtures {
+		t.Fatal("expected hasFixtures=true")
+	}
+	if err == nil {
+		t.Fatal("expected identical candidate to be rejected as 'no improvement', got nil")
+	}
+	if !containsStr(err.Error(), "no improvement") {
+		t.Fatalf("expected 'no improvement', got: %v", err)
+	}
+}
+
+func TestE2E_Gate_TraceCallGraph_EnhancedCandidateAccepted(t *testing.T) {
+	wikiRoot := realWikiFixturesDir()
+	if wikiRoot == "" {
+		t.Skip("real wiki fixture directory not present; skipping")
+	}
+	currentBody := readCurrentSkillBody(t, wikiRoot, "trace-call-graph")
+	if currentBody == "" {
+		t.Skip("could not read current trace-call-graph skill body")
+	}
+
+	// 4 fixtures: better, better, equivalent, equivalent, equivalent
+	// → 2 wins, 0 losses → accepted.
+	verdicts := []fixtureVerdict{
+		verdictBetter, verdictBetter,
+		verdictEquivalent, verdictEquivalent, verdictEquivalent,
+	}
+	srv, _ := fakeAnthropicServerSequence(t, verdicts)
+	defer srv.Close()
+	gate := gateWithFakeServer(t, srv)
+
+	hasFixtures, err := gate.Validate(
+		context.Background(),
+		"trace-call-graph",
+		betterTraceCallGraphCandidate,
+		currentBody,
+		wikiRoot,
+	)
+	if !hasFixtures {
+		t.Fatal("expected hasFixtures=true")
+	}
+	if err != nil {
+		t.Fatalf("expected enhanced trace-call-graph candidate to be accepted, got: %v", err)
+	}
+}
+
+func TestE2E_Gate_UserPromptContainsRealSkillBodies(t *testing.T) {
+	// Verifies the judge actually receives the real current body and candidate
+	// body verbatim — not truncated, not swapped.
+	wikiRoot := realWikiFixturesDir()
+	if wikiRoot == "" {
+		t.Skip("real wiki fixture directory not present; skipping")
+	}
+	currentBody := readCurrentSkillBody(t, wikiRoot, "explore-data-layer")
+	if currentBody == "" {
+		t.Skip("could not read current explore-data-layer skill body")
+	}
+
+	type anthropicMsg struct {
+		Role    string `json:"role"`
+		Content string `json:"content"`
+	}
+	type payload struct {
+		Messages []anthropicMsg `json:"messages"`
+	}
+
+	var captured payload
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &captured)
+		resp := map[string]any{
+			"content": []map[string]any{
+				{"type": "text", "text": `{"verdict":"better","reasoning":"ok"}`},
+			},
+		}
+		b, _ := json.Marshal(resp)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(b)
+	}))
+	defer srv.Close()
+	gate := gateWithFakeServer(t, srv)
+
+	// Only one fixture so we get exactly one capture.
+	dir := t.TempDir()
+	writeFixtureFile(t, dir, "explore-data-layer", []string{
+		"A new microservice has been handed off. Audit its schema before the first migration.",
+	})
+
+	_, _ = gate.Validate(context.Background(), "explore-data-layer",
+		betterExploreDataLayerCandidate, currentBody, dir)
+
+	if len(captured.Messages) == 0 {
+		t.Fatal("no messages captured from judge request")
+	}
+	userContent := captured.Messages[0].Content
+
+	// The current body must appear as the baseline.
+	if !containsStr(userContent, "Locate the schema files") {
+		t.Fatal("user prompt does not contain current skill body as baseline")
+	}
+	// The candidate must appear in the candidate section.
+	if !containsStr(userContent, "Query cost estimate") {
+		t.Fatal("user prompt does not contain candidate skill body (missing new section)")
+	}
+	// The baseline and candidate must not be swapped.
+	baselineIdx := strings.Index(userContent, "BASELINE SKILL:")
+	candidateIdx := strings.Index(userContent, "CANDIDATE SKILL:")
+	if baselineIdx == -1 || candidateIdx == -1 {
+		t.Fatal("user prompt missing BASELINE SKILL or CANDIDATE SKILL headers")
+	}
+	if candidateIdx < baselineIdx {
+		t.Fatal("CANDIDATE SKILL appears before BASELINE SKILL — sections are swapped")
+	}
+}

--- a/internal/team/skill_validation_gate_test.go
+++ b/internal/team/skill_validation_gate_test.go
@@ -1,0 +1,675 @@
+package team
+
+// skill_validation_gate_test.go covers the held-out validation gate for Stage
+// B skill synthesis (issue #1004). Tests are split into three layers:
+//
+//  1. Pure-function unit tests: splitFixtures, loadFixturesForSlug,
+//     validationCacheKey, parseJudgeResponse.
+//  2. defaultSkillValidationGate integration tests with a fake HTTP server
+//     (stubbed Anthropic endpoint via rewriteTransport).
+//  3. Synthesizer-level integration tests with stubValidationGate injected
+//     directly into SkillSynthesizer.gate.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// Stub gate
+// ---------------------------------------------------------------------------
+
+// stubValidationGate is an in-process implementation of skillValidationGate
+// for synthesizer-level tests. It drains a queue FIFO; once empty it falls
+// back to the rejectAll / noFixtures flags.
+type stubValidationGate struct {
+	calls      atomic.Int64
+	mu         sync.Mutex
+	rejectAll  bool
+	noFixtures bool
+	lastSlug   string
+	queue      []stubValidationResult
+}
+
+type stubValidationResult struct {
+	hasFixtures bool
+	err         error
+}
+
+func (s *stubValidationGate) Validate(_ context.Context, slug, _, _, _ string) (bool, error) {
+	s.calls.Add(1)
+	s.mu.Lock()
+	s.lastSlug = slug
+	if len(s.queue) > 0 {
+		r := s.queue[0]
+		s.queue = s.queue[1:]
+		s.mu.Unlock()
+		return r.hasFixtures, r.err
+	}
+	s.mu.Unlock()
+	if s.noFixtures {
+		return false, nil
+	}
+	if s.rejectAll {
+		return true, errors.New("stub: rejected")
+	}
+	return true, nil
+}
+
+// ---------------------------------------------------------------------------
+// Pure-function tests: splitFixtures
+// ---------------------------------------------------------------------------
+
+func TestSplitFixtures_EmptyString(t *testing.T) {
+	if got := splitFixtures(""); len(got) != 0 {
+		t.Fatalf("expected 0 sections, got %d", len(got))
+	}
+}
+
+func TestSplitFixtures_WhitespaceOnly(t *testing.T) {
+	if got := splitFixtures("   \n\t\n   "); len(got) != 0 {
+		t.Fatalf("expected 0 sections for whitespace-only, got %d", len(got))
+	}
+}
+
+func TestSplitFixtures_SingleSection(t *testing.T) {
+	raw := "Deploy the service to production."
+	got := splitFixtures(raw)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 section, got %d", len(got))
+	}
+	if got[0] != "Deploy the service to production." {
+		t.Fatalf("unexpected content: %q", got[0])
+	}
+}
+
+func TestSplitFixtures_MultipleSections(t *testing.T) {
+	raw := "Task A.\n---\nTask B.\n---\nTask C."
+	got := splitFixtures(raw)
+	if len(got) != 3 {
+		t.Fatalf("expected 3 sections, got %d: %v", len(got), got)
+	}
+}
+
+func TestSplitFixtures_DiscardEmptySections(t *testing.T) {
+	raw := "Task A.\n---\n\n---\nTask B."
+	got := splitFixtures(raw)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 non-empty sections, got %d: %v", len(got), got)
+	}
+}
+
+func TestSplitFixtures_TrimsWhitespace(t *testing.T) {
+	raw := "  Task A.  \n---\n  Task B.  "
+	got := splitFixtures(raw)
+	for i, s := range got {
+		if len(s) > 0 && (s[0] == ' ' || s[len(s)-1] == ' ') {
+			t.Fatalf("section %d not trimmed: %q", i, s)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Pure-function tests: loadFixturesForSlug
+// ---------------------------------------------------------------------------
+
+func TestLoadFixturesForSlug_FileNotExist(t *testing.T) {
+	dir := t.TempDir()
+	got, err := loadFixturesForSlug(dir, "nonexistent-slug")
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if got != nil {
+		t.Fatalf("expected nil fixtures, got %v", got)
+	}
+}
+
+func TestLoadFixturesForSlug_EmptyFile(t *testing.T) {
+	dir := t.TempDir()
+	fixtureDir := filepath.Join(dir, "team", "skills", ".fixtures")
+	if err := os.MkdirAll(fixtureDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(fixtureDir, "my-skill.md"), []byte("   \n\t  "), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, err := loadFixturesForSlug(dir, "my-skill")
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected 0 fixtures for whitespace-only file, got %d", len(got))
+	}
+}
+
+func TestLoadFixturesForSlug_TwoFixtures(t *testing.T) {
+	dir := t.TempDir()
+	fixtureDir := filepath.Join(dir, "team", "skills", ".fixtures")
+	if err := os.MkdirAll(fixtureDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	content := "Deploy a microservice to production.\n---\nRollback after a bad deploy."
+	if err := os.WriteFile(filepath.Join(fixtureDir, "deploy-service.md"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, err := loadFixturesForSlug(dir, "deploy-service")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 fixtures, got %d", len(got))
+	}
+}
+
+func TestLoadFixturesForSlug_EmptyWikiRoot(t *testing.T) {
+	got, err := loadFixturesForSlug("", "some-slug")
+	if err != nil || got != nil {
+		t.Fatalf("expected (nil, nil), got (%v, %v)", got, err)
+	}
+}
+
+func TestLoadFixturesForSlug_EmptySlug(t *testing.T) {
+	got, err := loadFixturesForSlug(t.TempDir(), "")
+	if err != nil || got != nil {
+		t.Fatalf("expected (nil, nil) for empty slug, got (%v, %v)", got, err)
+	}
+}
+
+func TestLoadFixturesForSlug_SlugWithSeparator(t *testing.T) {
+	// Slugs containing a path separator should be silently rejected.
+	got, err := loadFixturesForSlug(t.TempDir(), "foo/bar")
+	if err != nil || got != nil {
+		t.Fatalf("expected (nil, nil) for separator-slug, got (%v, %v)", got, err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Pure-function tests: validationCacheKey
+// ---------------------------------------------------------------------------
+
+func TestValidationCacheKey_Deterministic(t *testing.T) {
+	k1 := validationCacheKey("fixture", "candidate", "baseline")
+	k2 := validationCacheKey("fixture", "candidate", "baseline")
+	if k1 != k2 {
+		t.Fatalf("cache key is not deterministic: %q != %q", k1, k2)
+	}
+}
+
+func TestValidationCacheKey_DifferentFixture(t *testing.T) {
+	k1 := validationCacheKey("fixture-a", "candidate", "baseline")
+	k2 := validationCacheKey("fixture-b", "candidate", "baseline")
+	if k1 == k2 {
+		t.Fatal("different fixtures should produce different keys")
+	}
+}
+
+func TestValidationCacheKey_DifferentCandidate(t *testing.T) {
+	k1 := validationCacheKey("fixture", "candidate-a", "baseline")
+	k2 := validationCacheKey("fixture", "candidate-b", "baseline")
+	if k1 == k2 {
+		t.Fatal("different candidates should produce different keys")
+	}
+}
+
+func TestValidationCacheKey_DifferentBaseline(t *testing.T) {
+	k1 := validationCacheKey("fixture", "candidate", "baseline-a")
+	k2 := validationCacheKey("fixture", "candidate", "baseline-b")
+	if k1 == k2 {
+		t.Fatal("different baselines should produce different keys")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Pure-function tests: parseJudgeResponse
+// ---------------------------------------------------------------------------
+
+func TestParseJudgeResponse_Better(t *testing.T) {
+	raw := `{"verdict":"better","reasoning":"candidate is clearly better"}`
+	v, err := parseJudgeResponse(raw)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if v != verdictBetter {
+		t.Fatalf("expected %q, got %q", verdictBetter, v)
+	}
+}
+
+func TestParseJudgeResponse_Equivalent(t *testing.T) {
+	raw := `{"verdict":"equivalent","reasoning":"no difference"}`
+	v, err := parseJudgeResponse(raw)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if v != verdictEquivalent {
+		t.Fatalf("expected %q, got %q", verdictEquivalent, v)
+	}
+}
+
+func TestParseJudgeResponse_Worse(t *testing.T) {
+	raw := `{"verdict":"worse","reasoning":"baseline was better"}`
+	v, err := parseJudgeResponse(raw)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if v != verdictWorse {
+		t.Fatalf("expected %q, got %q", verdictWorse, v)
+	}
+}
+
+func TestParseJudgeResponse_UnknownVerdict(t *testing.T) {
+	raw := `{"verdict":"uncertain","reasoning":"not sure"}`
+	v, err := parseJudgeResponse(raw)
+	if err == nil {
+		t.Fatal("expected error for unknown verdict, got nil")
+	}
+	if v != verdictEquivalent {
+		t.Fatalf("unknown verdict should degrade to equivalent, got %q", v)
+	}
+}
+
+func TestParseJudgeResponse_Empty(t *testing.T) {
+	_, err := parseJudgeResponse("")
+	if err == nil {
+		t.Fatal("expected error for empty response, got nil")
+	}
+}
+
+func TestParseJudgeResponse_JSONFenced(t *testing.T) {
+	raw := "```json\n{\"verdict\":\"better\",\"reasoning\":\"ok\"}\n```"
+	v, err := parseJudgeResponse(raw)
+	if err != nil {
+		t.Fatalf("expected stripJSONNoise to handle fenced block, got error: %v", err)
+	}
+	if v != verdictBetter {
+		t.Fatalf("expected %q, got %q", verdictBetter, v)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// defaultSkillValidationGate integration tests (fake HTTP server)
+// ---------------------------------------------------------------------------
+
+// anthropicJudgeResponse builds a minimal Anthropic /v1/messages response
+// whose text content is the given judge JSON string.
+func anthropicJudgeResponse(t *testing.T, judgeJSON string) []byte {
+	t.Helper()
+	resp := map[string]any{
+		"content": []map[string]any{
+			{"type": "text", "text": judgeJSON},
+		},
+	}
+	b, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("marshal fake response: %v", err)
+	}
+	return b
+}
+
+// writeFixtureFile creates <wikiRoot>/team/skills/.fixtures/<slug>.md with
+// content split into sections by "\n---\n".
+func writeFixtureFile(t *testing.T, wikiRoot, slug string, sections []string) {
+	t.Helper()
+	dir := filepath.Join(wikiRoot, "team", "skills", ".fixtures")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	content := ""
+	for i, s := range sections {
+		if i > 0 {
+			content += "\n---\n"
+		}
+		content += s
+	}
+	if err := os.WriteFile(filepath.Join(dir, slug+".md"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestValidationGate_NoFixtures_PassesThrough(t *testing.T) {
+	dir := t.TempDir()
+	gate := newDefaultSkillValidationGate()
+	hasFixtures, err := gate.Validate(context.Background(), "missing-slug", "candidate", "", dir)
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if hasFixtures {
+		t.Fatal("expected hasFixtures=false when no fixture file exists")
+	}
+}
+
+func TestValidationGate_RejectsOnRegression(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "test-key")
+	dir := t.TempDir()
+	writeFixtureFile(t, dir, "my-skill", []string{
+		"Task A: deploy to prod.",
+		"Task B: rollback after incident.",
+		"Task C: coordinate hotfix under load.",
+	})
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(anthropicJudgeResponse(t, `{"verdict":"worse","reasoning":"baseline was clearer"}`))
+	}))
+	defer srv.Close()
+
+	gate := newDefaultSkillValidationGate()
+	gate.httpClient = &http.Client{Transport: rewriteTransport{target: srv.URL}}
+
+	hasFixtures, err := gate.Validate(context.Background(), "my-skill", "candidate body", "baseline body", dir)
+	if !hasFixtures {
+		t.Fatal("expected hasFixtures=true (fixture file exists)")
+	}
+	if err == nil {
+		t.Fatal("expected rejection error for all-worse fixtures, got nil")
+	}
+	if !containsStr(err.Error(), "regresses") {
+		t.Fatalf("expected 'regresses' in error, got: %v", err)
+	}
+}
+
+func TestValidationGate_RejectsOnAllEquivalent(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "test-key")
+	dir := t.TempDir()
+	writeFixtureFile(t, dir, "my-skill", []string{
+		"Task A: deploy to prod.",
+		"Task B: rollback after incident.",
+	})
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(anthropicJudgeResponse(t, `{"verdict":"equivalent","reasoning":"no change"}`))
+	}))
+	defer srv.Close()
+
+	gate := newDefaultSkillValidationGate()
+	gate.httpClient = &http.Client{Transport: rewriteTransport{target: srv.URL}}
+
+	hasFixtures, err := gate.Validate(context.Background(), "my-skill", "candidate body", "baseline body", dir)
+	if !hasFixtures {
+		t.Fatal("expected hasFixtures=true")
+	}
+	if err == nil {
+		t.Fatal("expected rejection error for all-equivalent fixtures, got nil")
+	}
+	if !containsStr(err.Error(), "no improvement") {
+		t.Fatalf("expected 'no improvement' in error, got: %v", err)
+	}
+}
+
+func TestValidationGate_AcceptsOneWinZeroLosses(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "test-key")
+	dir := t.TempDir()
+	writeFixtureFile(t, dir, "my-skill", []string{
+		"Task A: deploy to prod.",
+		"Task B: rollback after incident.",
+		"Task C: coordinate hotfix under load.",
+	})
+
+	// Return "better" for the first request, "equivalent" for the rest.
+	callCount := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		callCount++
+		verdict := "equivalent"
+		if callCount == 1 {
+			verdict = "better"
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(anthropicJudgeResponse(t, fmt.Sprintf(`{"verdict":%q,"reasoning":"ok"}`, verdict)))
+	}))
+	defer srv.Close()
+
+	gate := newDefaultSkillValidationGate()
+	gate.httpClient = &http.Client{Transport: rewriteTransport{target: srv.URL}}
+
+	hasFixtures, err := gate.Validate(context.Background(), "my-skill", "candidate body", "baseline body", dir)
+	if !hasFixtures {
+		t.Fatal("expected hasFixtures=true")
+	}
+	if err != nil {
+		t.Fatalf("expected acceptance (1 win, 0 losses), got error: %v", err)
+	}
+}
+
+func TestValidationGate_JudgeFailure_DegradesToEquivalent(t *testing.T) {
+	// When all judge HTTP calls fail, all fixtures degrade to equivalent.
+	// Result: 0 wins, 0 losses → "no improvement" rejection.
+	// This is the correct behaviour — if we cannot evaluate, we do not accept.
+	t.Setenv("ANTHROPIC_API_KEY", "test-key")
+	dir := t.TempDir()
+	writeFixtureFile(t, dir, "my-skill", []string{
+		"Task A: deploy to prod.",
+		"Task B: rollback after incident.",
+	})
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	gate := newDefaultSkillValidationGate()
+	gate.httpClient = &http.Client{Transport: rewriteTransport{target: srv.URL}}
+
+	hasFixtures, err := gate.Validate(context.Background(), "my-skill", "candidate body", "baseline body", dir)
+	if !hasFixtures {
+		t.Fatal("expected hasFixtures=true (fixture file exists)")
+	}
+	if err == nil {
+		t.Fatal("expected rejection (no wins when all judges fail), got nil")
+	}
+	if !containsStr(err.Error(), "no improvement") {
+		t.Fatalf("expected 'no improvement' in error, got: %v", err)
+	}
+}
+
+func TestValidationGate_CachePreventsDuplicateLLMCalls(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "test-key")
+	dir := t.TempDir()
+	writeFixtureFile(t, dir, "my-skill", []string{
+		"Task A: deploy to prod.",
+	})
+
+	callCount := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		callCount++
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(anthropicJudgeResponse(t, `{"verdict":"better","reasoning":"ok"}`))
+	}))
+	defer srv.Close()
+
+	gate := newDefaultSkillValidationGate()
+	gate.httpClient = &http.Client{Transport: rewriteTransport{target: srv.URL}}
+
+	// Call Validate twice with identical inputs.
+	for i := range 2 {
+		_, err := gate.Validate(context.Background(), "my-skill", "same-candidate", "same-baseline", dir)
+		if err != nil {
+			t.Fatalf("call %d: unexpected error: %v", i+1, err)
+		}
+	}
+	if callCount != 1 {
+		t.Fatalf("expected 1 LLM call (cache hit on second), got %d", callCount)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Synthesizer-level integration tests with stubValidationGate
+// ---------------------------------------------------------------------------
+
+// goodSynthBody returns a skill body that passes ScanSkill at TrustAgentCreated.
+func goodSynthBody() string {
+	return "## Steps\n" +
+		"1. Tag the release in git.\n" +
+		"2. Deploy to staging and watch for errors.\n" +
+		"3. Promote to production after smoke tests pass.\n"
+}
+
+// newCandidateForGateTests creates a minimal SkillCandidate for synthesizer tests.
+func newCandidateForGateTests(name string) SkillCandidate {
+	return SkillCandidate{
+		Source:               SourceNotebookCluster,
+		SuggestedName:        name,
+		SuggestedDescription: "Coordinate " + name + ".",
+		SignalCount:          3,
+	}
+}
+
+func TestSynthesizeOnce_GateAccepts(t *testing.T) {
+	b := newTestBroker(t)
+	gate := &stubValidationGate{} // default: returns (true, nil)
+	prov := &stubLLMProvider{
+		queue: []stubLLMResponse{{
+			fm:   SkillFrontmatter{Name: "deploy-gate", Description: "Deploy something."},
+			body: goodSynthBody(),
+		}},
+	}
+	synth := newSynthWithCandidates(t, b, prov, []SkillCandidate{newCandidateForGateTests("deploy-gate")})
+	synth.gate = gate
+
+	res, err := synth.SynthesizeOnce(context.Background(), "manual")
+	if err != nil {
+		t.Fatalf("SynthesizeOnce: %v", err)
+	}
+	if res.Synthesized != 1 {
+		t.Fatalf("Synthesized: got %d want 1 (errors: %+v)", res.Synthesized, res.Errors)
+	}
+	if res.RejectedByValidation != 0 {
+		t.Fatalf("RejectedByValidation: got %d want 0", res.RejectedByValidation)
+	}
+	if gate.calls.Load() != 1 {
+		t.Fatalf("gate called %d times, want 1", gate.calls.Load())
+	}
+}
+
+func TestSynthesizeOnce_GateRejects(t *testing.T) {
+	b := newTestBroker(t)
+	gate := &stubValidationGate{rejectAll: true}
+	prov := &stubLLMProvider{
+		queue: []stubLLMResponse{{
+			fm:   SkillFrontmatter{Name: "deploy-gate", Description: "Deploy something."},
+			body: goodSynthBody(),
+		}},
+	}
+	synth := newSynthWithCandidates(t, b, prov, []SkillCandidate{newCandidateForGateTests("deploy-gate")})
+	synth.gate = gate
+
+	res, err := synth.SynthesizeOnce(context.Background(), "manual")
+	if err != nil {
+		t.Fatalf("SynthesizeOnce: %v", err)
+	}
+	if res.Synthesized != 0 {
+		t.Fatalf("Synthesized: got %d want 0 (gate should have rejected)", res.Synthesized)
+	}
+	if res.RejectedByValidation != 1 {
+		t.Fatalf("RejectedByValidation: got %d want 1", res.RejectedByValidation)
+	}
+	if atomic.LoadInt64(&b.skillCompileMetrics.ValidationGateRejections) != 1 {
+		t.Fatalf("ValidationGateRejections metric: got %d want 1",
+			atomic.LoadInt64(&b.skillCompileMetrics.ValidationGateRejections))
+	}
+}
+
+func TestSynthesizeOnce_GateNoFixtures(t *testing.T) {
+	b := newTestBroker(t)
+	gate := &stubValidationGate{noFixtures: true}
+	prov := &stubLLMProvider{
+		queue: []stubLLMResponse{{
+			fm:   SkillFrontmatter{Name: "deploy-gate", Description: "Deploy something."},
+			body: goodSynthBody(),
+		}},
+	}
+	synth := newSynthWithCandidates(t, b, prov, []SkillCandidate{newCandidateForGateTests("deploy-gate")})
+	synth.gate = gate
+
+	res, err := synth.SynthesizeOnce(context.Background(), "manual")
+	if err != nil {
+		t.Fatalf("SynthesizeOnce: %v", err)
+	}
+	// noFixtures=true means the gate skips but the proposal still proceeds.
+	if res.Synthesized != 1 {
+		t.Fatalf("Synthesized: got %d want 1 (no-fixture gate should not block; errors: %+v)",
+			res.Synthesized, res.Errors)
+	}
+	if res.RejectedByValidation != 0 {
+		t.Fatalf("RejectedByValidation: got %d want 0", res.RejectedByValidation)
+	}
+	if atomic.LoadInt64(&b.skillCompileMetrics.ValidationGateNoFixtures) != 1 {
+		t.Fatalf("ValidationGateNoFixtures metric: got %d want 1",
+			atomic.LoadInt64(&b.skillCompileMetrics.ValidationGateNoFixtures))
+	}
+}
+
+func TestSynthesizeOnce_GateDisabledByEnv(t *testing.T) {
+	t.Setenv("WUPHF_SKILL_VALIDATION_GATE_DISABLED", "true")
+	b := newTestBroker(t)
+	cands := []SkillCandidate{newCandidateForGateTests("some-skill")}
+	synth := newSynthWithCandidates(t, b, &stubLLMProvider{}, cands)
+	if synth.gate != nil {
+		t.Fatal("expected gate==nil when WUPHF_SKILL_VALIDATION_GATE_DISABLED=true")
+	}
+}
+
+func TestSynthesizeOnce_EnhancePath_GateUsesEnhanceSlug(t *testing.T) {
+	b := newTestBroker(t)
+	// Pre-seed an existing skill that will be the enhance target.
+	b.mu.Lock()
+	b.skills = append(b.skills, teamSkill{
+		Name:      "existing-skill",
+		Title:     "Existing Skill",
+		Content:   "## Steps\n1. Do the thing.\n",
+		Status:    "active",
+		CreatedBy: "scanner",
+	})
+	b.mu.Unlock()
+
+	gate := &stubValidationGate{} // accepts everything
+	prov := &stubLLMProvider{
+		queue: []stubLLMResponse{{
+			fm:      SkillFrontmatter{Name: "existing-skill", Description: "Enhanced."},
+			body:    goodSynthBody(),
+			enhance: "existing-skill",
+		}},
+	}
+	synth := newSynthWithCandidates(t, b, prov, []SkillCandidate{newCandidateForGateTests("new-signal")})
+	synth.gate = gate
+
+	_, err := synth.SynthesizeOnce(context.Background(), "manual")
+	if err != nil {
+		t.Fatalf("SynthesizeOnce: %v", err)
+	}
+	gate.mu.Lock()
+	slug := gate.lastSlug
+	gate.mu.Unlock()
+	if slug != "existing-skill" {
+		t.Fatalf("gate called with slug %q, want %q", slug, "existing-skill")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+func containsStr(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsStrInner(s, substr))
+}
+
+func containsStrInner(s, substr string) bool {
+	for i := range len(s) - len(substr) + 1 {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

Implements the dynamic quality gate for Stage B skill synthesis described in issue #1004.

Before a `NEW` or `ENHANCE` proposal is written to the wiki, the gate compares the candidate body against a baseline (empty for new skills, existing body for enhance) on representative task fixtures using an LLM-as-judge. Acceptance requires **zero regressions on any fixture and at least one win**. The gate gracefully skips when no fixture file exists for the slug.

### Design decisions

- **No fixture → skip, not reject**: `(false, nil)` increments `ValidationGateNoFixtures` so the metric is observable without blocking early adoption.
- **All-judge-failure → reject**: When every HTTP call fails, all fixtures degrade to `equivalent` → 0 wins, 0 losses → "no improvement" rejection. Conservative by design.
- **Mutex: acquire-read-release before gate call**: Gate's LLM call can be slow; the mutex is held only for the skill lookup, not the full gate execution.
- **`slog.Info` not `Warn` on gate rejection**: A rejection is an expected outcome, not an anomaly.

### Known gaps / follow-ups

- No tooling to prompt agents to author fixture tasks when a new skill is promoted (fixture authorship trigger).
- No-API-key path silently rejects all proposals after the first `sync.Once` warning — should surface this more clearly.
- `enhance` fall-through: if the enhance target disappears between synthesis and gate execution, the gate runs with `baselineBody=""` (treated as new-skill comparison).

🤖 Generated with [Claude Code](https://claude.com/claude-code)