### PR TITLE
fix(team): use atomic writes in playbook_commit.go

### DIFF
--- a/internal/team/playbook_commit.go
+++ b/internal/team/playbook_commit.go
@@ -51,7 +51,7 @@ func (r *Repo) CommitPlaybookSkill(ctx context.Context, slug, relPath, content, 
 	if err := os.MkdirAll(filepath.Dir(fullPath), 0o700); err != nil {
 		return "", 0, fmt.Errorf("playbook commit: mkdir: %w", err)
 	}
-	if err := os.WriteFile(fullPath, []byte(content), 0o600); err != nil {
+	if err := writeFileAtomic(fullPath, []byte(content), 0o600); err != nil {
 		return "", 0, fmt.Errorf("playbook commit: write: %w", err)
 	}
 
@@ -107,7 +107,7 @@ func (r *Repo) CommitPlaybookExecution(ctx context.Context, slug, relPath, conte
 	if err := os.MkdirAll(filepath.Dir(fullPath), 0o700); err != nil {
 		return "", 0, fmt.Errorf("playbook execution: mkdir: %w", err)
 	}
-	if err := os.WriteFile(fullPath, []byte(content), 0o600); err != nil {
+	if err := writeFileAtomic(fullPath, []byte(content), 0o600); err != nil {
 		return "", 0, fmt.Errorf("playbook execution: write: %w", err)
 	}
 	if out, err := r.runGitLocked(ctx, slug, "add", "--", clean); err != nil {


### PR DESCRIPTION
## Problem

`CommitPlaybookSkill` and `CommitPlaybookExecution` in `internal/team/playbook_commit.go` use `os.WriteFile` to write `SKILL.md` and `.executions.jsonl` files. `os.WriteFile` truncates the file to zero bytes *before* writing new content. If the process crashes between truncation and write completion, the file is left at zero bytes or partially written.

Playbooks are how agents learn from past work — `SKILL.md` is the compiled skill definition and `.executions.jsonl` is the execution history. Silent corruption here degrades agent quality over time and is hard to detect because the file exists but contains garbage or nothing.

## Solution

Replace both `os.WriteFile` calls with `writeFileAtomic`, a helper already in the same package (`learning_commit.go:108`). It writes to a temp file in the same directory, then does an `os.Rename` — which is atomic on POSIX filesystems. The file is either fully written or untouched; there is no partial-write window.

No new code introduced — just reusing an existing internal helper for consistency.

Closes #1043

## Test plan

- [x] All 39 Go packages pass (`internal/team` included)
- [x] Pre-commit hooks (gofmt, go vet, golangci-lint, secretlint) pass
- [x] Pre-push hooks (build, go-unit, smoke) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)