### PR TITLE
perf(broker): add taskIndex map for O(1) task lookup by ID

### DIFF
--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -71,6 +71,7 @@ type Broker struct {
 	oneOnOneAgent     string
 	focusMode         bool
 	tasks             []teamTask
+	taskIndex         map[string]int // task ID → index into tasks; guarded by mu
 	// lifecycleIndex is the inverse-index map maintained by the
 	// broker_lifecycle_transition.go layer. Inbox queries for "all tasks
 	// in state X" are O(1) lookups against this map instead of O(N) scans
@@ -1063,6 +1064,7 @@ func (b *Broker) Purge() {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	b.tasks = nil
+	b.taskIndex = nil
 	if err := b.saveLocked(); err != nil {
 		log.Printf("broker: Purge: save failed: %v", err)
 	}
@@ -1079,6 +1081,7 @@ func (b *Broker) Reset() {
 	b.sessionMode = mode
 	b.oneOnOneAgent = agent
 	b.tasks = []teamTask{}
+	b.taskIndex = make(map[string]int)
 	b.requests = nil
 	b.approvalAudit = nil
 	b.humanInvites = nil
@@ -1239,6 +1242,25 @@ func (b *Broker) rebuildMemberIndexLocked() {
 	for i, m := range b.members {
 		b.memberIndex[m.Slug] = i
 	}
+}
+
+// rebuildTaskIndexLocked rebuilds taskIndex from b.tasks. Callers must
+// hold b.mu. Called after bulk mutations (load, GC, channel delete) that
+// invalidate slice indices. Appends update the map inline.
+func (b *Broker) rebuildTaskIndexLocked() {
+	b.taskIndex = make(map[string]int, len(b.tasks))
+	for i, t := range b.tasks {
+		b.taskIndex[t.ID] = i
+	}
+}
+
+// indexTaskLocked updates taskIndex for a newly-appended task.
+// Initializes the map if nil (test paths that skip load).
+func (b *Broker) indexTaskLocked(id string, idx int) {
+	if b.taskIndex == nil {
+		b.taskIndex = make(map[string]int, len(b.tasks))
+	}
+	b.taskIndex[id] = idx
 }
 
 // OpenClaw bridge wiring, provider binding, persistence cursors, pane capture,

--- a/internal/team/broker_gc.go
+++ b/internal/team/broker_gc.go
@@ -61,6 +61,7 @@ func (b *Broker) pruneCompletedTasksLocked() int {
 
 	if pruned > 0 {
 		b.tasks = kept
+		b.rebuildTaskIndexLocked()
 		slog.Info("broker_gc: pruned completed tasks",
 			"pruned", pruned, "remaining", len(b.tasks),
 			"retention_days", int(retention.Hours()/24))

--- a/internal/team/broker_inbox.go
+++ b/internal/team/broker_inbox.go
@@ -417,17 +417,17 @@ func mergedAtTimestamp(task *teamTask) time.Time {
 }
 
 // findTaskByIDLocked returns a pointer to the task with the given ID
-// or nil if not present. Caller must hold b.mu. Linear scan is OK
-// because the inbox row builder calls this once per row, NOT once per
-// task in the broker.
+// or nil if not present. Caller must hold b.mu. Uses taskIndex for
+// O(1) lookup with a lazy-rebuild guard (same pattern as findMemberLocked).
 func (b *Broker) findTaskByIDLocked(id string) *teamTask {
 	if id == "" {
 		return nil
 	}
-	for i := range b.tasks {
-		if b.tasks[i].ID == id {
-			return &b.tasks[i]
-		}
+	if len(b.taskIndex) != len(b.tasks) {
+		b.rebuildTaskIndexLocked()
+	}
+	if i, ok := b.taskIndex[id]; ok && i < len(b.tasks) && b.tasks[i].ID == id {
+		return &b.tasks[i]
 	}
 	return nil
 }

--- a/internal/team/broker_intake.go
+++ b/internal/team/broker_intake.go
@@ -739,6 +739,7 @@ func (b *Broker) createIntakeTask(intent string) string {
 		log.Printf("intake: applyLifecycleStateLocked(intake) for new task: %v", err)
 	}
 	b.tasks = append(b.tasks, task)
+	b.indexTaskLocked(task.ID, len(b.tasks)-1)
 	b.appendActionLocked("intake_started", "office", task.Channel, intakeAgentSlug, truncateSummary(title, 140), task.ID)
 	if err := b.saveLocked(); err != nil {
 		log.Printf("intake: saveLocked after createIntakeTask: %v", err)
@@ -781,6 +782,7 @@ func (b *Broker) discardIntakeTask(taskID string) {
 		// bucket. Then splice it out of the slice.
 		b.indexLifecycleLocked(taskID, b.tasks[i].LifecycleState, "")
 		b.tasks = append(b.tasks[:i], b.tasks[i+1:]...)
+		b.rebuildTaskIndexLocked()
 		break
 	}
 	if err := b.saveLocked(); err != nil {

--- a/internal/team/broker_office_channels.go
+++ b/internal/team/broker_office_channels.go
@@ -857,6 +857,7 @@ func (b *Broker) handleChannels(w http.ResponseWriter, r *http.Request) {
 				}
 			}
 			b.tasks = filteredTasks
+			b.rebuildTaskIndexLocked()
 			filteredRequests := b.requests[:0]
 			for _, req := range b.requests {
 				if normalizeChannelSlug(req.Channel) != slug {

--- a/internal/team/broker_onboarding.go
+++ b/internal/team/broker_onboarding.go
@@ -281,6 +281,7 @@ func (b *Broker) seedFromBlueprintLocked(bp operations.Blueprint, selectedAgents
 	}
 	b.channels = blankSlateOfficeChannelsFromBlueprint(bp, b.members)
 	b.tasks = blankSlateOfficeTasksFromBlueprint(bp)
+	b.rebuildTaskIndexLocked()
 	if len(b.channels) == 0 {
 		b.channels = []teamChannel{{
 			Slug:        "general",

--- a/internal/team/broker_onboarding_phase2.go
+++ b/internal/team/broker_onboarding_phase2.go
@@ -253,6 +253,7 @@ func (b *Broker) ensureOnboardingFirstIssueDraft(s *onboarding.State) error {
 		syncTaskMemoryWorkflow(&task, now)
 		b.scheduleTaskLifecycleLocked(&task)
 		b.tasks = append(b.tasks, task)
+		b.indexTaskLocked(task.ID, len(b.tasks)-1)
 		taskID = task.ID
 		s.FirstIssueID = taskID
 		changedState = true
@@ -340,6 +341,7 @@ func (b *Broker) seedMinimalScratchLocked(s *onboarding.State) error {
 
 	// Clear tasks and message history for a fresh start.
 	b.tasks = nil
+	b.taskIndex = nil
 	b.messages = nil
 	b.counter = 0
 	b.lastTaggedAt = make(map[string]time.Time)

--- a/internal/team/broker_persistence.go
+++ b/internal/team/broker_persistence.go
@@ -127,6 +127,7 @@ func (b *Broker) loadState() error {
 	if b.tasks == nil {
 		b.tasks = []teamTask{}
 	}
+	b.rebuildTaskIndexLocked()
 	b.requests = state.Requests
 	b.approvalAudit = state.ApprovalAudit
 	// Sanitize loaded audit entries — older persisted state (pre-sanitizer)

--- a/internal/team/broker_skills.go
+++ b/internal/team/broker_skills.go
@@ -740,6 +740,7 @@ func (b *Broker) createSkillRunTaskLocked(sk *teamSkill, channel, invoker, now s
 	b.queueTaskBehindActiveOwnerLaneLocked(&task)
 	b.scheduleTaskLifecycleLocked(&task)
 	b.tasks = append(b.tasks, task)
+	b.indexTaskLocked(task.ID, len(b.tasks)-1)
 	b.appendActionLocked("task_created", "office", channel, invoker, truncateSummary(task.Title, 140), task.ID)
 	return task.ID, nil
 }

--- a/internal/team/broker_tasks.go
+++ b/internal/team/broker_tasks.go
@@ -28,6 +28,7 @@ func snapshotBrokerTaskMutationLocked(b *Broker) brokerTaskMutationSnapshot {
 
 func (snapshot brokerTaskMutationSnapshot) restore(b *Broker) {
 	b.tasks = cloneTeamTasksForRollback(snapshot.tasks)
+	b.rebuildTaskIndexLocked()
 	b.channels = cloneTeamChannelsForRollback(snapshot.channels)
 	b.messages = cloneChannelMessagesForRollback(snapshot.messages)
 	b.agentIssues = append([]agentIssueRecord(nil), snapshot.agentIssues...)

--- a/internal/team/broker_tasks_lifecycle.go
+++ b/internal/team/broker_tasks_lifecycle.go
@@ -298,6 +298,7 @@ func (b *Broker) EnsureTask(channel, title, details, owner, createdBy, threadID 
 	}
 	b.reindexTaskLifecycleFromLegacyLocked(&task)
 	b.tasks = append(b.tasks, task)
+	b.indexTaskLocked(task.ID, len(b.tasks)-1)
 	b.appendActionLocked("task_created", "office", channel, createdBy, truncateSummary(task.Title, 140), task.ID)
 	if err := b.saveLocked(); err != nil {
 		return teamTask{}, false, err

--- a/internal/team/broker_tasks_mutation_service.go
+++ b/internal/team/broker_tasks_mutation_service.go
@@ -453,6 +453,7 @@ func (b *Broker) MutateTask(body TaskPostRequest) (TaskResponse, error) {
 		}
 		b.reindexTaskLifecycleFromLegacyLocked(&task)
 		b.tasks = append(b.tasks, task)
+		b.indexTaskLocked(task.ID, len(b.tasks)-1)
 		// Issues start in `drafting` regardless of whether an owner is
 		// set, so the human sees the new Issue in the Drafting column
 		// with an Approve & Start button before the agent begins work.

--- a/internal/team/broker_tasks_plan.go
+++ b/internal/team/broker_tasks_plan.go
@@ -143,6 +143,7 @@ func (b *Broker) handleTaskPlan(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		b.tasks = append(b.tasks, task)
+		b.indexTaskLocked(task.ID, len(b.tasks)-1)
 		b.appendActionLocked("task_created", "office", taskChannel, createdBy, truncateSummary(task.Title, 140), task.ID)
 		created = append(created, task)
 	}
@@ -299,6 +300,7 @@ func (b *Broker) EnsurePlannedTask(input plannedTaskInput) (teamTask, bool, erro
 		return teamTask{}, false, err
 	}
 	b.tasks = append(b.tasks, task)
+	b.indexTaskLocked(task.ID, len(b.tasks)-1)
 	b.appendActionWithRefsLocked("task_created", "office", channel, input.CreatedBy, truncateSummary(task.Title, 140), task.ID, compactStringList([]string{task.SourceSignalID}), task.SourceDecisionID)
 	if err := b.saveLocked(); err != nil {
 		rollbackTask()

--- a/internal/team/self_healing.go
+++ b/internal/team/self_healing.go
@@ -200,6 +200,7 @@ func (b *Broker) requestSelfHealingLocked(agentSlug, taskID string, reason agent
 	}
 	b.reindexTaskLifecycleFromLegacyLocked(&task)
 	b.tasks = append(b.tasks, task)
+	b.indexTaskLocked(task.ID, len(b.tasks)-1)
 	b.appendActionLocked("task_created", "office", channel, createdBy, truncateSummary(task.Title, 140), task.ID)
 	if err := b.saveLocked(); err != nil {
 		return teamTask{}, false, err

--- a/internal/team/skill_review_nudge.go
+++ b/internal/team/skill_review_nudge.go
@@ -73,6 +73,7 @@ func (b *Broker) fireSkillReviewNudgeLocked(agentSlug string) (string, error) {
 		return "", fmt.Errorf("syncTaskWorktree: %w", err)
 	}
 	b.tasks = append(b.tasks, task)
+	b.indexTaskLocked(task.ID, len(b.tasks)-1)
 	b.appendActionLocked(
 		"task_created",
 		"office",


### PR DESCRIPTION
## Problem

`findTaskByIDLocked` linearly scans `b.tasks` to find a task by ID. It's called from 20+ call sites across inbox fetch, inbox counts, decision packets, task mutations, self-healing, and handlers.

The inbox fetch path (`inboxLocked`) calls it once per lifecycle-bucket entry, and `inboxCountsLocked` calls it again for every approved task. With the frontend polling every 5 seconds (`refetchInterval: 5_000`), and with 200 tasks × 30 inbox rows, that's ~6,000 string comparisons every 5 seconds per connected user — O(N×M) per poll.

## Solution

Add a `taskIndex map[string]int` (task ID → slice index) on the Broker struct, following the exact pattern already established by `memberIndex`:

- **`indexTaskLocked(id, idx)`** — nil-safe helper called at all 10 append sites
- **`rebuildTaskIndexLocked()`** — full rebuild called after bulk mutations (GC prune, channel delete, state load, rollback)
- **Lazy-rebuild guard** in `findTaskByIDLocked` — catches any code path that skips explicit index maintenance (including tests that assign `b.tasks` directly)

Changes `findTaskByIDLocked` from O(N) to O(1). No test changes needed — the lazy rebuild handles test paths that bypass the load/append code.

Closes #1045

## Test plan

- [x] `internal/team` package tests pass (177s, all green)
- [x] Full Go test suite: all 39 packages green
- [x] Pre-commit hooks (gofmt, go vet, golangci-lint, secretlint) pass
- [x] Pre-push hooks (build, go-unit, smoke) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)