### PR TITLE
perf(search): add server-side message search, eliminate client fan-out

### DIFF
--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -541,6 +541,7 @@ func (b *Broker) StartOnPort(port int) error {
 	mux.HandleFunc("/session-mode", b.requireAuth(b.handleSessionMode))
 	mux.HandleFunc("/focus-mode", b.requireAuth(b.handleFocusMode))
 	mux.HandleFunc("/messages", b.requireAuth(b.handleMessages))
+	mux.HandleFunc("/messages/search", b.requireAuth(b.handleSearchMessages))
 	mux.HandleFunc("/reactions", b.requireAuth(b.handleReactions))
 	mux.HandleFunc("/notifications/nex", b.requireAuth(b.handleNexNotifications))
 	mux.HandleFunc("/office-members", b.requireAuth(b.handleOfficeMembers))

--- a/internal/team/broker_auth.go
+++ b/internal/team/broker_auth.go
@@ -116,6 +116,7 @@ func humanRouteAllowed(r *http.Request) bool {
 			path == "/status/local-providers",
 			path == "/humans",
 			path == "/wiki/read",
+			path == "/messages/search",
 			path == "/wiki/search",
 			path == "/wiki/lookup",
 			path == "/wiki/list",

--- a/internal/team/broker_messages.go
+++ b/internal/team/broker_messages.go
@@ -712,6 +712,46 @@ func (b *Broker) handleGetMessages(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// handleSearchMessages searches across all channels for messages matching a
+// substring pattern. Returns results newest-first, capped at `limit`.
+//
+//	GET /messages/search?q={pattern}&limit=8&viewer_slug=human
+func (b *Broker) handleSearchMessages(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	pattern := strings.TrimSpace(r.URL.Query().Get("q"))
+	if pattern == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "q is required"})
+		return
+	}
+	limit := 8
+	if l, err := strconv.Atoi(r.URL.Query().Get("limit")); err == nil && l > 0 && l <= 50 {
+		limit = l
+	}
+
+	needle := strings.ToLower(pattern)
+	viewerSlug := strings.TrimSpace(r.URL.Query().Get("viewer_slug"))
+
+	b.mu.Lock()
+	var hits []channelMessage
+	for i := len(b.messages) - 1; i >= 0 && len(hits) < limit; i-- {
+		msg := b.messages[i]
+		if !strings.Contains(strings.ToLower(msg.Content), needle) {
+			continue
+		}
+		if viewerSlug != "" && !b.canAccessChannelLocked(viewerSlug, normalizeChannelSlug(msg.Channel)) {
+			continue
+		}
+		hits = append(hits, cloneChannelMessageForRead(msg))
+	}
+	b.mu.Unlock()
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{"messages": hits})
+}
+
 func messageInThread(msg channelMessage, threadID string) bool {
 	threadID = strings.TrimSpace(threadID)
 	if threadID == "" {

--- a/internal/team/broker_workspaces_test.go
+++ b/internal/team/broker_workspaces_test.go
@@ -1021,6 +1021,7 @@ func TestBrokerMuxAuthCoverage(t *testing.T) {
 		"/session-mode",
 		"/focus-mode",
 		"/messages",
+		"/messages/search",
 		"/reactions",
 		"/notifications/nex",
 		// office members + channels

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -380,6 +380,26 @@ export function getMessages(
   });
 }
 
+export async function searchMessages(
+  query: string,
+  limit = 8,
+  signal?: AbortSignal,
+): Promise<Message[]> {
+  const trimmed = query.trim();
+  if (!trimmed) return [];
+  const url =
+    baseURL() +
+    `/messages/search?q=${encodeURIComponent(trimmed)}&limit=${limit}&viewer_slug=human`;
+  try {
+    const r = await fetch(url, { headers: authHeaders(), signal });
+    if (!r.ok) return [];
+    const res = await r.json();
+    return Array.isArray(res?.messages) ? res.messages : [];
+  } catch {
+    return [];
+  }
+}
+
 export function postMessage(
   content: string,
   channel: string,
@@ -715,25 +735,25 @@ export function deletePolicy(id: string) {
 // Moved to ./scheduler.ts; re-exported here for back-compat with existing
 // imports from "./api/client" or "../api/client".
 export type {
-  SchedulerJob,
+  CreateSchedulerJobBody,
   PatchSchedulerJobBody,
   PatchSchedulerJobResponse,
-  SystemCronSpec,
-  SchedulerRun,
   SchedulerActivity,
+  SchedulerJob,
   SchedulerRevision,
-  CreateSchedulerJobBody,
+  SchedulerRun,
+  SystemCronSpec,
 } from "./scheduler";
 export {
+  createSchedulerJob,
   getScheduler,
-  patchSchedulerJob,
-  getSystemCronSpecs,
-  runSchedulerJob,
-  getSchedulerRuns,
   getSchedulerActivity,
   getSchedulerRevisions,
+  getSchedulerRuns,
+  getSystemCronSpecs,
+  patchSchedulerJob,
   restoreSchedulerRevision,
-  createSchedulerJob,
+  runSchedulerJob,
 } from "./scheduler";
 
 // ── Skills ──
@@ -1013,10 +1033,9 @@ export function editSkillContent(
   name: string,
   content: string,
 ): Promise<EditSkillContentResponse> {
-  return put<EditSkillContentResponse>(
-    `/skills/${encodeURIComponent(name)}`,
-    { content },
-  );
+  return put<EditSkillContentResponse>(`/skills/${encodeURIComponent(name)}`, {
+    content,
+  });
 }
 
 // ── Memory ──

--- a/web/src/components/search/SearchModal.tsx
+++ b/web/src/components/search/SearchModal.tsx
@@ -3,7 +3,7 @@
 import type { ReactNode } from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
-import { getMessages, type Message, post } from "../../api/client";
+import { type Message, post, searchMessages } from "../../api/client";
 import { type NotebookSearchHit, searchNotebook } from "../../api/notebook";
 import { searchWiki, type WikiSearchHit } from "../../api/wiki";
 import { useChannels } from "../../hooks/useChannels";
@@ -121,41 +121,31 @@ export function SearchModal() {
   const [searching, setSearching] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
 
-  const close = useCallback(() => setSearchOpen(false), [setSearchOpen]);
+  const close = useCallback(() => {
+    abortRef.current?.abort();
+    setSearchOpen(false);
+  }, [setSearchOpen]);
 
   const runSearch = useCallback(
     async (raw: string) => {
       const trimmed = raw.trim();
       const needle = trimmed.toLowerCase();
-      if (needle.length < 2 || channels.length === 0) {
+      if (needle.length < 3) {
         setMessageHits([]);
         setWikiHits([]);
         setNotebookHits([]);
         return;
       }
+      abortRef.current?.abort();
+      const controller = new AbortController();
+      abortRef.current = controller;
       setSearching(true);
       try {
-        const messagesP = Promise.all(
-          channels.map(async (ch) => {
-            try {
-              const { messages } = await getMessages(ch.slug, null, 100);
-              return messages
-                .filter((m) => m.content?.toLowerCase().includes(needle))
-                .map((m): MessageHit => ({ ...m, matchedChannel: ch.slug }));
-            } catch {
-              return [] as MessageHit[];
-            }
-          }),
-        ).then((messageGroups) =>
-          messageGroups
-            .flat()
-            .sort(
-              (a, b) =>
-                new Date(b.timestamp).getTime() -
-                new Date(a.timestamp).getTime(),
-            )
-            .slice(0, 8),
+        const messagesP = searchMessages(trimmed, 8, controller.signal).then(
+          (msgs) =>
+            msgs.map((m): MessageHit => ({ ...m, matchedChannel: m.channel })),
         );
 
         const wikiP = searchWiki(trimmed).then((hits) => hits.slice(0, 8));
@@ -182,6 +172,7 @@ export function SearchModal() {
           wikiP,
           notebookP,
         ]);
+        if (controller.signal.aborted) return;
         setMessageHits(msg);
         setWikiHits(wiki);
         setNotebookHits(nb);
@@ -189,7 +180,7 @@ export function SearchModal() {
         setSearching(false);
       }
     },
-    [channels, members],
+    [members],
   );
 
   const handleQueryChange = useCallback(
@@ -197,7 +188,7 @@ export function SearchModal() {
       setQuery(value);
       setSelectedIdx(0);
       if (debounceRef.current) clearTimeout(debounceRef.current);
-      debounceRef.current = setTimeout(() => runSearch(value), 250);
+      debounceRef.current = setTimeout(() => runSearch(value), 400);
     },
     [runSearch],
   );
@@ -286,7 +277,7 @@ export function SearchModal() {
       });
     }
 
-    if (q.length >= 2) {
+    if (q.length >= 3) {
       for (const hit of messageHits) {
         const snippet =
           hit.content.length > 100
@@ -450,7 +441,7 @@ export function SearchModal() {
             <div className="cmd-palette-empty">
               {query
                 ? `No results for "${query}"`
-                : "Start typing to search..."}
+                : "Type at least 3 characters to search..."}
             </div>
           ) : (
             grouped.map((g) => (


### PR DESCRIPTION
## Problem

The `SearchModal` searches messages by fetching 100 messages per channel via `GET /messages` and filtering client-side with `String.includes`. With 10 channels, that's 10 parallel API calls returning up to 1,000 messages — to display at most 8 results.

Wiki and notebook search already have proper server-side endpoints (`GET /wiki/search`, `GET /notebook/search`); messages were the outlier.

Additional issues:
- Min query was 2 chars — fires on "ai" which matches nearly everything
- Debounce was only 250ms
- No request cancellation — fast typing stacked up multiple full fan-outs

## Solution

**Backend**: Add `GET /messages/search?q={pattern}&limit=8&viewer_slug=human` that scans `b.messages` server-side in a single reverse pass (newest-first, stops at limit, respects channel access control). ~40 lines of Go following the existing `handleWikiSearch` / `handleNotebookSearch` pattern.

**Frontend**: Replace the N-channel `Promise.all(channels.map(ch => getMessages(...)))` fan-out with a single `searchMessages()` call. Also:
- Min query: 2 → 3 characters
- Debounce: 250ms → 400ms
- Add `AbortController` to cancel stale in-flight requests on re-type or modal close

**Result**: N API calls → 1. Up to 1,000 messages transferred → at most 8. Stale requests cancelled instead of completing silently.

Closes #1047

## Test plan

- [x] `internal/team` Go tests pass (195s, all green)
- [x] Web test suite: 203 files, 1961 tests pass
- [x] TypeScript type check passes
- [x] Biome lint clean on changed files
- [x] Pre-commit hooks (gofmt, go vet, golangci-lint, biome, secretlint) pass
- [x] Pre-push hooks (build, go-unit, web-unit, smoke) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)