### PR TITLE
feat(packer): Slack inbound context-packer — egress core + prerequisites

### DIFF
--- a/docs/specs/slack-context-packer.md
+++ b/docs/specs/slack-context-packer.md
@@ -524,3 +524,35 @@ No direct disagreements required escalation: severity divergences (architecture
 BLOCK vs security HIGH on H3/H5) agreed *that* each was a problem; the higher
 severity was taken.
 ```
+
+## Implementation status
+
+The egress core is implemented in `internal/packer` (decoupled package; imports
+only `internal/scanner` + stdlib — the cloud-portability seam). Three code
+prerequisites the review surfaced shipped first:
+
+- `scanner.RedactForEgress` — fail-closed redaction (deny on poison / entropy
+  cap), `internal/scanner/egress_redaction.go`.
+- `LearningSearchFilters.TaskID` — exact task-scope filter, `learnings.go`.
+- `teamTask.WikiRefs` — the task→article backing link, `broker_types.go` +
+  `broker_tasks_mutation_service.go`.
+
+Implemented stages: `Gather → Classify → budget → render → Deliver`, the
+`DefaultEgressPolicy` table, audience-aware classification, the sealed-delegation
+gate, snapshot binding, and the fail-closed `Deliver`. Brain / bridge / validator
+/ audit-sink are interfaces; the team-side adapter and the real Slack bridge land
+with the bridge PR.
+
+### Implementation review dispositions (verification agent, 2026-06-09)
+
+An adversarial verification agent on the implemented classifier found 6 issues;
+all FIXED (see the `fix(packer)` commit).
+
+| # | Finding | Sev | Disposition |
+|---|---------|-----|-------------|
+| F1 | `Render`/`Budget` exported + `PackedDelegation` hand-constructible = scanner bypass | HIGH | FIXED — `budget`/`render` unexported; `sealed` marker only `render` sets; `Deliver` refuses unsealed |
+| F2 | Guard lines skipped `policy.Classify` | HIGH | FIXED — each guard line is policy-classified before scan |
+| F3 | `Pack` took a raw audience tier (footgun); `Gather` retrieved on target tier | BLOCK | FIXED — `Pack` computes audience from a typed `DeliveryAudience`; Gather + Classify use it |
+| F4 | `Deliver` validated `req`, not the packed snapshot | BLOCK | FIXED — `snapshotMatches` binds delivery to the `InjectionRecord` snapshot |
+| F5 | Idempotency not atomic; pending didn't block re-post | HIGH | FIXED — pending blocks re-post; sink-atomicity + bridge-idempotency contract documented |
+| F6 | Budget could evict the required plan / overflow caps | MEDIUM | FIXED — plan + envelope reserved and capped; only non-essentials trimmed |

--- a/docs/specs/slack-context-packer.md
+++ b/docs/specs/slack-context-packer.md
@@ -1,0 +1,526 @@
+# Inbound Context Packer
+
+> Status: **DRAFT / design v2** (2026-06-09). Not yet implemented. Revised after a
+> `/codex` consult review — see "Review dispositions" at the end.
+> Owner: founder + harness team.
+> Scope: open-source self-hosted WUPHF. Designed as a **shared kernel** the Nex
+> cloud (hosted, multi-tenant) version inherits without forking.
+
+## One line
+
+The component that lets an agent from **anywhere** — a custom Slack bot, a dev's
+Cursor/Claude session, a vendor bot — participate fully in a WUPHF office with
+**zero integration on its side**, by having our CEO agent retrieve the right
+slice of the team brain, **classify and redact it for export**, and deliver it
+inside the message the bot already reads.
+
+## Why this exists
+
+WUPHF's compounding loop works because, when a WUPHF-hosted agent spawns,
+`promptBuilder.Build(slug)` (`internal/team/prompt_builder.go:53`) injects the
+roster, the `== AVAILABLE SKILLS ==` catalog (`renderSkillsCatalogBlock`, `:483`),
+and the `== PRIOR TEAM LEARNINGS ==` block (`learningSnapshot` →
+`renderPriorLearningsBlock`, `:403`/`:410`) into its system prompt. That is
+**push-side** injection.
+
+A foreign bot in Slack sets its own system prompt and never receives our
+injection, so by default it is a dumb bot in a channel. The CEO membrane fixes
+this from our side only:
+
+- **Inbound (this doc): retrieve, classify, inject.** Before the CEO delegates a
+  step to a foreign bot, the packer gathers candidate brain context, runs it
+  through an **export-classification and redaction stage**, fits the survivors to
+  a budget, and writes them into the `@`-mention the bot already reads.
+- **Outbound (shipped by #1033): observe-and-curate.** The Librarian (Pam)
+  observes the thread and is the sole writer to the wiki; foreign output is
+  promoted only through the existing human gate.
+
+The packer is the inbound half and the **only large net-new component** of the
+feature. It is also a **data-egress boundary** — see the egress section, which is
+the highest-risk part of this design and the reason the v1 "task-attached is safe"
+model was rejected.
+
+## Where it sits
+
+```
+Slack workspace channel  (just a workspace; carries no structure)
+        │  human posts a goal / bot posts a reply
+        ▼
+  Slack bridge  ──────────────►  Broker  (holds the broker token; one trust domain)
+   (transport adapter)            │
+        ▲                         ├─ Task lifecycle (#1033): plan → approve → run → review
+        │ posts packed delegation │
+        │                         ├─ CEO triage: assign present agents, restate intent
+        │                         │        │ StepIntent (+taint) + target bot
+        │                         │        ▼
+        │                         │   ┌──────────────────────────────────┐
+        │                         │   │  INBOUND CONTEXT PACKER           │ ◄── this doc
+        │                         │   │  Gather → CLASSIFY/REDACT →       │
+        │                         │   │  Budget → Render → Deliver        │
+        │                         │   └──────────┬───────────────────────┘
+        │                         │              │ reads via BrainHandle
+        │                         │   ┌──────────▼───────────┐
+        │                         │   │ shared retrieval      │ primitives + ranking
+        │                         │   │ (Learnings·Wiki·Skills·Roster·Task)
+        └─────────────────────────┘   └──────────────────────┘
+```
+
+The Slack channel has no model of tasks. The Task lives in the broker. The packer
+turns "CEO wants bot B to do step S of task T" into a Slack message B can act on
+— minus anything the egress policy forbids B from seeing.
+
+## Data model
+
+All structs immutable once constructed (return new values, never mutate). No
+`any`. Validate at the `Gather` boundary.
+
+```go
+// BrainHandle is the office/tenant brain the packer reads from. OSS self-hosted:
+// a singleton. Nex cloud: one per tenant. The packer NEVER touches global state
+// directly. This is the single seam that keeps the component cloud-portable
+// without a fork.
+type BrainHandle interface {
+    OfficeID() string
+    Task(id string) (TaskView, error)        // teamTask + IssueDraftSpec + approved plan + UpdatedAt
+    Roster(taskID string) ([]RosterLine, error)
+    Learnings() LearningSearcher              // wraps LearningLog.Search (learnings.go:247) — task-scoped filters
+    Wiki() WikiSearcher                       // wraps WikiIndex.Search (wiki_index.go:418) + retrieveWithClass
+    Skills() SkillCatalog                     // wraps ListActiveSkillSummaries
+    Egress() EgressPolicy                     // versioned; see egress section
+    Secrets() SecretScanner                   // redaction pass over every export candidate
+}
+
+// BotIdentity is the full provenance anchor. A bare Slack user id is NOT enough
+// across workspaces / enterprise grids, and display names are spoofable. Trust
+// binds to this whole tuple, never to DisplayName.
+type BotIdentity struct {
+    SlackTeamID     string // workspace id
+    SlackEnterprise string // enterprise-grid id, if any
+    AppUserID       string // the bot's app/bot user id
+    DisplayName     string // advisory only — never a trust input
+    VerifiedVia     string // how identity was confirmed (install OAuth, admin add)
+}
+
+// BotDataHandling describes where this bot's prompts actually go. Trust is about
+// data handling, not just "we built it" — a first-party bot can still forward
+// prompts to a third-party LLM, retain logs, or run in a personal workspace.
+type BotDataHandling struct {
+    ModelProvider      string // "anthropic" | "openai" | "self-hosted" | "unknown"
+    RetainsLogs        bool
+    WorkspaceOwned     bool   // company-owned workspace vs a personal one
+    NetworkEgress      string // "none" | "vendor-llm" | "open" | "unknown"
+    ReadsThreadHistory bool
+}
+
+type BotTrust int // DERIVED partly from DataHandling, not just origin
+const (
+    BotUntrusted BotTrust = iota // DEFAULT for anything externally originated
+    BotFirstParty                // in-house, company-owned-workspace, known data handling
+    BotHosted                    // WUPHF-hosted agent (also gets push-side injection)
+)
+
+type ReadScope int
+const ( ReadMentionOnly ReadScope = iota; ReadThread )
+
+type Invocation int
+const ( InvokeMention Invocation = iota; InvokeSlash; InvokeKeyword )
+
+type BotProfile struct {
+    Version      int          // bumped on every change; referenced by every InjectionRecord
+    Slug         string
+    Identity     BotIdentity
+    Trust        BotTrust
+    DataHandling BotDataHandling
+    ReadScope    ReadScope    // upgraded to ReadThread ONLY via a nonce probe (below)
+    Invoke       Invocation
+    Trigger      string       // slash command or keyword when Invoke != InvokeMention
+    Specialties  []string     // from OBSERVED task history + human confirmation — NOT display name
+    Notes        string
+}
+
+// StepIntent is tainted if it was influenced by foreign-bot output. Tainted
+// intent must NOT drive free retrieval (it would be a retrieval prompt-injection
+// path into WikiIndex.Search). Taint is DERIVED, not caller-declared: if any
+// SourceRef is a foreign-bot message, the intent stays TaintForeign unless it is
+// rebuilt from approved task metadata / human-authored text with NO spans copied
+// from the foreign source. The CEO cannot launder foreign text into a "clean"
+// restatement. Only genuinely clean terms drive retrieval.
+type Taint int
+const ( TaintClean Taint = iota; TaintForeign )
+
+type StepIntent struct {
+    Text       string   // the precise ask, CEO-restated
+    Taint      Taint
+    SourceRefs []string // message ids the intent derives from, for audit
+}
+
+// ContextRequest — the packer's input for one delegation. Carries snapshot +
+// version guards so Gather/Classify/Deliver cannot race a task edit or a trust
+// downgrade.
+type ContextRequest struct {
+    Brain           BrainHandle
+    TaskID          string
+    TaskUpdatedAt   string      // re-checked before Deliver; stale → abort
+    PlanID          string
+    PlanVersion     int
+    Target          BotProfile  // carries Target.Version
+    Intent          StepIntent
+    Thread          ThreadRef   // workspace + channel + thread ts
+    EgressPolicyVer int
+    Approver        string      // who approved the plan / this egress, when a gate applies
+    IdempotencyKey  string      // dedupes both delivery and the InjectionRecord
+}
+
+// ExportClass is decided per item by the egress policy + secret scan.
+type ExportClass int
+const (
+    ExportDenied   ExportClass = iota // never leaves the brain
+    ExportRedacted                    // leaves only after redaction
+    ExportAllowed                     // leaves as-is
+)
+
+type ContextItem struct {
+    Ref        string      // id/path of the source brain item
+    Kind       string      // "plan" | "learning" | "wiki" | "roster" | "skill" | "task"
+    Body       string      // POST-redaction text
+    Class      ExportClass
+    Redactions int         // count of secrets/PII removed
+}
+
+// ContextBundle — classified + redacted, pre-budget. Only ExportAllowed and
+// ExportRedacted items survive Classify into here.
+type ContextBundle struct {
+    Ask        string        // Intent.Text, length-capped + taint-checked; NOT a retrieval input
+    ReturnPact string        // what to return, where, who to tag
+    Guards     []string      // ADVISORY to the bot — explicitly NOT a security control
+    Items      []ContextItem
+}
+
+// PackedDelegation — the output the bridge posts to Slack.
+type PackedDelegation struct {
+    MentionText   string          // ALWAYS carries the essentials
+    ThreadContext string          // CHANNEL-VISIBLE: classified against the LEAST-trusted reader
+                                  // in the channel, not just Target (Slack threads are not ACL)
+    Injection     InjectionRecord
+}
+
+type DeliveryStatus int
+const ( DeliveryPending DeliveryStatus = iota; DeliverySent; DeliveryFailed )
+
+type ItemAudit struct {
+    Ref        string
+    Kind       string
+    Class      ExportClass
+    Redactions int
+}
+
+// InjectionRecord — append-only egress audit. Strong enough for incident
+// response: proves exactly what was sent, where, under which policy, and whether
+// it landed.
+type InjectionRecord struct {
+    IdempotencyKey string
+    TaskID         string
+    PlanID         string
+    PlanVersion    int
+    Identity       BotIdentity   // full tuple, not a bare id
+    BotTrust       BotTrust
+    ProfileVersion int
+    PolicyVersion  int
+    WorkspaceID    string
+    ChannelID      string
+    ThreadTS       string
+    MessageTS      string        // filled on DeliverySent
+    Items          []ItemAudit
+    RenderedHash   string        // hash of exactly what was sent
+    TokenCount     int
+    Status         DeliveryStatus
+    FailureReason  string
+    Timestamp      string
+}
+```
+
+## The pipeline
+
+Security-first ordering: **classify and redact before you rank**, so containment
+is never traded away for relevance.
+
+```go
+func Gather(ctx context.Context, req ContextRequest) (RawBundle, error)        // task-scoped retrieval
+func Classify(ctx context.Context, raw RawBundle, req ContextRequest) (ContextBundle, error) // export-class + redact; drop ExportDenied
+func Budget(b ContextBundle, t BotProfile) ContextBundle                       // rank + trim the survivors to fit
+func Render(b ContextBundle, t BotProfile) PackedDelegation                    // shape to profile; ThreadContext classified vs channel
+func Deliver(ctx context.Context, bridge SlackBridge, d PackedDelegation, key string) error // idempotent
+```
+
+1. **Gather** — retrieve candidates, **task-scoped**. Always sets `Ask`,
+   `ReturnPact`, `Guards`. Pulls the approved plan step (`teamTask.IssueDraftSpec`
+   `broker_types.go:269` + the owner-notebook plan from `LifecycleStatePlanning`).
+   Retrieval uses `Learnings().Search` scoped by the task's tags/files (the
+   current push-side `learningSnapshot` is broad — `Limit: 8`, no task scope
+   `prompts.go:61` — so the shared primitive must add scoping, not be extracted
+   as-is) and `Wiki().Search` driven **only by clean intent terms** (tainted
+   intent cannot reach retrieval).
+2. **Classify** — the egress boundary. The classified unit is the **whole
+   delegation envelope**, not just `Items`: `Ask`, `ReturnPact`, and `Guards` are
+   export data too — a tainted task can plant a secret or customer datum in the
+   ask, and those fields are "never dropped" by Budget, so an unclassified
+   envelope is a direct exfiltration channel. For every candidate item **and each
+   envelope field**: assign `ExportClass` from `Egress().Allow(item, audience)`
+   and run the **egress redaction contract** (see Egress boundary) to redact
+   secrets/PII. Drop `ExportDenied`; a field that cannot be sanitized **fails
+   closed** — the whole delegation is held, never sent partial. `Redactions` is
+   recorded per item. Runs **before** budgeting so denied content is gone before
+   ranking.
+3. **Budget** — rank the survivors and trim to the profile's token tier. `Ask`,
+   `ReturnPact`, `Guards` are never dropped, but `Ask` is length-capped and
+   taint-checked (an oversized or tainted ask is truncated/flagged, not trusted).
+4. **Render** — shape to the profile. `ThreadContext` is classified against the
+   **least-trusted reader in the channel**, because a thread post is visible to
+   every human and bot in that channel, not just the target.
+5. **Deliver** — idempotent on `IdempotencyKey`. First **re-validate the
+   snapshot**: re-check `TaskUpdatedAt`, `Target.Version`, `EgressPolicyVer`, and
+   the *live* trust tier — not just `TaskUpdatedAt`. A trust downgrade or policy
+   bump between Classify and Deliver must abort the send; stale-authorized context
+   must never ship. Then run a **final redaction scan over the exact rendered
+   bytes** (`MentionText` + `ThreadContext`): Render can reintroduce raw refs,
+   titles, plan text, or failure reasons that a pre-render item scan never saw, so
+   the post-render sealed text is what gets hashed into `RenderedHash`. Write
+   `InjectionRecord` as `DeliveryPending` first, post, then update to
+   `DeliverySent` (with the Slack `ts`) or `DeliveryFailed` (with reason). **Do
+   not rely on the generic outbound dispatcher** (`broker_outbound_dispatch.go`),
+   which marks delivered on dequeue and drops send failures — for an egress
+   boundary, dropped or duplicated context is security-relevant, so the packer
+   tracks its own delivery state.
+
+### Shared retrieval, not a shared bundle
+
+`promptBuilder` (push) and the packer (pull) **share the retrieval primitives and
+ranking** — `LearningLog.Search`, `WikiIndex.Search`, the skill match, the roster
+read — so the two cannot drift on what the brain *contains*. They do **not** share
+a bundle contract. Hosted agents get durable system instructions, policies, the
+full skills catalog, and broad learnings through trusted tools; foreign bots get
+an **egress-filtered, task-scoped, redacted subset**. The packer's `Classify`
+stage is the difference, and it has no push-side equivalent. Extract the query +
+rank helpers into one place; keep the bundle shaping separate.
+
+## Egress boundary (the hard part — read this twice)
+
+The packer ships internal brain content into a foreign LLM we do not control,
+which may log the prompt or forward it to a third-party model. **It is not safe by
+default and the v1 "task-attached content is safe" rule was wrong.** "Attached to
+the task" proves *relevance*, not *exportability*: `teamTask.Details` and
+`IssueDraftSpec` are free-form and routinely contain pasted logs, customer data,
+credentials, or injection text.
+
+Required controls, all of them, before any item is injected:
+
+1. **Per-item export classification.** Every candidate runs through
+   `EgressPolicy.Allow(item, target)` → `ExportAllowed | ExportRedacted |
+   ExportDenied`. No item reaches Slack without a class.
+2. **Secret/PII redaction on every export candidate**, including task-attached
+   content and the envelope fields. Redaction count is audited. **The existing
+   display scanner is not a deny gate.** `scanner.RedactSecretsForDisplay`
+   (`internal/scanner/scanner_detector.go:130`) returns a `RedactionResult` with
+   **no error**; its entropy pass *stops* after `maxEntropyHitsPerFile` (`:191`),
+   leaving over-cap secrets in `.Content`; and the current caller
+   `redactSecretsInText` (`internal/team/message_redaction.go:9`) returns
+   `.Content` directly. The egress path needs a **fail-closed wrapper** on top of
+   it: deny the item when `RedactionResult.Poisoned` is true, when the entropy-hit
+   cap was reached (the remainder cannot be proven clean), or on any scanner
+   error. Never emit `.Content` from a result that hit a limit.
+3. **First-egress human gate for untrusted bots.** The first time the office
+   sends *any* brain content to a given bot, raise the approval card (reuse the
+   deterministic-integrations `ExternalActionApprovalCard`) so a human signs off
+   on "this external bot may now receive task context." The approval is keyed to
+   the **verified install** — Slack app/install id + `SlackTeamID` +
+   `SlackEnterprise` + `AppUserID` + a `BotDataHandling` fingerprint + trust tier +
+   profile version — **never a bare user id or display name**. Any reinstall,
+   enterprise-grid move, data-handling change, trust downgrade, or revocation
+   **re-gates**. Subsequent sends to the same verified install are gated only by
+   classification.
+4. **Channel-visibility classification.** `ThreadContext` is visible to everyone
+   in the channel — **and to anyone who joins later and reads history.** Classify
+   it against the **least-trusted reader present**; and because membership at
+   classify time cannot prove a future untrusted joiner won't read the thread,
+   treat a non-DM thread post as visible to a future unknown reader unless history
+   visibility is provably closed. Deliver sensitive, target-only context via
+   ephemeral/DM rather than a thread post. `Egress().Allow` therefore takes the
+   **audience**, not a single target.
+5. **Taint-aware intent.** `StepIntent.Taint == TaintForeign` cannot drive
+   retrieval. The CEO must restate intent in clean terms; the packer enforces this
+   structurally rather than trusting the CEO to have done it.
+6. **Trust reflects data handling, not origin.** A bot is `BotFirstParty` only if
+   `DataHandling` is known and acceptable (company-owned workspace, known model
+   provider). Origin alone never grants a tier.
+
+Policy by tier (still conservative; labels are a later refinement that only
+*widens* first-party reach):
+
+| Bot trust | What survives Classify |
+|---|---|
+| `BotUntrusted` (default) | The CEO-authored `Ask` + `ReturnPact` + the approved plan step, all redacted. **Raw `Details`/`IssueDraftSpec` prose is NOT exported wholesale** — redaction catches credential *tokens*, not confidential narrative, source, or customer data — so untrusted bots get only human-approved excerpts until per-item sensitivity labels exist. No free wiki/learning retrieval. First egress human-gated. |
+| `BotFirstParty` | The above + task-scoped learnings + **explicitly task-linked** wiki refs (not free wiki retrieval until per-item sensitivity labels exist) |
+| `BotHosted` | Everything (it already gets the full push-side injection) |
+
+**`Guards` are advisory, not a control.** A foreign bot may ignore "no external
+action without approval." The real boundary is withholding the data and never
+embedding credentials or high-sensitivity detail. The action gate
+(`ExternalActionApprovalCard`) is the enforced control; `Guards` text is a hint.
+
+## Budget heuristic
+
+Run the security pass first, then rank what remains.
+
+| ReadScope | Mention budget | Thread block budget |
+|---|---|---|
+| `ReadMentionOnly` (default) | ~600 tok hard cap | — |
+| `ReadThread` (nonce-verified) | ~400 tok | up to ~2000 tok |
+
+- **Never dropped:** `Ask`, `ReturnPact`, `Guards`. `Ask` is length-capped and
+  taint-checked; if it overflows, truncate the `Ask`, never the `Guards`.
+- **Rank order for `Items`** (trim from the bottom): approved plan step → task-
+  scoped high-confidence learnings → task-linked wiki refs → roster lines (cap ~3)
+  → matching skill hints. Reuse `WikiIndex.Search` (BM25), `retrieveWithClass`
+  (typed/relationship), `LearningLog.Search` (filtered). Do not reinvent retrieval.
+
+## Per-bot delivery profile
+
+- **On first sight:** `Trust=BotUntrusted`, `ReadScope=ReadMentionOnly`,
+  `Invoke=InvokeMention`, empty `Specialties`. Safe defaults that work for any bot.
+- **ReadScope upgrade requires an explicit nonce probe.** Send a unique token in
+  thread-only context and confirm the bot echoes/acts on it before setting
+  `ReadThread`; store the evidence. Never infer thread-reading from ordinary
+  replies (humans paste, LLMs quote — both produce false positives).
+- **Specialties** come from observed successful task history plus human
+  confirmation for routing-sensitive changes, never from the display name.
+- **Trust** is set by a human, informed by `DataHandling`. Default stays
+  `BotUntrusted`. Hosted agents are `BotHosted` automatically.
+
+## Plan-mode interaction (#1033)
+
+Plan mode stays on. For foreign-bot work the CEO owns planning, a human approves
+the plan, then the packer delivers only the approved step(s). The bot never plans
+into a notebook; it receives a scoped, approved `Ask`. Combined with the
+first-egress gate, a human has signed off on both *what* the bot does and *that it
+may receive context* before any brain content leaves.
+
+## Reuse map (verified surfaces)
+
+| Need | Existing surface |
+|---|---|
+| Push-side reference behavior | `promptBuilder.Build` `internal/team/prompt_builder.go:53` |
+| Prior-learnings gather/render | `learningSnapshot` `:403`, `renderPriorLearningsBlock` `:410`; broad call site `prompts.go:61` |
+| Skills catalog | `renderSkillsCatalogBlock` `:483`, `ListActiveSkillSummaries` |
+| Learning search (typed filters) | `LearningLog.Search` `learnings.go:247`; HTTP `handleLearningSearch` `broker_learning.go:90` |
+| Wiki retrieval | `WikiIndex.Search` `wiki_index.go:418`; `retrieveWithClass` `wiki_query_retrieve.go:44`; `searchArticles` `wiki_git.go:926` |
+| Task spec / plan | `teamTask` + `IssueDraftSpec` `broker_types.go:261/269`; `LifecycleStatePlanning` |
+| Roster + watching | `officeMember` `broker_types.go:465`, `.Watching` `:483` |
+| Slack delivery | `transport.Host` `transport/transport.go:156`; `PostInboundSurfaceMessage`/`ReceiveMessage`/`UpsertParticipant` `broker_transport.go`; model the bridge on `telegram.go` |
+| Delivery state caution | generic dispatch marks delivered on dequeue, drops failures: `broker_outbound_dispatch.go` — do not reuse for egress |
+| Action gate + first-egress gate | `ExternalActionApprovalCard` from the deterministic-integrations lane |
+| Egress redaction (fail-closed wrapper) | `scanner.RedactSecretsForDisplay` `scanner_detector.go:130` + `RedactionResult.Poisoned`/entropy cap `:191` — **wrap, do not call raw** like `message_redaction.go:9` |
+| Channel membership (least-trusted reader) | `teamChannel` member lists `broker_types.go:452` — a stored list; cannot prove thread history is closed |
+
+**Two primitives must be extended before this is implementable as specified:**
+
+- `LearningSearchFilters` (`learnings.go:107`) has **no `TaskID` field** — only
+  scope/playbook/file/query, and `LearningRecord` carries `TaskID` (`:99`) that
+  is never filterable. Task-scoped learning egress requires adding an exact
+  `TaskID` (and entity/tag) filter and **AND-scoping**; deny export if exact
+  scope cannot be expressed. Fuzzy scope matching is not acceptable for egress.
+- "Explicitly task-linked wiki refs" (`BotFirstParty` policy) has **no backing
+  link** — a task carries `Details`/`Tags` but no wiki-ref field, and the only
+  wiki primitive is free `WikiIndex.Search` (`wiki_index.go:418`). Either add a
+  real task→article link, or drop wiki from the FirstParty tier until per-item
+  sensitivity labels exist. Do **not** fall back to free search — that is exactly
+  the path the policy forbids.
+
+## Acceptance scenarios (ICP-first — test against all three)
+
+1. **Untrusted vendor bot + redaction + first-egress gate.** A vendor
+   `@notetaker` (`BotUntrusted`, `ReadMentionOnly`) is assigned a step where the
+   task `Details` contain a pasted API key. Assert: (a) the first send to this
+   identity raised the human egress gate; (b) the key is redacted (`Redactions > 0`)
+   and never appears in `RenderedHash`'s source; (c) the mention carries
+   `Ask`/`ReturnPact`/`Guards`/plan step and **no** wiki; (d) `InjectionRecord`
+   lists only task items, each `ExportAllowed`/`ExportRedacted`, with full identity
+   tuple and `DeliverySent` + a Slack `ts`.
+2. **First-party warehouse bot, thread-verified.** `@warehouse-bot`
+   (`BotFirstParty`, `ReadThread` set only after a passed nonce probe) gets a lean
+   mention plus a thread block carrying a task-scoped learning and a
+   **task-linked** wiki ref (not free wiki retrieval). Assert the thread block was
+   classified against the least-trusted reader in the channel.
+3. **Hosted parity = same retrieval, filtered bundle.** A `BotHosted` agent on the
+   same task gets context via the push path; the packer does not double-inject.
+   Assert the **shared retrieval primitive** returns the same candidate set for
+   both paths, and the packer's `Classify` yields a subset for any non-hosted bot.
+   Not byte-identical bundles.
+
+## Out of scope
+
+- Multi-tenant auth, network listener, credential issuance — that is **Nex cloud**.
+  Here the bridge holds the broker token inside one trust domain.
+- Per-item wiki sensitivity labels (later refinement that widens first-party wiki
+  reach; the default policy ships without them).
+- The Slack bridge adapter and the Block Kit gate cards (separate specs).
+
+## Before implementation
+
+The egress boundary is the highest-risk surface. Triangulation
+(`scripts/dispatch-triangulation.sh`, security/API/architecture lenses) **plus** a
+verification agent on `Classify` + `EgressPolicy` + redaction were run on
+2026-06-09 — dispositions below. New wire shapes still get a cross-language sanity
+check if any cross a process boundary to the bridge.
+
+**Implementation is gated on three code prerequisites surfaced by the review:**
+(1) a fail-closed egress redaction wrapper over `internal/scanner` (deny on
+`Poisoned`/entropy-cap/error); (2) a `TaskID` filter on `LearningSearchFilters`;
+(3) a task→wiki-article link field (or wiki dropped from the FirstParty tier).
+None exist today.
+
+## Review dispositions (codex consult, 2026-06-09)
+
+| # | Finding | Sev | Disposition |
+|---|---------|-----|-------------|
+| 1 | "task-attached is safe" is wrong; Details/IssueDraftSpec are free-form | CRITICAL | FIXED — per-item classification + redaction + first-egress human gate |
+| 2 | `BotFirstParty` "non-sensitive wiki" undefined without labels | CRITICAL | FIXED — FirstParty = task-linked wiki refs only until labels exist |
+| 3 | StepIntent taint hand-waved; drives `WikiIndex.Search` | CRITICAL | FIXED — `StepIntent.Taint`; tainted intent cannot reach retrieval |
+| 4 | `InjectionRecord` too weak for audit | HIGH | FIXED — added identity tuple, channel/ts, status, policy/profile versions, hash, redactions, failure reason |
+| 5 | Delivery atomicity/idempotency unspecified | HIGH | FIXED — `IdempotencyKey` + pending→sent/failed; do not reuse generic dispatcher |
+| 6 | Slack identity underspecified (bare id, spoofable name) | HIGH | FIXED — `BotIdentity` tuple; DisplayName never a trust input |
+| 7 | Trust models ownership, not data handling | HIGH | FIXED — `BotDataHandling`; tier derived from it |
+| 8 | Guards treated as a control | HIGH | FIXED — Guards labeled advisory; data withholding + action gate are the controls |
+| 9 | Shared `ContextGatherer` wrong if identical queries | MEDIUM | FIXED — share retrieval+ranking primitives, not the bundle; `Classify` is packer-only |
+| 10 | Push-side learning retrieval not task-scoped | MEDIUM | FIXED — shared primitive must add task scope (noted at `prompts.go:61`) |
+| 11 | Wire shapes lack snapshot/version fields | MEDIUM | FIXED — plan id/version, TaskUpdatedAt, policy/profile versions on `ContextRequest` |
+| 12 | Budget optimizes relevance over containment | MEDIUM | FIXED — Classify/redact runs before Budget; `Ask` length-capped + taint-checked |
+| 13 | ReadScope auto-discovery fragile | MEDIUM | FIXED — explicit nonce probe + stored evidence |
+| 14 | Specialties from display name is weak/manipulable | LOW | FIXED — observed task history + human confirmation |
+| 15 | ThreadContext is channel-visible, not target-scoped | LOW | FIXED — classify vs least-trusted channel reader; prefer ephemeral/DM |
+| 16 | Acceptance #3 overreaches (byte-identical bundles) | LOW | FIXED — relaxed to shared retrieval semantics + subset |
+
+## Review dispositions (triangulation + verification, 2026-06-09)
+
+Three orthogonal codex lenses (security/API/architecture) plus one adversarial
+verification agent, scoped to `Classify` + `EgressPolicy` + redaction. Confidence
+= number of independent agents that hit the same `file:line`. Several findings
+were confirmed against real code (noted). All FIXED in the design above; three
+also create code prerequisites tracked in **Before implementation**.
+
+| # | Finding | Agents | Sev | Disposition |
+|---|---------|--------|-----|-------------|
+| H1 | `Ask`/`ReturnPact`/`Guards` are "never dropped" → bypass Classify (unredacted egress channel) | 4 | BLOCK | FIXED — Classify covers the whole envelope; a field that can't be sanitized fails closed |
+| H2 | "redaction failure denies item" unbacked — `RedactSecretsForDisplay` returns no error, entropy caps & leaves over-cap secrets in `.Content`; no post-render scan (code-verified `scanner_detector.go:130/191`, `message_redaction.go:9`) | 4 | BLOCK | FIXED — fail-closed wrapper (deny on `Poisoned`/cap/error) + final byte-scan at Deliver; **code prereq** |
+| H3 | `BotUntrusted` exports raw free-form `Details`/`IssueDraftSpec`; redaction catches tokens, not confidential prose/source/customer data | 3 | BLOCK/HIGH | FIXED — untrusted tier ships only redacted `Ask`/`ReturnPact`/plan step + human-approved excerpts (product call) |
+| H4 | Trust-downgrade/version race: only `TaskUpdatedAt` rechecked at Deliver | 3 | HIGH/BLOCK | FIXED — Deliver re-validates `Target.Version` + `EgressPolicyVer` + live tier, aborts on change |
+| H5 | Channel-visibility TOCTOU + `Allow(item, target)` can't express least-trusted reader | 4 | HIGH/BLOCK | FIXED — audience-aware `Allow`; non-DM thread = future-unknown-reader; sensitive context via ephemeral/DM |
+| H6 | `LearningSearchFilters` has no `TaskID` — "task-scoped learnings" unimplementable (code-verified `learnings.go:107`) | 4 | HIGH | FIXED — named in reuse map; add `TaskID` filter + AND-scope or deny; **code prereq** |
+| H7 | "task-linked wiki refs" has no backing link; only free `WikiIndex.Search` exists → implementer forced into the forbidden path | 2 | HIGH | FIXED — add task→article link or drop wiki from FirstParty; **code prereq** |
+| H8 | First-egress gate keyed loosely — reinstall/grid-move/spoof inherits stale approval | 2 | HIGH | FIXED — keyed to verified install + identity tuple + data-handling fingerprint + trust tier + profile version; re-gates on any change |
+| H9 | Taint caller-declared — CEO can launder foreign text into "clean" intent | 2 | HIGH | FIXED — taint derived structurally from `SourceRefs`; no copied spans |
+| H10 | `BotHosted` double-inject (packer + push path) | 1 | LOW | ALREADY-COVERED — acceptance #3 already asserts the packer does not double-inject hosted agents |
+
+No direct disagreements required escalation: severity divergences (architecture
+BLOCK vs security HIGH on H3/H5) agreed *that* each was a problem; the higher
+severity was taken.
+```

--- a/internal/packer/deliver.go
+++ b/internal/packer/deliver.go
@@ -1,0 +1,147 @@
+package packer
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// ErrFinalScanFailed is returned when the final redaction scan over the exact
+// rendered bytes refuses the content. Render can reintroduce raw refs/titles a
+// pre-render item scan never saw, so the last scan is over what actually leaves.
+var ErrFinalScanFailed = errors.New("packer: delivery aborted — final egress scan failed")
+
+// SlackBridge posts a packed delegation and returns the Slack message ts. The
+// real implementation lives in the Slack bridge adapter (a separate spec); tests
+// use a fake.
+type SlackBridge interface {
+	Post(ctx context.Context, d PackedDelegation, idempotencyKey string) (messageTS string, err error)
+}
+
+// SnapshotValidator re-checks, at delivery time, that the task/profile/policy
+// snapshot the delegation was built against is still current. A trust downgrade
+// or a version bump between Classify and Deliver must abort the send.
+type SnapshotValidator interface {
+	Validate(req ContextRequest) error
+}
+
+// InjectionSink is the append-only audit store. Write is called on every state
+// transition (pending -> sent/failed). Lookup powers idempotency: a delegation
+// already delivered for an idempotency key is never sent twice.
+type InjectionSink interface {
+	Lookup(idempotencyKey string) (InjectionRecord, bool)
+	Write(rec InjectionRecord) error
+}
+
+// Clock yields the current time. Injectable so tests are deterministic.
+type Clock func() time.Time
+
+// SystemClock is the default wall clock.
+func SystemClock() time.Time { return time.Now().UTC() }
+
+// Deliver is idempotent on req.IdempotencyKey. It (1) returns the prior record if
+// this key already delivered; (2) re-validates the snapshot and aborts on a
+// stale task / trust downgrade / version bump; (3) runs a FINAL redaction scan
+// over the exact rendered bytes; (4) writes the InjectionRecord pending first,
+// posts via the bridge, then updates to sent (with the Slack ts) or failed (with
+// a reason). It deliberately does NOT use the generic outbound dispatcher, which
+// marks delivered on dequeue and drops failures — for an egress boundary, dropped
+// or duplicated context is security-relevant.
+func Deliver(
+	ctx context.Context,
+	br SlackBridge,
+	val SnapshotValidator,
+	sc SecretScanner,
+	sink InjectionSink,
+	clock Clock,
+	d PackedDelegation,
+	req ContextRequest,
+) (InjectionRecord, error) {
+	if clock == nil {
+		clock = SystemClock
+	}
+	now := clock().Format(time.RFC3339Nano)
+
+	// 1. Idempotency: never ship the same delegation twice. Only a SENT record
+	//    short-circuits — a prior pending/failed attempt may be retried. (The
+	//    real broker-backed sink uses the pending marker as a lock to also close
+	//    the concurrent-send window; the in-process broker mutex covers it here.)
+	if prior, ok := sink.Lookup(req.IdempotencyKey); ok && prior.Status == DeliverySent {
+		return prior, nil
+	}
+
+	rec := d.Injection
+	rec.IdempotencyKey = req.IdempotencyKey
+	rec.Timestamp = now
+
+	// 2. Re-validate the snapshot. A downgrade/edit between Classify and Deliver
+	//    must not ship stale-authorized context.
+	if val != nil {
+		if err := val.Validate(req); err != nil {
+			rec.Status = DeliveryFailed
+			rec.FailureReason = "snapshot stale: " + err.Error()
+			_ = sink.Write(rec)
+			return rec, fmt.Errorf("packer: delivery aborted: %w", err)
+		}
+	}
+
+	// 3. Final redaction scan over the EXACT bytes that will leave.
+	finalMention := sc.Scan(d.MentionText)
+	finalThread := sc.Scan(d.ThreadContext)
+	if !finalMention.OK || !finalThread.OK {
+		rec.Status = DeliveryFailed
+		rec.FailureReason = "final egress scan: " + firstNonEmpty(finalMention.Reason, finalThread.Reason)
+		_ = sink.Write(rec)
+		return rec, ErrFinalScanFailed
+	}
+
+	sealed := PackedDelegation{
+		MentionText:   finalMention.Content,
+		ThreadContext: finalThread.Content,
+	}
+	rec.RenderedHash = hashBytes(sealed.MentionText, sealed.ThreadContext)
+	rec.TokenCount = estimateTokens(sealed.MentionText) + estimateTokens(sealed.ThreadContext)
+
+	// 4. Pending -> post -> sent/failed.
+	rec.Status = DeliveryPending
+	if err := sink.Write(rec); err != nil {
+		return rec, fmt.Errorf("packer: write pending audit: %w", err)
+	}
+
+	ts, err := br.Post(ctx, sealed, req.IdempotencyKey)
+	if err != nil {
+		rec.Status = DeliveryFailed
+		rec.FailureReason = err.Error()
+		_ = sink.Write(rec)
+		return rec, fmt.Errorf("packer: bridge post: %w", err)
+	}
+
+	rec.MessageTS = ts
+	rec.Status = DeliverySent
+	if err := sink.Write(rec); err != nil {
+		return rec, fmt.Errorf("packer: write sent audit: %w", err)
+	}
+	return rec, nil
+}
+
+// hashBytes hashes exactly what was sent (mention + thread) with a NUL separator
+// so two fields cannot collide by concatenation.
+func hashBytes(mention, thread string) string {
+	h := sha256.New()
+	h.Write([]byte(mention))
+	h.Write([]byte{0})
+	h.Write([]byte(thread))
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+func firstNonEmpty(vals ...string) string {
+	for _, v := range vals {
+		if v != "" {
+			return v
+		}
+	}
+	return "unknown"
+}

--- a/internal/packer/deliver.go
+++ b/internal/packer/deliver.go
@@ -127,13 +127,18 @@ func Deliver(
 		return rec, ErrFinalScanFailed
 	}
 
+	rec.RenderedHash = hashBytes(finalMention.Content, finalThread.Content)
+	rec.TokenCount = estimateTokens(finalMention.Content) + estimateTokens(finalThread.Content)
 	final := PackedDelegation{
 		MentionText:   finalMention.Content,
 		ThreadContext: finalThread.Content,
-		sealed:        true,
+		// Carry the audit record — including the destination ChannelID/ThreadTS —
+		// on the sealed delegation: the bridge reads where to post from
+		// d.Injection. Dropping it ships an undeliverable delegation (the live
+		// Slack probe caught exactly that).
+		Injection: rec,
+		sealed:    true,
 	}
-	rec.RenderedHash = hashBytes(final.MentionText, final.ThreadContext)
-	rec.TokenCount = estimateTokens(final.MentionText) + estimateTokens(final.ThreadContext)
 
 	// 5. Pending -> post -> sent/failed.
 	rec.Status = DeliveryPending

--- a/internal/packer/deliver.go
+++ b/internal/packer/deliver.go
@@ -14,6 +14,11 @@ import (
 // pre-render item scan never saw, so the last scan is over what actually leaves.
 var ErrFinalScanFailed = errors.New("packer: delivery aborted — final egress scan failed")
 
+// ErrUnsealed is returned when Deliver is handed a PackedDelegation that did not
+// come from Pack. Only render() sets the seal, so an unsealed delegation skipped
+// classification and must never be delivered.
+var ErrUnsealed = errors.New("packer: refusing to deliver an unsealed delegation (must come from Pack)")
+
 // SlackBridge posts a packed delegation and returns the Slack message ts. The
 // real implementation lives in the Slack bridge adapter (a separate spec); tests
 // use a fake.
@@ -65,20 +70,43 @@ func Deliver(
 	}
 	now := clock().Format(time.RFC3339Nano)
 
-	// 1. Idempotency: never ship the same delegation twice. Only a SENT record
-	//    short-circuits — a prior pending/failed attempt may be retried. (The
-	//    real broker-backed sink uses the pending marker as a lock to also close
-	//    the concurrent-send window; the in-process broker mutex covers it here.)
-	if prior, ok := sink.Lookup(req.IdempotencyKey); ok && prior.Status == DeliverySent {
-		return prior, nil
+	// 0. Only a sealed delegation (produced by Pack -> render) may be delivered.
+	//    A hand-constructed PackedDelegation skipped Classify, so it is refused.
+	if !d.sealed {
+		return InjectionRecord{}, ErrUnsealed
+	}
+
+	// 1. Idempotency. A SENT record short-circuits (already delivered). A PENDING
+	//    record means an attempt is in flight or crashed mid-flight: do NOT
+	//    re-post — return it for the caller/reconciler to resolve. Only an absent
+	//    or FAILED record proceeds to a fresh attempt. The sink's Lookup+Write
+	//    must be atomic in the real adapter (broker mutex / row lock) to fully
+	//    close the concurrent-send window, and the bridge Post must be idempotent
+	//    on the key so a post-success / write-failure retry cannot duplicate.
+	if prior, ok := sink.Lookup(req.IdempotencyKey); ok {
+		switch prior.Status {
+		case DeliverySent, DeliveryPending:
+			return prior, nil
+		}
 	}
 
 	rec := d.Injection
 	rec.IdempotencyKey = req.IdempotencyKey
 	rec.Timestamp = now
 
-	// 2. Re-validate the snapshot. A downgrade/edit between Classify and Deliver
-	//    must not ship stale-authorized context.
+	// 2. Bind delivery to the PACKED snapshot. The delegation's own
+	//    InjectionRecord records the task / plan / profile / policy / identity /
+	//    destination it was built for; refuse if the caller paired it with a
+	//    different req (e.g. a stale high-trust payload + a fresh downgraded req).
+	if err := snapshotMatches(d.Injection, req); err != nil {
+		rec.Status = DeliveryFailed
+		rec.FailureReason = "snapshot mismatch: " + err.Error()
+		_ = sink.Write(rec)
+		return rec, fmt.Errorf("packer: delivery aborted: %w", err)
+	}
+
+	// 3. Re-validate against LIVE state. A trust downgrade or task edit between
+	//    Classify and Deliver must not ship stale-authorized context.
 	if val != nil {
 		if err := val.Validate(req); err != nil {
 			rec.Status = DeliveryFailed
@@ -88,7 +116,8 @@ func Deliver(
 		}
 	}
 
-	// 3. Final redaction scan over the EXACT bytes that will leave.
+	// 4. Final redaction scan over the EXACT bytes that will leave. Render can
+	//    reintroduce raw refs/titles a pre-render item scan never saw.
 	finalMention := sc.Scan(d.MentionText)
 	finalThread := sc.Scan(d.ThreadContext)
 	if !finalMention.OK || !finalThread.OK {
@@ -98,20 +127,21 @@ func Deliver(
 		return rec, ErrFinalScanFailed
 	}
 
-	sealed := PackedDelegation{
+	final := PackedDelegation{
 		MentionText:   finalMention.Content,
 		ThreadContext: finalThread.Content,
+		sealed:        true,
 	}
-	rec.RenderedHash = hashBytes(sealed.MentionText, sealed.ThreadContext)
-	rec.TokenCount = estimateTokens(sealed.MentionText) + estimateTokens(sealed.ThreadContext)
+	rec.RenderedHash = hashBytes(final.MentionText, final.ThreadContext)
+	rec.TokenCount = estimateTokens(final.MentionText) + estimateTokens(final.ThreadContext)
 
-	// 4. Pending -> post -> sent/failed.
+	// 5. Pending -> post -> sent/failed.
 	rec.Status = DeliveryPending
 	if err := sink.Write(rec); err != nil {
 		return rec, fmt.Errorf("packer: write pending audit: %w", err)
 	}
 
-	ts, err := br.Post(ctx, sealed, req.IdempotencyKey)
+	ts, err := br.Post(ctx, final, req.IdempotencyKey)
 	if err != nil {
 		rec.Status = DeliveryFailed
 		rec.FailureReason = err.Error()
@@ -125,6 +155,34 @@ func Deliver(
 		return rec, fmt.Errorf("packer: write sent audit: %w", err)
 	}
 	return rec, nil
+}
+
+// snapshotMatches refuses a delivery whose packed snapshot does not correspond
+// to the req it is being delivered under. This stops a caller from pairing a
+// stale, higher-trust PackedDelegation with a fresh, downgraded req that happens
+// to pass the live validator.
+func snapshotMatches(rec InjectionRecord, req ContextRequest) error {
+	switch {
+	case rec.TaskID != req.TaskID:
+		return fmt.Errorf("task id %q != %q", rec.TaskID, req.TaskID)
+	case rec.TaskUpdatedAt != req.TaskUpdatedAt:
+		return fmt.Errorf("task updated-at %q != %q", rec.TaskUpdatedAt, req.TaskUpdatedAt)
+	case rec.PlanID != req.PlanID:
+		return fmt.Errorf("plan id %q != %q", rec.PlanID, req.PlanID)
+	case rec.PlanVersion != req.PlanVersion:
+		return fmt.Errorf("plan version %d != %d", rec.PlanVersion, req.PlanVersion)
+	case rec.BotTrust != req.Target.Trust:
+		return fmt.Errorf("trust tier %d != %d", rec.BotTrust, req.Target.Trust)
+	case rec.ProfileVersion != req.Target.Version:
+		return fmt.Errorf("profile version %d != %d", rec.ProfileVersion, req.Target.Version)
+	case rec.PolicyVersion != req.EgressPolicyVer:
+		return fmt.Errorf("policy version %d != %d", rec.PolicyVersion, req.EgressPolicyVer)
+	case rec.Identity != req.Target.Identity:
+		return fmt.Errorf("identity tuple mismatch")
+	case rec.WorkspaceID != req.Thread.WorkspaceID || rec.ChannelID != req.Thread.ChannelID || rec.ThreadTS != req.Thread.ThreadTS:
+		return fmt.Errorf("destination mismatch")
+	}
+	return nil
 }
 
 // hashBytes hashes exactly what was sent (mention + thread) with a NUL separator

--- a/internal/packer/packer.go
+++ b/internal/packer/packer.go
@@ -1,0 +1,46 @@
+package packer
+
+import "fmt"
+
+// Pack runs the read-side pipeline: Gather -> Classify -> Budget -> Render. It
+// returns a PackedDelegation ready for Deliver, plus the egress audit, or
+// ErrEnvelopeHeld if a critical envelope field could not be sanitized.
+// audienceTier is the trust tier the content is classified against — pass the
+// LEAST-trusted reader present for a shared thread post, or the target's own
+// tier for an ephemeral/DM delivery (see Audience).
+func Pack(
+	brain BrainHandle,
+	policy EgressPolicy,
+	sc SecretScanner,
+	req ContextRequest,
+	opts GatherOptions,
+	audienceTier BotTrust,
+) (PackedDelegation, []ItemAudit, error) {
+	raw, err := Gather(brain, req, opts)
+	if err != nil {
+		return PackedDelegation{}, nil, fmt.Errorf("pack gather: %w", err)
+	}
+	bundle, audit, err := Classify(raw, audienceTier, policy, sc)
+	if err != nil {
+		return PackedDelegation{}, audit, err
+	}
+	bundle = Budget(bundle, req.Target)
+	packed := Render(bundle, req, audit)
+	return packed, audit, nil
+}
+
+// Audience computes the trust tier to classify a delivery against. For a shared
+// channel thread post the content is visible to the least-trusted reader present
+// (and to unknown future joiners, so a public thread should be treated as
+// untrusted unless its history is provably closed). For an ephemeral/DM delivery
+// the audience is the target bot alone. BotTrust is ordered least-to-most
+// trusted, so the audience is the minimum of target and least-trusted-present.
+func Audience(target, leastTrustedPresent BotTrust, targetOnly bool) BotTrust {
+	if targetOnly {
+		return target
+	}
+	if leastTrustedPresent < target {
+		return leastTrustedPresent
+	}
+	return target
+}

--- a/internal/packer/packer.go
+++ b/internal/packer/packer.go
@@ -2,21 +2,39 @@ package packer
 
 import "fmt"
 
-// Pack runs the read-side pipeline: Gather -> Classify -> Budget -> Render. It
-// returns a PackedDelegation ready for Deliver, plus the egress audit, or
-// ErrEnvelopeHeld if a critical envelope field could not be sanitized.
-// audienceTier is the trust tier the content is classified against — pass the
-// LEAST-trusted reader present for a shared thread post, or the target's own
-// tier for an ephemeral/DM delivery (see Audience).
+// DeliveryAudience describes who will be able to read the delegation, so Pack can
+// compute the classification tier itself rather than trusting the caller to pass
+// the right one. For a shared-channel thread post the content is visible to the
+// least-trusted reader present (and to unknown future joiners). For an
+// ephemeral/DM delivery only the target reads it.
+type DeliveryAudience struct {
+	// TargetOnly is true for ephemeral/DM delivery (audience == the target bot).
+	TargetOnly bool
+	// LeastTrustedPresent is the least-trusted reader in the channel. Ignored
+	// when TargetOnly. A public thread whose history is not provably closed
+	// should pass BotUntrusted here.
+	LeastTrustedPresent BotTrust
+}
+
+// Pack runs the read-side pipeline: Gather -> Classify -> budget -> render. It
+// computes the classification audience INTERNALLY from aud + the target tier
+// (the minimum), so a caller cannot accidentally classify a shared-thread post
+// against the target's own higher tier. It returns a sealed PackedDelegation
+// ready for Deliver, plus the egress audit, or ErrEnvelopeHeld if a critical
+// envelope field could not be sanitized.
 func Pack(
 	brain BrainHandle,
 	policy EgressPolicy,
 	sc SecretScanner,
 	req ContextRequest,
 	opts GatherOptions,
-	audienceTier BotTrust,
+	aud DeliveryAudience,
 ) (PackedDelegation, []ItemAudit, error) {
-	raw, err := Gather(brain, req, opts)
+	audienceTier := Audience(req.Target.Trust, aud.LeastTrustedPresent, aud.TargetOnly)
+
+	// Retrieve against the AUDIENCE tier, not the target tier: a downgraded
+	// audience must not even pull first-party content into the pipeline.
+	raw, err := Gather(brain, req, opts, audienceTier)
 	if err != nil {
 		return PackedDelegation{}, nil, fmt.Errorf("pack gather: %w", err)
 	}
@@ -24,17 +42,15 @@ func Pack(
 	if err != nil {
 		return PackedDelegation{}, audit, err
 	}
-	bundle = Budget(bundle, req.Target)
-	packed := Render(bundle, req, audit)
+	bundle = budget(bundle, req.Target)
+	packed := render(bundle, req, audit, audienceTier)
 	return packed, audit, nil
 }
 
-// Audience computes the trust tier to classify a delivery against. For a shared
-// channel thread post the content is visible to the least-trusted reader present
-// (and to unknown future joiners, so a public thread should be treated as
-// untrusted unless its history is provably closed). For an ephemeral/DM delivery
-// the audience is the target bot alone. BotTrust is ordered least-to-most
-// trusted, so the audience is the minimum of target and least-trusted-present.
+// Audience computes the trust tier to classify a delivery against. BotTrust is
+// ordered least-to-most trusted, so for a shared thread the audience is the
+// minimum of target and least-trusted-present; for a target-only (DM/ephemeral)
+// delivery it is the target alone.
 func Audience(target, leastTrustedPresent BotTrust, targetOnly bool) BotTrust {
 	if targetOnly {
 		return target

--- a/internal/packer/packer_test.go
+++ b/internal/packer/packer_test.go
@@ -9,6 +9,7 @@ package packer
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -116,7 +117,7 @@ func TestICP1_UntrustedRedactsAndWithholds(t *testing.T) {
 	req := baseRequest(untrustedProfile(), "Reconcile June invoices and report totals.")
 	policy := NewDefaultEgressPolicy(7)
 
-	packed, audit, err := Pack(brain, policy, EgressScanner{}, req, GatherOptions{ReturnPact: "Reply in this thread with the totals."}, BotUntrusted)
+	packed, audit, err := Pack(brain, policy, EgressScanner{}, req, GatherOptions{ReturnPact: "Reply in this thread with the totals."}, DeliveryAudience{LeastTrustedPresent: BotUntrusted})
 	if err != nil {
 		t.Fatalf("Pack: %v", err)
 	}
@@ -167,7 +168,7 @@ func TestICP2_FirstPartyThreadGetsScopedKnowledge(t *testing.T) {
 		roster:    []BrainItem{{Ref: "roster-1", Body: "warehouse-bot owns counts"}},
 	}
 	req := baseRequest(firstPartyThreadProfile(), "Audit SKU-42 counts.")
-	packed, audit, err := Pack(brain, NewDefaultEgressPolicy(7), EgressScanner{}, req, GatherOptions{ReturnPact: "Post the reconciled count here."}, BotFirstParty)
+	packed, audit, err := Pack(brain, NewDefaultEgressPolicy(7), EgressScanner{}, req, GatherOptions{ReturnPact: "Post the reconciled count here."}, DeliveryAudience{LeastTrustedPresent: BotFirstParty})
 	if err != nil {
 		t.Fatalf("Pack: %v", err)
 	}
@@ -196,7 +197,7 @@ func TestICP3_HostedGetsEverythingAllowed(t *testing.T) {
 	p := firstPartyThreadProfile()
 	p.Trust = BotHosted
 	req := baseRequest(p, "Cut the release.")
-	_, audit, err := Pack(brain, NewDefaultEgressPolicy(7), EgressScanner{}, req, GatherOptions{}, BotHosted)
+	_, audit, err := Pack(brain, NewDefaultEgressPolicy(7), EgressScanner{}, req, GatherOptions{}, DeliveryAudience{TargetOnly: true})
 	if err != nil {
 		t.Fatalf("Pack: %v", err)
 	}
@@ -259,14 +260,26 @@ func TestPolicy_RawTaskBodyDeniedForNonHosted(t *testing.T) {
 	}
 }
 
-// Deliver aborts on a stale snapshot (trust downgrade / version bump) and never
-// calls the bridge.
+// packForDelivery builds a real, sealed, snapshot-valid delegation via Pack so
+// Deliver tests exercise the actual seal + snapshot binding rather than a
+// hand-constructed payload.
+func packForDelivery(t *testing.T, key string) (PackedDelegation, ContextRequest) {
+	t.Helper()
+	brain := fakeBrain{plan: "Reconcile the open invoices."}
+	req := baseRequest(untrustedProfile(), "Reconcile June invoices.")
+	req.IdempotencyKey = key
+	packed, _, err := Pack(brain, NewDefaultEgressPolicy(7), EgressScanner{}, req, GatherOptions{ReturnPact: "Reply here."}, DeliveryAudience{LeastTrustedPresent: BotUntrusted})
+	if err != nil {
+		t.Fatalf("packForDelivery: %v", err)
+	}
+	return packed, req
+}
+
+// Deliver aborts on a stale live snapshot and never calls the bridge.
 func TestDeliver_StaleSnapshotAbortsBeforePost(t *testing.T) {
+	packed, req := packForDelivery(t, "k1")
 	bridge := &fakeBridge{ts: "200.2"}
 	sink := newMemSink()
-	packed := PackedDelegation{MentionText: "hello", Injection: InjectionRecord{IdempotencyKey: "k1"}}
-	req := baseRequest(untrustedProfile(), "x")
-	req.IdempotencyKey = "k1"
 
 	rec, err := Deliver(context.Background(), bridge, fakeValidator{err: errStale()}, EgressScanner{}, sink, fixedClock, packed, req)
 	if err == nil {
@@ -280,14 +293,13 @@ func TestDeliver_StaleSnapshotAbortsBeforePost(t *testing.T) {
 	}
 }
 
-// Deliver's final byte-scan catches a secret in the rendered bytes even if it
-// somehow survived earlier stages, and never posts it.
+// Deliver's final byte-scan catches a secret reintroduced into the rendered
+// bytes after classification, and never posts it.
 func TestDeliver_FinalScanCatchesReintroducedSecret(t *testing.T) {
+	packed, req := packForDelivery(t, "k2")
+	packed.MentionText = "ship it with " + fixturePEMKey // simulate render reintroducing a secret
 	bridge := &fakeBridge{ts: "200.2"}
 	sink := newMemSink()
-	packed := PackedDelegation{MentionText: "ship it with " + fixturePEMKey, Injection: InjectionRecord{IdempotencyKey: "k2"}}
-	req := baseRequest(untrustedProfile(), "x")
-	req.IdempotencyKey = "k2"
 
 	_, err := Deliver(context.Background(), bridge, fakeValidator{}, EgressScanner{}, sink, fixedClock, packed, req)
 	if err == nil {
@@ -300,11 +312,9 @@ func TestDeliver_FinalScanCatchesReintroducedSecret(t *testing.T) {
 
 // Delivering the same idempotency key twice posts exactly once.
 func TestDeliver_IdempotentOnKey(t *testing.T) {
+	packed, req := packForDelivery(t, "k3")
 	bridge := &fakeBridge{ts: "200.2"}
 	sink := newMemSink()
-	packed := PackedDelegation{MentionText: "clean mention", Injection: InjectionRecord{IdempotencyKey: "k3"}}
-	req := baseRequest(untrustedProfile(), "x")
-	req.IdempotencyKey = "k3"
 
 	if _, err := Deliver(context.Background(), bridge, fakeValidator{}, EgressScanner{}, sink, fixedClock, packed, req); err != nil {
 		t.Fatalf("first deliver: %v", err)
@@ -314,6 +324,62 @@ func TestDeliver_IdempotentOnKey(t *testing.T) {
 	}
 	if bridge.calls != 1 {
 		t.Fatalf("bridge.calls = %d, want 1 (idempotent)", bridge.calls)
+	}
+}
+
+// Deliver refuses an unsealed (hand-constructed) delegation that skipped Classify.
+func TestDeliver_RefusesUnsealedDelegation(t *testing.T) {
+	bridge := &fakeBridge{ts: "200.2"}
+	sink := newMemSink()
+	hand := PackedDelegation{MentionText: "trust me", Injection: InjectionRecord{IdempotencyKey: "k4"}}
+	req := baseRequest(untrustedProfile(), "x")
+	req.IdempotencyKey = "k4"
+
+	_, err := Deliver(context.Background(), bridge, fakeValidator{}, EgressScanner{}, sink, fixedClock, hand, req)
+	if !errors.Is(err, ErrUnsealed) {
+		t.Fatalf("expected ErrUnsealed, got %v", err)
+	}
+	if bridge.calls != 0 {
+		t.Fatalf("bridge must not be called for an unsealed delegation, calls=%d", bridge.calls)
+	}
+}
+
+// Deliver refuses a delegation whose packed snapshot does not match the req it is
+// delivered under (a stale payload paired with a downgraded req).
+func TestDeliver_RefusesSnapshotMismatch(t *testing.T) {
+	packed, req := packForDelivery(t, "k5")
+	mismatch := req
+	mismatch.Target.Trust = BotFirstParty // packed snapshot says untrusted
+	bridge := &fakeBridge{ts: "200.2"}
+	sink := newMemSink()
+
+	_, err := Deliver(context.Background(), bridge, fakeValidator{}, EgressScanner{}, sink, fixedClock, packed, mismatch)
+	if err == nil {
+		t.Fatal("expected snapshot-mismatch abort")
+	}
+	if bridge.calls != 0 {
+		t.Fatalf("bridge must not be called on snapshot mismatch, calls=%d", bridge.calls)
+	}
+}
+
+// A first-party bot on a SHARED thread with an untrusted reader present is
+// classified against the untrusted audience: no learnings/wiki are retrieved or
+// exported, even though the target itself is first-party. This is the H5/F3 fix.
+func TestPack_SharedThreadDowngradesFirstPartyAudience(t *testing.T) {
+	brain := fakeBrain{
+		plan:      "Audit SKU-42.",
+		learnings: []BrainItem{{Ref: "learn-1", Body: "reconcile twice"}},
+		wiki:      []BrainItem{{Ref: "wiki/x.md", Body: "playbook"}},
+	}
+	req := baseRequest(firstPartyThreadProfile(), "Audit SKU-42.")
+	_, audit, err := Pack(brain, NewDefaultEgressPolicy(7), EgressScanner{}, req, GatherOptions{}, DeliveryAudience{LeastTrustedPresent: BotUntrusted})
+	if err != nil {
+		t.Fatalf("Pack: %v", err)
+	}
+	for _, a := range audit {
+		if a.Kind == KindLearning || a.Kind == KindWiki {
+			t.Fatalf("downgraded audience must not export %s; audit=%+v", a.Kind, audit)
+		}
 	}
 }
 

--- a/internal/packer/packer_test.go
+++ b/internal/packer/packer_test.go
@@ -1,0 +1,354 @@
+package packer
+
+// packer_test.go covers the egress boundary end to end: the three ICP
+// acceptance scenarios from docs/specs/slack-context-packer.md plus focused
+// tests for the security-critical invariants (envelope held on unsanitizable
+// ask, item dropped on scanner deny, delivery re-validation, final byte-scan,
+// and idempotency). The real fail-closed EgressScanner is used throughout so
+// redaction behavior is exercised for real.
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// A real openai key matches a non-poison pattern → redacted but emittable.
+const fixtureAPIKey = "sk-proj-ABCDEFGHIJKLMNOPQRSTUVWXYZ012345"
+
+// A PEM private key is a poison-class secret → withheld entirely.
+const fixturePEMKey = "-----BEGIN OPENSSH PRIVATE KEY-----\nb3BlbnNzaC1rZXkt\n-----END OPENSSH PRIVATE KEY-----"
+
+// --- fakes ---
+
+type fakeBrain struct {
+	plan      string
+	planErr   error
+	learnings []BrainItem
+	wiki      []BrainItem
+	roster    []BrainItem
+}
+
+func (f fakeBrain) PlanStep(string) (string, error)                { return f.plan, f.planErr }
+func (f fakeBrain) TaskLearnings(string, int) ([]BrainItem, error) { return f.learnings, nil }
+func (f fakeBrain) TaskWikiRefs(string) ([]BrainItem, error)       { return f.wiki, nil }
+func (f fakeBrain) Roster(string) ([]BrainItem, error)             { return f.roster, nil }
+
+type fakeBridge struct {
+	posted []PackedDelegation
+	ts     string
+	err    error
+	calls  int
+}
+
+func (b *fakeBridge) Post(_ context.Context, d PackedDelegation, _ string) (string, error) {
+	b.calls++
+	if b.err != nil {
+		return "", b.err
+	}
+	b.posted = append(b.posted, d)
+	return b.ts, nil
+}
+
+type fakeValidator struct{ err error }
+
+func (v fakeValidator) Validate(ContextRequest) error { return v.err }
+
+type memSink struct{ recs map[string]InjectionRecord }
+
+func newMemSink() *memSink { return &memSink{recs: map[string]InjectionRecord{}} }
+func (s *memSink) Lookup(key string) (InjectionRecord, bool) {
+	r, ok := s.recs[key]
+	return r, ok
+}
+func (s *memSink) Write(rec InjectionRecord) error {
+	s.recs[rec.IdempotencyKey] = rec
+	return nil
+}
+
+func fixedClock() time.Time { return time.Unix(1_700_000_000, 0).UTC() }
+
+func untrustedProfile() BotProfile {
+	return BotProfile{
+		Version:   1,
+		Slug:      "notetaker",
+		Trust:     BotUntrusted,
+		ReadScope: ReadMentionOnly,
+		Identity:  BotIdentity{SlackTeamID: "T1", AppUserID: "U_BOT", InstallID: "I1"},
+	}
+}
+
+func firstPartyThreadProfile() BotProfile {
+	p := untrustedProfile()
+	p.Slug = "warehouse-bot"
+	p.Trust = BotFirstParty
+	p.ReadScope = ReadThread
+	return p
+}
+
+func baseRequest(p BotProfile, ask string) ContextRequest {
+	return ContextRequest{
+		TaskID:          "task-1",
+		TaskUpdatedAt:   "2026-06-09T00:00:00Z",
+		PlanID:          "plan-1",
+		PlanVersion:     1,
+		Target:          p,
+		Intent:          StepIntent{Text: ask, Taint: TaintClean},
+		Thread:          ThreadRef{WorkspaceID: "T1", ChannelID: "C1", ThreadTS: "100.1"},
+		EgressPolicyVer: 7,
+		IdempotencyKey:  "task-1:notetaker:step-1",
+	}
+}
+
+// --- ICP acceptance scenarios ---
+
+// ICP 1: Untrusted vendor bot + redaction + first-egress. The approved plan step
+// carries a pasted API key; a raw task-body item is also present. Assert the key
+// is redacted, the raw task body is denied, no wiki/learning leaks, and delivery
+// records a sent InjectionRecord whose rendered bytes never contain the secret.
+func TestICP1_UntrustedRedactsAndWithholds(t *testing.T) {
+	brain := fakeBrain{
+		plan:      "Reconcile the open invoices. Credentials if needed: " + fixtureAPIKey,
+		learnings: []BrainItem{{Ref: "learn-1", Body: "prior reconciliation note"}},
+		wiki:      []BrainItem{{Ref: "wiki/refunds.md", Body: "refund policy"}},
+	}
+	req := baseRequest(untrustedProfile(), "Reconcile June invoices and report totals.")
+	policy := NewDefaultEgressPolicy(7)
+
+	packed, audit, err := Pack(brain, policy, EgressScanner{}, req, GatherOptions{ReturnPact: "Reply in this thread with the totals."}, BotUntrusted)
+	if err != nil {
+		t.Fatalf("Pack: %v", err)
+	}
+
+	if strings.Contains(packed.MentionText, fixtureAPIKey) {
+		t.Fatalf("API key leaked into mention:\n%s", packed.MentionText)
+	}
+	if !strings.Contains(packed.MentionText, "[REDACTED]") {
+		t.Fatalf("expected redaction marker in mention:\n%s", packed.MentionText)
+	}
+	// Untrusted gets NO learning / wiki, even though the brain returned them.
+	for _, it := range audit {
+		if it.Kind == KindLearning || it.Kind == KindWiki {
+			if it.Class != ExportDenied {
+				t.Fatalf("untrusted received %s with class %s, want denied", it.Kind, it.Class)
+			}
+		}
+	}
+	// The plan step (human-approved) is exported, redacted.
+	if !hasAudit(audit, KindPlan, ExportRedacted) {
+		t.Fatalf("plan step should be exported redacted; audit=%+v", audit)
+	}
+
+	bridge := &fakeBridge{ts: "200.2"}
+	sink := newMemSink()
+	rec, err := Deliver(context.Background(), bridge, fakeValidator{}, EgressScanner{}, sink, fixedClock, packed, req)
+	if err != nil {
+		t.Fatalf("Deliver: %v", err)
+	}
+	if rec.Status != DeliverySent || rec.MessageTS != "200.2" {
+		t.Fatalf("delivery status=%s ts=%q, want sent/200.2", rec.Status, rec.MessageTS)
+	}
+	if rec.RenderedHash == "" || rec.Timestamp == "" {
+		t.Fatalf("injection record missing hash/timestamp: %+v", rec)
+	}
+	if strings.Contains(bridge.posted[0].MentionText, fixtureAPIKey) {
+		t.Fatalf("API key leaked through the bridge")
+	}
+}
+
+// ICP 2: First-party warehouse bot, thread-verified. Gets a lean mention plus a
+// thread block carrying a task-scoped learning and a task-linked wiki ref.
+func TestICP2_FirstPartyThreadGetsScopedKnowledge(t *testing.T) {
+	brain := fakeBrain{
+		plan:      "Audit the warehouse counts for SKU-42.",
+		learnings: []BrainItem{{Ref: "learn-1", Body: "counts drift after restock; reconcile twice"}},
+		wiki:      []BrainItem{{Ref: "wiki/inventory.md", Body: "inventory reconciliation playbook"}},
+		roster:    []BrainItem{{Ref: "roster-1", Body: "warehouse-bot owns counts"}},
+	}
+	req := baseRequest(firstPartyThreadProfile(), "Audit SKU-42 counts.")
+	packed, audit, err := Pack(brain, NewDefaultEgressPolicy(7), EgressScanner{}, req, GatherOptions{ReturnPact: "Post the reconciled count here."}, BotFirstParty)
+	if err != nil {
+		t.Fatalf("Pack: %v", err)
+	}
+	if !hasAudit(audit, KindLearning, ExportRedacted) {
+		t.Fatalf("first-party should get a task-scoped learning; audit=%+v", audit)
+	}
+	if !hasAudit(audit, KindWiki, ExportRedacted) {
+		t.Fatalf("first-party should get a task-linked wiki ref; audit=%+v", audit)
+	}
+	if strings.TrimSpace(packed.ThreadContext) == "" {
+		t.Fatalf("thread-reading bot should get a non-empty thread block")
+	}
+	if !strings.Contains(packed.ThreadContext, "reconciliation playbook") {
+		t.Fatalf("wiki ref missing from thread block:\n%s", packed.ThreadContext)
+	}
+}
+
+// ICP 3: Hosted parity. A hosted bot is classified ExportAllowed for everything;
+// the same retrieval yields a superset of any non-hosted bundle.
+func TestICP3_HostedGetsEverythingAllowed(t *testing.T) {
+	brain := fakeBrain{
+		plan:      "Ship the release.",
+		learnings: []BrainItem{{Ref: "learn-1", Body: "tag before publish"}},
+		wiki:      []BrainItem{{Ref: "wiki/release.md", Body: "release checklist"}},
+	}
+	p := firstPartyThreadProfile()
+	p.Trust = BotHosted
+	req := baseRequest(p, "Cut the release.")
+	_, audit, err := Pack(brain, NewDefaultEgressPolicy(7), EgressScanner{}, req, GatherOptions{}, BotHosted)
+	if err != nil {
+		t.Fatalf("Pack: %v", err)
+	}
+	for _, it := range audit {
+		if it.Kind == KindLearning || it.Kind == KindWiki || it.Kind == KindPlan {
+			if it.Class != ExportAllowed {
+				t.Fatalf("hosted %s class = %s, want allowed", it.Kind, it.Class)
+			}
+		}
+	}
+}
+
+// --- Security-critical unit tests ---
+
+// An unsanitizable ASK (poison secret) holds the WHOLE delegation — never sent
+// without an ask, never sent partial.
+func TestClassify_PoisonAskHoldsDelegation(t *testing.T) {
+	raw := RawBundle{Ask: "Do the thing with " + fixturePEMKey}
+	_, _, err := Classify(raw, BotUntrusted, NewDefaultEgressPolicy(1), EgressScanner{})
+	if err == nil {
+		t.Fatal("expected ErrEnvelopeHeld for poison ask")
+	}
+	if !strings.Contains(err.Error(), "held") {
+		t.Fatalf("error should signal a held delegation, got %v", err)
+	}
+}
+
+// An item whose body cannot be proven clean is DROPPED (denied), while the rest
+// of the bundle survives.
+func TestClassify_PoisonItemDroppedOthersSurvive(t *testing.T) {
+	raw := RawBundle{
+		Ask: "Reconcile counts.",
+		Items: []RawItem{
+			{Ref: "learn-poison", Kind: KindLearning, Body: "key: " + fixturePEMKey},
+			{Ref: "learn-clean", Kind: KindLearning, Body: "reconcile twice after restock"},
+		},
+	}
+	bundle, audit, err := Classify(raw, BotFirstParty, NewDefaultEgressPolicy(1), EgressScanner{})
+	if err != nil {
+		t.Fatalf("Classify: %v", err)
+	}
+	if len(bundle.Items) != 1 || bundle.Items[0].Ref != "learn-clean" {
+		t.Fatalf("poison item should be dropped, clean kept; got %+v", bundle.Items)
+	}
+	if !hasAuditRef(audit, "learn-poison", ExportDenied) {
+		t.Fatalf("poison item should be audited as denied; audit=%+v", audit)
+	}
+}
+
+// Raw task body is never exported wholesale, for any non-hosted tier.
+func TestPolicy_RawTaskBodyDeniedForNonHosted(t *testing.T) {
+	p := NewDefaultEgressPolicy(1)
+	for _, tier := range []BotTrust{BotUntrusted, BotFirstParty} {
+		if got := p.Classify(KindTask, tier); got != ExportDenied {
+			t.Fatalf("KindTask at tier %d = %s, want denied", tier, got)
+		}
+	}
+	if got := p.Classify(KindWiki, BotUntrusted); got != ExportDenied {
+		t.Fatalf("untrusted wiki = %s, want denied (no free wiki)", got)
+	}
+}
+
+// Deliver aborts on a stale snapshot (trust downgrade / version bump) and never
+// calls the bridge.
+func TestDeliver_StaleSnapshotAbortsBeforePost(t *testing.T) {
+	bridge := &fakeBridge{ts: "200.2"}
+	sink := newMemSink()
+	packed := PackedDelegation{MentionText: "hello", Injection: InjectionRecord{IdempotencyKey: "k1"}}
+	req := baseRequest(untrustedProfile(), "x")
+	req.IdempotencyKey = "k1"
+
+	rec, err := Deliver(context.Background(), bridge, fakeValidator{err: errStale()}, EgressScanner{}, sink, fixedClock, packed, req)
+	if err == nil {
+		t.Fatal("expected delivery to abort on stale snapshot")
+	}
+	if bridge.calls != 0 {
+		t.Fatalf("bridge must not be called on stale snapshot, calls=%d", bridge.calls)
+	}
+	if rec.Status != DeliveryFailed {
+		t.Fatalf("status = %s, want failed", rec.Status)
+	}
+}
+
+// Deliver's final byte-scan catches a secret in the rendered bytes even if it
+// somehow survived earlier stages, and never posts it.
+func TestDeliver_FinalScanCatchesReintroducedSecret(t *testing.T) {
+	bridge := &fakeBridge{ts: "200.2"}
+	sink := newMemSink()
+	packed := PackedDelegation{MentionText: "ship it with " + fixturePEMKey, Injection: InjectionRecord{IdempotencyKey: "k2"}}
+	req := baseRequest(untrustedProfile(), "x")
+	req.IdempotencyKey = "k2"
+
+	_, err := Deliver(context.Background(), bridge, fakeValidator{}, EgressScanner{}, sink, fixedClock, packed, req)
+	if err == nil {
+		t.Fatal("expected final scan to abort delivery")
+	}
+	if bridge.calls != 0 {
+		t.Fatalf("bridge must not be called when final scan fails, calls=%d", bridge.calls)
+	}
+}
+
+// Delivering the same idempotency key twice posts exactly once.
+func TestDeliver_IdempotentOnKey(t *testing.T) {
+	bridge := &fakeBridge{ts: "200.2"}
+	sink := newMemSink()
+	packed := PackedDelegation{MentionText: "clean mention", Injection: InjectionRecord{IdempotencyKey: "k3"}}
+	req := baseRequest(untrustedProfile(), "x")
+	req.IdempotencyKey = "k3"
+
+	if _, err := Deliver(context.Background(), bridge, fakeValidator{}, EgressScanner{}, sink, fixedClock, packed, req); err != nil {
+		t.Fatalf("first deliver: %v", err)
+	}
+	if _, err := Deliver(context.Background(), bridge, fakeValidator{}, EgressScanner{}, sink, fixedClock, packed, req); err != nil {
+		t.Fatalf("second deliver: %v", err)
+	}
+	if bridge.calls != 1 {
+		t.Fatalf("bridge.calls = %d, want 1 (idempotent)", bridge.calls)
+	}
+}
+
+// Audience downgrades to the least-trusted reader present on a shared thread.
+func TestAudience_DowngradesToLeastTrustedOnSharedThread(t *testing.T) {
+	if got := Audience(BotFirstParty, BotUntrusted, false); got != BotUntrusted {
+		t.Fatalf("shared thread audience = %d, want untrusted", got)
+	}
+	if got := Audience(BotFirstParty, BotUntrusted, true); got != BotFirstParty {
+		t.Fatalf("target-only (DM) audience = %d, want first-party", got)
+	}
+}
+
+// --- helpers ---
+
+func hasAudit(audit []ItemAudit, kind ItemKind, class ExportClass) bool {
+	for _, a := range audit {
+		if a.Kind == kind && a.Class == class {
+			return true
+		}
+	}
+	return false
+}
+
+func hasAuditRef(audit []ItemAudit, ref string, class ExportClass) bool {
+	for _, a := range audit {
+		if a.Ref == ref && a.Class == class {
+			return true
+		}
+	}
+	return false
+}
+
+func errStale() error { return &staleErr{} }
+
+type staleErr struct{}
+
+func (*staleErr) Error() string { return "trust downgraded" }

--- a/internal/packer/packer_test.go
+++ b/internal/packer/packer_test.go
@@ -327,6 +327,29 @@ func TestDeliver_IdempotentOnKey(t *testing.T) {
 	}
 }
 
+// Deliver must hand the bridge a delegation that still carries the destination
+// (Injection.ChannelID/ThreadTS) — the bridge reads where to post from it. The
+// live Slack probe caught Deliver stripping it when sealing the final bytes.
+func TestDeliver_FinalDelegationCarriesDestination(t *testing.T) {
+	packed, req := packForDelivery(t, "k-dest")
+	bridge := &fakeBridge{ts: "200.2"}
+	sink := newMemSink()
+
+	if _, err := Deliver(context.Background(), bridge, fakeValidator{}, EgressScanner{}, sink, fixedClock, packed, req); err != nil {
+		t.Fatalf("Deliver: %v", err)
+	}
+	if len(bridge.posted) != 1 {
+		t.Fatalf("expected 1 post, got %d", len(bridge.posted))
+	}
+	got := bridge.posted[0].Injection
+	if got.ChannelID != req.Thread.ChannelID || got.ChannelID == "" {
+		t.Fatalf("posted delegation lost its destination: ChannelID=%q want %q", got.ChannelID, req.Thread.ChannelID)
+	}
+	if got.ThreadTS != req.Thread.ThreadTS {
+		t.Fatalf("posted delegation thread = %q, want %q", got.ThreadTS, req.Thread.ThreadTS)
+	}
+}
+
 // Deliver refuses an unsealed (hand-constructed) delegation that skipped Classify.
 func TestDeliver_RefusesUnsealedDelegation(t *testing.T) {
 	bridge := &fakeBridge{ts: "200.2"}

--- a/internal/packer/pipeline.go
+++ b/internal/packer/pipeline.go
@@ -1,0 +1,248 @@
+package packer
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// ErrEnvelopeHeld is returned by Classify when an envelope field (Ask /
+// ReturnPact) cannot be sanitized. Those fields are "never dropped", so an
+// unprovable secret in one of them holds the WHOLE delegation rather than
+// shipping it without an ask. A human must look at the task.
+var ErrEnvelopeHeld = errors.New("packer: delegation held — envelope field failed egress redaction")
+
+// BrainHandle is the office/tenant brain seam. OSS self-hosted: a singleton
+// adapter over the broker. Nex cloud: one per tenant. The packer never touches
+// global state directly. Every retrieval method is TASK-SCOPED — the packer
+// never drives a free, intent-text query, so foreign-tainted intent cannot reach
+// retrieval.
+type BrainHandle interface {
+	// PlanStep returns the human-approved plan step / IssueDraftSpec text.
+	PlanStep(taskID string) (string, error)
+	// TaskLearnings returns task-scoped learnings, already AND-scoped to taskID
+	// (exact match, never a fuzzy fallback), highest-confidence first.
+	TaskLearnings(taskID string, limit int) ([]BrainItem, error)
+	// TaskWikiRefs returns the bodies of articles EXPLICITLY linked to the task
+	// (teamTask.WikiRefs). Never free WikiIndex.Search.
+	TaskWikiRefs(taskID string) ([]BrainItem, error)
+	// Roster returns roster lines for the task.
+	Roster(taskID string) ([]BrainItem, error)
+}
+
+// BrainItem is a retrieved brain candidate.
+type BrainItem struct {
+	Ref  string
+	Body string
+}
+
+// GatherOptions tunes retrieval. ReturnPact and Guards are CEO-authored and
+// passed in (they are not retrieved from the brain).
+type GatherOptions struct {
+	ReturnPact    string
+	Guards        []string
+	LearningLimit int
+}
+
+// Gather retrieves candidates, task-scoped, for the target tier. Tainted intent
+// does NOT drive retrieval: retrieval is keyed by task id, and the Ask carries
+// the (CEO-restated) intent text only as an export to be classified, never as a
+// query. Untrusted bots get only the envelope + the approved plan step;
+// first-party (and hosted) additionally get task-scoped learnings, task-linked
+// wiki refs, and roster lines.
+func Gather(brain BrainHandle, req ContextRequest, opts GatherOptions) (RawBundle, error) {
+	rb := RawBundle{
+		Ask:        req.Intent.Text,
+		ReturnPact: opts.ReturnPact,
+		Guards:     append([]string(nil), opts.Guards...),
+	}
+
+	plan, err := brain.PlanStep(req.TaskID)
+	if err != nil {
+		return RawBundle{}, fmt.Errorf("gather plan step: %w", err)
+	}
+	if strings.TrimSpace(plan) != "" {
+		rb.Items = append(rb.Items, RawItem{Ref: "plan:" + req.TaskID, Kind: KindPlan, Body: plan})
+	}
+
+	if req.Target.Trust == BotUntrusted {
+		// Untrusted gets envelope + approved plan step only. No learnings, no
+		// wiki, no roster — nothing retrieved from the brain at large.
+		return rb, nil
+	}
+
+	limit := opts.LearningLimit
+	if limit <= 0 {
+		limit = defaultLearningLimit
+	}
+	learnings, err := brain.TaskLearnings(req.TaskID, limit)
+	if err != nil {
+		return RawBundle{}, fmt.Errorf("gather learnings: %w", err)
+	}
+	for _, l := range learnings {
+		rb.Items = append(rb.Items, RawItem{Ref: l.Ref, Kind: KindLearning, Body: l.Body})
+	}
+
+	wiki, err := brain.TaskWikiRefs(req.TaskID)
+	if err != nil {
+		return RawBundle{}, fmt.Errorf("gather wiki refs: %w", err)
+	}
+	for _, w := range wiki {
+		rb.Items = append(rb.Items, RawItem{Ref: w.Ref, Kind: KindWiki, Body: w.Body})
+	}
+
+	roster, err := brain.Roster(req.TaskID)
+	if err != nil {
+		return RawBundle{}, fmt.Errorf("gather roster: %w", err)
+	}
+	for i, r := range roster {
+		if i >= maxRosterLines {
+			break
+		}
+		rb.Items = append(rb.Items, RawItem{Ref: r.Ref, Kind: KindRoster, Body: r.Body})
+	}
+
+	return rb, nil
+}
+
+// Classify is the egress boundary. It classifies and redacts the WHOLE
+// delegation envelope (Ask, ReturnPact, Guards), not just Items, because those
+// fields are "never dropped" by Budget — an unclassified envelope is a direct
+// exfiltration channel. audience is the trust tier the content is classified
+// against: the LEAST-trusted reader present for a shared thread, or the target
+// for an ephemeral/DM delivery. It returns ErrEnvelopeHeld if Ask or ReturnPact
+// cannot be sanitized (the delegation is held, never sent partial); a Guard line
+// or an Item that cannot be sanitized is dropped, with an audit row.
+func Classify(raw RawBundle, audience BotTrust, policy EgressPolicy, sc SecretScanner) (ContextBundle, []ItemAudit, error) {
+	out := ContextBundle{}
+	audit := make([]ItemAudit, 0, len(raw.Items)+3)
+
+	// Ask — critical envelope field. Failure holds the whole delegation.
+	ask, askRed, err := scanEnvelopeField(raw.Ask, KindAsk, audience, policy, sc)
+	if err != nil {
+		return ContextBundle{}, nil, fmt.Errorf("ask: %w", err)
+	}
+	out.Ask = ask
+	if strings.TrimSpace(raw.Ask) != "" {
+		audit = append(audit, ItemAudit{Ref: "ask", Kind: KindAsk, Class: ExportRedacted, Redactions: askRed})
+	}
+
+	// ReturnPact — critical envelope field. Failure holds the whole delegation.
+	pact, pactRed, err := scanEnvelopeField(raw.ReturnPact, KindReturnPact, audience, policy, sc)
+	if err != nil {
+		return ContextBundle{}, nil, fmt.Errorf("return pact: %w", err)
+	}
+	out.ReturnPact = pact
+	if strings.TrimSpace(raw.ReturnPact) != "" {
+		audit = append(audit, ItemAudit{Ref: "returnpact", Kind: KindReturnPact, Class: ExportRedacted, Redactions: pactRed})
+	}
+
+	// Guards — advisory list. A guard line that cannot be sanitized is dropped,
+	// not a held delegation.
+	for i, g := range raw.Guards {
+		if strings.TrimSpace(g) == "" {
+			continue
+		}
+		res := sc.Scan(g)
+		ref := fmt.Sprintf("guard:%d", i)
+		if !res.OK {
+			audit = append(audit, ItemAudit{Ref: ref, Kind: KindGuard, Class: ExportDenied})
+			continue
+		}
+		out.Guards = append(out.Guards, res.Content)
+		audit = append(audit, ItemAudit{Ref: ref, Kind: KindGuard, Class: ExportRedacted, Redactions: res.Redactions})
+	}
+
+	// Items — drop ExportDenied (policy) and anything the scanner cannot prove
+	// clean. This runs BEFORE budgeting so denied content is gone before ranking.
+	for _, it := range raw.Items {
+		class := policy.Classify(it.Kind, audience)
+		if class == ExportDenied {
+			audit = append(audit, ItemAudit{Ref: it.Ref, Kind: it.Kind, Class: ExportDenied})
+			continue
+		}
+		res := sc.Scan(it.Body)
+		if !res.OK {
+			audit = append(audit, ItemAudit{Ref: it.Ref, Kind: it.Kind, Class: ExportDenied})
+			continue
+		}
+		body := res.Content
+		if class == ExportAllowed {
+			body = it.Body // hosted tier: emit as-is (still scanned for safety)
+		}
+		out.Items = append(out.Items, ContextItem{Ref: it.Ref, Kind: it.Kind, Body: body, Class: class, Redactions: res.Redactions})
+		audit = append(audit, ItemAudit{Ref: it.Ref, Kind: it.Kind, Class: class, Redactions: res.Redactions})
+	}
+
+	return out, audit, nil
+}
+
+// scanEnvelopeField classifies and redacts a single critical envelope field.
+// An empty field is a no-op. A policy-denied or unsanitizable field returns an
+// error so the caller holds the whole delegation.
+func scanEnvelopeField(text string, kind ItemKind, audience BotTrust, policy EgressPolicy, sc SecretScanner) (string, int, error) {
+	if strings.TrimSpace(text) == "" {
+		return "", 0, nil
+	}
+	if policy.Classify(kind, audience) == ExportDenied {
+		return "", 0, fmt.Errorf("%w: policy denied %s", ErrEnvelopeHeld, kind)
+	}
+	res := sc.Scan(text)
+	if !res.OK {
+		return "", 0, fmt.Errorf("%w: %s (%s)", ErrEnvelopeHeld, kind, res.Reason)
+	}
+	return res.Content, res.Redactions, nil
+}
+
+// Budget ranks the surviving items and trims them to the profile's token tier.
+// Ask, ReturnPact, and Guards are never dropped (already classified); the Ask is
+// length-capped. Items are trimmed from the bottom in rank order:
+// plan -> learning -> wiki -> roster -> skill.
+func Budget(b ContextBundle, p BotProfile) ContextBundle {
+	limit := mentionTokenCap
+	if p.ReadScope == ReadThread {
+		limit = threadTokenCap
+	}
+
+	b.Ask = capTokens(b.Ask, askTokenCap)
+
+	sort.SliceStable(b.Items, func(i, j int) bool {
+		return kindRank(b.Items[i].Kind) < kindRank(b.Items[j].Kind)
+	})
+
+	used := estimateTokens(b.Ask) + estimateTokens(b.ReturnPact)
+	for _, g := range b.Guards {
+		used += estimateTokens(g)
+	}
+
+	kept := make([]ContextItem, 0, len(b.Items))
+	for _, it := range b.Items {
+		t := estimateTokens(it.Body)
+		if used+t > limit {
+			continue // drop lower-ranked items that do not fit
+		}
+		used += t
+		kept = append(kept, it)
+	}
+	b.Items = kept
+	return b
+}
+
+// kindRank orders items for trimming. Lower is kept longer.
+func kindRank(k ItemKind) int {
+	switch k {
+	case KindPlan:
+		return 0
+	case KindLearning:
+		return 1
+	case KindWiki:
+		return 2
+	case KindRoster:
+		return 3
+	case KindSkill:
+		return 4
+	default:
+		return 5
+	}
+}

--- a/internal/packer/pipeline.go
+++ b/internal/packer/pipeline.go
@@ -45,13 +45,15 @@ type GatherOptions struct {
 	LearningLimit int
 }
 
-// Gather retrieves candidates, task-scoped, for the target tier. Tainted intent
-// does NOT drive retrieval: retrieval is keyed by task id, and the Ask carries
-// the (CEO-restated) intent text only as an export to be classified, never as a
-// query. Untrusted bots get only the envelope + the approved plan step;
-// first-party (and hosted) additionally get task-scoped learnings, task-linked
-// wiki refs, and roster lines.
-func Gather(brain BrainHandle, req ContextRequest, opts GatherOptions) (RawBundle, error) {
+// Gather retrieves candidates, task-scoped, for the AUDIENCE tier (the
+// least-trusted reader, computed by Pack), not the target's own tier — a
+// downgraded audience must not even pull first-party content into the pipeline.
+// Tainted intent does NOT drive retrieval: retrieval is keyed by task id, and
+// the Ask carries the (CEO-restated) intent text only as an export to be
+// classified, never as a query. An untrusted audience gets only the envelope +
+// the approved plan step; first-party (and hosted) additionally get task-scoped
+// learnings, task-linked wiki refs, and roster lines.
+func Gather(brain BrainHandle, req ContextRequest, opts GatherOptions, audienceTier BotTrust) (RawBundle, error) {
 	rb := RawBundle{
 		Ask:        req.Intent.Text,
 		ReturnPact: opts.ReturnPact,
@@ -66,9 +68,10 @@ func Gather(brain BrainHandle, req ContextRequest, opts GatherOptions) (RawBundl
 		rb.Items = append(rb.Items, RawItem{Ref: "plan:" + req.TaskID, Kind: KindPlan, Body: plan})
 	}
 
-	if req.Target.Trust == BotUntrusted {
-		// Untrusted gets envelope + approved plan step only. No learnings, no
-		// wiki, no roster — nothing retrieved from the brain at large.
+	if audienceTier == BotUntrusted {
+		// Untrusted audience gets envelope + approved plan step only. No
+		// learnings, no wiki, no roster — nothing retrieved from the brain at
+		// large, regardless of the target bot's own tier.
 		return rb, nil
 	}
 
@@ -138,20 +141,27 @@ func Classify(raw RawBundle, audience BotTrust, policy EgressPolicy, sc SecretSc
 		audit = append(audit, ItemAudit{Ref: "returnpact", Kind: KindReturnPact, Class: ExportRedacted, Redactions: pactRed})
 	}
 
-	// Guards — advisory list. A guard line that cannot be sanitized is dropped,
-	// not a held delegation.
+	// Guards — advisory list. Each line is policy-classified like any item (so a
+	// policy/tenant that denies KindGuard is enforced) and then scanned. A guard
+	// line that is denied or cannot be sanitized is dropped — not a held
+	// delegation, since guards are advisory.
 	for i, g := range raw.Guards {
 		if strings.TrimSpace(g) == "" {
 			continue
 		}
-		res := sc.Scan(g)
 		ref := fmt.Sprintf("guard:%d", i)
+		class := policy.Classify(KindGuard, audience)
+		if class == ExportDenied {
+			audit = append(audit, ItemAudit{Ref: ref, Kind: KindGuard, Class: ExportDenied})
+			continue
+		}
+		res := sc.Scan(g)
 		if !res.OK {
 			audit = append(audit, ItemAudit{Ref: ref, Kind: KindGuard, Class: ExportDenied})
 			continue
 		}
 		out.Guards = append(out.Guards, res.Content)
-		audit = append(audit, ItemAudit{Ref: ref, Kind: KindGuard, Class: ExportRedacted, Redactions: res.Redactions})
+		audit = append(audit, ItemAudit{Ref: ref, Kind: KindGuard, Class: class, Redactions: res.Redactions})
 	}
 
 	// Items — drop ExportDenied (policy) and anything the scanner cannot prove
@@ -195,32 +205,51 @@ func scanEnvelopeField(text string, kind ItemKind, audience BotTrust, policy Egr
 	return res.Content, res.Redactions, nil
 }
 
-// Budget ranks the surviving items and trims them to the profile's token tier.
-// Ask, ReturnPact, and Guards are never dropped (already classified); the Ask is
-// length-capped. Items are trimmed from the bottom in rank order:
-// plan -> learning -> wiki -> roster -> skill.
-func Budget(b ContextBundle, p BotProfile) ContextBundle {
+// budget ranks the surviving items and trims them to the profile's token tier.
+// The ESSENTIALS — Ask, ReturnPact, Guards, and the approved plan step — are
+// never dropped: the bot cannot act without them. They are length-capped
+// instead, and only the non-essential items (learning -> wiki -> roster ->
+// skill) are trimmed from the bottom to fit whatever budget remains. This means
+// a large ReturnPact can never evict the plan step.
+func budget(b ContextBundle, p BotProfile) ContextBundle {
 	limit := mentionTokenCap
 	if p.ReadScope == ReadThread {
 		limit = threadTokenCap
 	}
 
+	// Cap the critical envelope fields so essentials always fit.
 	b.Ask = capTokens(b.Ask, askTokenCap)
+	b.ReturnPact = capTokens(b.ReturnPact, returnPactTokenCap)
+	b.Guards = capGuards(b.Guards, guardsTokenCap)
 
-	sort.SliceStable(b.Items, func(i, j int) bool {
-		return kindRank(b.Items[i].Kind) < kindRank(b.Items[j].Kind)
+	// Split essentials (plan) from trimmable items, preserving plan unconditionally.
+	var plan []ContextItem
+	var trimmable []ContextItem
+	for _, it := range b.Items {
+		if it.Kind == KindPlan {
+			plan = append(plan, ContextItem{Ref: it.Ref, Kind: it.Kind, Class: it.Class, Redactions: it.Redactions, Body: capTokens(it.Body, planTokenCap)})
+			continue
+		}
+		trimmable = append(trimmable, it)
+	}
+
+	sort.SliceStable(trimmable, func(i, j int) bool {
+		return kindRank(trimmable[i].Kind) < kindRank(trimmable[j].Kind)
 	})
 
 	used := estimateTokens(b.Ask) + estimateTokens(b.ReturnPact)
 	for _, g := range b.Guards {
 		used += estimateTokens(g)
 	}
+	for _, it := range plan {
+		used += estimateTokens(it.Body)
+	}
 
-	kept := make([]ContextItem, 0, len(b.Items))
-	for _, it := range b.Items {
+	kept := plan
+	for _, it := range trimmable {
 		t := estimateTokens(it.Body)
 		if used+t > limit {
-			continue // drop lower-ranked items that do not fit
+			continue // drop lower-ranked non-essential items that do not fit
 		}
 		used += t
 		kept = append(kept, it)

--- a/internal/packer/policy.go
+++ b/internal/packer/policy.go
@@ -1,0 +1,58 @@
+package packer
+
+// EgressPolicy decides, per candidate kind and audience tier, whether content
+// may leave the brain. It is intentionally conservative and label-free for v1;
+// per-item sensitivity labels are a later refinement that only WIDENS first-party
+// reach. The audience tier passed in is the LEAST-trusted reader the content
+// will reach, not necessarily the target bot (a shared-thread post is visible to
+// everyone in the channel and to future joiners).
+type EgressPolicy interface {
+	Version() int
+	Classify(kind ItemKind, audience BotTrust) ExportClass
+}
+
+// DefaultEgressPolicy encodes the spec's per-tier table:
+//
+//	BotUntrusted  -> ask/returnpact/guard/plan REDACTED; everything else DENIED.
+//	                 No free wiki/learning. Raw task body never exported wholesale.
+//	BotFirstParty -> the above + task-scoped learnings + task-linked wiki refs +
+//	                 roster + skill hints, all REDACTED. Raw task body still DENIED.
+//	BotHosted     -> everything ALLOWED (it already gets the full push-side
+//	                 injection; the packer is permissive if ever called for it).
+type DefaultEgressPolicy struct{ version int }
+
+// NewDefaultEgressPolicy returns the default policy stamped with a version that
+// every InjectionRecord references for audit.
+func NewDefaultEgressPolicy(version int) DefaultEgressPolicy {
+	return DefaultEgressPolicy{version: version}
+}
+
+// Version reports the policy version.
+func (p DefaultEgressPolicy) Version() int { return p.version }
+
+// Classify returns the export class for a candidate kind at an audience tier.
+func (p DefaultEgressPolicy) Classify(kind ItemKind, audience BotTrust) ExportClass {
+	switch audience {
+	case BotHosted:
+		return ExportAllowed
+	case BotFirstParty:
+		switch kind {
+		case KindAsk, KindReturnPact, KindGuard, KindPlan,
+			KindLearning, KindWiki, KindRoster, KindSkill:
+			return ExportRedacted
+		default:
+			// KindTask (raw free-form body) and anything unknown: never exported
+			// wholesale. Redaction catches credential tokens, not confidential
+			// prose / source / customer data.
+			return ExportDenied
+		}
+	default: // BotUntrusted — the default for anything externally originated.
+		switch kind {
+		case KindAsk, KindReturnPact, KindGuard, KindPlan:
+			return ExportRedacted
+		default:
+			// No free wiki/learning retrieval; raw task body denied.
+			return ExportDenied
+		}
+	}
+}

--- a/internal/packer/render.go
+++ b/internal/packer/render.go
@@ -1,0 +1,128 @@
+package packer
+
+import "strings"
+
+// Budget tiers (approximate tokens). The security pass runs first; these only
+// govern how much of what SURVIVED classification is ranked in. See the spec's
+// budget heuristic.
+const (
+	mentionTokenCap = 600  // ReadMentionOnly hard cap
+	threadTokenCap  = 2400 // ReadThread: ~400 mention + up to ~2000 thread block
+	askTokenCap     = 220  // the Ask is length-capped, never dropped
+
+	defaultLearningLimit = 6
+	maxRosterLines       = 3
+)
+
+// estimateTokens is a cheap char-based token estimate (~4 chars/token). The
+// packer never needs exact token counts — only a stable budget heuristic.
+func estimateTokens(s string) int {
+	if s == "" {
+		return 0
+	}
+	return (len(s) + 3) / 4
+}
+
+// capTokens truncates s to roughly maxTokens, on a word boundary where possible.
+// A truncated string is marked so the reader knows it was cut.
+func capTokens(s string, maxTokens int) string {
+	if estimateTokens(s) <= maxTokens {
+		return s
+	}
+	maxChars := maxTokens * 4
+	if maxChars >= len(s) {
+		return s
+	}
+	cut := s[:maxChars]
+	if idx := strings.LastIndexAny(cut, " \n\t"); idx > maxChars/2 {
+		cut = cut[:idx]
+	}
+	return strings.TrimRight(cut, " \n\t") + " …"
+}
+
+// Render shapes a classified, budgeted bundle into a neutral PackedDelegation.
+// The Slack-specific surface (Block Kit) is the bridge's job; here we produce
+// MentionText (always carries the essentials: ask, return pact, guards, plan)
+// and ThreadContext (the remaining items, only when the bot is verified to read
+// the thread). ThreadContext was already classified against the least-trusted
+// reader in Classify. The InjectionRecord is seeded as DeliveryPending; Deliver
+// fills RenderedHash, TokenCount, MessageTS, and the final status.
+func Render(b ContextBundle, req ContextRequest, audit []ItemAudit) PackedDelegation {
+	mention := renderMention(b, req.Target.ReadScope)
+
+	thread := ""
+	if req.Target.ReadScope == ReadThread {
+		thread = renderThread(b)
+	}
+
+	rec := InjectionRecord{
+		IdempotencyKey: req.IdempotencyKey,
+		TaskID:         req.TaskID,
+		PlanID:         req.PlanID,
+		PlanVersion:    req.PlanVersion,
+		Identity:       req.Target.Identity,
+		BotTrust:       req.Target.Trust,
+		ProfileVersion: req.Target.Version,
+		PolicyVersion:  req.EgressPolicyVer,
+		WorkspaceID:    req.Thread.WorkspaceID,
+		ChannelID:      req.Thread.ChannelID,
+		ThreadTS:       req.Thread.ThreadTS,
+		Items:          audit,
+		Status:         DeliveryPending,
+	}
+
+	return PackedDelegation{MentionText: mention, ThreadContext: thread, Injection: rec}
+}
+
+// renderMention builds the always-delivered mention. For ReadMentionOnly bots it
+// carries the essentials plus the approved plan step (everything they will ever
+// see). For ReadThread bots it stays lean — the bulk goes in the thread block.
+func renderMention(b ContextBundle, scope ReadScope) string {
+	var sb strings.Builder
+	writeSection(&sb, "ASK", b.Ask)
+	writeSection(&sb, "RETURN", b.ReturnPact)
+	if len(b.Guards) > 0 {
+		writeSection(&sb, "GUARDS", "- "+strings.Join(b.Guards, "\n- "))
+	}
+	// The approved plan step always rides in the mention — even a mention-only
+	// bot needs the scoped step to act.
+	for _, it := range b.Items {
+		if it.Kind == KindPlan {
+			writeSection(&sb, "PLAN", it.Body)
+		}
+	}
+	if scope == ReadMentionOnly {
+		// Mention-only bots get the non-plan survivors inline too, since they
+		// never read the thread block.
+		for _, it := range b.Items {
+			if it.Kind != KindPlan {
+				writeSection(&sb, strings.ToUpper(string(it.Kind)), it.Body)
+			}
+		}
+	}
+	return strings.TrimSpace(sb.String())
+}
+
+// renderThread builds the channel-visible thread block: the non-plan survivors
+// (learnings, wiki, roster, skills) for a thread-reading bot.
+func renderThread(b ContextBundle) string {
+	var sb strings.Builder
+	for _, it := range b.Items {
+		if it.Kind == KindPlan {
+			continue
+		}
+		writeSection(&sb, strings.ToUpper(string(it.Kind)), it.Body)
+	}
+	return strings.TrimSpace(sb.String())
+}
+
+func writeSection(sb *strings.Builder, label, body string) {
+	if strings.TrimSpace(body) == "" {
+		return
+	}
+	sb.WriteString("== ")
+	sb.WriteString(label)
+	sb.WriteString(" ==\n")
+	sb.WriteString(strings.TrimSpace(body))
+	sb.WriteString("\n\n")
+}

--- a/internal/packer/render.go
+++ b/internal/packer/render.go
@@ -8,7 +8,12 @@ import "strings"
 const (
 	mentionTokenCap = 600  // ReadMentionOnly hard cap
 	threadTokenCap  = 2400 // ReadThread: ~400 mention + up to ~2000 thread block
-	askTokenCap     = 220  // the Ask is length-capped, never dropped
+
+	// Essentials are never dropped, only length-capped so they always fit.
+	askTokenCap        = 220
+	returnPactTokenCap = 160
+	guardsTokenCap     = 160 // total across all guard lines
+	planTokenCap       = 600
 
 	defaultLearningLimit = 6
 	maxRosterLines       = 3
@@ -40,14 +45,15 @@ func capTokens(s string, maxTokens int) string {
 	return strings.TrimRight(cut, " \n\t") + " …"
 }
 
-// Render shapes a classified, budgeted bundle into a neutral PackedDelegation.
+// render shapes a classified, budgeted bundle into a neutral PackedDelegation.
+// It is unexported and sets the `sealed` marker, so a delivered delegation can
+// only come from Pack — never a hand-constructed bundle that skipped Classify.
 // The Slack-specific surface (Block Kit) is the bridge's job; here we produce
 // MentionText (always carries the essentials: ask, return pact, guards, plan)
 // and ThreadContext (the remaining items, only when the bot is verified to read
-// the thread). ThreadContext was already classified against the least-trusted
-// reader in Classify. The InjectionRecord is seeded as DeliveryPending; Deliver
-// fills RenderedHash, TokenCount, MessageTS, and the final status.
-func Render(b ContextBundle, req ContextRequest, audit []ItemAudit) PackedDelegation {
+// the thread). The InjectionRecord is seeded DeliveryPending; Deliver fills
+// RenderedHash, TokenCount, MessageTS, and the final status.
+func render(b ContextBundle, req ContextRequest, audit []ItemAudit, audienceTier BotTrust) PackedDelegation {
 	mention := renderMention(b, req.Target.ReadScope)
 
 	thread := ""
@@ -58,10 +64,12 @@ func Render(b ContextBundle, req ContextRequest, audit []ItemAudit) PackedDelega
 	rec := InjectionRecord{
 		IdempotencyKey: req.IdempotencyKey,
 		TaskID:         req.TaskID,
+		TaskUpdatedAt:  req.TaskUpdatedAt,
 		PlanID:         req.PlanID,
 		PlanVersion:    req.PlanVersion,
 		Identity:       req.Target.Identity,
 		BotTrust:       req.Target.Trust,
+		AudienceTrust:  audienceTier,
 		ProfileVersion: req.Target.Version,
 		PolicyVersion:  req.EgressPolicyVer,
 		WorkspaceID:    req.Thread.WorkspaceID,
@@ -71,7 +79,24 @@ func Render(b ContextBundle, req ContextRequest, audit []ItemAudit) PackedDelega
 		Status:         DeliveryPending,
 	}
 
-	return PackedDelegation{MentionText: mention, ThreadContext: thread, Injection: rec}
+	return PackedDelegation{MentionText: mention, ThreadContext: thread, Injection: rec, sealed: true}
+}
+
+// capGuards trims a guard list so its combined token estimate stays under total,
+// dropping whole lines from the end (guards are advisory, so the earliest /
+// most-important survive).
+func capGuards(guards []string, total int) []string {
+	used := 0
+	kept := make([]string, 0, len(guards))
+	for _, g := range guards {
+		t := estimateTokens(g)
+		if used+t > total {
+			break
+		}
+		used += t
+		kept = append(kept, g)
+	}
+	return kept
 }
 
 // renderMention builds the always-delivered mention. For ReadMentionOnly bots it

--- a/internal/packer/scanner.go
+++ b/internal/packer/scanner.go
@@ -1,0 +1,40 @@
+package packer
+
+import "github.com/nex-crm/wuphf/internal/scanner"
+
+// SecretScanner is the redaction seam at the egress boundary. The default
+// implementation wraps the fail-closed scanner.RedactForEgress; cloud can swap a
+// tenant-specific scanner. A scan that is not OK means the content could not be
+// proven clean and MUST NOT be emitted — the caller drops the item or holds the
+// whole delegation, never sends the partially-scrubbed text.
+type SecretScanner interface {
+	Scan(content string) ScanResult
+}
+
+// ScanResult is the outcome of an egress scan.
+type ScanResult struct {
+	Content    string   // safe to emit ONLY when OK
+	OK         bool     // false => withhold; could not be proven clean
+	Redactions int      // number of secrets/PII tokens scrubbed
+	Reason     string   // "" when OK; else "poisoned" | "entropy-cap"
+	Reasons    []string // human/audit-facing redaction labels
+}
+
+// EgressScanner is the default SecretScanner, backed by the fail-closed
+// scanner.RedactForEgress. Empty input is trivially clean.
+type EgressScanner struct{}
+
+// Scan runs the fail-closed egress redactor and adapts its result.
+func (EgressScanner) Scan(content string) ScanResult {
+	if content == "" {
+		return ScanResult{OK: true}
+	}
+	r := scanner.RedactForEgress(content)
+	return ScanResult{
+		Content:    r.Content,
+		OK:         r.Allowed,
+		Redactions: r.Redactions,
+		Reason:     r.DenyReason,
+		Reasons:    r.Reasons,
+	}
+}

--- a/internal/packer/types.go
+++ b/internal/packer/types.go
@@ -230,11 +230,16 @@ type ItemAudit struct {
 	Redactions int
 }
 
-// PackedDelegation is the output the bridge posts to Slack.
+// PackedDelegation is the output the bridge posts to Slack. It can only be
+// produced by Pack: the unexported `sealed` marker is set by render(), and
+// Deliver refuses any delegation that is not sealed. This forces every delivered
+// payload through the classifier — a hand-constructed PackedDelegation (which
+// would skip Classify) cannot be delivered.
 type PackedDelegation struct {
 	MentionText   string // ALWAYS carries the essentials
 	ThreadContext string // CHANNEL-VISIBLE: classified against the least-trusted reader
 	Injection     InjectionRecord
+	sealed        bool // set only by render(); gate-checked by Deliver
 }
 
 // InjectionRecord is the append-only egress audit row. It is strong enough for
@@ -243,10 +248,12 @@ type PackedDelegation struct {
 type InjectionRecord struct {
 	IdempotencyKey string
 	TaskID         string
+	TaskUpdatedAt  string // the task snapshot the delegation was built against
 	PlanID         string
 	PlanVersion    int
 	Identity       BotIdentity // full tuple, not a bare id
-	BotTrust       BotTrust
+	BotTrust       BotTrust    // the target's own tier
+	AudienceTrust  BotTrust    // the tier the content was actually classified against
 	ProfileVersion int
 	PolicyVersion  int
 	WorkspaceID    string

--- a/internal/packer/types.go
+++ b/internal/packer/types.go
@@ -1,0 +1,262 @@
+// Package packer implements the Slack inbound context-packer: the CEO-membrane
+// component that does task-scoped retrieval against the office brain and injects
+// egress-classified, redacted context into the Slack @-mention a foreign bot
+// reads. It is the one place internal brain content crosses into a foreign LLM
+// we do not control, so the egress boundary (Classify + EgressPolicy +
+// redaction) is the security core. See docs/specs/slack-context-packer.md.
+//
+// The package depends only on internal/scanner and the standard library. The
+// brain, the delivery transport, the snapshot validator, and the audit sink are
+// all interfaces (the cloud-portability seams), so the same core runs in the OSS
+// self-hosted broker and in the Nex cloud multi-tenant host without a fork.
+package packer
+
+// --- Trust, identity, data handling ---
+
+// BotTrust is the trust tier a bot is granted. It is DERIVED partly from data
+// handling, not just origin: a first-party bot that forwards prompts to a
+// third-party LLM is not automatically trusted. BotUntrusted is the default for
+// anything externally originated.
+type BotTrust int
+
+const (
+	BotUntrusted  BotTrust = iota // default for anything externally originated
+	BotFirstParty                 // in-house, company-owned workspace, known data handling
+	BotHosted                     // WUPHF-hosted agent (also gets push-side injection)
+)
+
+// ReadScope is how much of the conversation a bot reads. Upgraded to ReadThread
+// only via an explicit nonce probe, never inferred from ordinary replies.
+type ReadScope int
+
+const (
+	ReadMentionOnly ReadScope = iota // default: the bot reads only its @-mention
+	ReadThread                       // verified to read thread history
+)
+
+// Invocation is how the bot is triggered.
+type Invocation int
+
+const (
+	InvokeMention Invocation = iota
+	InvokeSlash
+	InvokeKeyword
+)
+
+// BotIdentity is the full provenance anchor. A bare Slack user id is not enough
+// across workspaces / enterprise grids, and display names are spoofable, so
+// trust and the first-egress gate bind to this whole tuple (plus InstallID),
+// never to DisplayName.
+type BotIdentity struct {
+	SlackTeamID     string // workspace id
+	SlackEnterprise string // enterprise-grid id, if any
+	AppUserID       string // the bot's app/bot user id
+	InstallID       string // verified app-install id; part of the first-egress gate key
+	DisplayName     string // advisory only — never a trust input
+	VerifiedVia     string // how identity was confirmed (install OAuth, admin add)
+}
+
+// BotDataHandling describes where this bot's prompts actually go. Trust is about
+// data handling, not just "we built it".
+type BotDataHandling struct {
+	ModelProvider      string // "anthropic" | "openai" | "self-hosted" | "unknown"
+	RetainsLogs        bool
+	WorkspaceOwned     bool   // company-owned workspace vs a personal one
+	NetworkEgress      string // "none" | "vendor-llm" | "open" | "unknown"
+	ReadsThreadHistory bool
+}
+
+// BotProfile is the per-bot delivery profile. Version is bumped on every change
+// and referenced by every InjectionRecord.
+type BotProfile struct {
+	Version      int
+	Slug         string
+	Identity     BotIdentity
+	Trust        BotTrust
+	DataHandling BotDataHandling
+	ReadScope    ReadScope
+	Invoke       Invocation
+	Trigger      string   // slash command or keyword when Invoke != InvokeMention
+	Specialties  []string // observed task history + human confirmation, never the display name
+	Notes        string
+}
+
+// --- Intent + taint ---
+
+// Taint marks whether intent was influenced by foreign-bot output. It is DERIVED
+// from SourceRefs, not caller-declared: tainted intent cannot drive free
+// retrieval. v1 retrieval is task-scoped (keyed by task id, never by intent
+// text), so taint cannot reach retrieval here; the Ask field still carries the
+// text and is classified + redacted like any other export.
+type Taint int
+
+const (
+	TaintClean Taint = iota
+	TaintForeign
+)
+
+// StepIntent is the precise ask for one delegation, CEO-restated.
+type StepIntent struct {
+	Text       string
+	Taint      Taint
+	SourceRefs []string // message ids the intent derives from, for audit
+}
+
+// --- Request ---
+
+// ThreadRef locates the Slack destination.
+type ThreadRef struct {
+	WorkspaceID string
+	ChannelID   string
+	ThreadTS    string
+}
+
+// ContextRequest is the packer's input for one delegation. It carries snapshot +
+// version guards so Gather / Classify / Deliver cannot race a task edit or a
+// trust downgrade.
+type ContextRequest struct {
+	TaskID          string
+	TaskUpdatedAt   string // re-checked before Deliver; stale aborts
+	PlanID          string
+	PlanVersion     int
+	Target          BotProfile // carries Target.Version
+	Intent          StepIntent
+	Thread          ThreadRef
+	EgressPolicyVer int
+	Approver        string // who approved the plan / this egress, when a gate applies
+	IdempotencyKey  string // dedupes both delivery and the InjectionRecord
+}
+
+// --- Export classes + items ---
+
+// ExportClass is decided per item by the egress policy + secret scan.
+type ExportClass int
+
+const (
+	ExportDenied   ExportClass = iota // never leaves the brain
+	ExportRedacted                    // leaves only after redaction
+	ExportAllowed                     // leaves as-is
+)
+
+func (c ExportClass) String() string {
+	switch c {
+	case ExportRedacted:
+		return "redacted"
+	case ExportAllowed:
+		return "allowed"
+	default:
+		return "denied"
+	}
+}
+
+// ItemKind enumerates the provenance of a candidate. The egress policy keys on
+// it. The envelope kinds (ask/returnpact/guard) are export data too — a tainted
+// task can plant a secret in the ask — so they are classified, not waved through.
+type ItemKind string
+
+const (
+	KindAsk        ItemKind = "ask"
+	KindReturnPact ItemKind = "returnpact"
+	KindGuard      ItemKind = "guard"
+	KindPlan       ItemKind = "plan"     // human-approved plan step / IssueDraftSpec
+	KindTask       ItemKind = "task"     // raw teamTask.Details — free-form, untrusted body
+	KindLearning   ItemKind = "learning" // task-scoped, AND-scoped to the task id
+	KindWiki       ItemKind = "wiki"     // explicitly task-linked article, never free search
+	KindRoster     ItemKind = "roster"
+	KindSkill      ItemKind = "skill"
+)
+
+// RawItem is a pre-classification candidate produced by Gather.
+type RawItem struct {
+	Ref  string
+	Kind ItemKind
+	Body string
+}
+
+// RawBundle is what Gather produces: the envelope fields plus candidate items,
+// before any classification or redaction.
+type RawBundle struct {
+	Ask        string
+	ReturnPact string
+	Guards     []string
+	Items      []RawItem
+}
+
+// ContextItem is a classified, post-redaction item.
+type ContextItem struct {
+	Ref        string
+	Kind       ItemKind
+	Body       string // POST-redaction text
+	Class      ExportClass
+	Redactions int
+}
+
+// ContextBundle is classified + redacted, pre-budget. Only ExportAllowed and
+// ExportRedacted items survive Classify into here.
+type ContextBundle struct {
+	Ask        string
+	ReturnPact string
+	Guards     []string
+	Items      []ContextItem
+}
+
+// --- Output + audit ---
+
+// DeliveryStatus tracks an injection through delivery.
+type DeliveryStatus int
+
+const (
+	DeliveryPending DeliveryStatus = iota
+	DeliverySent
+	DeliveryFailed
+)
+
+func (s DeliveryStatus) String() string {
+	switch s {
+	case DeliverySent:
+		return "sent"
+	case DeliveryFailed:
+		return "failed"
+	default:
+		return "pending"
+	}
+}
+
+// ItemAudit is the per-item record of what was classified, for the egress audit.
+type ItemAudit struct {
+	Ref        string
+	Kind       ItemKind
+	Class      ExportClass
+	Redactions int
+}
+
+// PackedDelegation is the output the bridge posts to Slack.
+type PackedDelegation struct {
+	MentionText   string // ALWAYS carries the essentials
+	ThreadContext string // CHANNEL-VISIBLE: classified against the least-trusted reader
+	Injection     InjectionRecord
+}
+
+// InjectionRecord is the append-only egress audit row. It is strong enough for
+// incident response: it proves exactly what was sent, where, under which policy,
+// and whether it landed.
+type InjectionRecord struct {
+	IdempotencyKey string
+	TaskID         string
+	PlanID         string
+	PlanVersion    int
+	Identity       BotIdentity // full tuple, not a bare id
+	BotTrust       BotTrust
+	ProfileVersion int
+	PolicyVersion  int
+	WorkspaceID    string
+	ChannelID      string
+	ThreadTS       string
+	MessageTS      string // filled on DeliverySent
+	Items          []ItemAudit
+	RenderedHash   string // hash of exactly what was sent
+	TokenCount     int
+	Status         DeliveryStatus
+	FailureReason  string
+	Timestamp      string
+}

--- a/internal/scanner/egress_redaction.go
+++ b/internal/scanner/egress_redaction.go
@@ -1,0 +1,67 @@
+package scanner
+
+// egress_redaction.go adds a FAIL-CLOSED redaction contract on top of the
+// display redactor, for the Slack context-packer's egress boundary.
+//
+// The display path (RedactSecretsForDisplay) is best-effort: it returns scrubbed
+// text even when the scanner hit a limit, because a chat message with a few
+// surviving high-entropy tokens is a tolerable display risk. That is the WRONG
+// default when the text is leaving the office brain to a foreign LLM we do not
+// control. A result that is Poisoned, or that reached the entropy-hit cap and
+// stopped scanning early, cannot be proven clean — so the content must be
+// WITHHELD, not emitted partially scrubbed. See
+// docs/specs/slack-context-packer.md (Egress boundary).
+
+// EgressRedaction is the result of running content through the fail-closed
+// egress redactor. Content is safe to emit ONLY when Allowed is true.
+type EgressRedaction struct {
+	// Content is the redacted text. It is the empty string whenever Allowed is
+	// false, so a caller can never accidentally emit partially-scrubbed bytes.
+	Content string
+	// Allowed reports whether the content may leave the brain.
+	Allowed bool
+	// Redactions is the total number of secret/PII tokens scrubbed.
+	Redactions int
+	// DenyReason is "" when Allowed, else one of: "poisoned", "entropy-cap".
+	DenyReason string
+	// Reasons are the human/audit-facing redaction labels (pattern names plus
+	// the generic "entropy" label). Populated on both allow and deny so the
+	// caller can record why an item was withheld.
+	Reasons []string
+}
+
+// RedactForEgress is the fail-closed variant of RedactSecretsForDisplay. Use it
+// for any brain content the context-packer ships to a foreign bot. It denies
+// (emits no content) when:
+//
+//   - the scanner caught a poison-class secret (private key, service-account
+//     JSON, aws secret) — Poisoned is set on the first such hit; or
+//   - the entropy pass reached maxEntropyHitsPerFile and stopped early, so the
+//     remainder of the text cannot be proven free of high-entropy secrets.
+//
+// Pattern redaction always runs to completion — every known pattern is applied —
+// so a high pattern-hit count alone is NOT a deny signal; only an unproven
+// remainder (entropy cap) or a poison hit is. The caller treats !Allowed as
+// "drop this item / hold this delegation", never as "send the scrubbed text".
+func RedactForEgress(content string) EgressRedaction {
+	res := redactSecretsDetailed(content)
+	out := EgressRedaction{
+		Content:    res.Content,
+		Redactions: res.Matches(),
+		Reasons:    res.ReasonLabels(),
+	}
+	switch {
+	case res.Poisoned:
+		out.DenyReason = "poisoned"
+	case res.EntropyHits >= maxEntropyHitsPerFile:
+		out.DenyReason = "entropy-cap"
+	default:
+		out.Allowed = true
+	}
+	if !out.Allowed {
+		// Never expose partially-scrubbed content on a deny. The whole point of
+		// the egress boundary is that an unprovable item does not leave at all.
+		out.Content = ""
+	}
+	return out
+}

--- a/internal/scanner/egress_redaction_test.go
+++ b/internal/scanner/egress_redaction_test.go
@@ -1,0 +1,98 @@
+package scanner
+
+// egress_redaction_test.go proves the fail-closed egress contract: clean and
+// single-token content is allowed (the latter scrubbed), while poison-class
+// secrets and over-cap entropy content are DENIED with no content emitted.
+
+import (
+	"encoding/base64"
+	"math/rand"
+	"strings"
+	"testing"
+)
+
+func TestRedactForEgress_CleanProseAllowedUnchanged(t *testing.T) {
+	in := "The warehouse bot should reconcile the open invoices and report totals back in the thread."
+	got := RedactForEgress(in)
+	if !got.Allowed {
+		t.Fatalf("clean prose denied: reason=%q", got.DenyReason)
+	}
+	if got.Redactions != 0 {
+		t.Fatalf("clean prose had %d redactions, want 0", got.Redactions)
+	}
+	if got.Content != in {
+		t.Fatalf("clean prose content mutated:\n got %q\nwant %q", got.Content, in)
+	}
+}
+
+func TestRedactForEgress_KnownTokenRedactedButAllowed(t *testing.T) {
+	// A single non-poison pattern hit (openai key) is scrubbed, and the item is
+	// still safe to emit because pattern redaction is exhaustive.
+	secret := "sk-proj-ABCDEFGHIJKLMNOPQRSTUVWXYZ012345"
+	in := "Use key " + secret + " for the call."
+	got := RedactForEgress(in)
+	if !got.Allowed {
+		t.Fatalf("single-token content denied: reason=%q", got.DenyReason)
+	}
+	if got.Redactions < 1 {
+		t.Fatalf("expected >=1 redaction, got %d", got.Redactions)
+	}
+	if strings.Contains(got.Content, secret) {
+		t.Fatalf("secret survived into emitted content: %q", got.Content)
+	}
+	if !strings.Contains(got.Content, "[REDACTED]") {
+		t.Fatalf("expected [REDACTED] marker, got %q", got.Content)
+	}
+}
+
+func TestRedactForEgress_PoisonDeniesAndWithholdsContent(t *testing.T) {
+	in := "Deploy key:\n-----BEGIN OPENSSH PRIVATE KEY-----\nb3BlbnNzaC1rZXkt\n-----END OPENSSH PRIVATE KEY-----\n"
+	got := RedactForEgress(in)
+	if got.Allowed {
+		t.Fatalf("poison content was allowed")
+	}
+	if got.DenyReason != "poisoned" {
+		t.Fatalf("deny reason = %q, want poisoned", got.DenyReason)
+	}
+	if got.Content != "" {
+		t.Fatalf("denied content must be empty, got %q", got.Content)
+	}
+}
+
+func TestRedactForEgress_EntropyCapDeniesAndWithholdsContent(t *testing.T) {
+	// More than maxEntropyHitsPerFile high-entropy tokens: the entropy pass
+	// stops early, so the remainder is unproven and the whole item is withheld.
+	r := rand.New(rand.NewSource(7))
+	var b strings.Builder
+	b.WriteString("batch of opaque handles: ")
+	for i := 0; i < maxEntropyHitsPerFile+2; i++ {
+		b.WriteString(highEntropyEgressToken(r))
+		b.WriteByte(' ')
+	}
+	got := RedactForEgress(b.String())
+	if got.Allowed {
+		t.Fatalf("over-cap entropy content was allowed (redactions=%d)", got.Redactions)
+	}
+	if got.DenyReason != "entropy-cap" {
+		t.Fatalf("deny reason = %q, want entropy-cap", got.DenyReason)
+	}
+	if got.Content != "" {
+		t.Fatalf("denied content must be empty, got %q", got.Content)
+	}
+}
+
+// highEntropyEgressToken returns a 44-char base64 token (32 random bytes)
+// guaranteed to mix letters and digits, so it reliably trips the entropy
+// heuristic. hasLetterAndDigit is shared from scanner_entropy_test.go.
+func highEntropyEgressToken(r *rand.Rand) string {
+	buf := make([]byte, 32)
+	for {
+		for i := range buf {
+			buf[i] = byte(r.Intn(256))
+		}
+		tok := base64.RawStdEncoding.EncodeToString(buf)
+		if hasLetterAndDigit(tok) {
+			return tok
+		}
+	}
+}

--- a/internal/team/broker_task_wiki_refs_test.go
+++ b/internal/team/broker_task_wiki_refs_test.go
@@ -1,0 +1,79 @@
+package team
+
+// broker_task_wiki_refs_test.go proves the task->wiki-article backing link that
+// the Slack context-packer reads for the first-party "task-linked wiki refs"
+// tier: the WikiRefs field round-trips through the wire, and the create path
+// trims/normalizes/dedupes the linked set.
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestWikiRefsRoundTripsThroughWire(t *testing.T) {
+	original := teamTask{
+		ID:       "task-1",
+		Title:    "demo",
+		WikiRefs: []string{"team/playbooks/onboarding.md", "team/policies/refunds.md"},
+	}
+	data, err := original.MarshalJSON()
+	if err != nil {
+		t.Fatalf("MarshalJSON: %v", err)
+	}
+	if want := `"wiki_refs":[`; !strings.Contains(string(data), want) {
+		t.Fatalf("marshalled task missing %s; got %s", want, string(data))
+	}
+	var decoded teamTask
+	if err := decoded.UnmarshalJSON(data); err != nil {
+		t.Fatalf("UnmarshalJSON: %v", err)
+	}
+	if len(decoded.WikiRefs) != 2 || decoded.WikiRefs[0] != "team/playbooks/onboarding.md" {
+		t.Fatalf("round-trip WikiRefs = %v, want the two linked paths", decoded.WikiRefs)
+	}
+}
+
+func TestWikiRefsOmittedWhenEmpty(t *testing.T) {
+	// The default is "no wiki egress": a task with no links emits no wire key.
+	data, err := teamTask{ID: "task-2", Title: "no links"}.MarshalJSON()
+	if err != nil {
+		t.Fatalf("MarshalJSON: %v", err)
+	}
+	if strings.Contains(string(data), "wiki_refs") {
+		t.Fatalf("empty WikiRefs should be omitted, got %s", string(data))
+	}
+}
+
+func TestMutateTaskCreateDedupesWikiRefs(t *testing.T) {
+	b := newTestBroker(t)
+	b.channels = []teamChannel{
+		{Slug: "general", Name: "general", Members: []string{"ceo"}},
+	}
+
+	created, err := b.MutateTask(TaskPostRequest{
+		Action:    "create",
+		Channel:   "general",
+		Title:     "Reconcile invoices",
+		Owner:     "alice",
+		CreatedBy: "ceo",
+		// Duplicates (incl. after trimming) and blanks: dedupePaths normalizes.
+		WikiRefs: []string{
+			"team/playbooks/billing.md",
+			"  team/playbooks/billing.md  ",
+			"",
+			"team/policies/refunds.md",
+		},
+	})
+	if err != nil {
+		t.Fatalf("MutateTask create: %v", err)
+	}
+	got := created.Task.WikiRefs
+	want := []string{"team/playbooks/billing.md", "team/policies/refunds.md"}
+	if len(got) != len(want) {
+		t.Fatalf("WikiRefs = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("WikiRefs[%d] = %q, want %q (full: %v)", i, got[i], want[i], got)
+		}
+	}
+}

--- a/internal/team/broker_tasks_contracts.go
+++ b/internal/team/broker_tasks_contracts.go
@@ -34,6 +34,7 @@ type TaskPostRequest struct {
 	WorktreePath                 string   `json:"worktree_path"`
 	WorktreeBranch               string   `json:"worktree_branch"`
 	DependsOn                    []string `json:"depends_on"`
+	WikiRefs                     []string `json:"wiki_refs"`
 	ParentIssueID                string   `json:"parent_issue_id"`
 	MemoryWorkflowOverride       bool     `json:"memory_workflow_override"`
 	MemoryWorkflowOverrideActor  string   `json:"memory_workflow_override_actor"`

--- a/internal/team/broker_tasks_mutation_service.go
+++ b/internal/team/broker_tasks_mutation_service.go
@@ -431,6 +431,7 @@ func (b *Broker) MutateTask(body TaskPostRequest) (TaskResponse, error) {
 			WorktreePath:     strings.TrimSpace(body.WorktreePath),
 			WorktreeBranch:   strings.TrimSpace(body.WorktreeBranch),
 			DependsOn:        trimTaskDependencies(body.DependsOn),
+			WikiRefs:         dedupePaths(body.WikiRefs),
 			ParentIssueID:    strings.TrimSpace(body.ParentIssueID),
 			CreatedAt:        now,
 			UpdatedAt:        now,
@@ -799,6 +800,13 @@ func (b *Broker) MutateTask(body TaskPostRequest) (TaskResponse, error) {
 		}
 		if taskType := strings.TrimSpace(body.TaskType); taskType != "" {
 			task.TaskType = taskType
+		}
+		if len(body.WikiRefs) > 0 {
+			// Wiki links are routing metadata, not the spec body, so they stay
+			// mutable after approval (like TaskType/ExecutionMode) and are not
+			// gated by the spec freeze. Replace semantics: the caller sends the
+			// full linked set; dedupePaths trims/normalizes/dedupes.
+			task.WikiRefs = dedupePaths(body.WikiRefs)
 		}
 		if pipelineID := strings.TrimSpace(body.PipelineID); pipelineID != "" {
 			task.PipelineID = pipelineID

--- a/internal/team/broker_types.go
+++ b/internal/team/broker_types.go
@@ -267,6 +267,13 @@ type teamTask struct {
 	// for v1 the task carries its own copy so the routing logic does not
 	// need a Lane-B dependency.
 	Tags []string `json:"tags,omitempty"`
+	// WikiRefs are wiki-relative article paths explicitly linked to this task.
+	// The Slack context-packer treats them as the ONLY wiki content a first-party
+	// foreign bot may receive ("explicitly task-linked wiki refs"), never free
+	// WikiIndex.Search, which would be a retrieval-injection / over-share path.
+	// Empty for every task until something links an article, so the safe default
+	// is "no wiki egress". Wire key "wiki_refs" is additive + stable.
+	WikiRefs []string `json:"wiki_refs,omitempty"`
 	// ReviewStartedAt is the RFC3339 timestamp at which the task entered
 	// the review state. The convergence sweeper compares this against
 	// ReviewTimeoutSeconds (or the package-level default) to decide
@@ -381,6 +388,7 @@ type teamTaskWire struct {
 	LifecycleState       LifecycleState  `json:"lifecycle_state,omitempty"`
 	Reviewers            []string        `json:"reviewers,omitempty"`
 	Tags                 []string        `json:"tags,omitempty"`
+	WikiRefs             []string        `json:"wiki_refs,omitempty"`
 	ReviewStartedAt      string          `json:"review_started_at,omitempty"`
 	ReviewTimeoutSeconds int             `json:"review_timeout_seconds,omitempty"`
 	AckedAt              string          `json:"acked_at,omitempty"`
@@ -429,6 +437,7 @@ func (t teamTask) MarshalJSON() ([]byte, error) {
 		LifecycleState:       t.LifecycleState,
 		Reviewers:            t.Reviewers,
 		Tags:                 t.Tags,
+		WikiRefs:             t.WikiRefs,
 		ReviewStartedAt:      t.ReviewStartedAt,
 		ReviewTimeoutSeconds: t.ReviewTimeoutSeconds,
 		AckedAt:              t.AckedAt,
@@ -479,6 +488,7 @@ func (t *teamTask) UnmarshalJSON(data []byte) error {
 	t.blocked = w.Blocked
 	t.LifecycleState = normalizeLegacyLifecycleStateName(w.LifecycleState)
 	t.Tags = w.Tags
+	t.WikiRefs = w.WikiRefs
 	t.ReviewStartedAt = w.ReviewStartedAt
 	t.ReviewTimeoutSeconds = w.ReviewTimeoutSeconds
 	t.AckedAt = w.AckedAt

--- a/internal/team/learnings.go
+++ b/internal/team/learnings.go
@@ -112,7 +112,13 @@ type LearningSearchFilters struct {
 	Trusted      *bool
 	PlaybookSlug string
 	File         string
-	Limit        int
+	// TaskID, when set, restricts results to learnings recorded against that
+	// exact task. Unlike Scope/File/Query (which are fuzzy), this is an exact
+	// match on LearningRecord.TaskID. The egress path (the Slack context-packer)
+	// requires it: "task-scoped learnings" handed to a foreign bot must AND-scope
+	// to the task, never leak unrelated durable brain content via a fuzzy match.
+	TaskID string
+	Limit  int
 }
 
 type LearningSearchResult struct {
@@ -263,6 +269,7 @@ func (l *LearningLog) Search(filters LearningSearchFilters) ([]LearningSearchRes
 	scope := strings.TrimSpace(filters.Scope)
 	playbookSlug := strings.TrimSpace(filters.PlaybookSlug)
 	file := strings.TrimSpace(filters.File)
+	taskID := strings.TrimSpace(filters.TaskID)
 	results := make([]LearningSearchResult, 0, len(deduped))
 	for _, rec := range deduped {
 		if filters.Type != "" && rec.Type != filters.Type {
@@ -281,6 +288,9 @@ func (l *LearningLog) Search(filters LearningSearchFilters) ([]LearningSearchRes
 			continue
 		}
 		if file != "" && !stringSliceContains(rec.Files, file) {
+			continue
+		}
+		if taskID != "" && rec.TaskID != taskID {
 			continue
 		}
 		if query != "" && !learningMatchesQuery(rec, query) {

--- a/internal/team/learnings_taskid_test.go
+++ b/internal/team/learnings_taskid_test.go
@@ -1,0 +1,65 @@
+package team
+
+// learnings_taskid_test.go proves the exact TaskID scope filter that the Slack
+// context-packer relies on for "task-scoped learnings": a foreign bot must only
+// ever receive learnings recorded against its own task, never the whole brain.
+
+import (
+	"context"
+	"testing"
+)
+
+func TestLearningSearchFiltersByTaskID(t *testing.T) {
+	_, _, log, teardown := newLearningFixture(t)
+	defer teardown()
+	ctx := context.Background()
+
+	mustAppend := func(key, taskID string) {
+		t.Helper()
+		if _, err := log.Append(ctx, LearningRecord{
+			Type:       LearningTypePitfall,
+			Key:        key,
+			Insight:    "insight for " + key,
+			Confidence: 7,
+			Source:     LearningSourceObserved,
+			Scope:      "repo",
+			CreatedBy:  "codex",
+			TaskID:     taskID,
+		}); err != nil {
+			t.Fatalf("append %s: %v", key, err)
+		}
+	}
+	mustAppend("learning-task-a", "task-A")
+	mustAppend("learning-task-b", "task-B")
+	mustAppend("learning-no-task", "")
+
+	// Exact TaskID match returns only that task's learning.
+	got, err := log.Search(LearningSearchFilters{TaskID: "task-A"})
+	if err != nil {
+		t.Fatalf("search by task: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("TaskID filter returned %d results, want 1: %+v", len(got), got)
+	}
+	if got[0].Key != "learning-task-a" {
+		t.Fatalf("TaskID filter returned wrong record: %q", got[0].Key)
+	}
+
+	// A task with no learnings yields nothing — never a fuzzy fallback.
+	none, err := log.Search(LearningSearchFilters{TaskID: "task-Z"})
+	if err != nil {
+		t.Fatalf("search empty task: %v", err)
+	}
+	if len(none) != 0 {
+		t.Fatalf("unknown TaskID returned %d results, want 0", len(none))
+	}
+
+	// Empty TaskID must NOT filter — all three records come back.
+	all, err := log.Search(LearningSearchFilters{})
+	if err != nil {
+		t.Fatalf("search all: %v", err)
+	}
+	if len(all) != 3 {
+		t.Fatalf("unfiltered search returned %d, want 3", len(all))
+	}
+}


### PR DESCRIPTION
## What

First slice of the **Slack inbound context-packer** — the CEO-membrane component
that lets agents-from-anywhere compound on the office brain inside a company
Slack. This PR lands the **spec**, the **three code prerequisites** the review
proved were missing, and the **packer's egress core** (the security boundary).
It does **not** include the Slack bridge adapter or Block Kit gate cards — those
are a separate spec/PR (the packer's `BrainHandle`/`SlackBridge`/`SnapshotValidator`/
`InjectionSink` are interfaces; the team-side adapters land with the bridge).

Design context: `docs/specs/slack-context-packer.md`. OSS self-hosted scope; the
multi-tenant host is Nex cloud, which shares this same kernel.

## Why this shape

The packer ships internal office-brain content into a foreign LLM we do not
control. That makes the **egress boundary** (`Classify` + `EgressPolicy` +
redaction) the one place a miss leaks customer data. The design was reviewed by
codex (16 findings), then by a triangulation pass (security/API/architecture)
plus an adversarial verification agent — which caught that the spec's "redaction
failure denies the item" had **no backing** in the real scanner. The three
prerequisites here close exactly the gaps that review surfaced.

## Commits

1. `docs(slack-packer)` — the spec (v3, triangulation-hardened, with both review
   disposition tables).
2. `feat(scanner)` — **Prerequisite 1**: `RedactForEgress`, a fail-closed wrapper
   over the display redactor. Denies (emits no content) when the scan is
   `Poisoned` or hit the entropy cap; pattern redaction is exhaustive, so a high
   pattern count alone is not a deny signal.
3. `feat(learnings)` — **Prerequisite 2**: an exact `TaskID` filter on
   `LearningSearchFilters`. Previously only fuzzy scope/file/query existed;
   task-scoped learning egress requires an exact AND-scope so a foreign bot never
   gets unrelated durable learnings. Empty `TaskID` preserves existing behavior.
4. `feat(tasks)` — **Prerequisite 3**: `WikiRefs []string` on `teamTask` (the
   task→article backing link), wired through both custom JSON marshalers and
   `TaskPostRequest`, applied on create + mutation via `dedupePaths`. Without it,
   "explicitly task-linked wiki refs" would have forced the implementer onto the
   forbidden free-search path. Empty by default ⇒ "no wiki egress".
5. `feat(packer)` — the egress core: `Gather → Classify → Budget → Render →
   Deliver` in a new decoupled package (`internal/packer`, imports only
   `internal/scanner` + stdlib).

## Egress boundary highlights

- **Whole-envelope classification.** `Classify` redacts `Ask`/`ReturnPact`/
  `Guards`, not just `Items` — they are "never dropped" by Budget, so an
  unclassified envelope was an exfiltration channel. An unsanitizable
  Ask/ReturnPact **holds the whole delegation** (`ErrEnvelopeHeld`); a bad guard
  line or item is dropped.
- **Per-tier policy.** Untrusted gets only the redacted envelope + approved plan
  step; raw task body and free wiki/learning are denied. First-party adds
  task-scoped learnings + task-linked wiki + roster. Hosted gets everything.
- **Fail-closed Deliver.** Re-validates the task/profile/policy snapshot (aborts
  on a trust downgrade or version bump), runs a **final scan over the exact
  rendered bytes**, is idempotent on the key (only a `sent` record
  short-circuits), and writes an append-only `InjectionRecord` pending→sent/
  failed. Deliberately does **not** use the generic outbound dispatcher.
- **Audience-aware.** A shared-thread post is classified against the
  least-trusted reader present; only an ephemeral/DM delivery is target-only.

## Test plan

- [x] `go test ./internal/scanner/ ./internal/packer/` — green (4 scanner + 10
      packer tests; 3 ICP acceptance scenarios + every security invariant).
- [x] `go test ./internal/team/` — green (147s; includes the new TaskID + WikiRefs
      tests and confirms no regression in the wire shape / mutation service).
- [x] `bash scripts/test-go.sh` (full suite) — green (exit 0).
- [x] `gofmt`, `go vet ./...`, `golangci-lint run` on changed packages — 0 issues.
- [x] Adversarial verification agent on the implemented egress classifier —
      6 findings, all fixed (dispositions below).

## Verification dispositions

An adversarial verification agent (codex, read-only) on the implemented
classifier found 6 issues (2 BLOCK, 3 HIGH, 1 MEDIUM); all FIXED in the
`fix(packer)` commit, each with a regression test.

| # | Finding | Sev | Disposition |
|---|---------|-----|-------------|
| F1 | `Render`/`Budget` exported + hand-constructible `PackedDelegation` = scanner bypass | HIGH | FIXED — unexported `budget`/`render`; `sealed` marker; `Deliver` refuses unsealed |
| F2 | Guard lines skipped `policy.Classify` | HIGH | FIXED — each guard line is policy-classified |
| F3 | `Pack` took a raw audience tier; `Gather` used the target tier | BLOCK | FIXED — `Pack` computes audience from a typed `DeliveryAudience`; Gather + Classify use it |
| F4 | `Deliver` validated `req`, not the packed snapshot | BLOCK | FIXED — `snapshotMatches` binds delivery to the `InjectionRecord` |
| F5 | Idempotency not atomic; pending didn't block re-post | HIGH | FIXED — pending blocks re-post; sink/bridge contract documented |
| F6 | Budget could evict the required plan / overflow caps | MEDIUM | FIXED — plan + envelope reserved; only non-essentials trimmed |

The design also went through codex (16 findings) + triangulation
(security/API/architecture) + a verification agent on the egress boundary; those
dispositions live in the spec's two review tables.

## Not in this PR (next: bridge)

- The Slack bridge adapter (model on `telegram.go`) + Block Kit gate cards.
- The team-side `BrainHandle` adapter wiring the packer to the live broker
  (`LearningLog.Search` with `TaskID`, `teamTask.WikiRefs`, roster) and the real
  `SlackBridge`/`SnapshotValidator`/`InjectionSink`.
- The user-facing flow that links wiki articles to a task (the CEO/Librarian
  planning surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
