### PR TITLE
feat(team): wire context-packer to the broker (BrainHandle adapter) [PR-B]

### DIFF
--- a/internal/team/packer_adapter.go
+++ b/internal/team/packer_adapter.go
@@ -1,0 +1,235 @@
+package team
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/nex-crm/wuphf/internal/packer"
+)
+
+// packer_adapter.go is the seam that wires the inbound context-packer
+// (internal/packer) to the live broker. The packer is transport- and
+// brain-agnostic; this file implements its BrainHandle / SnapshotValidator /
+// InjectionSink interfaces over the OSS self-hosted broker (one office = one
+// brain). Nex cloud provides a per-tenant adapter over the same interfaces.
+
+// packerBrain adapts the broker to packer.BrainHandle. Every retrieval is
+// task-scoped, and only human-vetted content leaves: the approved plan step, the
+// task's TRUSTED learnings, and EXPLICITLY task-linked wiki articles. Nothing is
+// driven by foreign intent text.
+type packerBrain struct {
+	b *Broker
+}
+
+// NewPackerBrain returns a packer.BrainHandle backed by this broker.
+func (b *Broker) NewPackerBrain() packer.BrainHandle {
+	return &packerBrain{b: b}
+}
+
+// PlanStep renders the human-approved plan step from the task's IssueDraftSpec.
+// It deliberately does NOT fall back to the raw teamTask.Details: that free-form
+// field is the untrusted task body the egress policy denies, never the approved
+// plan. A task with no drafted spec yields an empty plan step.
+func (p *packerBrain) PlanStep(taskID string) (string, error) {
+	p.b.mu.Lock()
+	defer p.b.mu.Unlock()
+	task := p.b.findTaskByIDLocked(taskID)
+	if task == nil {
+		return "", fmt.Errorf("packer brain: task %q not found", taskID)
+	}
+	return renderPlanStep(task), nil
+}
+
+func renderPlanStep(task *teamTask) string {
+	spec := task.IssueDraftSpec
+	if spec == nil {
+		return ""
+	}
+	var sb strings.Builder
+	writePlanSection(&sb, "Goal", spec.Goal)
+	writePlanSection(&sb, "Context", spec.Context)
+	writePlanSection(&sb, "Approach", spec.Approach)
+	writePlanSection(&sb, "Acceptance", spec.Acceptance)
+	return strings.TrimSpace(sb.String())
+}
+
+func writePlanSection(sb *strings.Builder, label, body string) {
+	if strings.TrimSpace(body) == "" {
+		return
+	}
+	sb.WriteString(label)
+	sb.WriteString(": ")
+	sb.WriteString(strings.TrimSpace(body))
+	sb.WriteString("\n")
+}
+
+// TaskLearnings returns the task's TRUSTED learnings only — promoted, human-
+// vetted insights. Untrusted draft learnings are unvetted and never egress to a
+// foreign bot. Results are exact-scoped to the task id (no fuzzy fallback).
+func (p *packerBrain) TaskLearnings(taskID string, limit int) ([]packer.BrainItem, error) {
+	log := p.b.TeamLearningLog()
+	if log == nil {
+		return nil, nil
+	}
+	trusted := true
+	results, err := log.Search(LearningSearchFilters{
+		TaskID:  taskID,
+		Trusted: &trusted,
+		Limit:   limit,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("packer brain learnings: %w", err)
+	}
+	items := make([]packer.BrainItem, 0, len(results))
+	for _, r := range results {
+		body := strings.TrimSpace(r.Insight)
+		if body == "" {
+			continue
+		}
+		items = append(items, packer.BrainItem{Ref: "learning:" + r.Key, Body: body})
+	}
+	return items, nil
+}
+
+// TaskWikiRefs resolves the task's EXPLICITLY linked wiki articles
+// (teamTask.WikiRefs) to their bodies. It never runs a free WikiIndex.Search — a
+// foreign bot only ever sees articles a human linked to the task. A missing or
+// invalid linked article is skipped, not fatal.
+func (p *packerBrain) TaskWikiRefs(taskID string) ([]packer.BrainItem, error) {
+	p.b.mu.Lock()
+	task := p.b.findTaskByIDLocked(taskID)
+	var refs []string
+	if task != nil {
+		refs = append(refs, task.WikiRefs...)
+	}
+	worker := p.b.wikiWorker
+	p.b.mu.Unlock()
+
+	if worker == nil || len(refs) == 0 {
+		return nil, nil
+	}
+	items := make([]packer.BrainItem, 0, len(refs))
+	for _, ref := range refs {
+		raw, err := worker.ReadArticle(ref)
+		if err != nil {
+			continue
+		}
+		body := strings.TrimSpace(stripFrontmatter(string(raw)))
+		if body == "" {
+			continue
+		}
+		items = append(items, packer.BrainItem{Ref: "wiki:" + ref, Body: body})
+	}
+	return items, nil
+}
+
+// Roster returns brief who-is-who lines for the task: its owner and assigned
+// reviewers, resolved to office-member slug + role. Display names are not a
+// trust input anywhere, but a roster line is advisory context only.
+func (p *packerBrain) Roster(taskID string) ([]packer.BrainItem, error) {
+	p.b.mu.Lock()
+	defer p.b.mu.Unlock()
+	task := p.b.findTaskByIDLocked(taskID)
+	if task == nil {
+		return nil, nil
+	}
+	seen := make(map[string]struct{})
+	var items []packer.BrainItem
+	add := func(slug string) {
+		slug = strings.TrimSpace(slug)
+		if slug == "" {
+			return
+		}
+		if _, ok := seen[slug]; ok {
+			return
+		}
+		seen[slug] = struct{}{}
+		m := p.b.findMemberLocked(slug)
+		if m == nil {
+			return
+		}
+		line := m.Slug
+		if strings.TrimSpace(m.Role) != "" {
+			line += " — " + strings.TrimSpace(m.Role)
+		}
+		items = append(items, packer.BrainItem{Ref: "roster:" + m.Slug, Body: line})
+	}
+	add(task.Owner)
+	for _, r := range task.Reviewers {
+		add(r)
+	}
+	return items, nil
+}
+
+// packerSnapshotValidator re-checks, at delivery time, that the task is still in
+// the state the delegation was built against. v1 validates task freshness
+// (UpdatedAt); per-bot trust-tier liveness is enforced by the bridge's profile
+// store plus the packer's own snapshotMatches binding (which refuses a delivery
+// whose packed trust tier differs from the delivering request).
+type packerSnapshotValidator struct {
+	b *Broker
+}
+
+// NewPackerSnapshotValidator returns a packer.SnapshotValidator over this broker.
+func (b *Broker) NewPackerSnapshotValidator() packer.SnapshotValidator {
+	return &packerSnapshotValidator{b: b}
+}
+
+// Validate returns a non-nil error if the task no longer exists or has been
+// edited since the delegation was packed.
+func (v *packerSnapshotValidator) Validate(req packer.ContextRequest) error {
+	v.b.mu.Lock()
+	defer v.b.mu.Unlock()
+	task := v.b.findTaskByIDLocked(req.TaskID)
+	if task == nil {
+		return fmt.Errorf("task %q no longer exists", req.TaskID)
+	}
+	if task.UpdatedAt != req.TaskUpdatedAt {
+		return fmt.Errorf("task edited since pack (updated_at %q != %q)", task.UpdatedAt, req.TaskUpdatedAt)
+	}
+	return nil
+}
+
+// PackerInjectionSink is an append-only egress audit store for InjectionRecords.
+// It keys current state by idempotency key (for the packer's dedup) and keeps the
+// full transition history. Lookup/Write are individually mutex-guarded; the
+// bridge serializes a whole Deliver under the broker mutex, which satisfies the
+// cross-call atomicity the packer's Deliver assumes. A persistent on-disk store
+// is a follow-up.
+type PackerInjectionSink struct {
+	mu   sync.Mutex
+	recs map[string]packer.InjectionRecord
+	hist []packer.InjectionRecord
+}
+
+// NewPackerInjectionSink returns an empty in-memory sink.
+func NewPackerInjectionSink() *PackerInjectionSink {
+	return &PackerInjectionSink{recs: make(map[string]packer.InjectionRecord)}
+}
+
+// Lookup returns the current record for an idempotency key.
+func (s *PackerInjectionSink) Lookup(key string) (packer.InjectionRecord, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	r, ok := s.recs[key]
+	return r, ok
+}
+
+// Write upserts the current record and appends to the audit history.
+func (s *PackerInjectionSink) Write(rec packer.InjectionRecord) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.recs[rec.IdempotencyKey] = rec
+	s.hist = append(s.hist, rec)
+	return nil
+}
+
+// History returns a copy of the append-only audit log.
+func (s *PackerInjectionSink) History() []packer.InjectionRecord {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]packer.InjectionRecord, len(s.hist))
+	copy(out, s.hist)
+	return out
+}

--- a/internal/team/packer_adapter_test.go
+++ b/internal/team/packer_adapter_test.go
@@ -1,0 +1,202 @@
+package team
+
+// packer_adapter_test.go verifies the broker-backed packer brain seam: the
+// approved plan step (never raw Details), trusted task-scoped learnings only,
+// explicitly task-linked wiki bodies, roster lines, the snapshot validator, and
+// the injection sink.
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nex-crm/wuphf/internal/packer"
+)
+
+func newAdapterFixture(t *testing.T) (*Broker, func()) {
+	t.Helper()
+	repo, worker, log, teardown := newLearningFixture(t)
+	b := newTestBroker(t)
+	b.wikiWorker = worker
+	b.SetTeamLearningLog(log)
+	b.members = []officeMember{
+		{Slug: "alice", Name: "Alice", Role: "RevOps"},
+		{Slug: "pam", Name: "Pam", Role: "Librarian"},
+	}
+
+	// A linked wiki article.
+	art := filepath.Join(repo.Root(), "team", "playbooks", "billing.md")
+	if err := os.MkdirAll(filepath.Dir(art), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(art, []byte("---\ntitle: Billing\n---\nReconcile invoices monthly."), 0o644); err != nil {
+		t.Fatalf("write article: %v", err)
+	}
+
+	// Trust is derived from Source: UserStated => trusted, Observed => untrusted.
+	mustAppendLearning(t, log, "billing-trusted", "task-1", LearningSourceUserStated)
+	mustAppendLearning(t, log, "billing-untrusted", "task-1", LearningSourceObserved)
+	mustAppendLearning(t, log, "other-task-trusted", "task-2", LearningSourceUserStated)
+
+	b.tasks = append(b.tasks, teamTask{
+		ID:             "task-1",
+		Title:          "Reconcile",
+		Owner:          "alice",
+		Reviewers:      []string{"pam"},
+		UpdatedAt:      "2026-06-09T00:00:00Z",
+		WikiRefs:       []string{"team/playbooks/billing.md"},
+		IssueDraftSpec: &IssueDraftSpec{Goal: "Reconcile June invoices", Approach: "Pull the ledger", DraftedAt: "2026-06-09T00:00:00Z"},
+	})
+	return b, teardown
+}
+
+func mustAppendLearning(t *testing.T, log *LearningLog, key, taskID string, source LearningSource) {
+	t.Helper()
+	if _, err := log.Append(context.Background(), LearningRecord{
+		Type:       LearningTypePitfall,
+		Key:        key,
+		Insight:    "insight for " + key,
+		Confidence: 8,
+		Source:     source,
+		Scope:      "repo",
+		CreatedBy:  "codex",
+		TaskID:     taskID,
+	}); err != nil {
+		t.Fatalf("append %s: %v", key, err)
+	}
+}
+
+// task1 locates the fixture's task-1 (the test broker seeds other tasks, so its
+// index is not stable).
+func task1(t *testing.T, b *Broker) *teamTask {
+	t.Helper()
+	for i := range b.tasks {
+		if b.tasks[i].ID == "task-1" {
+			return &b.tasks[i]
+		}
+	}
+	t.Fatal("task-1 not found in broker")
+	return nil
+}
+
+func TestPackerBrain_PlanStepUsesApprovedSpecNotRawDetails(t *testing.T) {
+	b, teardown := newAdapterFixture(t)
+	defer teardown()
+	// Raw Details must NEVER surface as the plan step.
+	task1(t, b).Details = "PASTED SECRET BLOB do-not-export"
+	brain := b.NewPackerBrain()
+
+	plan, err := brain.PlanStep("task-1")
+	if err != nil {
+		t.Fatalf("PlanStep: %v", err)
+	}
+	if plan == "" {
+		t.Fatal("expected a rendered plan step from the spec")
+	}
+	if want := "Reconcile June invoices"; !strings.Contains(plan, want) {
+		t.Fatalf("plan missing %q: %q", want, plan)
+	}
+	if strings.Contains(plan, "do-not-export") {
+		t.Fatalf("raw Details leaked into the plan step: %q", plan)
+	}
+}
+
+func TestPackerBrain_PlanStepEmptyWhenNoSpec(t *testing.T) {
+	b, teardown := newAdapterFixture(t)
+	defer teardown()
+	tk := task1(t, b)
+	tk.IssueDraftSpec = nil
+	tk.Details = "raw body only"
+	plan, err := b.NewPackerBrain().PlanStep("task-1")
+	if err != nil {
+		t.Fatalf("PlanStep: %v", err)
+	}
+	if plan != "" {
+		t.Fatalf("expected empty plan when no spec, got %q", plan)
+	}
+}
+
+func TestPackerBrain_TaskLearningsTrustedAndScoped(t *testing.T) {
+	b, teardown := newAdapterFixture(t)
+	defer teardown()
+	got, err := b.NewPackerBrain().TaskLearnings("task-1", 10)
+	if err != nil {
+		t.Fatalf("TaskLearnings: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("want exactly 1 trusted task-scoped learning, got %d: %+v", len(got), got)
+	}
+	if got[0].Ref != "learning:billing-trusted" {
+		t.Fatalf("wrong learning: %q", got[0].Ref)
+	}
+}
+
+func TestPackerBrain_TaskWikiRefsResolveLinkedArticles(t *testing.T) {
+	b, teardown := newAdapterFixture(t)
+	defer teardown()
+	got, err := b.NewPackerBrain().TaskWikiRefs("task-1")
+	if err != nil {
+		t.Fatalf("TaskWikiRefs: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("want 1 linked wiki article, got %d: %+v", len(got), got)
+	}
+	if !strings.Contains(got[0].Body, "Reconcile invoices monthly") {
+		t.Fatalf("wiki body missing content: %q", got[0].Body)
+	}
+	if strings.Contains(got[0].Body, "title: Billing") {
+		t.Fatalf("frontmatter should be stripped: %q", got[0].Body)
+	}
+}
+
+func TestPackerBrain_RosterFromOwnerAndReviewers(t *testing.T) {
+	b, teardown := newAdapterFixture(t)
+	defer teardown()
+	got, err := b.NewPackerBrain().Roster("task-1")
+	if err != nil {
+		t.Fatalf("Roster: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("want owner + reviewer roster lines, got %d: %+v", len(got), got)
+	}
+	if !strings.Contains(got[0].Body, "alice") || !strings.Contains(got[0].Body, "RevOps") {
+		t.Fatalf("owner roster line wrong: %q", got[0].Body)
+	}
+}
+
+func TestPackerSnapshotValidator(t *testing.T) {
+	b, teardown := newAdapterFixture(t)
+	defer teardown()
+	val := b.NewPackerSnapshotValidator()
+
+	ok := packer.ContextRequest{TaskID: "task-1", TaskUpdatedAt: "2026-06-09T00:00:00Z"}
+	if err := val.Validate(ok); err != nil {
+		t.Fatalf("fresh snapshot should validate: %v", err)
+	}
+	stale := packer.ContextRequest{TaskID: "task-1", TaskUpdatedAt: "2020-01-01T00:00:00Z"}
+	if err := val.Validate(stale); err == nil {
+		t.Fatal("edited task should fail validation")
+	}
+	missing := packer.ContextRequest{TaskID: "nope", TaskUpdatedAt: "x"}
+	if err := val.Validate(missing); err == nil {
+		t.Fatal("missing task should fail validation")
+	}
+}
+
+func TestPackerInjectionSink(t *testing.T) {
+	s := NewPackerInjectionSink()
+	if _, ok := s.Lookup("k"); ok {
+		t.Fatal("empty sink should miss")
+	}
+	_ = s.Write(packer.InjectionRecord{IdempotencyKey: "k", Status: packer.DeliveryPending})
+	_ = s.Write(packer.InjectionRecord{IdempotencyKey: "k", Status: packer.DeliverySent, MessageTS: "1.2"})
+	cur, ok := s.Lookup("k")
+	if !ok || cur.Status != packer.DeliverySent || cur.MessageTS != "1.2" {
+		t.Fatalf("lookup should return latest sent record: %+v", cur)
+	}
+	if len(s.History()) != 2 {
+		t.Fatalf("history should keep both transitions, got %d", len(s.History()))
+	}
+}


### PR DESCRIPTION
**Stacked on #1051** (`feat/slack-context-packer`). PR-B of the Slack agent-coordination series.

Implements the packer's brain/validator/sink seams over the live broker, so the egress core (#1051) can run against real office data.

## What
- **`packerBrain`** (`packer.BrainHandle`): `PlanStep` renders the human-approved `IssueDraftSpec` — **never** the raw free-form `Details` (which the egress policy denies); `TaskLearnings` returns only **trusted**, exact-task-scoped learnings (uses the new `LearningSearchFilters.TaskID`); `TaskWikiRefs` resolves the task's explicitly-linked `WikiRefs` to article bodies (never a free wiki search); `Roster` lists owner + reviewers.
- **`packerSnapshotValidator`**: re-checks task freshness (`UpdatedAt`) at delivery time.
- **`PackerInjectionSink`**: in-memory append-only egress audit with idempotency lookup + transition history.

OSS self-hosted seam; Nex cloud provides a per-tenant adapter over the same interfaces.

## Test plan
- [x] `go test ./internal/team/ -run TestPacker` — 8 tests green (plan-step-not-details, trusted+scoped learnings, linked-wiki resolution, roster, validator fresh/stale/missing, sink).
- [x] `gofmt` / `go vet` / `golangci-lint` (diff) — 0 issues; `go build ./...` OK.

## Not in this PR
The Slack bridge transport (PR-C) calls `Pack`/`Deliver` with these seams; the wiki-link surface (PR-E) populates `WikiRefs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)