### PR TITLE
feat(teammcp): link_task_wiki — link wiki articles to a task [PR-E]

### DIFF
--- a/internal/teammcp/server.go
+++ b/internal/teammcp/server.go
@@ -177,6 +177,9 @@ func configureServerTools(server *mcp.Server, slug string, channel string, oneOn
 		// private chat. Same gate as the office and DM branches below.
 		if slug == "" || slug == "ceo" || slug == team.LibrarianSlug {
 			registerNotebookReviewTool(server)
+			// The wiki-curation roles also link wiki articles to tasks, so the
+			// context-packer can hand those refs to first-party agents.
+			registerWikiLinkTool(server)
 		}
 
 		if hasActionProvider() {
@@ -221,6 +224,7 @@ func configureServerTools(server *mcp.Server, slug string, channel string, oneOn
 		registerSkillAuthoringTools(server)
 		if isLead || isLibrarian {
 			registerNotebookReviewTool(server)
+			registerWikiLinkTool(server)
 		}
 		if hasActionProvider() {
 			registerActionTools(server)
@@ -366,6 +370,10 @@ func configureServerTools(server *mcp.Server, slug string, channel string, oneOn
 	// team_plan / team_channel / team_member.
 	if isLead || isLibrarian {
 		registerNotebookReviewTool(server)
+		// link_task_wiki rides with the wiki-curation roles: the CEO/Librarian
+		// link the canonical articles a task needs so the context-packer can
+		// hand exactly those refs to first-party agents.
+		registerWikiLinkTool(server)
 	}
 }
 

--- a/internal/teammcp/wiki_link_tools.go
+++ b/internal/teammcp/wiki_link_tools.go
@@ -1,0 +1,270 @@
+package teammcp
+
+// wiki_link_tools.go defines the link_task_wiki MCP tool: the CEO/Librarian
+// surface for explicitly linking wiki articles to a task. The inbound Slack
+// context-packer delivers ONLY these explicitly task-linked wiki refs to a
+// first-party agent ("explicitly task-linked wiki refs"), never a free wiki
+// search, so this tool is the deliberate, audited way an article becomes
+// readable in that channel.
+//
+// The backing field (teamTask.WikiRefs) and its apply path (MutateTask, which
+// runs dedupePaths on body.WikiRefs) already exist. This tool only computes
+// the desired full ref set and routes it through the existing broker mutation:
+//
+//   action="link"    add the given paths to the current set (dedup, order-stable)
+//   action="replace" set the linked set to exactly the given paths
+//   action="unlink"  remove the given paths from the current set
+//
+// Every path is validated before linking by hitting the broker's /wiki/read
+// endpoint, which runs the canonical validateArticlePath check (rejecting
+// traversal, absolute, non-team/, non-.md paths) AND confirms the path
+// resolves to a real article (404 otherwise). Invalid paths are rejected with
+// a clear, per-path message and never linked; for action="unlink" a path that
+// does not currently exist on the task is simply a no-op (no validation
+// needed — you can always detach something).
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"path/filepath"
+	"strings"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// TeamWikiLinkArgs is the contract for link_task_wiki.
+type TeamWikiLinkArgs struct {
+	MySlug string   `json:"my_slug,omitempty" jsonschema:"Your agent slug. Defaults to WUPHF_AGENT_SLUG env."`
+	TaskID string   `json:"task_id" jsonschema:"The task (Issue) id whose linked wiki articles you are changing."`
+	Action string   `json:"action" jsonschema:"One of: link (add the given paths to the current set), replace (set the linked set to exactly the given paths), unlink (remove the given paths)."`
+	Paths  []string `json:"paths" jsonschema:"Wiki-relative article paths, e.g. team/playbooks/onboarding.md. Each must be a real article under team/ ending in .md. For link/replace, every path is validated; invalid or missing articles are rejected."`
+}
+
+func registerWikiLinkTool(server *mcp.Server) {
+	mcp.AddTool(server, officeWriteTool(
+		"link_task_wiki",
+		"Link, replace, or unlink the wiki articles attached to a task. The context-packer treats these explicitly task-linked articles as the ONLY wiki content first-party agents may receive for the task, so link the canonical references an agent needs and nothing more. action=link adds paths, action=replace sets the exact set, action=unlink removes paths. Each linked path must be a real article under team/ ending in .md; invalid or missing paths are rejected. Returns the resulting linked set.",
+	), handleTeamWikiLink)
+}
+
+func handleTeamWikiLink(ctx context.Context, _ *mcp.CallToolRequest, args TeamWikiLinkArgs) (*mcp.CallToolResult, any, error) {
+	slug, err := resolveSlug(args.MySlug)
+	if err != nil {
+		return toolError(err), nil, nil
+	}
+	taskID := strings.TrimSpace(args.TaskID)
+	if taskID == "" {
+		return toolError(fmt.Errorf("task_id is required")), nil, nil
+	}
+	action := strings.ToLower(strings.TrimSpace(args.Action))
+	switch action {
+	case "link", "replace", "unlink":
+	default:
+		return toolError(fmt.Errorf("action must be one of link | replace | unlink; got %q", args.Action)), nil, nil
+	}
+
+	// Normalize the requested paths up front. Empty/blank entries are dropped;
+	// duplicates within the request are collapsed (order-stable).
+	requested := dedupeWikiPaths(args.Paths)
+	if len(requested) == 0 {
+		return toolError(fmt.Errorf("paths is required (at least one wiki article path)")), nil, nil
+	}
+
+	// Validate the requested paths before doing anything that touches task
+	// state. unlink never validates: detaching a stale or even malformed ref
+	// must always be possible (it just won't match anything live). link and
+	// replace MUST validate, because they make an article readable to agents.
+	if action != "unlink" {
+		for _, p := range requested {
+			// Cheap structural pre-check first so a clearly-bad path fails
+			// with a precise message before any network round-trip. This
+			// mirrors the broker's validateArticlePath rules; the broker
+			// remains the authoritative validator below.
+			if structErr := wikiArticlePathStructuralError(p); structErr != nil {
+				return toolError(fmt.Errorf("refusing to link %q: %w", p, structErr)), nil, nil
+			}
+			// Authoritative check: the broker runs validateArticlePath AND
+			// confirms the article actually exists (404 otherwise). A non-2xx
+			// surfaces here as an error carrying the broker's own message.
+			if _, readErr := brokerGetRaw(ctx, "/wiki/read?path="+url.QueryEscape(p)); readErr != nil {
+				return toolError(fmt.Errorf("refusing to link %q: not a valid, existing wiki article: %w", p, readErr)), nil, nil
+			}
+		}
+	}
+
+	// For link/unlink we need the task's current linked set so we can compute
+	// the delta and send the full list (MutateTask uses replace semantics for
+	// WikiRefs). replace ignores the current set entirely.
+	var current []string
+	if action != "replace" {
+		current, err = fetchTaskWikiRefs(ctx, taskID)
+		if err != nil {
+			return toolError(err), nil, nil
+		}
+	}
+
+	next := computeWikiRefSet(current, requested, action)
+
+	// Known v1 limitation: the existing MutateTask apply path only writes
+	// body.WikiRefs when len > 0 (it treats an empty list as "leave the set
+	// unchanged", not "clear it"). So a link tool call that would empty the set
+	// — an unlink of the last ref, or a replace with everything removed —
+	// cannot take effect through the path we are told to call and must not
+	// re-edit. Rather than silently report an empty set the broker did not
+	// actually store, fail loudly with the workaround. This keeps the tool
+	// honest: it never claims a result the broker did not apply.
+	if len(next) == 0 {
+		return toolError(fmt.Errorf(
+			"this would leave task %s with no linked wiki articles, which the broker cannot apply (an empty set is treated as \"unchanged\"); leave at least one linked article, or clear the last link from the Issue detail surface",
+			taskID,
+		)), nil, nil
+	}
+
+	// Route through the existing MutateTask path. action="comment" is open to
+	// every actor (no CEO-only scope gate) and applies body.WikiRefs
+	// independently of the comment itself; an empty details string is a no-op
+	// for packet feedback, so this is a pure wiki-ref update with no spurious
+	// comment. MutateTask runs dedupePaths on the list we send.
+	payload := map[string]any{
+		"action":     "comment",
+		"id":         taskID,
+		"created_by": slug,
+		"wiki_refs":  next,
+	}
+
+	var result struct {
+		Task struct {
+			ID       string   `json:"id"`
+			WikiRefs []string `json:"wiki_refs"`
+		} `json:"task"`
+	}
+	if err := brokerPostJSON(ctx, "/tasks", payload, &result); err != nil {
+		return toolError(err), nil, nil
+	}
+
+	linked := result.Task.WikiRefs
+	if linked == nil {
+		linked = []string{}
+	}
+	out, _ := json.Marshal(map[string]any{
+		"task_id":      taskID,
+		"action":       action,
+		"wiki_refs":    linked,
+		"linked_count": len(linked),
+	})
+	return textResult(string(out)), nil, nil
+}
+
+// fetchTaskWikiRefs reads the task's current linked wiki refs from the broker's
+// GET /tasks/{id} detail endpoint, whose "task" snapshot carries wiki_refs.
+func fetchTaskWikiRefs(ctx context.Context, taskID string) ([]string, error) {
+	var resp struct {
+		Task *struct {
+			WikiRefs []string `json:"wiki_refs"`
+		} `json:"task"`
+	}
+	if err := brokerGetJSON(ctx, "/tasks/"+url.PathEscape(taskID), &resp); err != nil {
+		return nil, fmt.Errorf("read task %s: %w", taskID, err)
+	}
+	if resp.Task == nil {
+		return nil, fmt.Errorf("task %s not found", taskID)
+	}
+	return resp.Task.WikiRefs, nil
+}
+
+// computeWikiRefSet returns the new linked set given the current set, the
+// requested paths, and the action. The result is order-stable and deduped:
+//   - link:    current followed by any requested paths not already present.
+//   - replace: exactly the requested paths.
+//   - unlink:  current minus any requested paths.
+//
+// Inputs are normalized (trimmed, slash-cleaned, blanks dropped) so the
+// comparison is on the same canonical form MutateTask's dedupePaths produces.
+func computeWikiRefSet(current, requested []string, action string) []string {
+	cur := dedupeWikiPaths(current)
+	req := dedupeWikiPaths(requested)
+	switch strings.ToLower(strings.TrimSpace(action)) {
+	case "replace":
+		return req
+	case "unlink":
+		remove := make(map[string]struct{}, len(req))
+		for _, p := range req {
+			remove[p] = struct{}{}
+		}
+		out := make([]string, 0, len(cur))
+		for _, p := range cur {
+			if _, drop := remove[p]; drop {
+				continue
+			}
+			out = append(out, p)
+		}
+		return out
+	default: // link
+		seen := make(map[string]struct{}, len(cur)+len(req))
+		out := make([]string, 0, len(cur)+len(req))
+		for _, p := range cur {
+			if _, ok := seen[p]; ok {
+				continue
+			}
+			seen[p] = struct{}{}
+			out = append(out, p)
+		}
+		for _, p := range req {
+			if _, ok := seen[p]; ok {
+				continue
+			}
+			seen[p] = struct{}{}
+			out = append(out, p)
+		}
+		return out
+	}
+}
+
+// dedupeWikiPaths trims, slash-normalizes, and dedups wiki paths preserving
+// first-seen order. It mirrors the broker-side dedupePaths so the set the tool
+// computes matches what MutateTask stores.
+func dedupeWikiPaths(paths []string) []string {
+	seen := make(map[string]struct{}, len(paths))
+	out := make([]string, 0, len(paths))
+	for _, p := range paths {
+		p = filepath.ToSlash(strings.TrimSpace(p))
+		if p == "" {
+			continue
+		}
+		if _, ok := seen[p]; ok {
+			continue
+		}
+		seen[p] = struct{}{}
+		out = append(out, p)
+	}
+	return out
+}
+
+// wikiArticlePathStructuralError mirrors the broker's validateArticlePath so a
+// clearly-malformed path fails fast with a precise message before any network
+// call. validateArticlePath itself is unexported in internal/team; the broker
+// remains the authoritative validator (re-run server-side on /wiki/read), so
+// this is a best-effort, fail-fast pre-check and intentionally conservative —
+// anything it passes is still checked by the broker.
+func wikiArticlePathStructuralError(relPath string) error {
+	relPath = strings.TrimSpace(relPath)
+	if relPath == "" {
+		return fmt.Errorf("article path is required")
+	}
+	if filepath.IsAbs(relPath) {
+		return fmt.Errorf("article path must be relative")
+	}
+	clean := filepath.ToSlash(filepath.Clean(relPath))
+	if strings.HasPrefix(clean, "../") || strings.Contains(clean, "/../") || clean == ".." {
+		return fmt.Errorf("article path must not contain a parent-directory (..) segment")
+	}
+	if !strings.HasPrefix(clean, "team/") {
+		return fmt.Errorf("article path must be within team/")
+	}
+	if !strings.HasSuffix(strings.ToLower(clean), ".md") {
+		return fmt.Errorf("article path must end with .md")
+	}
+	return nil
+}

--- a/internal/teammcp/wiki_link_tools_test.go
+++ b/internal/teammcp/wiki_link_tools_test.go
@@ -1,0 +1,397 @@
+package teammcp
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+)
+
+// ── Pure set-computation helper ─────────────────────────────────────────────
+
+func TestComputeWikiRefSet(t *testing.T) {
+	cases := []struct {
+		name      string
+		current   []string
+		requested []string
+		action    string
+		want      []string
+	}{
+		{
+			name:      "link adds to existing set",
+			current:   []string{"team/a.md"},
+			requested: []string{"team/b.md"},
+			action:    "link",
+			want:      []string{"team/a.md", "team/b.md"},
+		},
+		{
+			name:      "link dedups already-linked path",
+			current:   []string{"team/a.md", "team/b.md"},
+			requested: []string{"team/b.md", "team/c.md", "team/b.md"},
+			action:    "link",
+			want:      []string{"team/a.md", "team/b.md", "team/c.md"},
+		},
+		{
+			name:      "link normalizes whitespace and slashes before dedup",
+			current:   []string{"team/a.md"},
+			requested: []string{"  team/a.md  ", "team/d.md"},
+			action:    "link",
+			want:      []string{"team/a.md", "team/d.md"},
+		},
+		{
+			name:      "replace sets exactly the requested set",
+			current:   []string{"team/a.md", "team/b.md"},
+			requested: []string{"team/c.md", "team/c.md", "team/d.md"},
+			action:    "replace",
+			want:      []string{"team/c.md", "team/d.md"},
+		},
+		{
+			name:      "unlink removes the requested path",
+			current:   []string{"team/a.md", "team/b.md", "team/c.md"},
+			requested: []string{"team/b.md"},
+			action:    "unlink",
+			want:      []string{"team/a.md", "team/c.md"},
+		},
+		{
+			name:      "unlink of an unlinked path is a no-op",
+			current:   []string{"team/a.md"},
+			requested: []string{"team/z.md"},
+			action:    "unlink",
+			want:      []string{"team/a.md"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := computeWikiRefSet(tc.current, tc.requested, tc.action)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("computeWikiRefSet(%v, %v, %q) = %v; want %v",
+					tc.current, tc.requested, tc.action, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestWikiArticlePathStructuralError(t *testing.T) {
+	bad := []string{
+		"",
+		"/etc/passwd",
+		"team/../secrets.md",
+		"notes/x.md", // not under team/
+		"team/x.txt", // not .md
+	}
+	for _, p := range bad {
+		if err := wikiArticlePathStructuralError(p); err == nil {
+			t.Errorf("expected structural error for %q, got nil", p)
+		}
+	}
+	if err := wikiArticlePathStructuralError("team/playbooks/onboarding.md"); err != nil {
+		t.Errorf("expected nil for a well-formed path, got %v", err)
+	}
+}
+
+// ── Registration gate ───────────────────────────────────────────────────────
+
+// link_task_wiki rides with the wiki-curation roles (CEO + Librarian) and must
+// NOT be exposed to ordinary specialist agents.
+func TestLinkTaskWikiRegisteredForCuratorsOnly(t *testing.T) {
+	t.Setenv("WUPHF_MEMORY_BACKEND", "markdown")
+	cases := []struct {
+		slug     string
+		mustHave bool
+	}{
+		{"ceo", true},
+		{"librarian", true},
+		{"pm", false},
+		{"engineer", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.slug, func(t *testing.T) {
+			names := listRegisteredToolsWithSlug(t, tc.slug, "general", false)
+			has := slices.Contains(names, "link_task_wiki")
+			if tc.mustHave && !has {
+				t.Errorf("slug=%s: expected link_task_wiki registered; got %v", tc.slug, names)
+			}
+			if !tc.mustHave && has {
+				t.Errorf("slug=%s: did not expect link_task_wiki registered; got %v", tc.slug, names)
+			}
+		})
+	}
+}
+
+// ── Integration against a fake broker ───────────────────────────────────────
+
+// fakeWikiLinkBroker stands up an httptest server that:
+//   - serves GET /wiki/read with 200 for known-good paths and 400/404 otherwise,
+//   - serves GET /tasks/{id} returning a fixed current wiki_refs set,
+//   - serves POST /tasks echoing back the wiki_refs it was sent and recording
+//     the last POST body.
+type fakeWikiLinkBroker struct {
+	srv         *httptest.Server
+	currentRefs []string
+	validPaths  map[string]bool
+	lastPost    map[string]any
+}
+
+func newFakeWikiLinkBroker(t *testing.T, currentRefs []string, validPaths []string) *fakeWikiLinkBroker {
+	t.Helper()
+	f := &fakeWikiLinkBroker{
+		currentRefs: currentRefs,
+		validPaths:  map[string]bool{},
+	}
+	for _, p := range validPaths {
+		f.validPaths[p] = true
+	}
+	f.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/wiki/read":
+			path := r.URL.Query().Get("path")
+			if !strings.HasPrefix(path, "team/") || !strings.HasSuffix(strings.ToLower(path), ".md") {
+				http.Error(w, `{"error":"invalid article path"}`, http.StatusBadRequest)
+				return
+			}
+			if !f.validPaths[path] {
+				http.Error(w, `{"error":"article not found"}`, http.StatusNotFound)
+				return
+			}
+			w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+			_, _ = w.Write([]byte("# article\nbody\n"))
+		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/tasks/"):
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"taskId": strings.TrimPrefix(r.URL.Path, "/tasks/"),
+				"task": map[string]any{
+					"id":        strings.TrimPrefix(r.URL.Path, "/tasks/"),
+					"wiki_refs": f.currentRefs,
+				},
+			})
+		case r.Method == http.MethodPost && r.URL.Path == "/tasks":
+			var body map[string]any
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			f.lastPost = body
+			refs := []string{}
+			if raw, ok := body["wiki_refs"].([]any); ok {
+				for _, v := range raw {
+					if s, ok := v.(string); ok {
+						refs = append(refs, s)
+					}
+				}
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"task": map[string]any{
+					"id":        body["id"],
+					"wiki_refs": refs,
+				},
+			})
+		default:
+			http.Error(w, `{"error":"unexpected path"}`, http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(f.srv.Close)
+	return f
+}
+
+// postedRefs returns the wiki_refs the tool sent on the last POST /tasks call.
+func (f *fakeWikiLinkBroker) postedRefs(t *testing.T) []string {
+	t.Helper()
+	raw, ok := f.lastPost["wiki_refs"].([]any)
+	if !ok {
+		t.Fatalf("last POST body has no wiki_refs slice: %#v", f.lastPost)
+	}
+	out := make([]string, 0, len(raw))
+	for _, v := range raw {
+		out = append(out, v.(string))
+	}
+	return out
+}
+
+func TestHandleTeamWikiLink_LinkAddsAndDedups(t *testing.T) {
+	broker := newFakeWikiLinkBroker(t,
+		[]string{"team/a.md"},
+		[]string{"team/a.md", "team/b.md"},
+	)
+	withBrokerURL(t, broker.srv.URL)
+	t.Setenv("WUPHF_AGENT_SLUG", "ceo")
+
+	// link b.md plus a duplicate a.md → result keeps a, adds b, no dupes.
+	res, _, err := handleTeamWikiLink(context.Background(), nil, TeamWikiLinkArgs{
+		TaskID: "ISS-1",
+		Action: "link",
+		Paths:  []string{"team/b.md", "team/a.md"},
+	})
+	if err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	if isToolError(res) {
+		t.Fatalf("expected success, got: %s", toolErrorText(res))
+	}
+	got := broker.postedRefs(t)
+	want := []string{"team/a.md", "team/b.md"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("posted wiki_refs = %v; want %v", got, want)
+	}
+	if broker.lastPost["action"] != "comment" {
+		t.Fatalf("expected mutation action=comment, got %v", broker.lastPost["action"])
+	}
+	if broker.lastPost["id"] != "ISS-1" {
+		t.Fatalf("expected id=ISS-1, got %v", broker.lastPost["id"])
+	}
+}
+
+func TestHandleTeamWikiLink_ReplaceSetsExactSet(t *testing.T) {
+	broker := newFakeWikiLinkBroker(t,
+		[]string{"team/a.md", "team/b.md"},
+		[]string{"team/c.md", "team/d.md"},
+	)
+	withBrokerURL(t, broker.srv.URL)
+	t.Setenv("WUPHF_AGENT_SLUG", "ceo")
+
+	res, _, err := handleTeamWikiLink(context.Background(), nil, TeamWikiLinkArgs{
+		TaskID: "ISS-2",
+		Action: "replace",
+		Paths:  []string{"team/c.md", "team/d.md"},
+	})
+	if err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	if isToolError(res) {
+		t.Fatalf("expected success, got: %s", toolErrorText(res))
+	}
+	got := broker.postedRefs(t)
+	want := []string{"team/c.md", "team/d.md"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("replace posted wiki_refs = %v; want %v", got, want)
+	}
+}
+
+func TestHandleTeamWikiLink_UnlinkRemoves(t *testing.T) {
+	broker := newFakeWikiLinkBroker(t,
+		[]string{"team/a.md", "team/b.md", "team/c.md"},
+		nil, // unlink never validates, so no valid paths needed
+	)
+	withBrokerURL(t, broker.srv.URL)
+	t.Setenv("WUPHF_AGENT_SLUG", "ceo")
+
+	res, _, err := handleTeamWikiLink(context.Background(), nil, TeamWikiLinkArgs{
+		TaskID: "ISS-3",
+		Action: "unlink",
+		Paths:  []string{"team/b.md"},
+	})
+	if err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	if isToolError(res) {
+		t.Fatalf("expected success, got: %s", toolErrorText(res))
+	}
+	got := broker.postedRefs(t)
+	want := []string{"team/a.md", "team/c.md"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("unlink posted wiki_refs = %v; want %v", got, want)
+	}
+}
+
+func TestHandleTeamWikiLink_InvalidPathRejected(t *testing.T) {
+	// Path is well-formed structurally but does not resolve to a real article:
+	// the broker /wiki/read returns 404, so the tool must reject it and NOT
+	// post any mutation.
+	broker := newFakeWikiLinkBroker(t,
+		[]string{"team/a.md"},
+		[]string{"team/a.md"}, // team/missing.md is intentionally NOT valid
+	)
+	withBrokerURL(t, broker.srv.URL)
+	t.Setenv("WUPHF_AGENT_SLUG", "ceo")
+
+	res, _, err := handleTeamWikiLink(context.Background(), nil, TeamWikiLinkArgs{
+		TaskID: "ISS-4",
+		Action: "link",
+		Paths:  []string{"team/missing.md"},
+	})
+	if err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	if !isToolError(res) {
+		t.Fatalf("expected a tool error for a non-existent article, got success")
+	}
+	if !strings.Contains(toolErrorText(res), "team/missing.md") {
+		t.Fatalf("error should name the rejected path; got %q", toolErrorText(res))
+	}
+	if broker.lastPost != nil {
+		t.Fatalf("no mutation should be posted when a path is rejected; got %#v", broker.lastPost)
+	}
+}
+
+func TestHandleTeamWikiLink_StructurallyBadPathRejectedBeforeNetwork(t *testing.T) {
+	broker := newFakeWikiLinkBroker(t, nil, nil)
+	withBrokerURL(t, broker.srv.URL)
+	t.Setenv("WUPHF_AGENT_SLUG", "ceo")
+
+	res, _, err := handleTeamWikiLink(context.Background(), nil, TeamWikiLinkArgs{
+		TaskID: "ISS-5",
+		Action: "link",
+		Paths:  []string{"team/../escape.md"},
+	})
+	if err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	if !isToolError(res) {
+		t.Fatalf("expected a tool error for a traversal path, got success")
+	}
+	if broker.lastPost != nil {
+		t.Fatalf("no mutation should be posted for a malformed path; got %#v", broker.lastPost)
+	}
+}
+
+func TestHandleTeamWikiLink_EmptyResultRejected(t *testing.T) {
+	// Unlinking the only ref would empty the set, which the MutateTask apply
+	// path cannot store. The tool must refuse honestly rather than report an
+	// empty set the broker did not apply.
+	broker := newFakeWikiLinkBroker(t,
+		[]string{"team/a.md"},
+		nil,
+	)
+	withBrokerURL(t, broker.srv.URL)
+	t.Setenv("WUPHF_AGENT_SLUG", "ceo")
+
+	res, _, err := handleTeamWikiLink(context.Background(), nil, TeamWikiLinkArgs{
+		TaskID: "ISS-6",
+		Action: "unlink",
+		Paths:  []string{"team/a.md"},
+	})
+	if err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	if !isToolError(res) {
+		t.Fatalf("expected a tool error when the set would be emptied, got success")
+	}
+	if broker.lastPost != nil {
+		t.Fatalf("no mutation should be posted when the result would be empty; got %#v", broker.lastPost)
+	}
+}
+
+func TestHandleTeamWikiLink_ValidationErrors(t *testing.T) {
+	broker := newFakeWikiLinkBroker(t, nil, nil)
+	withBrokerURL(t, broker.srv.URL)
+	t.Setenv("WUPHF_AGENT_SLUG", "ceo")
+
+	cases := []struct {
+		name string
+		args TeamWikiLinkArgs
+	}{
+		{"missing task_id", TeamWikiLinkArgs{Action: "link", Paths: []string{"team/a.md"}}},
+		{"bad action", TeamWikiLinkArgs{TaskID: "ISS-7", Action: "frobnicate", Paths: []string{"team/a.md"}}},
+		{"empty paths", TeamWikiLinkArgs{TaskID: "ISS-7", Action: "link", Paths: []string{"  "}}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			res, _, err := handleTeamWikiLink(context.Background(), nil, tc.args)
+			if err != nil {
+				t.Fatalf("handler: %v", err)
+			}
+			if !isToolError(res) {
+				t.Fatalf("expected a tool error, got success")
+			}
+		})
+	}
+}


### PR DESCRIPTION
**Stacked on #1051** (`feat/slack-context-packer`). PR-E of the Slack agent-coordination series.

Gives the CEO/Librarian a way to populate `teamTask.WikiRefs` so first-party agents can actually receive **explicitly task-linked** wiki articles (never a free wiki search).

## What
A new MCP tool **`link_task_wiki`** (`link` / `replace` / `unlink`) that updates a task's `WikiRefs` through the existing `MutateTask` path. Registered for the wiki-curation roles (CEO + Librarian) in all three MCP modes.

- **Mutation:** POSTs `/tasks` with `action="comment"` (the only actor-open action) + `wiki_refs`; `MutateTask` applies the refs via `dedupePaths` independently of the empty comment.
- **Validation:** each linked path is checked by the broker (`GET /wiki/read` → authoritative `validateArticlePath` + existence), with a client-side structural pre-check (relative, within `team/`, `.md`, no `..`) that mirrors the broker's rules to fail fast. `unlink` never validates (detaching a stale ref must always work).
- **Set math:** `link` adds+dedups, `replace` sets, `unlink` removes; delta actions read current refs from `GET /tasks/{id}` and send the full list.

## Known v1 limitation (surfaced, not hidden)
`MutateTask` only applies `wiki_refs` when the list is non-empty (empty = "leave unchanged"). A call that would empty the set (unlink the last ref / replace-with-empty) **fails loudly** with the workaround rather than reporting a result the broker didn't store. Follow-up: make the `len(body.WikiRefs) > 0` guard presence-based (`*[]string` or a `clear_wiki_refs` flag) to support clearing.

## Test plan
- [x] `go test ./internal/teammcp/ -run Wiki` — green (link/replace/unlink, dedup, invalid-path reject, structural reject, empty-set refusal, curator-only registration gate).
- [x] `gofmt` / `go vet` / `golangci-lint` (diff) — 0 issues; `go build ./...` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)