### PR TITLE
feat(slack): real Slack bridge transport (Socket Mode) [PR-C]

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/jackc/pgx/v5 v5.9.2
 	github.com/modelcontextprotocol/go-sdk v1.6.0
 	github.com/sahilm/fuzzy v0.1.2
+	github.com/slack-go/slack v0.25.0
 	go.uber.org/goleak v1.3.0
 	golang.org/x/net v0.55.0
 	golang.org/x/sync v0.20.0

--- a/go.sum
+++ b/go.sum
@@ -101,6 +101,8 @@ github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f h1:Y/CXytFA4m6
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f/go.mod h1:vw97MGsxSvLiUE2X8qFplwetxpGLQrlU1Q9AUEIzCaM=
 github.com/fsnotify/fsnotify v1.10.1 h1:b0/UzAf9yR5rhf3RPm9gf3ehBPpf0oZKIjtpKrx59Ho=
 github.com/fsnotify/fsnotify v1.10.1/go.mod h1:TLheqan6HD6GBK6PrDWyDPBaEV8LspOxvPSjC+bVfgo=
+github.com/go-test/deep v1.1.1 h1:0r/53hagsehfO4bzD2Pgr/+RgHqhmf+k1Bpse2cTu1U=
+github.com/go-test/deep v1.1.1/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncVwcsE=
 github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
 github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
@@ -206,6 +208,8 @@ github.com/segmentio/asm v1.1.3 h1:WM03sfUOENvvKexOLp+pCqgb/WDjsi7EK8gIsICtzhc=
 github.com/segmentio/asm v1.1.3/go.mod h1:Ld3L4ZXGNcSLRg4JBsZ3//1+f/TjYl0Mzen/DQy1EJg=
 github.com/segmentio/encoding v0.5.4 h1:OW1VRern8Nw6ITAtwSZ7Idrl3MXCFwXHPgqESYfvNt0=
 github.com/segmentio/encoding v0.5.4/go.mod h1:HS1ZKa3kSN32ZHVZ7ZLPLXWvOVIiZtyJnO1gPH1sKt0=
+github.com/slack-go/slack v0.25.0 h1:VN8qWsC+GJW9XlaLbOHePlgJHicrVVMGDoLHpEeC34E=
+github.com/slack-go/slack v0.25.0/go.mod h1:H0yR/YBuRJ39RkE+JpV/d/oEsbanzTRowR82bCN0cEs=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
@@ -248,8 +252,6 @@ golang.org/x/net v0.0.0-20190213061140-3a22650c66bd/go.mod h1:mL1N/T3taQHkDXs73r
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
-golang.org/x/net v0.54.0 h1:2zJIZAxAHV/OHCDTCOHAYehQzLfSXuf/5SoL/Dv6w/w=
-golang.org/x/net v0.54.0/go.mod h1:Sj4oj8jK6XmHpBZU/zWHw3BV3abl4Kvi+Ut7cQcY+cQ=
 golang.org/x/net v0.55.0 h1:bcvxaJn3e1U6InsFWt1JUq1aSjnRxLzT2rtD2KfkDF8=
 golang.org/x/net v0.55.0/go.mod h1:L5U2KuzuOe1lY7Z+aWVIKK6qEeJXnXV9yzGA+WCHJww=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -266,8 +268,6 @@ golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.44.0 h1:ildZl3J4uzeKP07r2F++Op7E9B29JRUy+a27EibtBTQ=
-golang.org/x/sys v0.44.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
 golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.43.0 h1:S4RLU2sB31O/NCl+zFN9Aru9A/Cq2aqKpTZJ6B+DwT4=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -66,6 +66,8 @@ type Config struct {
 	TaskReminderMinutes int      `json:"task_reminder_minutes,omitempty"`
 	TaskRecheckMinutes  int      `json:"task_recheck_minutes,omitempty"`
 	TelegramBotToken    string   `json:"telegram_bot_token,omitempty"`
+	SlackBotToken       string   `json:"slack_bot_token,omitempty"`
+	SlackAppToken       string   `json:"slack_app_token,omitempty"`
 	CompanyName         string   `json:"company_name,omitempty"`
 	CompanyDescription  string   `json:"company_description,omitempty"`
 	CompanyGoals        string   `json:"company_goals,omitempty"`
@@ -599,6 +601,40 @@ func ResolveTelegramBotToken() string {
 func SaveTelegramBotToken(token string) {
 	cfg, _ := Load()
 	cfg.TelegramBotToken = strings.TrimSpace(token)
+	_ = Save(cfg)
+}
+
+// ResolveSlackBotToken returns the Slack bot token used for the Web API
+// (chat.postMessage, users.info, conversations.members). This is the
+// workspace-scoped "xoxb-" token issued when the app is installed.
+// Resolution: SLACK_BOT_TOKEN env > config file.
+func ResolveSlackBotToken() string {
+	if v := strings.TrimSpace(os.Getenv("SLACK_BOT_TOKEN")); v != "" {
+		return v
+	}
+	cfg, _ := Load()
+	return strings.TrimSpace(cfg.SlackBotToken)
+}
+
+// ResolveSlackAppToken returns the Slack app-level token used to open a
+// Socket Mode connection for inbound events. This is the app-scoped "xapp-"
+// token with the connections:write scope; it is distinct from the bot token
+// and is required only for the inbound (Socket Mode) half of the bridge.
+// Resolution: SLACK_APP_TOKEN env > config file.
+func ResolveSlackAppToken() string {
+	if v := strings.TrimSpace(os.Getenv("SLACK_APP_TOKEN")); v != "" {
+		return v
+	}
+	cfg, _ := Load()
+	return strings.TrimSpace(cfg.SlackAppToken)
+}
+
+// SaveSlackTokens persists the Slack bot and app tokens to config.json. Empty
+// values are stored as-is so a caller can clear a token by passing "".
+func SaveSlackTokens(botToken, appToken string) {
+	cfg, _ := Load()
+	cfg.SlackBotToken = strings.TrimSpace(botToken)
+	cfg.SlackAppToken = strings.TrimSpace(appToken)
 	_ = Save(cfg)
 }
 

--- a/internal/provider/binding.go
+++ b/internal/provider/binding.go
@@ -12,6 +12,11 @@ const (
 	KindOpenclaw     = "openclaw"
 	KindOpenclawHTTP = "openclaw-http"
 	KindHermesAgent  = "hermes-agent"
+	// KindSlack tags a foreign Slack agent bridged through the Slack transport's
+	// membrane: the broker never dispatches LLM turns for it — the agent is a
+	// foreign bot that acts in Slack and whose registered bot user id is the
+	// inbound routing key (see internal/team/broker_slack_agents.go).
+	KindSlack = "slack"
 	// Local OpenAI-compatible HTTP runtimes. These expose the same
 	// /v1/chat/completions API; only their default base URL and model differ.
 	// Configure per-kind overrides via Config.ProviderEndpoints or
@@ -32,6 +37,7 @@ type ProviderBinding struct {
 	Kind     string                   `json:"kind,omitempty"`
 	Model    string                   `json:"model,omitempty"`
 	Openclaw *OpenclawProviderBinding `json:"openclaw,omitempty"`
+	Slack    *SlackProviderBinding    `json:"slack,omitempty"`
 }
 
 // OpenclawProviderBinding holds OpenClaw-specific parameters. SessionKey is
@@ -42,17 +48,25 @@ type OpenclawProviderBinding struct {
 	AgentID    string `json:"agent_id,omitempty"`
 }
 
+// SlackProviderBinding holds Slack-specific parameters for a foreign agent
+// registered through the membrane. UserID is the bot's Slack user id (U…/W…) —
+// the key the Slack transport matches inbound bot-authored messages against.
+// Populated only when Kind == KindSlack.
+type SlackProviderBinding struct {
+	UserID string `json:"user_id,omitempty"`
+}
+
 // ValidateKind reports whether s is an acceptable ProviderBinding.Kind value.
 // The empty string is valid and means "use install-wide default."
 func ValidateKind(s string) error {
 	switch s {
 	case "",
 		KindClaudeCode, KindCodex, KindOpencode, KindOpenclaw, KindOpenclawHTTP, KindHermesAgent,
-		KindMLXLM, KindOllama, KindExo:
+		KindSlack, KindMLXLM, KindOllama, KindExo:
 		return nil
 	default:
-		return fmt.Errorf("unknown provider kind %q (valid: %s, %s, %s, %s, %s, %s, %s, %s, %s, or empty)",
-			s, KindClaudeCode, KindCodex, KindOpencode, KindOpenclaw, KindOpenclawHTTP, KindHermesAgent, KindMLXLM, KindOllama, KindExo)
+		return fmt.Errorf("unknown provider kind %q (valid: %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, or empty)",
+			s, KindClaudeCode, KindCodex, KindOpencode, KindOpenclaw, KindOpenclawHTTP, KindHermesAgent, KindSlack, KindMLXLM, KindOllama, KindExo)
 	}
 }
 
@@ -71,13 +85,13 @@ func ResolveKind(b ProviderBinding, global func() string) string {
 
 // IsGatewayKind reports whether kind names a gateway-controlled binding rather
 // than a directly-dispatched LLM runtime. Gateway kinds (openclaw, openclaw-http,
-// hermes-agent) tag agents that were imported through an external gateway; they
-// are managed via the Integrations app, not via the Default Runtime picker.
-// Per-agent provider pickers should hide gateway kinds and surface a
-// "Managed by <Gateway>" badge instead.
+// hermes-agent, slack) tag agents that were imported through an external gateway
+// or transport membrane; they are managed via the Integrations app, not via the
+// Default Runtime picker. Per-agent provider pickers should hide gateway kinds
+// and surface a "Managed by <Gateway>" badge instead.
 func IsGatewayKind(kind string) bool {
 	switch kind {
-	case KindOpenclaw, KindOpenclawHTTP, KindHermesAgent:
+	case KindOpenclaw, KindOpenclawHTTP, KindHermesAgent, KindSlack:
 		return true
 	default:
 		return false

--- a/internal/provider/binding_test.go
+++ b/internal/provider/binding_test.go
@@ -20,6 +20,7 @@ func TestValidateKind(t *testing.T) {
 		{"openclaw", "openclaw", false},
 		{"openclaw_http", "openclaw-http", false},
 		{"hermes_agent", "hermes-agent", false},
+		{"slack", "slack", false},
 		{"unknown", "gemini", true},
 		{"typo", "claud-code", true},
 		{"uppercase_rejected", "Codex", true},
@@ -98,6 +99,36 @@ func TestBindingJSONRoundTrip_Openclaw(t *testing.T) {
 	}
 }
 
+func TestBindingJSONRoundTrip_Slack(t *testing.T) {
+	t.Parallel()
+	in := ProviderBinding{
+		Kind:  KindSlack,
+		Slack: &SlackProviderBinding{UserID: "U0123ABCD"},
+	}
+	data, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var got ProviderBinding
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.Kind != in.Kind {
+		t.Fatalf("round-trip lost kind: got=%+v want=%+v", got, in)
+	}
+	if got.Slack == nil || *got.Slack != *in.Slack {
+		t.Fatalf("round-trip lost slack block: got=%+v want=%+v", got.Slack, in.Slack)
+	}
+	// A non-slack binding must not emit an empty slack object.
+	plain, err := json.Marshal(ProviderBinding{Kind: KindCodex})
+	if err != nil {
+		t.Fatalf("marshal plain: %v", err)
+	}
+	if strings.Contains(string(plain), "slack") {
+		t.Fatalf("non-slack binding leaked slack key: %s", plain)
+	}
+}
+
 func TestResolveKindFallsBackToGlobal(t *testing.T) {
 	t.Parallel()
 	// Caller-provided global resolver — tests the shape without depending on config.
@@ -112,7 +143,7 @@ func TestResolveKindFallsBackToGlobal(t *testing.T) {
 
 func TestIsGatewayKind(t *testing.T) {
 	t.Parallel()
-	gateways := []string{KindOpenclaw, KindOpenclawHTTP, KindHermesAgent}
+	gateways := []string{KindOpenclaw, KindOpenclawHTTP, KindHermesAgent, KindSlack}
 	for _, k := range gateways {
 		if !IsGatewayKind(k) {
 			t.Errorf("IsGatewayKind(%q) = false, want true", k)

--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -666,6 +666,7 @@ func (b *Broker) StartOnPort(port int) error {
 	mux.HandleFunc("/telegram/verify", b.requireAuth(b.handleTelegramVerify))
 	mux.HandleFunc("/telegram/discover", b.requireAuth(b.handleTelegramDiscover))
 	mux.HandleFunc("/telegram/connect", b.requireAuth(b.handleTelegramConnect))
+	mux.HandleFunc("/slack/connect", b.requireAuth(b.handleSlackConnect))
 	mux.HandleFunc("/bridges", b.requireAuth(b.handleBridge))
 	mux.HandleFunc("/company", b.requireAuth(b.handleCompany))
 	mux.HandleFunc("/config", b.requireAuth(b.handleConfig))

--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -66,6 +66,7 @@ type Broker struct {
 	memberIndex       map[string]int                  // slug → index into members; guarded by mu
 	memberPresence    map[string]memberPresenceRecord // slug → presence; guarded by mu, populated via brokerTransportHost
 	presenceKeyToSlug map[string]string               // "adapter:key" → slug; guarded by mu
+	webURL            string                          // base URL of the web UI, set by LaunchWeb; guarded by mu
 	channels          []teamChannel
 	channelIndex      map[string]int // slug → index into channels; guarded by mu
 	sessionMode       string
@@ -935,6 +936,21 @@ func (b *Broker) ExternalQueue(provider string) []channelMessage {
 		out = append(out, cloneChannelMessageForRead(msg))
 	}
 	return out
+}
+
+// SetWebURL records the web UI's base URL so surfaces that link back to the
+// app (e.g. the Slack App Home tab) can build real links.
+func (b *Broker) SetWebURL(url string) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.webURL = strings.TrimRight(strings.TrimSpace(url), "/")
+}
+
+// WebURL returns the web UI's base URL, or "" before LaunchWeb has run.
+func (b *Broker) WebURL() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.webURL
 }
 
 // EnsureBridgedMember registers a bridged external agent as an office member

--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -667,6 +667,7 @@ func (b *Broker) StartOnPort(port int) error {
 	mux.HandleFunc("/telegram/discover", b.requireAuth(b.handleTelegramDiscover))
 	mux.HandleFunc("/telegram/connect", b.requireAuth(b.handleTelegramConnect))
 	mux.HandleFunc("/slack/connect", b.requireAuth(b.handleSlackConnect))
+	mux.HandleFunc("/slack/agents", b.requireAuth(b.handleSlackAgents))
 	mux.HandleFunc("/bridges", b.requireAuth(b.handleBridge))
 	mux.HandleFunc("/company", b.requireAuth(b.handleCompany))
 	mux.HandleFunc("/config", b.requireAuth(b.handleConfig))

--- a/internal/team/broker_office_members.go
+++ b/internal/team/broker_office_members.go
@@ -155,6 +155,10 @@ func cloneOfficeMemberForRead(member officeMember) officeMember {
 		openclaw := *member.Provider.Openclaw
 		clone.Provider.Openclaw = &openclaw
 	}
+	if member.Provider.Slack != nil {
+		slack := *member.Provider.Slack
+		clone.Provider.Slack = &slack
+	}
 	return clone
 }
 

--- a/internal/team/broker_slack_agents.go
+++ b/internal/team/broker_slack_agents.go
@@ -1,0 +1,258 @@
+package team
+
+// broker_slack_agents.go registers FOREIGN Slack agents — bots that live in a
+// bridged Slack channel but are not this office's own bot — as bridged office
+// members, following the OpenClaw pattern: the office member roster is the
+// source of truth, and the external identity (the bot's Slack user id) lives in
+// the member's ProviderBinding (Kind == provider.KindSlack).
+//
+// Registration is the INGRESS allowlist for the Slack transport: routeInbound
+// drops every bot-authored message unless the author's Slack user id is
+// registered here (fail-closed — see slack_transport.go). It is also the
+// outbound mention map: an office message that @mentions a registered agent's
+// slug is rendered with a real <@U…> ping so the foreign bot actually wakes.
+//
+//	POST /slack/agents { user_id, name, slug? } → { slug, name, user_id, created }
+//	GET  /slack/agents → { agents: [ { slug, name, user_id } ] }
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/nex-crm/wuphf/internal/provider"
+)
+
+type slackAgentRegisterRequest struct {
+	UserID string `json:"user_id,omitempty"`
+	Name   string `json:"name,omitempty"`
+	Slug   string `json:"slug,omitempty"`
+}
+
+type slackAgentView struct {
+	Slug   string `json:"slug"`
+	Name   string `json:"name"`
+	UserID string `json:"user_id"`
+}
+
+// handleSlackAgents serves the foreign-agent registry: POST registers (or
+// idempotently re-registers) a foreign Slack bot as a bridged member; GET lists
+// the current registrations.
+func (b *Broker) handleSlackAgents(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		writeJSON(w, http.StatusOK, map[string]any{"agents": b.slackAgents()})
+	case http.MethodPost:
+		var body slackAgentRegisterRequest
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			http.Error(w, "invalid json", http.StatusBadRequest)
+			return
+		}
+		userID := strings.TrimSpace(body.UserID)
+		if !isSlackUserID(userID) {
+			http.Error(w, "slack user_id required (U… or W…)", http.StatusBadRequest)
+			return
+		}
+		name := strings.TrimSpace(body.Name)
+		if name == "" {
+			name = userID
+		}
+		// normalizeChannelSlug falls back to "general" on empty input, so pick
+		// the non-empty source BEFORE normalizing (same gotcha as channel
+		// routing — see normalizeChannelSlug).
+		raw := strings.TrimSpace(body.Slug)
+		if raw == "" {
+			raw = name
+		}
+		slug := normalizeChannelSlug(raw)
+		if slug == "" || slug == "general" {
+			http.Error(w, "could not derive a usable slug; pass slug explicitly", http.StatusBadRequest)
+			return
+		}
+		created, err := b.RegisterSlackAgent(slug, name, userID)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusConflict)
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{
+			"slug": slug, "name": name, "user_id": userID, "created": created,
+		})
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+// RegisterSlackAgent registers a foreign Slack bot as a bridged office member
+// keyed by its Slack user id. Idempotent for an identical (slug, user id) pair;
+// any other collision — the slug names a non-slack member, the slug is bound to
+// a different Slack user, or the Slack user is already registered under another
+// slug — is rejected so attribution stays one-to-one. Returns created=false on
+// an idempotent re-registration.
+func (b *Broker) RegisterSlackAgent(slug, name, userID string) (created bool, err error) {
+	if slug == "" || slug == "general" {
+		return false, fmt.Errorf("slug %q is reserved", slug)
+	}
+	if !isSlackUserID(userID) {
+		return false, fmt.Errorf("invalid slack user id %q", userID)
+	}
+	// Serialize with every other member mutation so the conflict check below
+	// and the create/bind steps are atomic against concurrent registrations
+	// (same outer lock handleOfficeMembers mutations take).
+	b.officeMemberMutationMu.Lock()
+	defer b.officeMemberMutationMu.Unlock()
+	if conflictErr := b.slackAgentConflict(slug, userID); conflictErr != nil {
+		return false, conflictErr
+	}
+	existed := b.memberExists(slug)
+	if err := b.EnsureBridgedMember(slug, name, "slack"); err != nil {
+		return false, fmt.Errorf("register slack agent %q: %w", slug, err)
+	}
+	if err := b.SetMemberProvider(slug, provider.ProviderBinding{
+		Kind:  provider.KindSlack,
+		Slack: &provider.SlackProviderBinding{UserID: userID},
+	}); err != nil {
+		return false, fmt.Errorf("bind slack agent %q: %w", slug, err)
+	}
+	// Make the agent visible in every bridged room, not just #general (which
+	// EnsureBridgedMember already handles). Best-effort consistency: membership
+	// is presentation; inbound routing keys on the registry, not on membership.
+	if err := b.ensureMemberInSlackChannels(slug); err != nil {
+		return false, fmt.Errorf("join slack channels for %q: %w", slug, err)
+	}
+	return !existed, nil
+}
+
+// slackAgentConflict checks the one-to-one invariants between office slugs and
+// Slack user ids under the broker lock. A nil return means slug+userID is free
+// or already bound to exactly this pair.
+func (b *Broker) slackAgentConflict(slug, userID string) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	for i := range b.members {
+		m := &b.members[i]
+		boundID := ""
+		if m.Provider.Kind == provider.KindSlack && m.Provider.Slack != nil {
+			boundID = m.Provider.Slack.UserID
+		}
+		if m.Slug == slug {
+			if boundID == userID {
+				return nil // idempotent re-registration
+			}
+			if boundID != "" {
+				return fmt.Errorf("slug %q already bound to slack user %s", slug, boundID)
+			}
+			return fmt.Errorf("slug %q already names a non-slack member", slug)
+		}
+		if boundID == userID {
+			return fmt.Errorf("slack user %s already registered as %q", userID, m.Slug)
+		}
+	}
+	return nil
+}
+
+// memberExists reports whether slug names a current office member.
+func (b *Broker) memberExists(slug string) bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.findMemberLocked(slug) != nil
+}
+
+// ensureMemberInSlackChannels appends slug to the member list of every channel
+// carrying a "slack" surface, so agents registered after a channel was bridged
+// still show up in that room.
+func (b *Broker) ensureMemberInSlackChannels(slug string) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	changed := false
+	for i := range b.channels {
+		ch := &b.channels[i]
+		if ch.Surface == nil || ch.Surface.Provider != "slack" {
+			continue
+		}
+		if !containsString(ch.Members, slug) {
+			ch.Members = append(ch.Members, slug)
+			changed = true
+		}
+	}
+	if !changed {
+		return nil
+	}
+	return b.saveLocked()
+}
+
+// slackAgents returns the registered foreign agents (members whose provider
+// binding is Kind == slack), for the GET listing.
+func (b *Broker) slackAgents() []slackAgentView {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	out := []slackAgentView{}
+	for i := range b.members {
+		m := &b.members[i]
+		if m.Provider.Kind != provider.KindSlack || m.Provider.Slack == nil {
+			continue
+		}
+		out = append(out, slackAgentView{Slug: m.Slug, Name: m.Name, UserID: m.Provider.Slack.UserID})
+	}
+	return out
+}
+
+// SlackAgentSlugByUserID resolves a Slack user id to the office slug of a
+// registered foreign agent, or "" when the id is not registered. This is the
+// transport's inbound allowlist lookup — an empty return means "drop".
+func (b *Broker) SlackAgentSlugByUserID(userID string) string {
+	userID = strings.TrimSpace(userID)
+	if userID == "" {
+		return ""
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	for i := range b.members {
+		m := &b.members[i]
+		if m.Provider.Kind == provider.KindSlack && m.Provider.Slack != nil && m.Provider.Slack.UserID == userID {
+			return m.Slug
+		}
+	}
+	return ""
+}
+
+// SlackAgentUserIDBySlug resolves an office slug to its registered Slack user
+// id, or "" when slug is not a registered foreign agent. This is the outbound
+// mention map — the ONLY source a real <@U…> ping may be built from (never
+// message text).
+func (b *Broker) SlackAgentUserIDBySlug(slug string) string {
+	// Empty-check BEFORE normalizing: normalizeChannelSlug("") == "general".
+	if strings.TrimSpace(slug) == "" {
+		return ""
+	}
+	slug = normalizeChannelSlug(slug)
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	m := b.findMemberLocked(slug)
+	if m == nil || m.Provider.Kind != provider.KindSlack || m.Provider.Slack == nil {
+		return ""
+	}
+	return m.Provider.Slack.UserID
+}
+
+// isSlackUserID reports whether s is a well-formed Slack user id (U…) or an
+// Enterprise Grid workspace user id (W…): the prefix followed only by
+// uppercase alphanumerics. Strict on charset because the id is stored, listed
+// via GET /slack/agents, and embedded in outbound <@…> mentions.
+func isSlackUserID(s string) bool {
+	if len(s) < 2 {
+		return false
+	}
+	switch s[0] {
+	case 'U', 'W':
+	default:
+		return false
+	}
+	for i := 1; i < len(s); i++ {
+		c := s[i]
+		if (c < 'A' || c > 'Z') && (c < '0' || c > '9') {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/team/broker_slack_agents.go
+++ b/internal/team/broker_slack_agents.go
@@ -197,6 +197,24 @@ func (b *Broker) slackAgents() []slackAgentView {
 	return out
 }
 
+// MemberDisplayNames returns slug → display name for every office member.
+// The Slack renderer uses it to turn office-internal "@slug" tokens — which
+// mean nothing to real Slack users — into plain display names.
+func (b *Broker) MemberDisplayNames() map[string]string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	out := make(map[string]string, len(b.members))
+	for i := range b.members {
+		m := &b.members[i]
+		name := strings.TrimSpace(m.Name)
+		if name == "" {
+			name = m.Slug
+		}
+		out[m.Slug] = name
+	}
+	return out
+}
+
 // SlackAgentSlugByUserID resolves a Slack user id to the office slug of a
 // registered foreign agent, or "" when the id is not registered. This is the
 // transport's inbound allowlist lookup — an empty return means "drop".

--- a/internal/team/broker_slack_agents_test.go
+++ b/internal/team/broker_slack_agents_test.go
@@ -1,0 +1,137 @@
+package team
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/nex-crm/wuphf/internal/provider"
+)
+
+func TestRegisterSlackAgent_CreatesBridgedMemberWithBinding(t *testing.T) {
+	b := newTestBrokerWithSlackChannel(t, "C0123")
+
+	created, err := b.RegisterSlackAgent("claude-bot", "Claude Bot", "U777")
+	if err != nil {
+		t.Fatalf("RegisterSlackAgent: %v", err)
+	}
+	if !created {
+		t.Fatal("first registration should report created=true")
+	}
+
+	var member *officeMember
+	for _, m := range b.OfficeMembers() {
+		if m.Slug == "claude-bot" {
+			mm := m
+			member = &mm
+		}
+	}
+	if member == nil {
+		t.Fatal("registered agent should be an office member")
+	}
+	if member.CreatedBy != "slack" || member.Role != "Bridged agent" {
+		t.Fatalf("member = %+v, want CreatedBy=slack Role=Bridged agent", member)
+	}
+	if member.Provider.Kind != provider.KindSlack || member.Provider.Slack == nil || member.Provider.Slack.UserID != "U777" {
+		t.Fatalf("provider binding = %+v, want slack/U777", member.Provider)
+	}
+
+	// Both registry lookups round-trip.
+	if got := b.SlackAgentSlugByUserID("U777"); got != "claude-bot" {
+		t.Fatalf("SlackAgentSlugByUserID = %q, want claude-bot", got)
+	}
+	if got := b.SlackAgentUserIDBySlug("claude-bot"); got != "U777" {
+		t.Fatalf("SlackAgentUserIDBySlug = %q, want U777", got)
+	}
+
+	// The agent joined the bridged room (not just #general).
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	ch := b.findChannelLocked("slack-general")
+	if ch == nil || !containsString(ch.Members, "claude-bot") {
+		t.Fatalf("agent should be a member of the bridged slack channel, got %+v", ch)
+	}
+}
+
+func TestRegisterSlackAgent_IdempotentAndConflicts(t *testing.T) {
+	b := newTestBroker(t)
+	if _, err := b.RegisterSlackAgent("claude-bot", "Claude Bot", "U777"); err != nil {
+		t.Fatalf("first registration: %v", err)
+	}
+
+	// Identical pair → idempotent, created=false.
+	created, err := b.RegisterSlackAgent("claude-bot", "Claude Bot", "U777")
+	if err != nil || created {
+		t.Fatalf("re-registration = (created=%v, err=%v), want (false, nil)", created, err)
+	}
+
+	// Same slug, different Slack user → conflict.
+	if _, err := b.RegisterSlackAgent("claude-bot", "Impostor", "U888"); err == nil {
+		t.Fatal("rebinding a slug to a different slack user must error")
+	}
+
+	// Same Slack user, different slug → conflict (attribution stays 1:1).
+	if _, err := b.RegisterSlackAgent("other-bot", "Other", "U777"); err == nil {
+		t.Fatal("registering one slack user under two slugs must error")
+	}
+
+	// A slug already naming a native member → conflict, and the native member's
+	// provider binding must be untouched.
+	if _, err := b.RegisterSlackAgent("ceo", "Hijack", "U999"); err == nil {
+		t.Fatal("hijacking a native member slug must error")
+	}
+	if got := b.MemberProviderKind("ceo"); got == provider.KindSlack {
+		t.Fatal("conflicting registration must not mutate the native member")
+	}
+}
+
+func TestHandleSlackAgents_HTTP(t *testing.T) {
+	b := newTestBroker(t)
+
+	post := func(body string) *httptest.ResponseRecorder {
+		req := httptest.NewRequest(http.MethodPost, "/slack/agents", strings.NewReader(body))
+		w := httptest.NewRecorder()
+		b.handleSlackAgents(w, req)
+		return w
+	}
+
+	if w := post(`{"user_id":"U777","name":"Claude Bot"}`); w.Code != http.StatusOK {
+		t.Fatalf("register status = %d, body=%s", w.Code, w.Body.String())
+	}
+	// Slug derives from the name.
+	if got := b.SlackAgentSlugByUserID("U777"); got != "claude-bot" {
+		t.Fatalf("derived slug = %q, want claude-bot", got)
+	}
+
+	if w := post(`{"user_id":"B123","name":"bad"}`); w.Code != http.StatusBadRequest {
+		t.Fatalf("non-user id should 400, got %d", w.Code)
+	}
+	if w := post(`{"name":"no id"}`); w.Code != http.StatusBadRequest {
+		t.Fatalf("missing user_id should 400, got %d", w.Code)
+	}
+	if w := post(`{"user_id":"U888","slug":"claude-bot","name":"Impostor"}`); w.Code != http.StatusConflict {
+		t.Fatalf("slug conflict should 409, got %d", w.Code)
+	}
+
+	// GET lists the registration.
+	req := httptest.NewRequest(http.MethodGet, "/slack/agents", nil)
+	w := httptest.NewRecorder()
+	b.handleSlackAgents(w, req)
+	if w.Code != http.StatusOK || !strings.Contains(w.Body.String(), `"U777"`) {
+		t.Fatalf("list = %d %s, want 200 containing U777", w.Code, w.Body.String())
+	}
+}
+
+func TestIsSlackUserID(t *testing.T) {
+	for _, id := range []string{"U0123", "W0456"} {
+		if !isSlackUserID(id) {
+			t.Fatalf("%q should be a valid slack user id", id)
+		}
+	}
+	for _, id := range []string{"", "C0123", "B0123", "u", "U01 23", "U<@here>", "u0123", "Uabc"} {
+		if isSlackUserID(id) {
+			t.Fatalf("%q should not be a valid slack user id", id)
+		}
+	}
+}

--- a/internal/team/broker_slack_connect.go
+++ b/internal/team/broker_slack_connect.go
@@ -1,0 +1,131 @@
+package team
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// broker_slack_connect.go is the Slack equivalent of broker_telegram_connect.go:
+// it binds a Slack channel (C…/G…) to an office channel carrying a "slack"
+// surface, so the SlackTransport — which maps broker.SurfaceChannels("slack") to
+// office slugs — has a channel to bridge. Without a connected channel the
+// transport skips silently at boot (see launcher_transports.go).
+//
+//	POST /slack/connect { channel_id, name } → { channel_slug, name }
+
+var errSlackChannelAlreadyBridges = errors.New("channel already bridges a different slack channel")
+
+type slackConnectRequest struct {
+	ChannelID string `json:"channel_id,omitempty"`
+	Name      string `json:"name,omitempty"`
+}
+
+// handleSlackConnect binds a Slack channel id to an office channel. The bot must
+// already be invited to the Slack channel; this only records the binding.
+func (b *Broker) handleSlackConnect(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	var body slackConnectRequest
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, "invalid json", http.StatusBadRequest)
+		return
+	}
+	channelID := strings.TrimSpace(body.ChannelID)
+	if !isSlackChannelID(channelID) {
+		http.Error(w, "slack channel_id required (C… or G…)", http.StatusBadRequest)
+		return
+	}
+	name := strings.TrimSpace(body.Name)
+	if name == "" {
+		name = channelID
+	}
+
+	ch, err := b.createSlackChannel(channelID, name)
+	if err != nil && !errors.Is(err, errChannelAlreadyExists) {
+		http.Error(w, err.Error(), http.StatusConflict)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"channel_slug": ch.Slug, "name": ch.Name})
+}
+
+// createSlackChannel binds channelID to an office channel with a "slack" surface.
+// If a channel with the derived slug already exists it must already bridge the
+// same Slack channel id (idempotent reconnect); otherwise the call errors.
+// Returns errChannelAlreadyExists (wrapped) with the existing channel on an
+// idempotent reconnect so the handler can treat it as success.
+func (b *Broker) createSlackChannel(channelID, name string) (*teamChannel, error) {
+	slug := slackChannelSlug(name)
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	// Every adopted office member joins (ceo is prepended by createChannelLocked).
+	members := make([]string, 0, len(b.members))
+	for _, m := range b.members {
+		if m.Slug != "" && m.Slug != "ceo" {
+			members = append(members, m.Slug)
+		}
+	}
+
+	if existing := b.findChannelLocked(slug); existing != nil {
+		if existing.Surface == nil || existing.Surface.Provider != "slack" {
+			return existing, fmt.Errorf("%w: %q exists but is not a slack channel", errSlackChannelAlreadyBridges, slug)
+		}
+		if existing.Surface.RemoteID != "" && existing.Surface.RemoteID != channelID {
+			return existing, fmt.Errorf("%w: %q already bridges slack channel %s", errSlackChannelAlreadyBridges, slug, existing.Surface.RemoteID)
+		}
+		return existing, errChannelAlreadyExists
+	}
+
+	ch, cerr := b.createChannelLocked(channelCreateInput{
+		Slug:        slug,
+		Name:        name,
+		Description: fmt.Sprintf("Slack bridge for %s.", name),
+		Members:     members,
+		CreatedBy:   "you",
+		Surface: &channelSurface{
+			Provider:    "slack",
+			RemoteID:    channelID,
+			RemoteTitle: name,
+			BotTokenEnv: "SLACK_BOT_TOKEN",
+		},
+	})
+	if cerr != nil {
+		// Return a plain error, not the typed-nil *channelCreateError, to avoid
+		// the non-nil-interface gotcha on the success path below.
+		return nil, cerr
+	}
+	return ch, nil
+}
+
+// isSlackChannelID reports whether s looks like a Slack channel/group id.
+func isSlackChannelID(s string) bool {
+	if len(s) < 2 {
+		return false
+	}
+	switch s[0] {
+	case 'C', 'G':
+		return true
+	default:
+		return false
+	}
+}
+
+// slackChannelSlug derives a stable office slug from a Slack channel name,
+// prefixed "slack-" so Slack channels are visually grouped and never collide
+// with a same-named native channel.
+func slackChannelSlug(name string) string {
+	s := normalizeChannelSlug(name)
+	if s == "" {
+		s = "channel"
+	}
+	if !strings.HasPrefix(s, "slack-") {
+		s = "slack-" + s
+	}
+	return s
+}

--- a/internal/team/broker_slack_connect.go
+++ b/internal/team/broker_slack_connect.go
@@ -4,8 +4,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log"
 	"net/http"
 	"strings"
+
+	"github.com/nex-crm/wuphf/internal/company"
 )
 
 // broker_slack_connect.go is the Slack equivalent of broker_telegram_connect.go:
@@ -50,7 +53,46 @@ func (b *Broker) handleSlackConnect(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusConflict)
 		return
 	}
+	// Persist the binding to company.yaml so it survives a restart — otherwise
+	// the transport, which only starts when a slack surface channel exists at
+	// boot, would silently skip after every restart (mirrors the Telegram flow).
+	syncManifestForSlackChannel(ch.Slug, channelID, name)
 	writeJSON(w, http.StatusOK, map[string]any{"channel_slug": ch.Slug, "name": ch.Name})
+}
+
+// syncManifestForSlackChannel appends the slack-bridged channel to company.yaml
+// so a future restart re-reads it. Best-effort: the in-memory channel is already
+// created and persisted via saveLocked; a manifest failure is logged, not fatal.
+func syncManifestForSlackChannel(slug, channelID, name string) {
+	err := company.UpdateManifest(func(manifest *company.Manifest) error {
+		for _, ch := range manifest.Channels {
+			if ch.Slug == slug {
+				return nil
+			}
+		}
+		members := []string{manifest.Lead}
+		for _, m := range manifest.Members {
+			if m.Slug != "" && m.Slug != manifest.Lead {
+				members = append(members, m.Slug)
+			}
+		}
+		manifest.Channels = append(manifest.Channels, company.ChannelSpec{
+			Slug:        slug,
+			Name:        name,
+			Description: fmt.Sprintf("Slack bridge for %s.", name),
+			Members:     members,
+			Surface: &company.ChannelSurfaceSpec{
+				Provider:    "slack",
+				RemoteID:    channelID,
+				RemoteTitle: name,
+				BotTokenEnv: "SLACK_BOT_TOKEN",
+			},
+		})
+		return nil
+	})
+	if err != nil {
+		log.Printf("[slack] manifest sync failed for %s: %v", slug, err)
+	}
 }
 
 // createSlackChannel binds channelID to an office channel with a "slack" surface.

--- a/internal/team/broker_slack_connect_test.go
+++ b/internal/team/broker_slack_connect_test.go
@@ -1,0 +1,68 @@
+package team
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestCreateSlackChannelBindsSurface(t *testing.T) {
+	b := newTestBroker(t)
+
+	ch, err := b.createSlackChannel("C0123", "general")
+	if err != nil {
+		t.Fatalf("createSlackChannel: %v", err)
+	}
+	if ch.Slug != "slack-general" {
+		t.Fatalf("slug = %q, want slack-general", ch.Slug)
+	}
+	if ch.Surface == nil || ch.Surface.Provider != "slack" || ch.Surface.RemoteID != "C0123" {
+		t.Fatalf("surface = %+v, want slack/C0123", ch.Surface)
+	}
+
+	// The transport discovers it via SurfaceChannels("slack").
+	found := false
+	for _, sc := range b.SurfaceChannels("slack") {
+		if sc.Surface != nil && sc.Surface.RemoteID == "C0123" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("SurfaceChannels(slack) should include the connected channel")
+	}
+}
+
+func TestCreateSlackChannelIdempotentAndConflict(t *testing.T) {
+	b := newTestBroker(t)
+	if _, err := b.createSlackChannel("C0123", "general"); err != nil {
+		t.Fatalf("first connect: %v", err)
+	}
+
+	// Reconnecting the same channel id to the same slug is idempotent.
+	if _, err := b.createSlackChannel("C0123", "general"); !errors.Is(err, errChannelAlreadyExists) {
+		t.Fatalf("reconnect should be idempotent, got %v", err)
+	}
+
+	// A different channel id on the same slug is a conflict.
+	if _, err := b.createSlackChannel("C9999", "general"); !errors.Is(err, errSlackChannelAlreadyBridges) {
+		t.Fatalf("conflicting bind should error, got %v", err)
+	}
+}
+
+func TestIsSlackChannelIDAndSlug(t *testing.T) {
+	for _, id := range []string{"C0123", "G0456"} {
+		if !isSlackChannelID(id) {
+			t.Fatalf("%q should be a valid slack channel id", id)
+		}
+	}
+	for _, id := range []string{"", "U0123", "x"} {
+		if isSlackChannelID(id) {
+			t.Fatalf("%q should not be a valid slack channel id", id)
+		}
+	}
+	if got := slackChannelSlug("Revenue Ops"); got != "slack-revenue-ops" {
+		t.Fatalf("slug = %q, want slack-revenue-ops", got)
+	}
+	if got := slackChannelSlug("slack-foo"); got != "slack-foo" {
+		t.Fatalf("slug = %q, want slack-foo (no double prefix)", got)
+	}
+}

--- a/internal/team/headless_codex.go
+++ b/internal/team/headless_codex.go
@@ -46,6 +46,13 @@ func defaultHeadlessCodexRunTurn(l *Launcher, ctx context.Context, slug, notific
 			return l.runHeadlessOpencodeTurn(ctx, slug, notification, channel...)
 		case isOpenAICompatKind(kind):
 			return l.runHeadlessOpenAICompatTurn(ctx, slug, notification, channel...)
+		case kind == provider.KindSlack:
+			// Foreign Slack agents have no local runtime: their "turn" is the
+			// outbound Slack relay (a real <@U…> mention), which the transport
+			// dispatcher already delivered. Falling through to the Claude
+			// runner would spawn a doomed subprocess for an agent that acts on
+			// its own in Slack — so the queued turn is a deliberate no-op.
+			return nil
 		default:
 			return l.runHeadlessClaudeTurn(ctx, slug, notification, channel...)
 		}

--- a/internal/team/launcher_transports.go
+++ b/internal/team/launcher_transports.go
@@ -74,6 +74,44 @@ func RegisterTransports(b *Broker) (func(), error) {
 		}
 	}
 
+	// Slack: start if both a bot token (xoxb-, Web API) and an app token
+	// (xapp-, Socket Mode) are configured and the broker has at least one slack
+	// surface channel. Missing either token, or no connected channel yet, skips
+	// silently — the transport starts on the next launch once setup is complete.
+	slackBotToken := config.ResolveSlackBotToken()
+	slackAppToken := config.ResolveSlackAppToken()
+	if slackBotToken != "" && slackAppToken != "" {
+		st := NewSlackTransport(b, slackBotToken, slackAppToken)
+		if len(st.ChannelMap) == 0 {
+			log.Printf("[transport] slack: tokens present but no channels connected yet — skipping")
+		} else {
+			host := &brokerTransportHost{broker: b}
+			ctx, cancel := context.WithCancel(context.Background())
+			done := make(chan struct{})
+			dispatchDone := make(chan struct{})
+			stops = append(stops, func() {
+				cancel()
+				<-done         // wait for Run to return before broker.Stop()
+				<-dispatchDone // and the outbound dispatcher's goroutine
+			})
+			go func() {
+				defer close(done)
+				if err := st.Run(ctx, host); err != nil && ctx.Err() == nil {
+					log.Printf("[transport] slack: exited with error: %v", err)
+				}
+			}()
+			go func() {
+				defer close(dispatchDone)
+				if err := runOutboundDispatcher(ctx, b, st.Name(), st.FormatOutbound, st.Send); err != nil && ctx.Err() == nil {
+					log.Printf("[transport] slack: outbound dispatcher exited: %v", err)
+				}
+			}()
+			log.Printf("[transport] slack: started (%d channel(s))", len(st.ChannelMap))
+		}
+	} else if slackBotToken != "" || slackAppToken != "" {
+		log.Printf("[transport] slack: only one of SLACK_BOT_TOKEN / SLACK_APP_TOKEN set — both are required, skipping")
+	}
+
 	// OpenClaw: opt-in when members exist or a gateway URL is configured.
 	bridge, ocErr := BuildOpenclawBridgeFromConfig(b)
 	if ocErr != nil {

--- a/internal/team/launcher_web.go
+++ b/internal/team/launcher_web.go
@@ -167,6 +167,11 @@ func (l *Launcher) LaunchWeb(webPort int) error {
 	// even after the probe succeeds.
 	webAddr := fmt.Sprintf("127.0.0.1:%d", webPort)
 	webURL := fmt.Sprintf("http://%s", webAddr)
+	if l.broker != nil {
+		// Surfaces that link back to the web app (e.g. the Slack App Home
+		// tab) read this; before LaunchWeb runs they render without links.
+		l.broker.SetWebURL(webURL)
+	}
 	fmt.Printf("\n  Web UI:  %s\n", webURL)
 	fmt.Printf("  Broker:  %s\n", l.BrokerBaseURL())
 	fmt.Printf("  Press Ctrl+C to stop.\n\n")

--- a/internal/team/slack_bridge.go
+++ b/internal/team/slack_bridge.go
@@ -3,6 +3,7 @@ package team
 import (
 	"context"
 	"fmt"
+	"log"
 	"strings"
 	"time"
 
@@ -47,12 +48,13 @@ func newSlackBridge(api slackAPI) *SlackBridge {
 // dedupe; the current Web API has no native idempotency token, so the packer's
 // sink remains the dedupe authority (it short-circuits a re-Post of a SENT key).
 //
-// The mention ts is returned even if the thread-context follow-up fails: the
-// delegation's essentials (the mention) landed, the audit hash already covers
-// both fields, and a missing follow-up is a degraded — not failed — delivery. A
-// failed follow-up is surfaced via the returned error so the caller can log it,
-// but the returned ts stays valid so Deliver records DeliverySent with the real
-// anchor rather than discarding a delivered mention.
+// The thread-context follow-up is BEST-EFFORT: if it fails, Post still returns
+// (mentionTS, nil). The mention carries the essentials (ask + plan) and is the
+// audit anchor; returning an error here would make the packer's Deliver mark the
+// whole delegation FAILED, and because a FAILED record does not short-circuit
+// idempotency, a retry would DUPLICATE the mention. A dropped thread block is a
+// degraded — never an over- — delivery, so it is logged loudly rather than
+// surfaced as a failure. (Only the mention failing is a real delivery failure.)
 func (b *SlackBridge) Post(ctx context.Context, d packer.PackedDelegation, idempotencyKey string) (string, error) {
 	channelID := strings.TrimSpace(d.Injection.ChannelID)
 	if channelID == "" {
@@ -95,7 +97,7 @@ func (b *SlackBridge) Post(ctx context.Context, d packer.PackedDelegation, idemp
 			slack.MsgOptionTS(threadTS),
 		)
 		if ferr != nil {
-			return mentionTS, fmt.Errorf("slack bridge: post thread context: %w", ferr)
+			log.Printf("[slack-bridge] thread-context follow-up failed (key %q, channel %s): %v — mention delivered, thread block dropped", idempotencyKey, channelID, ferr)
 		}
 	}
 

--- a/internal/team/slack_bridge.go
+++ b/internal/team/slack_bridge.go
@@ -1,0 +1,99 @@
+package team
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/slack-go/slack"
+
+	"github.com/nex-crm/wuphf/internal/packer"
+)
+
+// slack_bridge.go implements packer.SlackBridge over the same slackAPI seam used
+// by SlackTransport, so the inbound context-packer can deliver a packed
+// delegation to a Slack thread without importing slack-go directly. The packer's
+// Deliver() owns idempotency, the egress audit, and the final redaction scan;
+// this bridge is the thin "put these exact bytes on Slack" step.
+
+// compile-time assertion: SlackBridge must satisfy packer.SlackBridge.
+var _ packer.SlackBridge = (*SlackBridge)(nil)
+
+// SlackBridge posts packed delegations to Slack. It is constructed with a
+// slackAPI (real or fake) and carries no broker state — the destination travels
+// on each PackedDelegation's InjectionRecord.
+type SlackBridge struct {
+	api slackAPI
+}
+
+// NewSlackBridge builds a SlackBridge from a configured bot token. The bot token
+// (xoxb-) is sufficient for chat.postMessage; Socket Mode is not needed for the
+// outbound delivery path.
+func NewSlackBridge(botToken string) *SlackBridge {
+	return &SlackBridge{api: &slackClient{api: slack.New(botToken)}}
+}
+
+// newSlackBridge is the injectable constructor used by tests.
+func newSlackBridge(api slackAPI) *SlackBridge {
+	return &SlackBridge{api: api}
+}
+
+// Post posts d.MentionText to the delegation's channel/thread (carried on
+// d.Injection.ChannelID / d.Injection.ThreadTS) and, when d.ThreadContext is
+// non-empty, posts it as a threaded follow-up under the mention. It returns the
+// Slack ts of the mention message — the anchor the packer records as proof of
+// delivery. The idempotencyKey is forwarded so a future idempotent transport can
+// dedupe; the current Web API has no native idempotency token, so the packer's
+// sink remains the dedupe authority (it short-circuits a re-Post of a SENT key).
+//
+// The mention ts is returned even if the thread-context follow-up fails: the
+// delegation's essentials (the mention) landed, the audit hash already covers
+// both fields, and a missing follow-up is a degraded — not failed — delivery. A
+// failed follow-up is surfaced via the returned error so the caller can log it,
+// but the returned ts stays valid so Deliver records DeliverySent with the real
+// anchor rather than discarding a delivered mention.
+func (b *SlackBridge) Post(ctx context.Context, d packer.PackedDelegation, idempotencyKey string) (string, error) {
+	channelID := strings.TrimSpace(d.Injection.ChannelID)
+	if channelID == "" {
+		return "", fmt.Errorf("slack bridge: empty channel id (idempotency key %q)", idempotencyKey)
+	}
+	mention := strings.TrimSpace(d.MentionText)
+	if mention == "" {
+		return "", fmt.Errorf("slack bridge: empty mention text (idempotency key %q)", idempotencyKey)
+	}
+
+	postCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	// Post the mention. If the delegation targets an existing thread, anchor the
+	// mention to it; otherwise the mention starts a new thread whose ts we reuse
+	// for the follow-up.
+	mentionOpts := []slack.MsgOption{slack.MsgOptionText(mention, false)}
+	if ts := strings.TrimSpace(d.Injection.ThreadTS); ts != "" {
+		mentionOpts = append(mentionOpts, slack.MsgOptionTS(ts))
+	}
+	_, mentionTS, err := b.api.PostMessageContext(postCtx, channelID, mentionOpts...)
+	if err != nil {
+		return "", fmt.Errorf("slack bridge: post mention: %w", err)
+	}
+
+	// Thread the remaining context under the mention, when present. Prefer the
+	// delegation's own thread anchor; fall back to the mention's ts so the
+	// follow-up always lands in the same thread as the mention.
+	if thread := strings.TrimSpace(d.ThreadContext); thread != "" {
+		threadTS := strings.TrimSpace(d.Injection.ThreadTS)
+		if threadTS == "" {
+			threadTS = mentionTS
+		}
+		_, _, ferr := b.api.PostMessageContext(postCtx, channelID,
+			slack.MsgOptionText(thread, false),
+			slack.MsgOptionTS(threadTS),
+		)
+		if ferr != nil {
+			return mentionTS, fmt.Errorf("slack bridge: post thread context: %w", ferr)
+		}
+	}
+
+	return mentionTS, nil
+}

--- a/internal/team/slack_bridge.go
+++ b/internal/team/slack_bridge.go
@@ -66,10 +66,14 @@ func (b *SlackBridge) Post(ctx context.Context, d packer.PackedDelegation, idemp
 	postCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
-	// Post the mention. If the delegation targets an existing thread, anchor the
-	// mention to it; otherwise the mention starts a new thread whose ts we reuse
-	// for the follow-up.
-	mentionOpts := []slack.MsgOption{slack.MsgOptionText(mention, false)}
+	// Post the mention. escapeText=true is deliberate and security-relevant: this
+	// is the foreign-facing egress boundary, and the packer redacts SECRETS, not
+	// Slack control sequences. Escaping &<> neutralizes injected mrkdwn like
+	// <!channel>/<!here> mass-pings and fake <url|text> links that a tainted Ask
+	// could otherwise smuggle into the workspace. If the delegation targets an
+	// existing thread, anchor the mention to it; otherwise the mention starts a
+	// new thread whose ts we reuse for the follow-up.
+	mentionOpts := []slack.MsgOption{slack.MsgOptionText(mention, true)}
 	if ts := strings.TrimSpace(d.Injection.ThreadTS); ts != "" {
 		mentionOpts = append(mentionOpts, slack.MsgOptionTS(ts))
 	}
@@ -87,7 +91,7 @@ func (b *SlackBridge) Post(ctx context.Context, d packer.PackedDelegation, idemp
 			threadTS = mentionTS
 		}
 		_, _, ferr := b.api.PostMessageContext(postCtx, channelID,
-			slack.MsgOptionText(thread, false),
+			slack.MsgOptionText(thread, true),
 			slack.MsgOptionTS(threadTS),
 		)
 		if ferr != nil {

--- a/internal/team/slack_bridge_test.go
+++ b/internal/team/slack_bridge_test.go
@@ -1,0 +1,141 @@
+package team
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/nex-crm/wuphf/internal/packer"
+)
+
+// newTestDelegation builds a PackedDelegation with the given mention/thread text
+// and destination. The packer normally seals delegations via render(); here we
+// only need the exported fields the bridge reads (MentionText, ThreadContext,
+// Injection.ChannelID, Injection.ThreadTS), so a literal is sufficient — the
+// bridge is downstream of the seal check, which Deliver enforces, not Post.
+func newTestDelegation(mention, thread, channelID, threadTS string) packer.PackedDelegation {
+	return packer.PackedDelegation{
+		MentionText:   mention,
+		ThreadContext: thread,
+		Injection: packer.InjectionRecord{
+			ChannelID: channelID,
+			ThreadTS:  threadTS,
+		},
+	}
+}
+
+func TestSlackBridgePostMentionOnly(t *testing.T) {
+	api := newFakeSlackAPI()
+	br := newSlackBridge(api)
+
+	ts, err := br.Post(context.Background(), newTestDelegation("@pam please review", "", "C0123", ""), "key-1")
+	if err != nil {
+		t.Fatalf("Post: %v", err)
+	}
+	if ts == "" {
+		t.Fatal("expected a non-empty message ts")
+	}
+	posts := api.snapshotPosts()
+	if len(posts) != 1 {
+		t.Fatalf("expected 1 post (mention only), got %d", len(posts))
+	}
+	if posts[0].ChannelID != "C0123" || posts[0].Text != "@pam please review" {
+		t.Fatalf("mention post = %+v", posts[0])
+	}
+	if posts[0].ThreadTS != "" {
+		t.Fatalf("expected mention to start a new thread, got thread_ts %q", posts[0].ThreadTS)
+	}
+}
+
+func TestSlackBridgePostThreadContextAsReply(t *testing.T) {
+	api := newFakeSlackAPI()
+	br := newSlackBridge(api)
+
+	// No existing thread ts: the mention starts the thread and the follow-up must
+	// reply under the mention's returned ts.
+	ts, err := br.Post(context.Background(), newTestDelegation("@pam mention", "full thread context here", "C0123", ""), "key-2")
+	if err != nil {
+		t.Fatalf("Post: %v", err)
+	}
+	posts := api.snapshotPosts()
+	if len(posts) != 2 {
+		t.Fatalf("expected 2 posts (mention + thread), got %d", len(posts))
+	}
+	if posts[0].Text != "@pam mention" {
+		t.Fatalf("first post should be the mention, got %q", posts[0].Text)
+	}
+	if posts[1].Text != "full thread context here" {
+		t.Fatalf("second post should be the thread context, got %q", posts[1].Text)
+	}
+	if posts[1].ThreadTS != ts {
+		t.Fatalf("thread follow-up thread_ts = %q, want mention ts %q", posts[1].ThreadTS, ts)
+	}
+}
+
+func TestSlackBridgePostIntoExistingThread(t *testing.T) {
+	api := newFakeSlackAPI()
+	br := newSlackBridge(api)
+
+	// An existing thread ts: BOTH the mention and the thread context anchor to it.
+	_, err := br.Post(context.Background(), newTestDelegation("@pam mention", "context", "C0123", "1699999999.0001"), "key-3")
+	if err != nil {
+		t.Fatalf("Post: %v", err)
+	}
+	posts := api.snapshotPosts()
+	if len(posts) != 2 {
+		t.Fatalf("expected 2 posts, got %d", len(posts))
+	}
+	if posts[0].ThreadTS != "1699999999.0001" {
+		t.Fatalf("mention thread_ts = %q, want the existing thread anchor", posts[0].ThreadTS)
+	}
+	if posts[1].ThreadTS != "1699999999.0001" {
+		t.Fatalf("thread context thread_ts = %q, want the existing thread anchor", posts[1].ThreadTS)
+	}
+}
+
+func TestSlackBridgePostEmptyChannel(t *testing.T) {
+	br := newSlackBridge(newFakeSlackAPI())
+	_, err := br.Post(context.Background(), newTestDelegation("@pam", "", "", ""), "key-4")
+	if err == nil || !contains(err.Error(), "empty channel id") {
+		t.Fatalf("expected empty channel error, got %v", err)
+	}
+}
+
+func TestSlackBridgePostEmptyMention(t *testing.T) {
+	br := newSlackBridge(newFakeSlackAPI())
+	_, err := br.Post(context.Background(), newTestDelegation("   ", "thread", "C0123", ""), "key-5")
+	if err == nil || !contains(err.Error(), "empty mention text") {
+		t.Fatalf("expected empty mention error, got %v", err)
+	}
+}
+
+func TestSlackBridgePostMentionAPIError(t *testing.T) {
+	api := newFakeSlackAPI()
+	api.postErr = errors.New("channel_not_found")
+	br := newSlackBridge(api)
+
+	_, err := br.Post(context.Background(), newTestDelegation("@pam", "ctx", "C0123", ""), "key-6")
+	if err == nil || !contains(err.Error(), "post mention") || !contains(err.Error(), "channel_not_found") {
+		t.Fatalf("expected wrapped mention error, got %v", err)
+	}
+	if len(api.snapshotPosts()) != 0 {
+		t.Fatal("no post should be recorded when the mention call fails")
+	}
+}
+
+func TestSlackBridgePostThreadContextErrorReturnsMentionTS(t *testing.T) {
+	api := newFakeSlackAPI()
+	// Fail only the SECOND post (the thread follow-up); the mention succeeds.
+	api.postErr = errors.New("thread_locked")
+	api.postErrAt = 2
+	br := newSlackBridge(api)
+
+	ts, err := br.Post(context.Background(), newTestDelegation("@pam", "ctx", "C0123", ""), "key-7")
+	if err == nil || !contains(err.Error(), "post thread context") {
+		t.Fatalf("expected wrapped thread error, got %v", err)
+	}
+	// The mention landed, so its ts must still be returned for the audit anchor.
+	if ts == "" {
+		t.Fatal("expected the mention ts to be returned even when the follow-up fails")
+	}
+}

--- a/internal/team/slack_bridge_test.go
+++ b/internal/team/slack_bridge_test.go
@@ -149,19 +149,24 @@ func TestSlackBridgePostEscapesControlSequences(t *testing.T) {
 	}
 }
 
-func TestSlackBridgePostThreadContextErrorReturnsMentionTS(t *testing.T) {
+func TestSlackBridgePostThreadContextFailureIsBestEffort(t *testing.T) {
 	api := newFakeSlackAPI()
 	// Fail only the SECOND post (the thread follow-up); the mention succeeds.
 	api.postErr = errors.New("thread_locked")
 	api.postErrAt = 2
 	br := newSlackBridge(api)
 
+	// A dropped thread block is degraded, not failed: Post returns the mention ts
+	// and NO error, so the packer's Deliver records DeliverySent (not FAILED) and
+	// a retry cannot duplicate the mention. The mention must have landed.
 	ts, err := br.Post(context.Background(), newTestDelegation("@pam", "ctx", "C0123", ""), "key-7")
-	if err == nil || !contains(err.Error(), "post thread context") {
-		t.Fatalf("expected wrapped thread error, got %v", err)
+	if err != nil {
+		t.Fatalf("follow-up failure must be best-effort (nil error), got %v", err)
 	}
-	// The mention landed, so its ts must still be returned for the audit anchor.
 	if ts == "" {
-		t.Fatal("expected the mention ts to be returned even when the follow-up fails")
+		t.Fatal("expected the mention ts to be returned")
+	}
+	if len(api.snapshotPosts()) != 1 {
+		t.Fatalf("only the mention should be recorded (follow-up failed), got %d", len(api.snapshotPosts()))
 	}
 }

--- a/internal/team/slack_bridge_test.go
+++ b/internal/team/slack_bridge_test.go
@@ -123,6 +123,32 @@ func TestSlackBridgePostMentionAPIError(t *testing.T) {
 	}
 }
 
+func TestSlackBridgePostEscapesControlSequences(t *testing.T) {
+	api := newFakeSlackAPI()
+	br := newSlackBridge(api)
+
+	// A tainted Ask could smuggle Slack control sequences into the egress text.
+	// The bridge posts with escapeText=true so &<> are neutralized — no mass-ping
+	// (<!channel>/<!here>) and no fake <url|label> link reaches the workspace.
+	_, err := br.Post(context.Background(),
+		newTestDelegation("ping <!channel> and <http://evil|click here>", "also <!here>", "C0123", ""), "key-escape")
+	if err != nil {
+		t.Fatalf("Post: %v", err)
+	}
+	posts := api.snapshotPosts()
+	if len(posts) != 2 {
+		t.Fatalf("expected 2 posts, got %d", len(posts))
+	}
+	for _, p := range posts {
+		if contains(p.Text, "<!channel>") || contains(p.Text, "<!here>") || contains(p.Text, "<http://evil|click here>") {
+			t.Fatalf("egress text must escape Slack control sequences, got %q", p.Text)
+		}
+	}
+	if !contains(posts[0].Text, "&lt;!channel&gt;") {
+		t.Fatalf("expected escaped control sequence in mention, got %q", posts[0].Text)
+	}
+}
+
 func TestSlackBridgePostThreadContextErrorReturnsMentionTS(t *testing.T) {
 	api := newFakeSlackAPI()
 	// Fail only the SECOND post (the thread follow-up); the mention succeeds.

--- a/internal/team/slack_home.go
+++ b/internal/team/slack_home.go
@@ -1,0 +1,142 @@
+package team
+
+// slack_home.go renders the wuphf Slack app's App Home tab: a native overview
+// of the office — task board by lane, the team wiki index, and links to every
+// web-app surface — published via views.publish whenever a user opens the
+// app's Home tab (app_home_opened). Slack cannot embed the web app, so the
+// Home tab is a glanceable summary with deep links into the real surfaces.
+//
+// Requires the Slack app config to have the Home Tab enabled (App Home →
+// Show Tabs → Home) and the app_home_opened bot event subscribed.
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"sort"
+	"strings"
+
+	"github.com/slack-go/slack"
+)
+
+// slackHomeMaxTasksPerLane caps each board lane so the Home view stays
+// glanceable (and under Slack's 100-block view limit).
+const slackHomeMaxTasksPerLane = 5
+
+// slackHomeWikiIndexCap bounds how much of the wiki index markdown is shown.
+// Slack section text tops out at 3000 chars; stay safely below.
+const slackHomeWikiIndexCap = 2200
+
+// publishHomeTab builds and publishes the App Home view for userID.
+// Best-effort: failures are logged, never fatal — the Home tab is a viewport,
+// not a control surface.
+func (t *SlackTransport) publishHomeTab(ctx context.Context, userID string) {
+	if t.api == nil || t.Broker == nil || strings.TrimSpace(userID) == "" {
+		return
+	}
+	blocks := buildSlackHomeBlocks(t.Broker)
+	view := slack.HomeTabViewRequest{
+		Type:   slack.VTHomeTab,
+		Blocks: slack.Blocks{BlockSet: blocks},
+	}
+	if err := t.api.PublishViewContext(ctx, userID, view); err != nil {
+		log.Printf("[slack] home tab publish failed for %s: %v", userID, err)
+	}
+}
+
+// buildSlackHomeBlocks renders the office overview: web-app surface links,
+// the task board grouped by lane, and the wiki index. Every dynamic field is
+// escaped; links are built only from the broker's own WebURL.
+func buildSlackHomeBlocks(b *Broker) []slack.Block {
+	var blocks []slack.Block
+	section := func(md string) {
+		blocks = append(blocks, slack.NewSectionBlock(
+			slack.NewTextBlockObject(slack.MarkdownType, md, false, false), nil, nil))
+	}
+	header := func(text string) {
+		blocks = append(blocks, slack.NewHeaderBlock(
+			slack.NewTextBlockObject(slack.PlainTextType, text, false, false)))
+	}
+
+	header("WUPHF Office")
+
+	// Web-app surfaces. Self-hosted: the URL is loopback, reachable on the
+	// machine running the office.
+	if base := b.WebURL(); base != "" {
+		section(fmt.Sprintf(
+			"*Open in the app:* <%s/tasks|Task board> · <%s/wiki|Wiki> · <%s/inbox|Inbox> · <%s/agents|Agents> · <%s/notebooks|Notebooks> · <%s/reviews|Reviews> · <%s/routines|Routines> · <%s|Settings & more>",
+			base, base, base, base, base, base, base, base))
+	}
+	blocks = append(blocks, slack.NewDividerBlock())
+
+	// Task board by lane.
+	header("Task board")
+	lanes := []struct {
+		title    string
+		statuses map[string]bool
+	}{
+		{"In progress", map[string]bool{"in_progress": true, "running": true}},
+		{"Planning / review", map[string]bool{"planning": true, "review": true, "pending": true, "open": true, "assigned": true}},
+		{"Done (recent)", map[string]bool{"done": true, "completed": true}},
+	}
+	tasks := b.AllTasks()
+	// Newest first so "recent" lanes show the latest work.
+	sort.SliceStable(tasks, func(i, j int) bool { return tasks[i].CreatedAt > tasks[j].CreatedAt })
+	for _, lane := range lanes {
+		var lines []string
+		overflow := 0
+		for i := range tasks {
+			task := &tasks[i]
+			status := strings.ToLower(strings.TrimSpace(task.status))
+			if !lane.statuses[status] {
+				continue
+			}
+			if len(lines) >= slackHomeMaxTasksPerLane {
+				overflow++
+				continue
+			}
+			owner := strings.TrimSpace(task.Owner)
+			if owner == "" {
+				owner = "unassigned"
+			}
+			lines = append(lines, fmt.Sprintf("• `%s` %s — _%s_",
+				slackEscape(task.ID), slackEscape(task.Title), slackEscape(owner)))
+		}
+		body := "_empty_"
+		if len(lines) > 0 {
+			body = strings.Join(lines, "\n")
+			if overflow > 0 {
+				body += fmt.Sprintf("\n_…and %d more_", overflow)
+			}
+		}
+		section(fmt.Sprintf("*%s*\n%s", lane.title, body))
+	}
+	blocks = append(blocks, slack.NewDividerBlock())
+
+	// Wiki: the curated index is already human-readable markdown.
+	header("Wiki")
+	if worker := b.WikiWorker(); worker != nil {
+		if indexMD, err := readIndexAll(worker.Repo()); err == nil {
+			section(slackHomeTrim(string(indexMD), slackHomeWikiIndexCap))
+		} else {
+			section("_wiki index unavailable_")
+		}
+	} else {
+		section("_wiki backend is not active_")
+	}
+
+	return blocks
+}
+
+// slackHomeTrim caps s at max runes-ish (byte cap is fine for display) and
+// marks the truncation.
+func slackHomeTrim(s string, max int) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return "_empty_"
+	}
+	if len(s) <= max {
+		return s
+	}
+	return s[:max] + "\n_…truncated — open the Wiki in the app for the rest_"
+}

--- a/internal/team/slack_home_test.go
+++ b/internal/team/slack_home_test.go
@@ -1,0 +1,91 @@
+package team
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/slack-go/slack/slackevents"
+	"github.com/slack-go/slack/socketmode"
+)
+
+// The App Home view shows the task board by lane, links to every web-app
+// surface, and the wiki index — the office overview inside Slack.
+func TestSlackHomeTabRendersBoardWikiAndWebSurfaces(t *testing.T) {
+	api := newFakeSlackAPI()
+	tr, b := newTestSlackTransport(t, "C0123", api)
+	b.SetWebURL("http://127.0.0.1:7905")
+	seedTask := func(id, title, status string) {
+		b.mu.Lock()
+		b.tasks = append(b.tasks, teamTask{ID: id, Title: title, Owner: "ceo", Channel: "slack-general", status: status})
+		b.mu.Unlock()
+	}
+	seedTask("OFFICE-1", "Ship the pricing facts", "in_progress")
+	seedTask("OFFICE-2", "Review the launch plan", "review")
+	seedTask("OFFICE-3", "Old win", "done")
+
+	// app_home_opened drives the publish through the normal event path.
+	evt := socketmode.Event{
+		Type: socketmode.EventTypeEventsAPI,
+		Data: slackevents.EventsAPIEvent{
+			InnerEvent: slackevents.EventsAPIInnerEvent{
+				Data: &slackevents.AppHomeOpenedEvent{User: "U777", Tab: "home"},
+			},
+		},
+	}
+	if ack := tr.handleEvent(context.Background(), &brokerTransportHost{broker: b}, evt); !ack {
+		t.Fatal("app_home_opened must be acked")
+	}
+
+	if len(api.publishedViews) != 1 {
+		t.Fatalf("expected 1 published view, got %d", len(api.publishedViews))
+	}
+	pv := api.publishedViews[0]
+	if pv.UserID != "U777" {
+		t.Fatalf("view published for %q, want U777", pv.UserID)
+	}
+	raw, err := json.Marshal(pv.View)
+	if err != nil {
+		t.Fatalf("marshal view: %v", err)
+	}
+	view := string(raw)
+
+	for _, want := range []string{
+		"WUPHF Office", "Task board", "Wiki",
+		"OFFICE-1", "Ship the pricing facts",
+		"OFFICE-2", "OFFICE-3",
+		"http://127.0.0.1:7905/tasks", "http://127.0.0.1:7905/wiki",
+		"http://127.0.0.1:7905/inbox", "http://127.0.0.1:7905/agents",
+	} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("home view missing %q\nview: %s", want, view)
+		}
+	}
+}
+
+// Without a web URL (broker booted before LaunchWeb, or headless tests) the
+// view still renders — just without app links.
+func TestSlackHomeTabWithoutWebURL(t *testing.T) {
+	api := newFakeSlackAPI()
+	tr, _ := newTestSlackTransport(t, "C0123", api)
+
+	tr.publishHomeTab(context.Background(), "U777")
+	if len(api.publishedViews) != 1 {
+		t.Fatalf("expected 1 published view, got %d", len(api.publishedViews))
+	}
+	raw, _ := json.Marshal(api.publishedViews[0].View)
+	if strings.Contains(string(raw), "Open in the app") {
+		t.Fatalf("no web links expected without a web URL, got %s", raw)
+	}
+}
+
+func TestSlackHomeTrim(t *testing.T) {
+	if got := slackHomeTrim("", 10); got != "_empty_" {
+		t.Fatalf("empty trim = %q", got)
+	}
+	long := strings.Repeat("x", 50)
+	if got := slackHomeTrim(long, 10); !strings.HasPrefix(got, "xxxxxxxxxx\n_…truncated") {
+		t.Fatalf("trim = %q", got)
+	}
+}

--- a/internal/team/slack_live_probe_test.go
+++ b/internal/team/slack_live_probe_test.go
@@ -1,0 +1,95 @@
+package team
+
+// slack_live_probe_test.go is an env-guarded LIVE integration probe: it runs the
+// real packer egress pipeline (Pack -> Deliver) through the real SlackBridge
+// against a real workspace, proving redaction + classification + audit on the
+// wire. It is skipped unless SLACK_LIVE_PROBE=1 and the Slack env vars are set,
+// so CI and normal test runs never touch the network.
+//
+//	SLACK_LIVE_PROBE=1 SLACK_BOT_TOKEN=xoxb-… SLACK_CHANNEL_ID=C… \
+//	  go test ./internal/team/ -run TestSlackLiveEgressProbe -v
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/nex-crm/wuphf/internal/packer"
+)
+
+// liveProbeBrain is a minimal in-memory BrainHandle whose plan step deliberately
+// carries a fake (but pattern-matching) API key, so the probe proves the
+// scanner redacts it before the text reaches Slack.
+type liveProbeBrain struct{}
+
+func (liveProbeBrain) PlanStep(string) (string, error) {
+	return "Reconcile the June invoices and post totals in this thread. " +
+		"Ops pasted a credential into the task: sk-proj-FAKELIVEPROBE000000000000000001 — " +
+		"the packer must redact it before egress.", nil
+}
+func (liveProbeBrain) TaskLearnings(string, int) ([]packer.BrainItem, error) { return nil, nil }
+func (liveProbeBrain) TaskWikiRefs(string) ([]packer.BrainItem, error)       { return nil, nil }
+func (liveProbeBrain) Roster(string) ([]packer.BrainItem, error)             { return nil, nil }
+
+func TestSlackLiveEgressProbe(t *testing.T) {
+	if os.Getenv("SLACK_LIVE_PROBE") != "1" {
+		t.Skip("live probe disabled (set SLACK_LIVE_PROBE=1)")
+	}
+	botToken := strings.TrimSpace(os.Getenv("SLACK_BOT_TOKEN"))
+	channelID := strings.TrimSpace(os.Getenv("SLACK_CHANNEL_ID"))
+	if botToken == "" || channelID == "" {
+		t.Skip("SLACK_BOT_TOKEN / SLACK_CHANNEL_ID not set")
+	}
+
+	req := packer.ContextRequest{
+		TaskID:        "live-probe-task",
+		TaskUpdatedAt: "live",
+		PlanID:        "live-probe-plan",
+		PlanVersion:   1,
+		Target: packer.BotProfile{
+			Version:   1,
+			Slug:      "live-probe-vendor-bot",
+			Trust:     packer.BotUntrusted,
+			ReadScope: packer.ReadMentionOnly,
+			Identity: packer.BotIdentity{
+				SlackTeamID: "live",
+				AppUserID:   "U_PROBE_TARGET",
+				InstallID:   "probe",
+			},
+		},
+		Intent:          packer.StepIntent{Text: "Reconcile June invoices and report totals.", Taint: packer.TaintClean},
+		Thread:          packer.ThreadRef{WorkspaceID: "live", ChannelID: channelID},
+		EgressPolicyVer: 1,
+		IdempotencyKey:  "live-probe-" + channelID,
+	}
+
+	packed, audit, err := packer.Pack(
+		liveProbeBrain{},
+		packer.NewDefaultEgressPolicy(1),
+		packer.EgressScanner{},
+		req,
+		packer.GatherOptions{ReturnPact: "Reply in this thread with the totals and tag @ceo."},
+		packer.DeliveryAudience{LeastTrustedPresent: packer.BotUntrusted},
+	)
+	if err != nil {
+		t.Fatalf("Pack: %v", err)
+	}
+	if strings.Contains(packed.MentionText, "sk-proj-FAKELIVEPROBE") {
+		t.Fatalf("planted key survived Pack: %s", packed.MentionText)
+	}
+
+	sink := NewPackerInjectionSink()
+	rec, err := packer.Deliver(context.Background(), NewSlackBridge(botToken), nil, packer.EgressScanner{}, sink, nil, packed, req)
+	if err != nil {
+		t.Fatalf("Deliver: %v", err)
+	}
+	if rec.Status != packer.DeliverySent || rec.MessageTS == "" {
+		t.Fatalf("delivery record = %+v, want sent with a ts", rec)
+	}
+
+	t.Logf("LIVE egress delivered: ts=%s hash=%s tokens=%d", rec.MessageTS, rec.RenderedHash[:12], rec.TokenCount)
+	for _, a := range audit {
+		t.Logf("  audit: %-12s %-10s class=%s redactions=%d", a.Kind, a.Ref, a.Class, a.Redactions)
+	}
+}

--- a/internal/team/slack_transport.go
+++ b/internal/team/slack_transport.go
@@ -1,0 +1,578 @@
+package team
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/slack-go/slack"
+	"github.com/slack-go/slack/slackevents"
+	"github.com/slack-go/slack/socketmode"
+
+	"github.com/nex-crm/wuphf/internal/team/transport"
+)
+
+// slack_transport.go bridges a Slack workspace with the office broker. It mirrors
+// the shape of telegram.go: a channel-id → office-slug map (built from the
+// broker's "slack" surface channels), a user-id → member-slug map, cached health
+// fields under a mutex, and the same transport.Transport method set.
+//
+// Inbound uses Socket Mode (no public URL required): an app-level "xapp-" token
+// opens a WebSocket; message events are routed to the office via the Host
+// contract (UpsertParticipant then ReceiveMessage). Outbound uses the Web API
+// (chat.postMessage) via the bot "xoxb-" token.
+//
+// All Web API calls go through the slackAPI seam so the transport (and the
+// SlackBridge in slack_bridge.go) are unit-testable against a fake with no
+// network. The Socket Mode event loop is kept thin and lives behind runSocketMode
+// so the routing logic (routeInbound) can be tested directly.
+
+// slackAPI is the narrow Web API surface this package depends on. The real
+// implementation wraps *slack.Client; tests supply a fake. Keeping it small
+// (the four calls actually used) follows "accept interfaces, return structs".
+type slackAPI interface {
+	// PostMessageContext posts a message and returns (channelID, messageTS, err).
+	PostMessageContext(ctx context.Context, channelID string, opts ...slack.MsgOption) (string, string, error)
+	// GetUserInfoContext resolves a Slack user id to its profile (for display
+	// name + IsBot classification).
+	GetUserInfoContext(ctx context.Context, userID string) (*slack.User, error)
+	// AuthTestContext identifies the bot's own user id so inbound self-messages
+	// can be dropped.
+	AuthTestContext(ctx context.Context) (*slack.AuthTestResponse, error)
+	// GetUsersInConversationContext lists the member ids of a channel, used to
+	// pre-warm the user → member-slug map.
+	GetUsersInConversationContext(ctx context.Context, params *slack.GetUsersInConversationParameters) ([]string, string, error)
+}
+
+// slackClient is the real slackAPI backed by *slack.Client.
+type slackClient struct {
+	api *slack.Client
+}
+
+func (c *slackClient) PostMessageContext(ctx context.Context, channelID string, opts ...slack.MsgOption) (string, string, error) {
+	return c.api.PostMessageContext(ctx, channelID, opts...)
+}
+
+func (c *slackClient) GetUserInfoContext(ctx context.Context, userID string) (*slack.User, error) {
+	return c.api.GetUserInfoContext(ctx, userID)
+}
+
+func (c *slackClient) AuthTestContext(ctx context.Context) (*slack.AuthTestResponse, error) {
+	return c.api.AuthTestContext(ctx)
+}
+
+func (c *slackClient) GetUsersInConversationContext(ctx context.Context, params *slack.GetUsersInConversationParameters) ([]string, string, error) {
+	return c.api.GetUsersInConversationContext(ctx, params)
+}
+
+// socketRunner is the inbound seam: it blocks reading Socket Mode events and
+// hands each to handle until ctx is cancelled. The real implementation wraps
+// *socketmode.Client; tests drive routeInbound directly and do not need a fake
+// socket connection.
+type socketRunner interface {
+	Run(ctx context.Context, handle func(socketmode.Event)) error
+}
+
+// socketModeRunner is the real socketRunner over *socketmode.Client.
+type socketModeRunner struct {
+	client *socketmode.Client
+}
+
+// Run starts the Socket Mode WebSocket loop in a sibling goroutine, drains the
+// Events channel and dispatches each event to handle, and blocks until ctx is
+// cancelled or RunContext returns. RunContext owns reconnection internally; a
+// returned error means the connection gave up and the caller (Run) should
+// surface it for supervised restart.
+func (r *socketModeRunner) Run(ctx context.Context, handle func(socketmode.Event)) error {
+	errCh := make(chan error, 1)
+	go func() { errCh <- r.client.RunContext(ctx) }()
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case err := <-errCh:
+			return err
+		case evt, ok := <-r.client.Events:
+			if !ok {
+				// Events closed: wait for RunContext to report why.
+				select {
+				case <-ctx.Done():
+					return ctx.Err()
+				case err := <-errCh:
+					return err
+				}
+			}
+			// Ack request-bearing events before processing so Slack does not
+			// redeliver while the office write is in flight.
+			if evt.Request != nil {
+				_ = r.client.Ack(*evt.Request)
+			}
+			handle(evt)
+		}
+	}
+}
+
+// compile-time assertion: SlackTransport must satisfy transport.Transport.
+var _ transport.Transport = (*SlackTransport)(nil)
+
+// SlackTransport bridges Slack channels with the office broker. Each mapped
+// Slack channel corresponds to an office channel with a "slack" surface.
+type SlackTransport struct {
+	BotToken string
+	AppToken string
+	Broker   *Broker
+	// ChannelMap maps slack channel id (e.g. "C0123") -> office channel slug.
+	ChannelMap map[string]string
+	// UserMap maps slack user id (e.g. "U0123") -> office member slug. Populated
+	// lazily from users.info on first contact and eagerly from conversation
+	// membership at startup. Misses fall back to the user's display name.
+	UserMap map[string]string
+
+	api    slackAPI
+	socket socketRunner
+
+	// botUserID is this bot's own Slack user id, resolved via auth.test at the
+	// start of Run. Inbound messages from this id are dropped (no echo loops).
+	botUserID string
+
+	// mapsMu protects ChannelMap and UserMap against concurrent reads from Send /
+	// FormatOutbound and writes from routeInbound (learning new users).
+	mapsMu sync.RWMutex
+
+	// health fields — written by the inbound loop, read by Health(). Protected by mu.
+	mu            sync.Mutex
+	healthState   transport.HealthState
+	lastSuccessAt time.Time
+	lastErr       error
+}
+
+// NewSlackTransport creates a transport from the broker's "slack" surface
+// channels, wiring the real Web API and Socket Mode clients from the configured
+// tokens. The app token enables the Socket Mode inbound half; the bot token
+// drives the Web API outbound half.
+func NewSlackTransport(broker *Broker, botToken, appToken string) *SlackTransport {
+	api := slack.New(botToken, slack.OptionAppLevelToken(appToken))
+	t := newSlackTransport(broker, botToken, appToken, &slackClient{api: api})
+	if appToken != "" {
+		t.socket = &socketModeRunner{client: socketmode.New(api)}
+	}
+	return t
+}
+
+// newSlackTransport is the injectable constructor used by tests: it builds the
+// channel map from the broker's surface channels and accepts a fake slackAPI.
+// The socket runner is left nil (tests exercise routeInbound directly).
+func newSlackTransport(broker *Broker, botToken, appToken string, api slackAPI) *SlackTransport {
+	channelMap := make(map[string]string)
+	if broker != nil {
+		for _, ch := range broker.SurfaceChannels("slack") {
+			if ch.Surface == nil || ch.Surface.RemoteID == "" {
+				continue
+			}
+			channelMap[ch.Surface.RemoteID] = ch.Slug
+		}
+	}
+	return &SlackTransport{
+		BotToken:    botToken,
+		AppToken:    appToken,
+		Broker:      broker,
+		ChannelMap:  channelMap,
+		UserMap:     make(map[string]string),
+		api:         api,
+		healthState: transport.HealthDisconnected,
+	}
+}
+
+// Name returns "slack" — the stable adapter name used as AdapterName in every
+// Participant value this transport creates.
+func (t *SlackTransport) Name() string { return "slack" }
+
+// Binding returns an empty binding because a single SlackTransport instance
+// covers multiple channels via ChannelMap. The per-message channel is carried in
+// each transport.Message.Binding constructed by routeInbound.
+func (t *SlackTransport) Binding() transport.Binding {
+	return transport.Binding{}
+}
+
+// Health returns a point-in-time snapshot of adapter connectivity. O(1): reads
+// cached fields updated by the inbound loop.
+func (t *SlackTransport) Health() transport.Health {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return transport.Health{
+		State:         t.healthState,
+		LastSuccessAt: t.lastSuccessAt,
+		LastError:     t.lastErr,
+	}
+}
+
+// Run starts the bidirectional bridge and blocks until ctx is cancelled.
+// Inbound Slack events are delivered to the office via host; outbound delivery
+// is driven by the Host-side dispatcher started alongside this Run in
+// launcher_transports.go (which calls FormatOutbound + Send). Implements
+// transport.Transport.
+func (t *SlackTransport) Run(ctx context.Context, host transport.Host) error {
+	if t.BotToken == "" {
+		return fmt.Errorf("slack bot token is empty")
+	}
+	if t.AppToken == "" {
+		return fmt.Errorf("slack app token is empty (Socket Mode requires an xapp- token)")
+	}
+	if t.socket == nil {
+		return fmt.Errorf("slack: socket runner not configured")
+	}
+	if len(t.ChannelMap) == 0 {
+		return fmt.Errorf("no slack channels configured")
+	}
+
+	// Resolve our own bot user id so we can drop self-authored messages.
+	if auth, err := t.api.AuthTestContext(ctx); err == nil && auth != nil {
+		t.botUserID = auth.UserID
+	} else if err != nil {
+		log.Printf("[slack] auth.test failed (self-echo guard disabled): %v", err)
+	}
+
+	// Pre-warm the user map from each mapped channel's membership. Best-effort:
+	// a failure here only means names resolve lazily on first message.
+	t.warmUserMap(ctx)
+
+	t.setHealth(transport.HealthConnected, nil)
+
+	// Run the Socket Mode loop in a sibling goroutine and select on ctx so a
+	// context cancellation returns nil (intentional shutdown — the Host must not
+	// reconnect) while a genuine connection failure surfaces for supervised
+	// restart. This mirrors telegram.go's Run/select shape.
+	ctx2, cancel := context.WithCancel(ctx)
+	defer cancel()
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- t.socket.Run(ctx2, func(evt socketmode.Event) {
+			t.handleEvent(ctx2, host, evt)
+		})
+	}()
+
+	select {
+	case <-ctx.Done():
+		return nil
+	case err := <-errCh:
+		cancel()
+		if ctx.Err() != nil || errors.Is(err, context.Canceled) {
+			return nil
+		}
+		return err
+	}
+}
+
+// Start is a compatibility shim for callers that predate the transport.Transport
+// contract. It creates a brokerTransportHost and delegates to Run.
+func (t *SlackTransport) Start(ctx context.Context) error {
+	host := &brokerTransportHost{broker: t.Broker}
+	return t.Run(ctx, host)
+}
+
+// handleEvent dispatches one Socket Mode event. Only EventsAPI message events are
+// routed inbound; connection lifecycle events update health. Everything else is
+// ignored.
+func (t *SlackTransport) handleEvent(ctx context.Context, host transport.Host, evt socketmode.Event) {
+	switch evt.Type {
+	case socketmode.EventTypeConnected, socketmode.EventTypeHello:
+		t.setHealth(transport.HealthConnected, nil)
+	case socketmode.EventTypeConnectionError, socketmode.EventTypeInvalidAuth, socketmode.EventTypeIncomingError:
+		t.setHealth(transport.HealthDegraded, fmt.Errorf("slack socket event: %s", evt.Type))
+	case socketmode.EventTypeEventsAPI:
+		apiEvent, ok := evt.Data.(slackevents.EventsAPIEvent)
+		if !ok {
+			return
+		}
+		msg, ok := apiEvent.InnerEvent.Data.(*slackevents.MessageEvent)
+		if !ok {
+			return
+		}
+		if err := t.routeInbound(ctx, host, msg); err != nil {
+			t.setHealth(transport.HealthDegraded, err)
+			log.Printf("[slack] route inbound error: %v", err)
+		}
+	}
+}
+
+// routeInbound resolves the office channel for a Slack message event and delivers
+// it to the office via host.UpsertParticipant + host.ReceiveMessage. Bot-authored
+// messages, the bot's own messages, subtyped events (edits/joins/etc.), and
+// messages on unmapped channels are skipped. Returns a non-nil error only on a
+// Host contract failure (e.g. ErrBindingChannelMissing), matching telegram's
+// routeInbound so the caller can surface it for supervised restart.
+func (t *SlackTransport) routeInbound(ctx context.Context, host transport.Host, msg *slackevents.MessageEvent) error {
+	if msg == nil {
+		return nil
+	}
+	// Skip non-plain messages: edits, deletes, joins, and bot_message subtypes
+	// all carry a SubType. Only a subtype-less message is a fresh human/agent post.
+	if msg.SubType != "" {
+		return nil
+	}
+	// Drop bot-authored messages (BotID set) and our own user id to avoid echo
+	// loops with the office's own outbound posts.
+	if msg.BotID != "" {
+		return nil
+	}
+	if msg.User == "" || (t.botUserID != "" && msg.User == t.botUserID) {
+		return nil
+	}
+	if strings.TrimSpace(msg.Text) == "" {
+		return nil
+	}
+
+	t.mapsMu.RLock()
+	channel, ok := t.ChannelMap[msg.Channel]
+	t.mapsMu.RUnlock()
+	if !ok {
+		log.Printf("[slack] inbound: unmapped channel %s", msg.Channel)
+		return nil
+	}
+
+	fromName, human := t.resolveUser(ctx, msg.User)
+
+	p := transport.Participant{
+		AdapterName: "slack",
+		Key:         msg.User,
+		DisplayName: fromName,
+		Human:       human,
+	}
+	b := transport.Binding{
+		Scope:       transport.ScopeChannel,
+		ChannelSlug: channel,
+	}
+
+	if err := host.UpsertParticipant(ctx, p, b); err != nil {
+		return fmt.Errorf("slack upsert participant: %w", err)
+	}
+	if err := host.ReceiveMessage(ctx, transport.Message{
+		Participant: p,
+		Binding:     b,
+		Text:        msg.Text,
+		ExternalID:  msg.TimeStamp,
+		ThreadKey:   msg.ThreadTimeStamp,
+	}); err != nil {
+		return fmt.Errorf("slack receive message: %w", err)
+	}
+	t.setHealth(transport.HealthConnected, nil)
+	return nil
+}
+
+// Send delivers one outbound message to the Slack channel mapped to
+// msg.Binding.ChannelSlug via chat.postMessage. Returns an error if no channel is
+// mapped for that slug or if the Slack API call fails. Implements
+// transport.Transport. A ThreadKey, when present, threads the reply.
+func (t *SlackTransport) Send(ctx context.Context, msg transport.Outbound) error {
+	channelID := t.channelIDForSlug(msg.Binding.ChannelSlug)
+	if channelID == "" {
+		return fmt.Errorf("slack: no channel mapped for %q", msg.Binding.ChannelSlug)
+	}
+	opts := []slack.MsgOption{slack.MsgOptionText(msg.Text, false)}
+	if msg.ThreadKey != "" {
+		opts = append(opts, slack.MsgOptionTS(msg.ThreadKey))
+	}
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	if _, _, err := t.api.PostMessageContext(ctx, channelID, opts...); err != nil {
+		return fmt.Errorf("slack send: %w", err)
+	}
+	return nil
+}
+
+// FormatOutbound converts a broker channelMessage to a transport.Outbound for the
+// per-transport dispatcher. Returns ok=false when no Slack channel is mapped for
+// the message's channel slug — a missing mapping is a routine skip, not a send
+// failure. Pure mapping: no side effects (the API call happens in Send).
+func (t *SlackTransport) FormatOutbound(msg channelMessage) (transport.Outbound, bool) {
+	ch := normalizeChannelSlug(msg.Channel)
+	if t.channelIDForSlug(ch) == "" {
+		log.Printf("[slack] outbound skip: no channel for %q", ch)
+		return transport.Outbound{}, false
+	}
+	return transport.Outbound{
+		Binding: transport.Binding{Scope: transport.ScopeChannel, ChannelSlug: ch},
+		Text:    formatSlackOutbound(msg),
+	}, true
+}
+
+// channelIDForSlug returns the Slack channel id for the given office channel
+// slug, or "" if no mapping exists.
+func (t *SlackTransport) channelIDForSlug(slug string) string {
+	t.mapsMu.RLock()
+	defer t.mapsMu.RUnlock()
+	for channelID, s := range t.ChannelMap {
+		if s == slug {
+			return channelID
+		}
+	}
+	return ""
+}
+
+// resolveUser maps a Slack user id to an office member slug (or display name
+// fallback) and reports whether the user is a human. The result is cached in
+// UserMap so repeat senders skip the users.info round-trip. A lookup failure
+// falls back to the raw user id and treats the sender as human.
+func (t *SlackTransport) resolveUser(ctx context.Context, userID string) (name string, human bool) {
+	if userID == "" {
+		return "unknown", true
+	}
+
+	t.mapsMu.RLock()
+	cached, ok := t.UserMap[userID]
+	t.mapsMu.RUnlock()
+	if ok {
+		// Cached slug never re-classifies humanity; a cached entry is advisory
+		// display data. Bots are dropped at routeInbound via BotID, so a cached
+		// hit here is, in practice, a human or a deliberately mapped member.
+		return cached, true
+	}
+
+	if t.api == nil {
+		return userID, true
+	}
+	user, err := t.api.GetUserInfoContext(ctx, userID)
+	if err != nil || user == nil {
+		return userID, true
+	}
+	name = slackDisplayName(user)
+	t.mapsMu.Lock()
+	t.UserMap[userID] = name
+	t.mapsMu.Unlock()
+	return name, !user.IsBot
+}
+
+// warmUserMap pre-populates UserMap from the membership of every mapped channel.
+// Best-effort: per-channel and per-user failures are logged and skipped so a
+// single bad lookup never blocks startup.
+func (t *SlackTransport) warmUserMap(ctx context.Context) {
+	t.mapsMu.RLock()
+	channelIDs := make([]string, 0, len(t.ChannelMap))
+	for channelID := range t.ChannelMap {
+		channelIDs = append(channelIDs, channelID)
+	}
+	t.mapsMu.RUnlock()
+
+	for _, channelID := range channelIDs {
+		members, _, err := t.api.GetUsersInConversationContext(ctx, &slack.GetUsersInConversationParameters{
+			ChannelID: channelID,
+			Limit:     200,
+		})
+		if err != nil {
+			log.Printf("[slack] warm user map: channel %s: %v", channelID, err)
+			continue
+		}
+		for _, userID := range members {
+			if userID == "" || userID == t.botUserID {
+				continue
+			}
+			t.mapsMu.RLock()
+			_, known := t.UserMap[userID]
+			t.mapsMu.RUnlock()
+			if known {
+				continue
+			}
+			// resolveUser caches under mapsMu; ignore the result here.
+			_, _ = t.resolveUser(ctx, userID)
+		}
+	}
+}
+
+// setHealth updates the cached health snapshot. On a connected state it stamps
+// LastSuccessAt and clears the error; on a degraded/disconnected state it records
+// the error and leaves LastSuccessAt untouched.
+func (t *SlackTransport) setHealth(state transport.HealthState, err error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.healthState = state
+	if state == transport.HealthConnected {
+		t.lastSuccessAt = time.Now()
+		t.lastErr = nil
+		return
+	}
+	if err != nil {
+		t.lastErr = err
+	}
+}
+
+// slackDisplayName picks the friendliest non-empty name for a Slack user.
+func slackDisplayName(user *slack.User) string {
+	if user == nil {
+		return "unknown"
+	}
+	for _, candidate := range []string{
+		strings.TrimSpace(user.Profile.DisplayName),
+		strings.TrimSpace(user.RealName),
+		strings.TrimSpace(user.Profile.RealName),
+		strings.TrimSpace(user.Name),
+	} {
+		if candidate != "" {
+			return candidate
+		}
+	}
+	if user.ID != "" {
+		return user.ID
+	}
+	return "unknown"
+}
+
+// formatSlackOutbound renders a broker message as Slack mrkdwn. It mirrors the
+// kind taxonomy of formatTelegramOutbound but emits Slack-flavored markup
+// (*bold* / _italic_) instead of Telegram HTML.
+func formatSlackOutbound(msg channelMessage) string {
+	switch {
+	case msg.Kind == "skill_invocation":
+		return fmt.Sprintf("⚡ *@%s* invoked a skill", msg.From)
+	case msg.Kind == "skill_proposal":
+		return fmt.Sprintf("💡 *Skill proposed*: %s", msg.Content)
+	case msg.Kind == "automation":
+		source := msg.Source
+		if msg.SourceLabel != "" {
+			source = msg.SourceLabel
+		}
+		if source == "" {
+			source = "automation"
+		}
+		return fmt.Sprintf("🤖 *[%s]*: %s", source, msg.Content)
+	case isHumanDecisionKind(msg.Kind):
+		return formatSlackDecision(msg)
+	case msg.From == "system":
+		return fmt.Sprintf("→ _%s_", msg.Content)
+	default:
+		var sb strings.Builder
+		if msg.From != "" {
+			sb.WriteString("*@")
+			sb.WriteString(msg.From)
+			sb.WriteString("*: ")
+		}
+		if msg.Title != "" {
+			sb.WriteString("[")
+			sb.WriteString(msg.Title)
+			sb.WriteString("] ")
+		}
+		sb.WriteString(msg.Content)
+		return sb.String()
+	}
+}
+
+// formatSlackDecision renders a human decision/interview message as Slack mrkdwn.
+func formatSlackDecision(msg channelMessage) string {
+	var sb strings.Builder
+	sb.WriteString("📋 *Decision needed*")
+	if msg.From != "" {
+		sb.WriteString(" from @")
+		sb.WriteString(msg.From)
+	}
+	sb.WriteString("\n\n")
+	sb.WriteString(msg.Content)
+	if msg.Title != "" {
+		sb.WriteString("\n\n_")
+		sb.WriteString(msg.Title)
+		sb.WriteString("_")
+	}
+	return sb.String()
+}

--- a/internal/team/slack_transport.go
+++ b/internal/team/slack_transport.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/slack-go/slack"
 	"github.com/slack-go/slack/slackevents"
+	"github.com/slack-go/slack/slackutilsx"
 	"github.com/slack-go/slack/socketmode"
 
 	"github.com/nex-crm/wuphf/internal/team/transport"
@@ -48,6 +49,12 @@ type slackAPI interface {
 	GetUsersInConversationContext(ctx context.Context, params *slack.GetUsersInConversationParameters) ([]string, string, error)
 }
 
+// slackUserInfo is the cached resolution of a Slack user id.
+type slackUserInfo struct {
+	name  string
+	human bool
+}
+
 // slackClient is the real slackAPI backed by *slack.Client.
 type slackClient struct {
 	api *slack.Client
@@ -70,11 +77,13 @@ func (c *slackClient) GetUsersInConversationContext(ctx context.Context, params 
 }
 
 // socketRunner is the inbound seam: it blocks reading Socket Mode events and
-// hands each to handle until ctx is cancelled. The real implementation wraps
-// *socketmode.Client; tests drive routeInbound directly and do not need a fake
-// socket connection.
+// hands each to handle until ctx is cancelled. handle returns whether the event
+// should be Ack'd; returning false (a Host write failed) leaves the event
+// un-Ack'd so Slack redelivers it. The real implementation wraps
+// *socketmode.Client; tests drive routeInbound/handleEvent directly and do not
+// need a fake socket connection.
 type socketRunner interface {
-	Run(ctx context.Context, handle func(socketmode.Event)) error
+	Run(ctx context.Context, handle func(socketmode.Event) bool) error
 }
 
 // socketModeRunner is the real socketRunner over *socketmode.Client.
@@ -87,7 +96,7 @@ type socketModeRunner struct {
 // cancelled or RunContext returns. RunContext owns reconnection internally; a
 // returned error means the connection gave up and the caller (Run) should
 // surface it for supervised restart.
-func (r *socketModeRunner) Run(ctx context.Context, handle func(socketmode.Event)) error {
+func (r *socketModeRunner) Run(ctx context.Context, handle func(socketmode.Event) bool) error {
 	errCh := make(chan error, 1)
 	go func() { errCh <- r.client.RunContext(ctx) }()
 	for {
@@ -106,12 +115,14 @@ func (r *socketModeRunner) Run(ctx context.Context, handle func(socketmode.Event
 					return err
 				}
 			}
-			// Ack request-bearing events before processing so Slack does not
-			// redeliver while the office write is in flight.
-			if evt.Request != nil {
+			// Ack AFTER handling and only when handle reports success. A failed
+			// Host write returns false → no Ack → Slack redelivers (the broker
+			// dedupes by ExternalID = the message ts). This makes inbound
+			// at-least-once instead of silently at-most-once.
+			ack := handle(evt)
+			if evt.Request != nil && ack {
 				_ = r.client.Ack(*evt.Request)
 			}
-			handle(evt)
 		}
 	}
 }
@@ -127,10 +138,12 @@ type SlackTransport struct {
 	Broker   *Broker
 	// ChannelMap maps slack channel id (e.g. "C0123") -> office channel slug.
 	ChannelMap map[string]string
-	// UserMap maps slack user id (e.g. "U0123") -> office member slug. Populated
-	// lazily from users.info on first contact and eagerly from conversation
-	// membership at startup. Misses fall back to the user's display name.
-	UserMap map[string]string
+	// UserMap maps slack user id (e.g. "U0123") -> resolved identity (display
+	// name + humanity). Populated lazily from users.info on first contact and
+	// eagerly from conversation membership at startup. Misses fall back to the
+	// raw user id. Caching humanity (not just the name) means a warmed bot/app
+	// user stays classified non-human even if a later message lacks bot_id.
+	UserMap map[string]slackUserInfo
 
 	api    slackAPI
 	socket socketRunner
@@ -181,7 +194,7 @@ func newSlackTransport(broker *Broker, botToken, appToken string, api slackAPI) 
 		AppToken:    appToken,
 		Broker:      broker,
 		ChannelMap:  channelMap,
-		UserMap:     make(map[string]string),
+		UserMap:     make(map[string]slackUserInfo),
 		api:         api,
 		healthState: transport.HealthDisconnected,
 	}
@@ -229,11 +242,13 @@ func (t *SlackTransport) Run(ctx context.Context, host transport.Host) error {
 		return fmt.Errorf("no slack channels configured")
 	}
 
-	// Resolve our own bot user id so we can drop self-authored messages.
-	if auth, err := t.api.AuthTestContext(ctx); err == nil && auth != nil {
-		t.botUserID = auth.UserID
-	} else if err != nil {
-		log.Printf("[slack] auth.test failed (self-echo guard disabled): %v", err)
+	// Resolve our own bot user id (with a short retry) so we can drop
+	// self-authored messages. If it never resolves we still start: the bot_id /
+	// subtype guards in routeInbound are the primary self/bot drop, and this id
+	// is a belt-and-suspenders third check.
+	t.botUserID = t.resolveBotUserID(ctx)
+	if t.botUserID == "" {
+		log.Printf("[slack] auth.test failed after retries — self-echo guard relies on bot_id/subtype only")
 	}
 
 	// Pre-warm the user map from each mapped channel's membership. Best-effort:
@@ -250,13 +265,22 @@ func (t *SlackTransport) Run(ctx context.Context, host transport.Host) error {
 	defer cancel()
 	errCh := make(chan error, 1)
 	go func() {
-		errCh <- t.socket.Run(ctx2, func(evt socketmode.Event) {
-			t.handleEvent(ctx2, host, evt)
+		errCh <- t.socket.Run(ctx2, func(evt socketmode.Event) bool {
+			return t.handleEvent(ctx2, host, evt)
 		})
 	}()
 
 	select {
 	case <-ctx.Done():
+		// Stop the socket loop and wait (bounded) for it to actually return, so
+		// the Host is not used after Run returns and the launcher proceeds with
+		// shutdown.
+		cancel()
+		select {
+		case <-errCh:
+		case <-time.After(5 * time.Second):
+			log.Printf("[slack] socket loop did not stop within 5s of cancellation")
+		}
 		return nil
 	case err := <-errCh:
 		cancel()
@@ -267,6 +291,22 @@ func (t *SlackTransport) Run(ctx context.Context, host transport.Host) error {
 	}
 }
 
+// resolveBotUserID calls auth.test with a short bounded retry, returning the
+// bot's own Slack user id or "" if it never resolves.
+func (t *SlackTransport) resolveBotUserID(ctx context.Context) string {
+	for attempt := 0; attempt < 3; attempt++ {
+		if auth, err := t.api.AuthTestContext(ctx); err == nil && auth != nil && auth.UserID != "" {
+			return auth.UserID
+		}
+		select {
+		case <-ctx.Done():
+			return ""
+		case <-time.After(time.Duration(attempt+1) * 200 * time.Millisecond):
+		}
+	}
+	return ""
+}
+
 // Start is a compatibility shim for callers that predate the transport.Transport
 // contract. It creates a brokerTransportHost and delegates to Run.
 func (t *SlackTransport) Start(ctx context.Context) error {
@@ -274,10 +314,13 @@ func (t *SlackTransport) Start(ctx context.Context) error {
 	return t.Run(ctx, host)
 }
 
-// handleEvent dispatches one Socket Mode event. Only EventsAPI message events are
-// routed inbound; connection lifecycle events update health. Everything else is
-// ignored.
-func (t *SlackTransport) handleEvent(ctx context.Context, host transport.Host, evt socketmode.Event) {
+// handleEvent dispatches one Socket Mode event and reports whether it should be
+// Ack'd. Only EventsAPI message events are routed inbound; connection lifecycle
+// events update health. It returns false ONLY when a routable message failed to
+// reach the Host (a transient broker error) so the event is left un-Ack'd and
+// Slack redelivers it; everything else (handled, ignored, or non-routable) is
+// Ack'd.
+func (t *SlackTransport) handleEvent(ctx context.Context, host transport.Host, evt socketmode.Event) bool {
 	switch evt.Type {
 	case socketmode.EventTypeConnected, socketmode.EventTypeHello:
 		t.setHealth(transport.HealthConnected, nil)
@@ -286,17 +329,19 @@ func (t *SlackTransport) handleEvent(ctx context.Context, host transport.Host, e
 	case socketmode.EventTypeEventsAPI:
 		apiEvent, ok := evt.Data.(slackevents.EventsAPIEvent)
 		if !ok {
-			return
+			return true
 		}
 		msg, ok := apiEvent.InnerEvent.Data.(*slackevents.MessageEvent)
 		if !ok {
-			return
+			return true
 		}
 		if err := t.routeInbound(ctx, host, msg); err != nil {
 			t.setHealth(transport.HealthDegraded, err)
-			log.Printf("[slack] route inbound error: %v", err)
+			log.Printf("[slack] route inbound error (leaving un-acked for redelivery): %v", err)
+			return false
 		}
 	}
+	return true
 }
 
 // routeInbound resolves the office channel for a Slack message event and delivers
@@ -426,10 +471,7 @@ func (t *SlackTransport) resolveUser(ctx context.Context, userID string) (name s
 	cached, ok := t.UserMap[userID]
 	t.mapsMu.RUnlock()
 	if ok {
-		// Cached slug never re-classifies humanity; a cached entry is advisory
-		// display data. Bots are dropped at routeInbound via BotID, so a cached
-		// hit here is, in practice, a human or a deliberately mapped member.
-		return cached, true
+		return cached.name, cached.human
 	}
 
 	if t.api == nil {
@@ -439,11 +481,11 @@ func (t *SlackTransport) resolveUser(ctx context.Context, userID string) (name s
 	if err != nil || user == nil {
 		return userID, true
 	}
-	name = slackDisplayName(user)
+	info := slackUserInfo{name: slackDisplayName(user), human: !user.IsBot}
 	t.mapsMu.Lock()
-	t.UserMap[userID] = name
+	t.UserMap[userID] = info
 	t.mapsMu.Unlock()
-	return name, !user.IsBot
+	return info.name, info.human
 }
 
 // warmUserMap pre-populates UserMap from the membership of every mapped channel.
@@ -523,12 +565,23 @@ func slackDisplayName(user *slack.User) string {
 // formatSlackOutbound renders a broker message as Slack mrkdwn. It mirrors the
 // kind taxonomy of formatTelegramOutbound but emits Slack-flavored markup
 // (*bold* / _italic_) instead of Telegram HTML.
+//
+// Every DYNAMIC field (From, Title, Content, SourceLabel) is run through
+// slackEscape before composition, so a broker message that carries hostile text
+// cannot inject Slack control sequences (<!channel>/<!here> mass-pings, <@U…>
+// pings, or fake <url|label> links). The structural markup this function adds
+// (*, _, [, ]) is intentionally left literal so it still renders. Posts then use
+// escapeText=false (in Send) because escaping already happened here at field
+// granularity.
 func formatSlackOutbound(msg channelMessage) string {
+	from := slackEscape(msg.From)
+	content := slackEscape(msg.Content)
+	title := slackEscape(msg.Title)
 	switch {
 	case msg.Kind == "skill_invocation":
-		return fmt.Sprintf("⚡ *@%s* invoked a skill", msg.From)
+		return fmt.Sprintf("⚡ *@%s* invoked a skill", from)
 	case msg.Kind == "skill_proposal":
-		return fmt.Sprintf("💡 *Skill proposed*: %s", msg.Content)
+		return fmt.Sprintf("💡 *Skill proposed*: %s", content)
 	case msg.Kind == "automation":
 		source := msg.Source
 		if msg.SourceLabel != "" {
@@ -537,42 +590,50 @@ func formatSlackOutbound(msg channelMessage) string {
 		if source == "" {
 			source = "automation"
 		}
-		return fmt.Sprintf("🤖 *[%s]*: %s", source, msg.Content)
+		return fmt.Sprintf("🤖 *[%s]*: %s", slackEscape(source), content)
 	case isHumanDecisionKind(msg.Kind):
 		return formatSlackDecision(msg)
 	case msg.From == "system":
-		return fmt.Sprintf("→ _%s_", msg.Content)
+		return fmt.Sprintf("→ _%s_", content)
 	default:
 		var sb strings.Builder
-		if msg.From != "" {
+		if from != "" {
 			sb.WriteString("*@")
-			sb.WriteString(msg.From)
+			sb.WriteString(from)
 			sb.WriteString("*: ")
 		}
-		if msg.Title != "" {
+		if title != "" {
 			sb.WriteString("[")
-			sb.WriteString(msg.Title)
+			sb.WriteString(title)
 			sb.WriteString("] ")
 		}
-		sb.WriteString(msg.Content)
+		sb.WriteString(content)
 		return sb.String()
 	}
 }
 
 // formatSlackDecision renders a human decision/interview message as Slack mrkdwn.
+// Dynamic fields are escaped (see formatSlackOutbound).
 func formatSlackDecision(msg channelMessage) string {
 	var sb strings.Builder
 	sb.WriteString("📋 *Decision needed*")
 	if msg.From != "" {
 		sb.WriteString(" from @")
-		sb.WriteString(msg.From)
+		sb.WriteString(slackEscape(msg.From))
 	}
 	sb.WriteString("\n\n")
-	sb.WriteString(msg.Content)
+	sb.WriteString(slackEscape(msg.Content))
 	if msg.Title != "" {
 		sb.WriteString("\n\n_")
-		sb.WriteString(msg.Title)
+		sb.WriteString(slackEscape(msg.Title))
 		sb.WriteString("_")
 	}
 	return sb.String()
+}
+
+// slackEscape neutralizes Slack control characters (& < >) in a dynamic field so
+// composed mrkdwn cannot smuggle pings or fake links. Wraps slack-go's canonical
+// EscapeMessage.
+func slackEscape(s string) string {
+	return slackutilsx.EscapeMessage(s)
 }

--- a/internal/team/slack_transport.go
+++ b/internal/team/slack_transport.go
@@ -91,6 +91,21 @@ type socketModeRunner struct {
 	client *socketmode.Client
 }
 
+// socketEventNeedsAck reports whether a Socket Mode envelope expects an Ack.
+// Only the request-bearing payload types do; connection-lifecycle events
+// (connecting/connected/hello/disconnect/incoming_error) must NOT be Acked —
+// acking them makes Slack drop the connection.
+func socketEventNeedsAck(t socketmode.EventType) bool {
+	switch t {
+	case socketmode.EventTypeEventsAPI,
+		socketmode.EventTypeInteractive,
+		socketmode.EventTypeSlashCommand:
+		return true
+	default:
+		return false
+	}
+}
+
 // Run starts the Socket Mode WebSocket loop in a sibling goroutine, drains the
 // Events channel and dispatches each event to handle, and blocks until ctx is
 // cancelled or RunContext returns. RunContext owns reconnection internally; a
@@ -119,8 +134,13 @@ func (r *socketModeRunner) Run(ctx context.Context, handle func(socketmode.Event
 			// Host write returns false → no Ack → Slack redelivers (the broker
 			// dedupes by ExternalID = the message ts). This makes inbound
 			// at-least-once instead of silently at-most-once.
+			//
+			// Only Ack the envelope types Slack expects an ack for (events_api,
+			// interactive, slash_command). Acking a connection-lifecycle envelope
+			// like "hello" makes Slack drop the connection — that caused a ~10s
+			// reconnect loop where no event ever landed.
 			ack := handle(evt)
-			if evt.Request != nil && ack {
+			if evt.Request != nil && ack && socketEventNeedsAck(evt.Type) {
 				_ = r.client.Ack(*evt.Request)
 			}
 		}

--- a/internal/team/slack_transport.go
+++ b/internal/team/slack_transport.go
@@ -106,6 +106,15 @@ func socketEventNeedsAck(t socketmode.EventType) bool {
 	}
 }
 
+// shouldAckEvent is the full Ack decision the socket loop makes for one event:
+// Ack only when the event carries a request envelope, the handler reports it was
+// handled, AND the type is one Slack expects an Ack for. Extracted as a pure
+// function so the loop's Ack behavior is testable without a live WebSocket — the
+// gap that let a "hello" Ack (which drops the connection) ship undetected.
+func shouldAckEvent(evt socketmode.Event, handled bool) bool {
+	return evt.Request != nil && handled && socketEventNeedsAck(evt.Type)
+}
+
 // Run starts the Socket Mode WebSocket loop in a sibling goroutine, drains the
 // Events channel and dispatches each event to handle, and blocks until ctx is
 // cancelled or RunContext returns. RunContext owns reconnection internally; a
@@ -139,8 +148,7 @@ func (r *socketModeRunner) Run(ctx context.Context, handle func(socketmode.Event
 			// interactive, slash_command). Acking a connection-lifecycle envelope
 			// like "hello" makes Slack drop the connection — that caused a ~10s
 			// reconnect loop where no event ever landed.
-			ack := handle(evt)
-			if evt.Request != nil && ack && socketEventNeedsAck(evt.Type) {
+			if shouldAckEvent(evt, handle(evt)) {
 				_ = r.client.Ack(*evt.Request)
 			}
 		}

--- a/internal/team/slack_transport.go
+++ b/internal/team/slack_transport.go
@@ -47,6 +47,9 @@ type slackAPI interface {
 	// GetUsersInConversationContext lists the member ids of a channel, used to
 	// pre-warm the user → member-slug map.
 	GetUsersInConversationContext(ctx context.Context, params *slack.GetUsersInConversationParameters) ([]string, string, error)
+	// PublishViewContext publishes a user's App Home tab view (views.publish),
+	// used to render the office overview when the Home tab is opened.
+	PublishViewContext(ctx context.Context, userID string, view slack.HomeTabViewRequest) error
 }
 
 // slackUserInfo is the cached resolution of a Slack user id.
@@ -74,6 +77,11 @@ func (c *slackClient) AuthTestContext(ctx context.Context) (*slack.AuthTestRespo
 
 func (c *slackClient) GetUsersInConversationContext(ctx context.Context, params *slack.GetUsersInConversationParameters) ([]string, string, error) {
 	return c.api.GetUsersInConversationContext(ctx, params)
+}
+
+func (c *slackClient) PublishViewContext(ctx context.Context, userID string, view slack.HomeTabViewRequest) error {
+	_, err := c.api.PublishViewContext(ctx, slack.PublishViewContextRequest{UserID: userID, View: view})
+	return err
 }
 
 // socketRunner is the inbound seam: it blocks reading Socket Mode events and
@@ -359,6 +367,11 @@ func (t *SlackTransport) handleEvent(ctx context.Context, host transport.Host, e
 		if !ok {
 			return true
 		}
+		if home, isHome := apiEvent.InnerEvent.Data.(*slackevents.AppHomeOpenedEvent); isHome {
+			// Best-effort render of the office overview; always Ack'd.
+			t.publishHomeTab(ctx, home.User)
+			return true
+		}
 		msg, ok := apiEvent.InnerEvent.Data.(*slackevents.MessageEvent)
 		if !ok {
 			return true
@@ -495,32 +508,74 @@ func (t *SlackTransport) FormatOutbound(msg channelMessage) (transport.Outbound,
 		log.Printf("[slack] outbound skip: no channel for %q", ch)
 		return transport.Outbound{}, false
 	}
+	// Resolve the office-internal sender to a Slack-facing display name BEFORE
+	// rendering: "@ceo" means nothing to real Slack users, so attribution is a
+	// plain bold name, never a fake tag.
+	msg.From = t.displayNameForOffice(msg.From)
 	return transport.Outbound{
 		Binding: transport.Binding{Scope: transport.ScopeChannel, ChannelSlug: ch},
-		Text:    t.linkSlackAgentMentions(formatSlackOutbound(msg), msg.Tagged),
+		Text:    t.renderOfficeTags(formatSlackOutbound(msg)),
 	}, true
 }
 
-// linkSlackAgentMentions upgrades "@slug" tokens for TAGGED, REGISTERED foreign
-// agents into real <@U…> Slack mentions so the foreign bot is actually pinged —
-// without this, office agents addressing a Slack agent produce inert plain text
-// and the bot never wakes. Two properties keep this injection-safe: the user id
-// comes exclusively from the registry (SlackAgentUserIDBySlug — never from
-// message text), and the rewrite runs AFTER formatSlackOutbound has escaped
-// every dynamic field, so surrounding text cannot smuggle its own control
-// sequences. Tags that aren't registered foreign agents are left as escaped
-// plain text.
-func (t *SlackTransport) linkSlackAgentMentions(text string, tagged []string) string {
-	if t.Broker == nil || len(tagged) == 0 {
+// displayNameForOffice maps an office sender identity to the name real Slack
+// users should see. Office-internal identities (member slugs, "you"/"human",
+// gate actor ids) are NOT taggable in Slack, so they render as plain display
+// names. "system" passes through untouched (formatSlackOutbound styles it).
+func (t *SlackTransport) displayNameForOffice(from string) string {
+	from = strings.TrimSpace(from)
+	if from == "" || from == "system" {
+		return from
+	}
+	if id, ok := strings.CutPrefix(from, "human:"); ok {
+		// Gate clicks attribute to human:<slack user id>. Show the cached
+		// Slack display name — attribution, not a mention, so no ping.
+		uid := strings.ToUpper(strings.TrimSpace(id))
+		t.mapsMu.RLock()
+		info, cached := t.UserMap[uid]
+		t.mapsMu.RUnlock()
+		if cached {
+			return info.name
+		}
+		return uid
+	}
+	if isHumanMessageSender(from) {
+		return "Human"
+	}
+	if t.Broker != nil {
+		if name := t.Broker.MemberDisplayNames()[normalizeActorSlug(from)]; name != "" {
+			return name
+		}
+	}
+	return from
+}
+
+// renderOfficeTags rewrites office-internal "@slug" tokens for SLACK READERS:
+// a REGISTERED foreign agent becomes a real <@U…> mention so the bot is
+// actually pinged; every other office member token becomes its plain display
+// name, because a tag that cannot be tagged in Slack is just noise. Two
+// properties keep this injection-safe: replacement values come exclusively
+// from the roster/registry (never from message text), and the rewrite runs
+// AFTER formatSlackOutbound has escaped every dynamic field, so surrounding
+// text cannot smuggle its own control sequences. Unknown "@whatever" tokens
+// are left as escaped plain text.
+func (t *SlackTransport) renderOfficeTags(text string) string {
+	if t.Broker == nil {
 		return text
 	}
-	for _, slug := range tagged {
-		userID := t.Broker.SlackAgentUserIDBySlug(slug)
-		if userID == "" {
+	for slug, name := range t.Broker.MemberDisplayNames() {
+		if slug == "" {
 			continue
 		}
-		text = replaceMentionToken(text, "@"+slug, "<@"+slackEscape(userID)+">")
+		if userID := t.Broker.SlackAgentUserIDBySlug(slug); userID != "" {
+			text = replaceMentionToken(text, "@"+slug, "<@"+slackEscape(userID)+">")
+			continue
+		}
+		text = replaceMentionToken(text, "@"+slug, slackEscape(name))
 	}
+	// Universal human identities never map to one Slack user; render plainly.
+	text = replaceMentionToken(text, "@human", "Human")
+	text = replaceMentionToken(text, "@you", "Human")
 	return text
 }
 
@@ -689,7 +744,7 @@ func formatSlackOutbound(msg channelMessage) string {
 	title := slackEscape(msg.Title)
 	switch {
 	case msg.Kind == "skill_invocation":
-		return fmt.Sprintf("⚡ *@%s* invoked a skill", from)
+		return fmt.Sprintf("⚡ *%s* invoked a skill", from)
 	case msg.Kind == "skill_proposal":
 		return fmt.Sprintf("💡 *Skill proposed*: %s", content)
 	case msg.Kind == "automation":
@@ -708,7 +763,9 @@ func formatSlackOutbound(msg channelMessage) string {
 	default:
 		var sb strings.Builder
 		if from != "" {
-			sb.WriteString("*@")
+			// Attribution is a plain bold name — office identities are not
+			// taggable in Slack, so no "@" theater.
+			sb.WriteString("*")
 			sb.WriteString(from)
 			sb.WriteString("*: ")
 		}
@@ -728,7 +785,7 @@ func formatSlackDecision(msg channelMessage) string {
 	var sb strings.Builder
 	sb.WriteString("📋 *Decision needed*")
 	if msg.From != "" {
-		sb.WriteString(" from @")
+		sb.WriteString(" from ")
 		sb.WriteString(slackEscape(msg.From))
 	}
 	sb.WriteString("\n\n")

--- a/internal/team/slack_transport.go
+++ b/internal/team/slack_transport.go
@@ -373,26 +373,27 @@ func (t *SlackTransport) handleEvent(ctx context.Context, host transport.Host, e
 }
 
 // routeInbound resolves the office channel for a Slack message event and delivers
-// it to the office via host.UpsertParticipant + host.ReceiveMessage. Bot-authored
-// messages, the bot's own messages, subtyped events (edits/joins/etc.), and
-// messages on unmapped channels are skipped. Returns a non-nil error only on a
-// Host contract failure (e.g. ErrBindingChannelMissing), matching telegram's
+// it to the office via host.UpsertParticipant + host.ReceiveMessage. Subtyped
+// events (edits/joins/etc.), the bot's own messages, and messages on unmapped
+// channels are skipped. Bot-authored messages are dropped UNLESS the author's
+// Slack user id is registered as a foreign agent via /slack/agents — those flow
+// inbound attributed to the registered office slug as non-human participants,
+// which is the ingress half of multi-agent coordination (the egress half is the
+// packer's @-mention delegation). Returns a non-nil error only on a Host
+// contract failure (e.g. ErrBindingChannelMissing), matching telegram's
 // routeInbound so the caller can surface it for supervised restart.
 func (t *SlackTransport) routeInbound(ctx context.Context, host transport.Host, msg *slackevents.MessageEvent) error {
 	if msg == nil {
 		return nil
 	}
-	// Skip non-plain messages: edits, deletes, joins, and bot_message subtypes
-	// all carry a SubType. Only a subtype-less message is a fresh human/agent post.
-	if msg.SubType != "" {
+	// Skip non-plain messages: edits, deletes, joins all carry a SubType. The
+	// one exception is "bot_message" — that is how some foreign bots' posts
+	// arrive, so it must reach the registry check below instead of dropping.
+	if msg.SubType != "" && msg.SubType != "bot_message" {
 		return nil
 	}
-	// Drop bot-authored messages (BotID set) and our own user id to avoid echo
-	// loops with the office's own outbound posts.
-	if msg.BotID != "" {
-		return nil
-	}
-	if msg.User == "" || (t.botUserID != "" && msg.User == t.botUserID) {
+	// Drop our own posts to avoid echo loops with the office's outbound relay.
+	if t.botUserID != "" && msg.User == t.botUserID {
 		return nil
 	}
 	if strings.TrimSpace(msg.Text) == "" {
@@ -407,7 +408,20 @@ func (t *SlackTransport) routeInbound(ctx context.Context, host transport.Host, 
 		return nil
 	}
 
-	fromName, human := t.resolveUser(ctx, msg.User)
+	// Resolve the sender. A registered foreign agent is attributed to its
+	// office slug and marked non-human; every OTHER bot-authored message —
+	// unregistered bot users, legacy bot_message posts without a user id, and
+	// our own posts when auth.test never resolved botUserID — drops here.
+	// Registration is the ingress allowlist: fail-closed by default.
+	var fromName string
+	var human bool
+	if agentSlug := t.foreignAgentSlug(msg.User); agentSlug != "" {
+		fromName, human = agentSlug, false
+	} else if msg.BotID != "" || msg.SubType == "bot_message" || msg.User == "" {
+		return nil
+	} else {
+		fromName, human = t.resolveUser(ctx, msg.User)
+	}
 
 	p := transport.Participant{
 		AdapterName: "slack",
@@ -434,6 +448,20 @@ func (t *SlackTransport) routeInbound(ctx context.Context, host transport.Host, 
 	}
 	t.setHealth(transport.HealthConnected, nil)
 	return nil
+}
+
+// foreignAgentSlug resolves a Slack user id to a registered foreign agent's
+// office slug via the /slack/agents registry. Returns "" for empty ids,
+// unregistered ids, and — as an echo guard even against a misconfigured
+// registration of our own bot — the transport's own bot user id.
+func (t *SlackTransport) foreignAgentSlug(userID string) string {
+	if userID == "" || t.Broker == nil {
+		return ""
+	}
+	if t.botUserID != "" && userID == t.botUserID {
+		return ""
+	}
+	return t.Broker.SlackAgentSlugByUserID(userID)
 }
 
 // Send delivers one outbound message to the Slack channel mapped to
@@ -469,8 +497,62 @@ func (t *SlackTransport) FormatOutbound(msg channelMessage) (transport.Outbound,
 	}
 	return transport.Outbound{
 		Binding: transport.Binding{Scope: transport.ScopeChannel, ChannelSlug: ch},
-		Text:    formatSlackOutbound(msg),
+		Text:    t.linkSlackAgentMentions(formatSlackOutbound(msg), msg.Tagged),
 	}, true
+}
+
+// linkSlackAgentMentions upgrades "@slug" tokens for TAGGED, REGISTERED foreign
+// agents into real <@U…> Slack mentions so the foreign bot is actually pinged —
+// without this, office agents addressing a Slack agent produce inert plain text
+// and the bot never wakes. Two properties keep this injection-safe: the user id
+// comes exclusively from the registry (SlackAgentUserIDBySlug — never from
+// message text), and the rewrite runs AFTER formatSlackOutbound has escaped
+// every dynamic field, so surrounding text cannot smuggle its own control
+// sequences. Tags that aren't registered foreign agents are left as escaped
+// plain text.
+func (t *SlackTransport) linkSlackAgentMentions(text string, tagged []string) string {
+	if t.Broker == nil || len(tagged) == 0 {
+		return text
+	}
+	for _, slug := range tagged {
+		userID := t.Broker.SlackAgentUserIDBySlug(slug)
+		if userID == "" {
+			continue
+		}
+		text = replaceMentionToken(text, "@"+slug, "<@"+slackEscape(userID)+">")
+	}
+	return text
+}
+
+// replaceMentionToken replaces whole-token occurrences of token in text with
+// replacement. An occurrence only counts when neither the byte before nor the
+// byte after could extend a slug, so "@bot" never rewrites inside "@bot-2" or
+// "mail@bot".
+func replaceMentionToken(text, token, replacement string) string {
+	var sb strings.Builder
+	for {
+		i := strings.Index(text, token)
+		if i < 0 {
+			sb.WriteString(text)
+			return sb.String()
+		}
+		end := i + len(token)
+		boundary := (i == 0 || !isSlugByte(text[i-1])) &&
+			(end >= len(text) || !isSlugByte(text[end]))
+		sb.WriteString(text[:i])
+		if boundary {
+			sb.WriteString(replacement)
+		} else {
+			sb.WriteString(token)
+		}
+		text = text[end:]
+	}
+}
+
+// isSlugByte reports whether c can be part of an office member slug.
+func isSlugByte(c byte) bool {
+	return c == '-' || c == '_' ||
+		(c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')
 }
 
 // channelIDForSlug returns the Slack channel id for the given office channel

--- a/internal/team/slack_transport_hardening_test.go
+++ b/internal/team/slack_transport_hardening_test.go
@@ -1,0 +1,122 @@
+package team
+
+// slack_transport_hardening_test.go covers the fixes from the PR-C verification
+// pass: outbound control-sequence escaping (F1), the self/bot drop without a
+// resolved bot user id (F2), the Ack-after-success decision (F3), and caching a
+// bot user as non-human (F6).
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/slack-go/slack"
+	"github.com/slack-go/slack/slackevents"
+	"github.com/slack-go/slack/socketmode"
+
+	teamTransport "github.com/nex-crm/wuphf/internal/team/transport"
+)
+
+// F1: dynamic fields are escaped so the office outbound path cannot inject Slack
+// control sequences, while the function's own markup stays literal.
+func TestFormatSlackOutboundEscapesControlSequences(t *testing.T) {
+	out := formatSlackOutbound(channelMessage{
+		From:    "<!channel>",
+		Title:   "<!here>",
+		Content: "see <http://evil|trusted label>",
+	})
+	for _, raw := range []string{"<!channel>", "<!here>", "<http://evil|trusted label>"} {
+		if strings.Contains(out, raw) {
+			t.Fatalf("control sequence %q must be escaped, got %q", raw, out)
+		}
+	}
+	if !strings.Contains(out, "&lt;!channel&gt;") {
+		t.Fatalf("expected escaped From, got %q", out)
+	}
+	if !strings.Contains(out, "*@") {
+		t.Fatalf("structural markup should remain literal, got %q", out)
+	}
+}
+
+// F2: bot/self messages are dropped via bot_id + subtype even when auth.test
+// never resolved a bot user id, and a genuine human message still flows.
+func TestSlackRouteInboundDropsBotsWithoutBotUserID(t *testing.T) {
+	api := newFakeSlackAPI()
+	tr, b := newTestSlackTransport(t, "C0123", api)
+	tr.botUserID = "" // simulate auth.test failure
+	host := &brokerTransportHost{broker: b}
+	ctx := context.Background()
+
+	_ = tr.routeInbound(ctx, host, &slackevents.MessageEvent{SubType: "bot_message", Channel: "C0123", Text: "x", TimeStamp: "1.1"})
+	_ = tr.routeInbound(ctx, host, &slackevents.MessageEvent{BotID: "B1", User: "U1", Channel: "C0123", Text: "y", TimeStamp: "1.2"})
+	if msgs := b.ChannelMessages("slack-general"); len(msgs) != 0 {
+		t.Fatalf("bot messages must be dropped even without botUserID, got %d", len(msgs))
+	}
+
+	api.users["U7"] = &slack.User{ID: "U7", RealName: "Alice"}
+	if err := tr.routeInbound(ctx, host, &slackevents.MessageEvent{User: "U7", Channel: "C0123", Text: "real", TimeStamp: "1.3"}); err != nil {
+		t.Fatalf("routeInbound human: %v", err)
+	}
+	if msgs := b.ChannelMessages("slack-general"); len(msgs) != 1 {
+		t.Fatalf("human message should flow, got %d", len(msgs))
+	}
+}
+
+// failingHost rejects every ReceiveMessage so handleEvent must report "do not
+// Ack" (so Slack redelivers).
+type failingHost struct{}
+
+func (failingHost) ReceiveMessage(context.Context, teamTransport.Message) error {
+	return errors.New("broker unavailable")
+}
+func (failingHost) UpsertParticipant(context.Context, teamTransport.Participant, teamTransport.Binding) error {
+	return nil
+}
+func (failingHost) DetachParticipant(context.Context, string, string) error { return nil }
+func (failingHost) RevokeParticipant(context.Context, string, string) error { return nil }
+
+// F3: a routable message whose Host write fails must NOT be Ack'd (handleEvent
+// returns false) so Slack redelivers; a successful one is Ack'd (true).
+func TestSlackHandleEventAckDecision(t *testing.T) {
+	api := newFakeSlackAPI()
+	api.users["U7"] = &slack.User{ID: "U7", RealName: "Alice"}
+	tr, b := newTestSlackTransport(t, "C0123", api)
+	ctx := context.Background()
+
+	evt := socketmode.Event{
+		Type: socketmode.EventTypeEventsAPI,
+		Data: slackevents.EventsAPIEvent{
+			InnerEvent: slackevents.EventsAPIInnerEvent{
+				Data: &slackevents.MessageEvent{User: "U7", Channel: "C0123", Text: "hi", TimeStamp: "1.1"},
+			},
+		},
+	}
+
+	if ack := tr.handleEvent(ctx, failingHost{}, evt); ack {
+		t.Fatal("a failed Host write must return ack=false so Slack redelivers")
+	}
+	if ack := tr.handleEvent(ctx, &brokerTransportHost{broker: b}, evt); !ack {
+		t.Fatal("a successfully-handled message must return ack=true")
+	}
+}
+
+// F6: a bot user resolved from users.info is cached as non-human and stays
+// non-human on the cached path.
+func TestSlackResolveUserCachesBotAsNonHuman(t *testing.T) {
+	api := newFakeSlackAPI()
+	api.users["UBOT2"] = &slack.User{ID: "UBOT2", RealName: "Notetaker", IsBot: true}
+	tr, _ := newTestSlackTransport(t, "C0123", api)
+	ctx := context.Background()
+
+	name, human := tr.resolveUser(ctx, "UBOT2")
+	if human {
+		t.Fatal("bot user must resolve to human=false")
+	}
+	if name != "Notetaker" {
+		t.Fatalf("name = %q, want Notetaker", name)
+	}
+	if _, human2 := tr.resolveUser(ctx, "UBOT2"); human2 {
+		t.Fatal("cached bot user must stay non-human")
+	}
+}

--- a/internal/team/slack_transport_hardening_test.go
+++ b/internal/team/slack_transport_hardening_test.go
@@ -120,3 +120,29 @@ func TestSlackResolveUserCachesBotAsNonHuman(t *testing.T) {
 		t.Fatal("cached bot user must stay non-human")
 	}
 }
+
+// Only request-bearing payload envelopes may be Acked. Acking a connection-
+// lifecycle event like "hello" makes Slack drop the Socket Mode connection,
+// which caused a ~10s reconnect loop where no event ever landed (caught live).
+func TestSocketEventNeedsAck(t *testing.T) {
+	for _, et := range []socketmode.EventType{
+		socketmode.EventTypeEventsAPI,
+		socketmode.EventTypeInteractive,
+		socketmode.EventTypeSlashCommand,
+	} {
+		if !socketEventNeedsAck(et) {
+			t.Fatalf("%q should be acked", et)
+		}
+	}
+	for _, et := range []socketmode.EventType{
+		socketmode.EventTypeHello,
+		socketmode.EventTypeConnected,
+		socketmode.EventTypeConnecting,
+		socketmode.EventTypeDisconnect,
+		socketmode.EventTypeIncomingError,
+	} {
+		if socketEventNeedsAck(et) {
+			t.Fatalf("%q must NOT be acked (acking it drops the Socket Mode connection)", et)
+		}
+	}
+}

--- a/internal/team/slack_transport_hardening_test.go
+++ b/internal/team/slack_transport_hardening_test.go
@@ -34,8 +34,8 @@ func TestFormatSlackOutboundEscapesControlSequences(t *testing.T) {
 	if !strings.Contains(out, "&lt;!channel&gt;") {
 		t.Fatalf("expected escaped From, got %q", out)
 	}
-	if !strings.Contains(out, "*@") {
-		t.Fatalf("structural markup should remain literal, got %q", out)
+	if !strings.HasPrefix(out, "*&lt;!channel&gt;*: ") {
+		t.Fatalf("structural bold-name attribution should remain literal, got %q", out)
 	}
 }
 
@@ -216,6 +216,52 @@ func TestSlackFormatOutboundLinksRegisteredAgentMentions(t *testing.T) {
 	}
 	if strings.Contains(out.Text, "<!channel>") {
 		t.Fatalf("escaping must still neutralize control sequences, got %q", out.Text)
+	}
+}
+
+// Office-internal identities are NOT taggable in Slack: "@ceo"/"@human"/"@you"
+// must render as plain display names, while registered foreign agents keep
+// their real <@U…> pings. Sender attribution resolves to the display name with
+// no "@" theater, and gate actors (human:<slack id>) resolve via the user cache.
+func TestSlackRenderOfficeTagsForRealSlackReaders(t *testing.T) {
+	api := newFakeSlackAPI()
+	tr, b := newTestSlackTransport(t, "C0123", api)
+	if _, err := b.RegisterSlackAgent("claude-bot", "Claude Bot", "U777"); err != nil {
+		t.Fatalf("RegisterSlackAgent: %v", err)
+	}
+
+	out, ok := tr.FormatOutbound(channelMessage{
+		From:    "ceo",
+		Channel: "slack-general",
+		Content: "Approved @ceo's request. @claude-bot take it from here, cc @human and @you.",
+		Tagged:  []string{"ceo", "claude-bot"},
+	})
+	if !ok {
+		t.Fatal("FormatOutbound should map slack-general")
+	}
+	if !strings.HasPrefix(out.Text, "*CEO*: ") {
+		t.Fatalf("sender must render as plain display name, got %q", out.Text)
+	}
+	if strings.Contains(out.Text, "@ceo") || strings.Contains(out.Text, "@human") || strings.Contains(out.Text, "@you") {
+		t.Fatalf("office-internal tags must not survive as fake @tags, got %q", out.Text)
+	}
+	if !strings.Contains(out.Text, "Approved CEO's request") {
+		t.Fatalf("member tag should become its display name, got %q", out.Text)
+	}
+	if !strings.Contains(out.Text, "<@U777>") {
+		t.Fatalf("registered foreign agent must keep its real mention, got %q", out.Text)
+	}
+	if !strings.Contains(out.Text, "cc Human and Human") {
+		t.Fatalf("@human/@you should render as Human, got %q", out.Text)
+	}
+
+	// Gate actor attribution: human:<slack id> resolves through the user cache.
+	tr.UserMap["U08TVALKJ86"] = slackUserInfo{name: "Naj", human: true}
+	if got := tr.displayNameForOffice("human:u08tvalkj86"); got != "Naj" {
+		t.Fatalf("gate actor should resolve to slack display name, got %q", got)
+	}
+	if got := tr.displayNameForOffice("human:UNKNOWNID1"); got != "UNKNOWNID1" {
+		t.Fatalf("uncached gate actor falls back to the id, got %q", got)
 	}
 }
 

--- a/internal/team/slack_transport_hardening_test.go
+++ b/internal/team/slack_transport_hardening_test.go
@@ -121,6 +121,124 @@ func TestSlackResolveUserCachesBotAsNonHuman(t *testing.T) {
 	}
 }
 
+// A foreign bot REGISTERED via /slack/agents flows inbound attributed to its
+// office slug — the ingress half of multi-agent coordination — while
+// unregistered bots keep dropping (the registry is a fail-closed allowlist).
+func TestSlackRouteInboundRegisteredForeignAgent(t *testing.T) {
+	api := newFakeSlackAPI()
+	tr, b := newTestSlackTransport(t, "C0123", api)
+	tr.botUserID = "UBOT"
+	host := &brokerTransportHost{broker: b}
+	ctx := context.Background()
+
+	if _, err := b.RegisterSlackAgent("claude-bot", "Claude Bot", "U777"); err != nil {
+		t.Fatalf("RegisterSlackAgent: %v", err)
+	}
+
+	// Modern app post: bot_id + user set, no subtype.
+	if err := tr.routeInbound(ctx, host, &slackevents.MessageEvent{
+		User: "U777", BotID: "B7", Channel: "C0123", Text: "analysis done", TimeStamp: "2.1",
+	}); err != nil {
+		t.Fatalf("routeInbound registered agent: %v", err)
+	}
+	// bot_message subtype variant with a user id also flows.
+	if err := tr.routeInbound(ctx, host, &slackevents.MessageEvent{
+		SubType: "bot_message", User: "U777", BotID: "B7", Channel: "C0123", Text: "follow-up", TimeStamp: "2.2",
+	}); err != nil {
+		t.Fatalf("routeInbound bot_message registered agent: %v", err)
+	}
+
+	msgs := b.ChannelMessages("slack-general")
+	if len(msgs) != 2 {
+		t.Fatalf("registered agent messages should flow, got %d", len(msgs))
+	}
+	for _, m := range msgs {
+		if m.From != "claude-bot" {
+			t.Fatalf("agent message must be attributed to the registered slug, got From=%q", m.From)
+		}
+	}
+
+	// An unregistered bot still drops.
+	_ = tr.routeInbound(ctx, host, &slackevents.MessageEvent{
+		User: "U888", BotID: "B8", Channel: "C0123", Text: "noise", TimeStamp: "2.3",
+	})
+	if got := len(b.ChannelMessages("slack-general")); got != 2 {
+		t.Fatalf("unregistered bot must stay dropped, got %d messages", got)
+	}
+}
+
+// Even a (mis)registration of our OWN bot user id must not open an echo loop:
+// the self-drop wins over the registry.
+func TestSlackRouteInboundSelfDropBeatsRegistration(t *testing.T) {
+	api := newFakeSlackAPI()
+	tr, b := newTestSlackTransport(t, "C0123", api)
+	tr.botUserID = "UBOT"
+	host := &brokerTransportHost{broker: b}
+
+	if _, err := b.RegisterSlackAgent("self-echo", "Self", "UBOT"); err != nil {
+		t.Fatalf("RegisterSlackAgent: %v", err)
+	}
+	_ = tr.routeInbound(context.Background(), host, &slackevents.MessageEvent{
+		User: "UBOT", BotID: "B0", Channel: "C0123", Text: "echo", TimeStamp: "3.1",
+	})
+	if got := len(b.ChannelMessages("slack-general")); got != 0 {
+		t.Fatalf("own bot id must drop even when registered, got %d messages", got)
+	}
+}
+
+// An office message that tags a registered foreign agent is rendered with a
+// real <@U…> mention (built from the registry, never from text) so the foreign
+// bot actually wakes; unregistered tags stay escaped plain text.
+func TestSlackFormatOutboundLinksRegisteredAgentMentions(t *testing.T) {
+	api := newFakeSlackAPI()
+	tr, b := newTestSlackTransport(t, "C0123", api)
+	if _, err := b.RegisterSlackAgent("claude-bot", "Claude Bot", "U777"); err != nil {
+		t.Fatalf("RegisterSlackAgent: %v", err)
+	}
+
+	out, ok := tr.FormatOutbound(channelMessage{
+		From:    "ceo",
+		Channel: "slack-general",
+		Content: "@claude-bot please review the draft; @claude-bot-2 and @pm stay put. <!channel>",
+		Tagged:  []string{"claude-bot", "pm"},
+	})
+	if !ok {
+		t.Fatal("FormatOutbound should map slack-general")
+	}
+	if !strings.Contains(out.Text, "<@U777>") {
+		t.Fatalf("registered tag should become a real mention, got %q", out.Text)
+	}
+	if strings.Contains(out.Text, "@claude-bot-2 ") == false || strings.Contains(out.Text, "<@U777>-2") {
+		t.Fatalf("longer slug must not be partially rewritten, got %q", out.Text)
+	}
+	if !strings.Contains(out.Text, "@pm") {
+		t.Fatalf("unregistered tag must stay plain text, got %q", out.Text)
+	}
+	if strings.Contains(out.Text, "<!channel>") {
+		t.Fatalf("escaping must still neutralize control sequences, got %q", out.Text)
+	}
+}
+
+func TestReplaceMentionToken(t *testing.T) {
+	cases := []struct {
+		name, text, token, repl, want string
+	}{
+		{"whole token", "ping @bot now", "@bot", "<@U1>", "ping <@U1> now"},
+		{"token at end", "ping @bot", "@bot", "<@U1>", "ping <@U1>"},
+		{"longer slug untouched", "ping @bot-2", "@bot", "<@U1>", "ping @bot-2"},
+		{"email-like untouched", "mail@bot down", "@bot", "<@U1>", "mail@bot down"},
+		{"multiple", "@bot and @bot", "@bot", "<@U1>", "<@U1> and <@U1>"},
+		{"absent", "nothing here", "@bot", "<@U1>", "nothing here"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := replaceMentionToken(tc.text, tc.token, tc.repl); got != tc.want {
+				t.Fatalf("replaceMentionToken(%q) = %q, want %q", tc.text, got, tc.want)
+			}
+		})
+	}
+}
+
 // Only request-bearing payload envelopes may be Acked. Acking a connection-
 // lifecycle event like "hello" makes Slack drop the Socket Mode connection,
 // which caused a ~10s reconnect loop where no event ever landed (caught live).

--- a/internal/team/slack_transport_hardening_test.go
+++ b/internal/team/slack_transport_hardening_test.go
@@ -146,3 +146,34 @@ func TestSocketEventNeedsAck(t *testing.T) {
 		}
 	}
 }
+
+// TestShouldAckEvent exercises the FULL ack decision the socket loop makes — the
+// behavior that had no coverage (the loop was hidden behind the socketRunner
+// seam), which let an Ack on the connection-handshake "hello" ship and trigger a
+// ~10s reconnect loop in which no message or interaction was ever delivered.
+func TestShouldAckEvent(t *testing.T) {
+	req := &socketmode.Request{}
+	cases := []struct {
+		name    string
+		evt     socketmode.Event
+		handled bool
+		want    bool
+	}{
+		// The exact bug: a hello envelope carries a Request, but acking it makes
+		// Slack drop the connection. Must NOT ack.
+		{"hello with request", socketmode.Event{Type: socketmode.EventTypeHello, Request: req}, true, false},
+		{"connected with request", socketmode.Event{Type: socketmode.EventTypeConnected, Request: req}, true, false},
+		{"events_api handled", socketmode.Event{Type: socketmode.EventTypeEventsAPI, Request: req}, true, true},
+		{"events_api not handled (host failure → redeliver)", socketmode.Event{Type: socketmode.EventTypeEventsAPI, Request: req}, false, false},
+		{"interactive handled", socketmode.Event{Type: socketmode.EventTypeInteractive, Request: req}, true, true},
+		{"slash_command handled", socketmode.Event{Type: socketmode.EventTypeSlashCommand, Request: req}, true, true},
+		{"events_api no request envelope", socketmode.Event{Type: socketmode.EventTypeEventsAPI, Request: nil}, true, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := shouldAckEvent(tc.evt, tc.handled); got != tc.want {
+				t.Fatalf("shouldAckEvent(%s, handled=%v) = %v, want %v", tc.evt.Type, tc.handled, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/team/slack_transport_test.go
+++ b/internal/team/slack_transport_test.go
@@ -232,9 +232,9 @@ func TestSlackRouteInbound(t *testing.T) {
 	if msgs[0].Source != "slack" {
 		t.Fatalf("source = %q, want slack", msgs[0].Source)
 	}
-	// Participant should be cached after resolution.
-	if got := tr.UserMap["U7"]; got != "Alice Dev" {
-		t.Fatalf("UserMap[U7] = %q, want Alice Dev", got)
+	// Participant should be cached after resolution, with humanity recorded.
+	if got := tr.UserMap["U7"]; got.name != "Alice Dev" || !got.human {
+		t.Fatalf("UserMap[U7] = %+v, want {name:Alice Dev human:true}", got)
 	}
 }
 

--- a/internal/team/slack_transport_test.go
+++ b/internal/team/slack_transport_test.go
@@ -28,6 +28,9 @@ type fakeSlackAPI struct {
 	postErrAt int // return postErr only on the Nth (1-based) post; 0 = every call
 	postCalls int
 
+	publishedViews []fakePublishedView
+	publishErr     error
+
 	users   map[string]*slack.User
 	userErr error
 
@@ -42,6 +45,21 @@ type fakePost struct {
 	ChannelID string
 	Text      string
 	ThreadTS  string
+}
+
+type fakePublishedView struct {
+	UserID string
+	View   slack.HomeTabViewRequest
+}
+
+func (f *fakeSlackAPI) PublishViewContext(_ context.Context, userID string, view slack.HomeTabViewRequest) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.publishErr != nil {
+		return f.publishErr
+	}
+	f.publishedViews = append(f.publishedViews, fakePublishedView{UserID: userID, View: view})
+	return nil
 }
 
 func newFakeSlackAPI() *fakeSlackAPI {
@@ -345,7 +363,9 @@ func TestSlackFormatOutbound(t *testing.T) {
 	if !ok {
 		t.Fatal("expected ok=true for mapped channel")
 	}
-	if out.Text != "*@ceo*: [Update] All good" {
+	// The office slug resolves to the member display name with NO "@" — office
+	// identities are not taggable in Slack, so attribution is a plain bold name.
+	if out.Text != "*CEO*: [Update] All good" {
 		t.Fatalf("text = %q", out.Text)
 	}
 	if out.Binding.Scope != teamTransport.ScopeChannel || out.Binding.ChannelSlug != "slack-general" {
@@ -429,12 +449,12 @@ func TestSlackFormatOutboundKinds(t *testing.T) {
 		msg  channelMessage
 		want string
 	}{
-		{"agent", channelMessage{From: "pm", Content: "hi"}, "*@pm*: hi"},
+		{"agent", channelMessage{From: "pm", Content: "hi"}, "*pm*: hi"},
 		{"system", channelMessage{From: "system", Content: "routing"}, "→ _routing_"},
 		{"automation", channelMessage{Kind: "automation", Source: "github", Content: "merged"}, "🤖 *[github]*: merged"},
-		{"skill", channelMessage{Kind: "skill_invocation", From: "ceo", Content: "x"}, "⚡ *@ceo* invoked a skill"},
+		{"skill", channelMessage{Kind: "skill_invocation", From: "ceo", Content: "x"}, "⚡ *ceo* invoked a skill"},
 		{"proposal", channelMessage{Kind: "skill_proposal", Content: "auto-deploy"}, "💡 *Skill proposed*: auto-deploy"},
-		{"decision", channelMessage{Kind: "interview", From: "ceo", Content: "ship?", Title: "Release"}, "📋 *Decision needed* from @ceo\n\nship?\n\n_Release_"},
+		{"decision", channelMessage{Kind: "interview", From: "ceo", Content: "ship?", Title: "Release"}, "📋 *Decision needed* from ceo\n\nship?\n\n_Release_"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/team/slack_transport_test.go
+++ b/internal/team/slack_transport_test.go
@@ -1,0 +1,485 @@
+package team
+
+import (
+	"context"
+	"errors"
+	"net/url"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/slack-go/slack"
+	"github.com/slack-go/slack/slackevents"
+
+	teamTransport "github.com/nex-crm/wuphf/internal/team/transport"
+)
+
+// fakeSlackAPI is an in-memory slackAPI used by both the transport and bridge
+// tests. It records every PostMessageContext call (rendered to channel/text/
+// thread-ts via the slack-go UnsafeApplyMsgOptions helper) and serves canned
+// user / auth / membership responses. All access is mutex-guarded so the
+// warm-up goroutine and the test goroutine cannot race.
+type fakeSlackAPI struct {
+	mu sync.Mutex
+
+	posts     []fakePost
+	postErr   error
+	postErrAt int // return postErr only on the Nth (1-based) post; 0 = every call
+	postCalls int
+
+	users   map[string]*slack.User
+	userErr error
+
+	authResp *slack.AuthTestResponse
+	authErr  error
+
+	members    map[string][]string
+	membersErr error
+}
+
+type fakePost struct {
+	ChannelID string
+	Text      string
+	ThreadTS  string
+}
+
+func newFakeSlackAPI() *fakeSlackAPI {
+	return &fakeSlackAPI{
+		users:    map[string]*slack.User{},
+		members:  map[string][]string{},
+		authResp: &slack.AuthTestResponse{UserID: "UBOT"},
+	}
+}
+
+func (f *fakeSlackAPI) PostMessageContext(_ context.Context, channelID string, opts ...slack.MsgOption) (string, string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.postCalls++
+	if f.postErr != nil && (f.postErrAt == 0 || f.postErrAt == f.postCalls) {
+		return "", "", f.postErr
+	}
+	_, values, err := slack.UnsafeApplyMsgOptions("token", channelID, "https://slack.test/api/", opts...)
+	if err != nil {
+		return "", "", err
+	}
+	ts := "1700000000.0000" + strconv.Itoa(f.postCalls)
+	f.posts = append(f.posts, fakePost{
+		ChannelID: channelID,
+		Text:      firstValue(values, "text"),
+		ThreadTS:  firstValue(values, "thread_ts"),
+	})
+	return channelID, ts, nil
+}
+
+func (f *fakeSlackAPI) GetUserInfoContext(_ context.Context, userID string) (*slack.User, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.userErr != nil {
+		return nil, f.userErr
+	}
+	u, ok := f.users[userID]
+	if !ok {
+		return nil, errors.New("user not found")
+	}
+	return u, nil
+}
+
+func (f *fakeSlackAPI) AuthTestContext(_ context.Context) (*slack.AuthTestResponse, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.authErr != nil {
+		return nil, f.authErr
+	}
+	return f.authResp, nil
+}
+
+func (f *fakeSlackAPI) GetUsersInConversationContext(_ context.Context, params *slack.GetUsersInConversationParameters) ([]string, string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.membersErr != nil {
+		return nil, "", f.membersErr
+	}
+	return f.members[params.ChannelID], "", nil
+}
+
+func (f *fakeSlackAPI) snapshotPosts() []fakePost {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]fakePost, len(f.posts))
+	copy(out, f.posts)
+	return out
+}
+
+func firstValue(v url.Values, key string) string {
+	if vals := v[key]; len(vals) > 0 {
+		return vals[0]
+	}
+	return ""
+}
+
+func newTestBrokerWithSlackChannel(t *testing.T, channelID string) *Broker {
+	t.Helper()
+	b := newTestBroker(t)
+	b.mu.Lock()
+	b.channels = append(b.channels, teamChannel{
+		Slug:    "slack-general",
+		Name:    "slack-general",
+		Members: []string{"ceo", "pm"},
+		Surface: &channelSurface{
+			Provider:    "slack",
+			RemoteID:    channelID,
+			RemoteTitle: "general",
+			Mode:        "channel",
+			BotTokenEnv: "SLACK_BOT_TOKEN",
+		},
+		CreatedBy: "test",
+		CreatedAt: time.Now().UTC().Format(time.RFC3339),
+		UpdatedAt: time.Now().UTC().Format(time.RFC3339),
+	})
+	b.mu.Unlock()
+	return b
+}
+
+func newTestSlackTransport(t *testing.T, channelID string, api slackAPI) (*SlackTransport, *Broker) {
+	t.Helper()
+	b := newTestBrokerWithSlackChannel(t, channelID)
+	tr := newSlackTransport(b, "xoxb-test", "xapp-test", api)
+	return tr, b
+}
+
+// --- Channel map + contract surface ---
+
+func TestSlackTransportChannelMap(t *testing.T) {
+	tr, _ := newTestSlackTransport(t, "C0123", newFakeSlackAPI())
+	if len(tr.ChannelMap) != 1 {
+		t.Fatalf("expected 1 channel mapping, got %d", len(tr.ChannelMap))
+	}
+	if got := tr.ChannelMap["C0123"]; got != "slack-general" {
+		t.Fatalf("expected slug slack-general for C0123, got %q", got)
+	}
+}
+
+func TestSlackTransportContractInterface(t *testing.T) {
+	tr, _ := newTestSlackTransport(t, "C0123", newFakeSlackAPI())
+
+	if tr.Name() != "slack" {
+		t.Fatalf("Name() = %q, want slack", tr.Name())
+	}
+	binding := tr.Binding()
+	if binding.ChannelSlug != "" || binding.MemberSlug != "" {
+		t.Fatalf("Binding() should be zero-value for multi-channel adapter, got %+v", binding)
+	}
+	h := tr.Health()
+	if h.State != teamTransport.HealthDisconnected {
+		t.Fatalf("Health().State before Run = %q, want disconnected", h.State)
+	}
+}
+
+func TestSlackRunGuards(t *testing.T) {
+	b := newTestBrokerWithSlackChannel(t, "C0123")
+	host := &brokerTransportHost{broker: b}
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	cases := []struct {
+		name string
+		tr   *SlackTransport
+		want string
+	}{
+		{"no bot token", newSlackTransport(b, "", "xapp", newFakeSlackAPI()), "bot token is empty"},
+		{"no app token", newSlackTransport(b, "xoxb", "", newFakeSlackAPI()), "app token is empty"},
+		{"no socket runner", newSlackTransport(b, "xoxb", "xapp", newFakeSlackAPI()), "socket runner not configured"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.tr.Run(ctx, host)
+			if err == nil || !contains(err.Error(), tc.want) {
+				t.Fatalf("Run: expected error containing %q, got %v", tc.want, err)
+			}
+		})
+	}
+}
+
+// --- Inbound mapping ---
+
+func TestSlackRouteInbound(t *testing.T) {
+	api := newFakeSlackAPI()
+	api.users["U7"] = &slack.User{ID: "U7", Name: "alice", RealName: "Alice Dev", IsBot: false}
+	tr, b := newTestSlackTransport(t, "C0123", api)
+	host := &brokerTransportHost{broker: b}
+
+	msg := &slackevents.MessageEvent{
+		User:      "U7",
+		Channel:   "C0123",
+		Text:      "hello via socket",
+		TimeStamp: "1700000001.0001",
+	}
+	if err := tr.routeInbound(context.Background(), host, msg); err != nil {
+		t.Fatalf("routeInbound: %v", err)
+	}
+
+	msgs := b.ChannelMessages("slack-general")
+	if len(msgs) != 1 {
+		t.Fatalf("expected 1 message in channel, got %d", len(msgs))
+	}
+	if msgs[0].Content != "hello via socket" {
+		t.Fatalf("content = %q, want %q", msgs[0].Content, "hello via socket")
+	}
+	if msgs[0].From != "Alice Dev" {
+		t.Fatalf("from = %q, want resolved display name Alice Dev", msgs[0].From)
+	}
+	if msgs[0].Source != "slack" {
+		t.Fatalf("source = %q, want slack", msgs[0].Source)
+	}
+	// Participant should be cached after resolution.
+	if got := tr.UserMap["U7"]; got != "Alice Dev" {
+		t.Fatalf("UserMap[U7] = %q, want Alice Dev", got)
+	}
+}
+
+func TestSlackRouteInboundUpsertsParticipantBeforeReceive(t *testing.T) {
+	api := newFakeSlackAPI()
+	api.users["U9"] = &slack.User{ID: "U9", RealName: "Bob"}
+	tr, b := newTestSlackTransport(t, "C0123", api)
+	rec := &slackOrderingHost{inner: &brokerTransportHost{broker: b}}
+
+	msg := &slackevents.MessageEvent{User: "U9", Channel: "C0123", Text: "hi", TimeStamp: "1.1"}
+	if err := tr.routeInbound(context.Background(), rec, msg); err != nil {
+		t.Fatalf("routeInbound: %v", err)
+	}
+	if rec.order != "upsert,receive" {
+		t.Fatalf("expected upsert before receive, got order %q", rec.order)
+	}
+	if rec.lastParticipant.AdapterName != "slack" || rec.lastParticipant.Key != "U9" {
+		t.Fatalf("participant = %+v, want adapter slack key U9", rec.lastParticipant)
+	}
+	if !rec.lastParticipant.Human {
+		t.Fatal("expected Human=true for a non-bot user")
+	}
+	if rec.lastBinding.Scope != teamTransport.ScopeChannel || rec.lastBinding.ChannelSlug != "slack-general" {
+		t.Fatalf("binding = %+v, want channel scope slack-general", rec.lastBinding)
+	}
+}
+
+func TestSlackRouteInboundSkips(t *testing.T) {
+	api := newFakeSlackAPI()
+	tr, b := newTestSlackTransport(t, "C0123", api)
+	host := &brokerTransportHost{broker: b}
+
+	cases := []struct {
+		name string
+		msg  *slackevents.MessageEvent
+	}{
+		{"bot message", &slackevents.MessageEvent{User: "U1", BotID: "B1", Channel: "C0123", Text: "bot says hi", TimeStamp: "1"}},
+		{"own bot user", &slackevents.MessageEvent{User: "UBOT", Channel: "C0123", Text: "self echo", TimeStamp: "2"}},
+		{"subtyped edit", &slackevents.MessageEvent{User: "U1", SubType: "message_changed", Channel: "C0123", Text: "edited", TimeStamp: "3"}},
+		{"empty text", &slackevents.MessageEvent{User: "U1", Channel: "C0123", Text: "   ", TimeStamp: "4"}},
+		{"unmapped channel", &slackevents.MessageEvent{User: "U1", Channel: "CZZZ", Text: "elsewhere", TimeStamp: "5"}},
+		{"empty user", &slackevents.MessageEvent{User: "", Channel: "C0123", Text: "ghost", TimeStamp: "6"}},
+	}
+	tr.botUserID = "UBOT"
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := tr.routeInbound(context.Background(), host, tc.msg); err != nil {
+				t.Fatalf("routeInbound returned error for skip case: %v", err)
+			}
+		})
+	}
+	if msgs := b.ChannelMessages("slack-general"); len(msgs) != 0 {
+		t.Fatalf("expected no messages delivered for skip cases, got %d", len(msgs))
+	}
+}
+
+func TestSlackRouteInboundChannelMissing(t *testing.T) {
+	api := newFakeSlackAPI()
+	api.users["U1"] = &slack.User{ID: "U1", RealName: "X"}
+	b := newTestBroker(t)
+	// Map a channel id to a slug that does not exist as a broker channel so the
+	// Host returns ErrBindingChannelMissing on ReceiveMessage.
+	tr := newSlackTransport(b, "xoxb", "xapp", api)
+	tr.ChannelMap["C0123"] = "ghost-channel"
+	host := &brokerTransportHost{broker: b}
+
+	msg := &slackevents.MessageEvent{User: "U1", Channel: "C0123", Text: "lost", TimeStamp: "1"}
+	err := tr.routeInbound(context.Background(), host, msg)
+	if err == nil || !errors.Is(err, teamTransport.ErrBindingChannelMissing) {
+		t.Fatalf("expected ErrBindingChannelMissing, got %v", err)
+	}
+}
+
+// --- resolveUser ---
+
+func TestSlackResolveUser(t *testing.T) {
+	api := newFakeSlackAPI()
+	api.users["U1"] = &slack.User{ID: "U1", Profile: slack.UserProfile{DisplayName: "alice"}, IsBot: false}
+	api.users["UBOTUSER"] = &slack.User{ID: "UBOTUSER", RealName: "Helper Bot", IsBot: true}
+	tr, _ := newTestSlackTransport(t, "C0123", api)
+
+	name, human := tr.resolveUser(context.Background(), "U1")
+	if name != "alice" || !human {
+		t.Fatalf("U1 = (%q, %v), want (alice, true)", name, human)
+	}
+	name, human = tr.resolveUser(context.Background(), "UBOTUSER")
+	if name != "Helper Bot" || human {
+		t.Fatalf("UBOTUSER = (%q, %v), want (Helper Bot, false)", name, human)
+	}
+	// Unknown user falls back to its id and is treated as human.
+	name, human = tr.resolveUser(context.Background(), "UMISSING")
+	if name != "UMISSING" || !human {
+		t.Fatalf("UMISSING = (%q, %v), want (UMISSING, true)", name, human)
+	}
+	// Empty id.
+	name, _ = tr.resolveUser(context.Background(), "")
+	if name != "unknown" {
+		t.Fatalf("empty user id = %q, want unknown", name)
+	}
+}
+
+// --- Outbound: Send + FormatOutbound ---
+
+func TestSlackFormatOutbound(t *testing.T) {
+	tr, _ := newTestSlackTransport(t, "C0123", newFakeSlackAPI())
+
+	out, ok := tr.FormatOutbound(channelMessage{Channel: "slack-general", From: "ceo", Title: "Update", Content: "All good"})
+	if !ok {
+		t.Fatal("expected ok=true for mapped channel")
+	}
+	if out.Text != "*@ceo*: [Update] All good" {
+		t.Fatalf("text = %q", out.Text)
+	}
+	if out.Binding.Scope != teamTransport.ScopeChannel || out.Binding.ChannelSlug != "slack-general" {
+		t.Fatalf("binding = %+v", out.Binding)
+	}
+
+	// Unmapped channel: ok=false, no panic.
+	if _, ok := tr.FormatOutbound(channelMessage{Channel: "nope", Content: "x"}); ok {
+		t.Fatal("expected ok=false for unmapped channel")
+	}
+}
+
+func TestSlackSend(t *testing.T) {
+	api := newFakeSlackAPI()
+	tr, _ := newTestSlackTransport(t, "C0123", api)
+
+	err := tr.Send(context.Background(), teamTransport.Outbound{
+		Binding: teamTransport.Binding{Scope: teamTransport.ScopeChannel, ChannelSlug: "slack-general"},
+		Text:    "*@pm*: shipping it",
+	})
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	posts := api.snapshotPosts()
+	if len(posts) != 1 {
+		t.Fatalf("expected 1 post, got %d", len(posts))
+	}
+	if posts[0].ChannelID != "C0123" || posts[0].Text != "*@pm*: shipping it" {
+		t.Fatalf("post = %+v", posts[0])
+	}
+	if posts[0].ThreadTS != "" {
+		t.Fatalf("expected no thread ts, got %q", posts[0].ThreadTS)
+	}
+}
+
+func TestSlackSendThreaded(t *testing.T) {
+	api := newFakeSlackAPI()
+	tr, _ := newTestSlackTransport(t, "C0123", api)
+
+	err := tr.Send(context.Background(), teamTransport.Outbound{
+		Binding:   teamTransport.Binding{Scope: teamTransport.ScopeChannel, ChannelSlug: "slack-general"},
+		Text:      "reply",
+		ThreadKey: "1700000000.0001",
+	})
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	posts := api.snapshotPosts()
+	if len(posts) != 1 || posts[0].ThreadTS != "1700000000.0001" {
+		t.Fatalf("expected threaded post, got %+v", posts)
+	}
+}
+
+func TestSlackSendUnmappedChannel(t *testing.T) {
+	tr, _ := newTestSlackTransport(t, "C0123", newFakeSlackAPI())
+	err := tr.Send(context.Background(), teamTransport.Outbound{
+		Binding: teamTransport.Binding{Scope: teamTransport.ScopeChannel, ChannelSlug: "does-not-exist"},
+		Text:    "x",
+	})
+	if err == nil || !contains(err.Error(), "no channel mapped") {
+		t.Fatalf("expected no-channel error, got %v", err)
+	}
+}
+
+func TestSlackSendAPIError(t *testing.T) {
+	api := newFakeSlackAPI()
+	api.postErr = errors.New("rate limited")
+	tr, _ := newTestSlackTransport(t, "C0123", api)
+	err := tr.Send(context.Background(), teamTransport.Outbound{
+		Binding: teamTransport.Binding{Scope: teamTransport.ScopeChannel, ChannelSlug: "slack-general"},
+		Text:    "x",
+	})
+	if err == nil || !contains(err.Error(), "rate limited") {
+		t.Fatalf("expected wrapped API error, got %v", err)
+	}
+}
+
+func TestSlackFormatOutboundKinds(t *testing.T) {
+	cases := []struct {
+		name string
+		msg  channelMessage
+		want string
+	}{
+		{"agent", channelMessage{From: "pm", Content: "hi"}, "*@pm*: hi"},
+		{"system", channelMessage{From: "system", Content: "routing"}, "→ _routing_"},
+		{"automation", channelMessage{Kind: "automation", Source: "github", Content: "merged"}, "🤖 *[github]*: merged"},
+		{"skill", channelMessage{Kind: "skill_invocation", From: "ceo", Content: "x"}, "⚡ *@ceo* invoked a skill"},
+		{"proposal", channelMessage{Kind: "skill_proposal", Content: "auto-deploy"}, "💡 *Skill proposed*: auto-deploy"},
+		{"decision", channelMessage{Kind: "interview", From: "ceo", Content: "ship?", Title: "Release"}, "📋 *Decision needed* from @ceo\n\nship?\n\n_Release_"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := formatSlackOutbound(tc.msg); got != tc.want {
+				t.Fatalf("formatSlackOutbound = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// slackOrderingHost wraps a Host and records the call order + last
+// participant/binding so a test can prove UpsertParticipant happens before
+// ReceiveMessage. (The package's share-test recordingHost is no-op for those two
+// methods, so it cannot witness ordering — hence a dedicated wrapper here.)
+type slackOrderingHost struct {
+	inner           teamTransport.Host
+	order           string
+	lastParticipant teamTransport.Participant
+	lastBinding     teamTransport.Binding
+}
+
+func (h *slackOrderingHost) ReceiveMessage(ctx context.Context, msg teamTransport.Message) error {
+	if h.order == "" {
+		h.order = "receive"
+	} else {
+		h.order += ",receive"
+	}
+	return h.inner.ReceiveMessage(ctx, msg)
+}
+
+func (h *slackOrderingHost) UpsertParticipant(ctx context.Context, p teamTransport.Participant, b teamTransport.Binding) error {
+	if h.order == "" {
+		h.order = "upsert"
+	} else {
+		h.order += ",upsert"
+	}
+	h.lastParticipant = p
+	h.lastBinding = b
+	return h.inner.UpsertParticipant(ctx, p, b)
+}
+
+func (h *slackOrderingHost) DetachParticipant(ctx context.Context, adapterName, key string) error {
+	return h.inner.DetachParticipant(ctx, adapterName, key)
+}
+
+func (h *slackOrderingHost) RevokeParticipant(ctx context.Context, adapterName, key string) error {
+	return h.inner.RevokeParticipant(ctx, adapterName, key)
+}


### PR DESCRIPTION
**Stacked on #1056 → #1051.** PR-C of the Slack agent-coordination series — the real Slack bridge that makes the packer end-to-end.

## What
A real Slack transport (`internal/team/slack_transport.go`) modeled on `telegram.go`, plus the packer's egress delivery (`slack_bridge.go`):

- **Inbound: Socket Mode** (`xapp-` app token) — no public URL / webhook needed, ideal for a self-hosted OSS broker. EventsAPI message events route to the office via the `Host` contract (`UpsertParticipant` then `ReceiveMessage`). Skips subtyped events, bot/self messages (echo-loop guard via `auth.test`), empty text, and unmapped channels. Events are Ack'd before processing.
- **Outbound: Web API** `chat.postMessage` via the `xoxb-` bot token. `FormatOutbound` is a pure slug→channel mapping; `Send` threads on `ThreadKey`.
- **`packer.SlackBridge.Post`** (`slack_bridge.go`): posts the egress-classified mention to the delegation's channel/thread and the thread-context block as a reply, returning the mention `ts` as the audit anchor. **Posts with `escapeText=true`** — the egress boundary, so injected Slack control sequences (`<!channel>`/`<!here>`, fake `<url|label>` links) in a tainted Ask are neutralized.
- **Seams for testing:** a narrow `slackAPI` interface (4 Web API calls) + a `socketRunner` seam, so the transport, the bridge, and the routing logic are unit-tested against a fake with **no network**.
- **Config:** `ResolveSlackBotToken()` / `ResolveSlackAppToken()` (env → config file, mirroring the Telegram resolver). **Registration:** a Slack block in `launcher_transports.go` (starts only when both tokens + ≥1 connected slack channel exist; skips silently otherwise).

## Test plan
- [x] `go test ./internal/team/ -run Slack -race` — green. Inbound mapping + upsert-before-receive ordering, all skip cases, user resolution (human/bot/fallback), `Send`/`FormatOutbound` (+unmapped, +API error), `SlackBridge.Post` (mention-only, threaded reply, existing-thread anchoring, guards, API errors, follow-up-error-still-returns-ts), and control-sequence escaping.
- [x] full `internal/team` suite green; `gofmt` / `go vet` / `golangci-lint` (diff) — 0 issues; `go build ./...` OK.
- [x] Adversarial verification agent on the Slack surface — dispositions below.

## Verification dispositions
Built by a subagent, then independently re-verified (build/vet/lint/`-race`) and read end-to-end by me. An adversarial verification agent on the Slack surface found 6 issues; **all fixed** in the `fix(slack)` hardening commit, each with a test.

| # | Finding | Sev | Disposition |
|---|---------|-----|-------------|
| F1 | Office outbound (`Send`/`formatSlackOutbound`) could inject Slack control sequences | HIGH | FIXED — escape every dynamic field via `slackutilsx.EscapeMessage`, keep own markup literal |
| F2 | `auth.test` failure left the self-echo guard off | LOW | FIXED — retry with backoff; `bot_id`/subtype remain primary; regression test for `botUserID==""` |
| F3 | Events Ack'd before processing → a transient Host failure silently dropped the message | MEDIUM | FIXED — Ack **after** success; failed Host write leaves it un-Ack'd so Slack redelivers (broker dedupes by `ExternalID`) |
| F4 | `Run` returned on cancel without waiting for the socket goroutine | MEDIUM | FIXED — cancel + bounded 5s wait so the Host isn't used after `Run` returns |
| F5 | Failed thread follow-up returned an error → Deliver marks FAILED → retry duplicates the mention | MEDIUM | FIXED — follow-up is best-effort: return `(mentionTS, nil)` + log |
| F6 | `UserMap` cached name only → a warmed bot could later be attributed human | LOW | FIXED — cache `{name, human}` |

I also caught + fixed (before the agent ran) the egress bridge posting with `escapeText=false` (commit `26c9c8ce`). Controls the agent confirmed held: no token interpolation in logs/errors, mutexed map access, `UpsertParticipant` before `ReceiveMessage`.

## Live run
Needs `SLACK_BOT_TOKEN` (`xoxb-`) + `SLACK_APP_TOKEN` (`xapp-`, Socket Mode) + a workspace/app. Everything above is tested against a mock Slack; the live run happens in the merged end-to-end test.

## Not in this PR
The Slack Block Kit approval gate cards (PR-D, stacked on the deterministic-integrations lane) use this transport's interactivity surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
