### PR TITLE
feat(wiki): collapsible panels + hide empty folders

### DIFF
--- a/internal/team/wiki_fs.go
+++ b/internal/team/wiki_fs.go
@@ -40,6 +40,9 @@ import (
 //   - Children is populated only for "dir" nodes. Apps and websites are
 //     leaves even though they are directories on disk.
 //   - Ext is populated only for "file" nodes (lowercase, with the dot).
+//   - Recursively-empty plain "dir" nodes are pruned from the tree: a folder
+//     that holds no pages/files anywhere beneath it is scaffolding, not
+//     navigation, so it never reaches the wire. See buildTreeNodes.
 type TreeNode struct {
 	Name     string     `json:"name"`
 	Path     string     `json:"path"`
@@ -267,6 +270,17 @@ func buildTreeNodes(repoRoot, dir string) ([]TreeNode, error) {
 			node, derr := buildDirNode(repoRoot, full, name)
 			if derr != nil {
 				return nil, derr
+			}
+			// Prune recursively-empty plain directories. A "dir" whose subtree
+			// holds no pages/files (after the same pruning runs on its
+			// children) is scaffolding noise, not navigation — the wiki tree
+			// should surface folders only once they hold content, and let the
+			// Librarian (or any writer) materialize a folder on demand by
+			// writing into it. App/website dirs are leaves (real content) and
+			// are never pruned. The check works bottom-up: an inner empty dir
+			// drops first, which can leave its parent empty, dropped in turn.
+			if node.Type == treeTypeDir && len(node.Children) == 0 {
+				continue
 			}
 			nodes = append(nodes, node)
 			continue

--- a/internal/team/wiki_fs_test.go
+++ b/internal/team/wiki_fs_test.go
@@ -230,6 +230,67 @@ func TestWikiTreeSortOrder(t *testing.T) {
 	}
 }
 
+// Empty folders are scaffolding, not navigation: a directory with no
+// pages/files anywhere beneath it must not reach the tree. The Librarian (or
+// any writer) materializes a folder on demand by writing into it, so a folder
+// only appears once it holds content. Pruning is recursive and bottom-up — a
+// parent whose only children are themselves empty folders is pruned too.
+func TestWikiTreeOmitsEmptyDirs(t *testing.T) {
+	baseURL, repo, cleanup := newWikiFSTestServer(t)
+	defer cleanup()
+
+	mkdir := func(rel string) {
+		t.Helper()
+		if err := os.MkdirAll(filepath.Join(repo.TeamDir(), filepath.FromSlash(rel)), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", rel, err)
+		}
+	}
+
+	// A flat empty folder.
+	mkdir("empty-section")
+	// A folder whose only descendant is itself an empty folder → both prune.
+	mkdir("nested/inner")
+	// A folder holding only an empty subfolder → the parent prunes too.
+	mkdir("mixed/hollow")
+	// A folder with real content survives.
+	seedFile(t, repo, "real/note.md", "# Note\n")
+	// A folder with BOTH an empty subfolder and a real page: the page keeps the
+	// folder, but the empty subfolder is still pruned from its children.
+	mkdir("partly/hollow")
+	seedFile(t, repo, "partly/keep.md", "# Keep\n")
+
+	nodes := fetchTree(t, baseURL, "")
+
+	if n := findNode(nodes, "empty-section"); n != nil {
+		t.Errorf("empty-section should be pruned, got %+v", n)
+	}
+	if n := findNode(nodes, "nested"); n != nil {
+		t.Errorf("nested (recursively empty) should be pruned, got %+v", n)
+	}
+	if n := findNode(nodes, "mixed"); n != nil {
+		t.Errorf("mixed (only empty subdir) should be pruned, got %+v", n)
+	}
+
+	real := findNode(nodes, "real")
+	if real == nil {
+		t.Fatal("real (has note.md) should survive pruning")
+	}
+	if findNode(real.Children, "note.md") == nil {
+		t.Error("real should keep its note.md page")
+	}
+
+	partly := findNode(nodes, "partly")
+	if partly == nil {
+		t.Fatal("partly (has keep.md) should survive pruning")
+	}
+	if findNode(partly.Children, "keep.md") == nil {
+		t.Error("partly should keep its keep.md page")
+	}
+	if h := findNode(partly.Children, "hollow"); h != nil {
+		t.Errorf("partly's empty 'hollow' subdir should be pruned, got %+v", h)
+	}
+}
+
 func TestWikiTreeSubPathTraversalRejected(t *testing.T) {
 	baseURL, _, cleanup := newWikiFSTestServer(t)
 	defer cleanup()

--- a/web/e2e/screenshots/wiki-collapsible-panels.mjs
+++ b/web/e2e/screenshots/wiki-collapsible-panels.mjs
@@ -1,0 +1,168 @@
+// Capture the wiki's collapsible flanking panels across their four states.
+// The left page tree and the right "details" rail each fold to a thin,
+// clickable strip so the reading column reclaims the width.
+//
+//   1. Both panels open — the baseline three-column article view.
+//   2. Left page tree folded to a rail.
+//   3. Right details rail folded.
+//   4. Both folded — the reading column at its widest.
+//
+// Run via the wrapper:
+//   web/e2e/screenshots/publish.sh wiki-collapsible-panels <pr-number>
+
+import {
+  bootShell,
+  installCommonMocks,
+  launchBrowser,
+  shotPage,
+} from "./lib.mjs";
+import process from "node:process";
+
+const OUT = process.env.WUPHF_SCREENSHOTS_OUT;
+if (!OUT) {
+  console.error("WUPHF_SCREENSHOTS_OUT is not set; run via publish.sh");
+  process.exit(2);
+}
+
+const ARTICLE = {
+  path: "team/companies/acme.md",
+  title: "Acme Corp",
+  content: [
+    "# Acme Corp",
+    "",
+    "Acme is a mid-market logistics company evaluating our platform for",
+    "their revenue operations team.",
+    "",
+    "## Background",
+    "",
+    "Founded in 2014, Acme runs a regional freight network across the",
+    "Midwest. Their RevOps lead, Dana, owns the evaluation.",
+    "",
+    "## Current status",
+    "",
+    "In a paid pilot. Two agents are embedded in their Slack, drafting",
+    "renewal briefs and reconciling the carrier scorecard each week.",
+    "",
+    "## Open questions",
+    "",
+    "Whether the pilot expands to the full carrier portfolio after Q3.",
+  ].join("\n"),
+  last_edited_by: "ceo",
+  last_edited_ts: "2026-06-12T12:00:00Z",
+  revisions: 7,
+  contributors: ["ceo", "pm", "revops"],
+  backlinks: [],
+  word_count: 96,
+  categories: ["Companies"],
+};
+
+const TREE = [
+  {
+    name: "companies",
+    path: "team/companies",
+    type: "dir",
+    title: "Companies",
+    children: [
+      {
+        name: "acme.md",
+        path: "team/companies/acme.md",
+        type: "page",
+        title: "Acme Corp",
+      },
+      {
+        name: "globex.md",
+        path: "team/companies/globex.md",
+        type: "page",
+        title: "Globex",
+      },
+    ],
+  },
+  {
+    name: "people",
+    path: "team/people",
+    type: "dir",
+    title: "People",
+    children: [
+      {
+        name: "dana.md",
+        path: "team/people/dana.md",
+        type: "page",
+        title: "Dana (RevOps lead)",
+      },
+    ],
+  },
+  {
+    name: "playbooks",
+    path: "team/playbooks",
+    type: "dir",
+    title: "Playbooks",
+    children: [
+      {
+        name: "renewal.md",
+        path: "team/playbooks/renewal.md",
+        type: "page",
+        title: "Renewal Playbook",
+      },
+    ],
+  },
+];
+
+async function mockWiki(ctx) {
+  const json = (body) => (r) =>
+    r.fulfill({ contentType: "application/json", body: JSON.stringify(body) });
+  await ctx.route("**/api/wiki/tree*", json({ nodes: TREE }));
+  await ctx.route("**/api/wiki/catalog*", json({ entries: [] }));
+  await ctx.route("**/api/wiki/sections*", json({ sections: [] }));
+  await ctx.route("**/api/wiki/article*", json(ARTICLE));
+  await ctx.route("**/api/wiki/history*", json({ commits: [] }));
+  await ctx.route("**/api/wiki/visual-artifact*", (r) =>
+    r.fulfill({ status: 404, body: "" }),
+  );
+  await ctx.route("**/api/humans*", json([]));
+}
+
+const { browser, context, page, errors } = await launchBrowser({
+  viewport: { width: 1480, height: 940 },
+});
+
+await installCommonMocks(context, { extra: mockWiki });
+await bootShell(page);
+await page.evaluate(() => {
+  window.location.hash = "#/wiki/team/companies/acme.md";
+});
+await page.waitForSelector('[data-testid="wk-article-body"]', {
+  timeout: 8_000,
+});
+// Expand the open page's branch so the tree shows real structure. Scope to
+// the sidebar — "Companies" also appears as a category link in the article.
+await page
+  .locator('[data-testid="wk-nav-sidebar"]')
+  .getByText("Companies", { exact: true })
+  .click();
+await page.waitForTimeout(250);
+await shotPage(page, OUT, "01-both-panels-open");
+
+// ─── Fold the left page tree ──
+await page.getByRole("button", { name: "Collapse Pages panel" }).click();
+await page.waitForSelector('button[aria-label="Expand Pages panel"]', {
+  timeout: 4_000,
+});
+await shotPage(page, OUT, "02-left-tree-collapsed");
+
+// ─── Also fold the right details rail ──
+await page.getByRole("button", { name: "Collapse Details panel" }).click();
+await page.waitForSelector('button[aria-label="Expand Details panel"]', {
+  timeout: 4_000,
+});
+await shotPage(page, OUT, "03-both-collapsed");
+
+// ─── Restore the tree; keep the right rail folded ──
+await page.getByRole("button", { name: "Expand Pages panel" }).click();
+await page.waitForSelector('[data-testid="wk-tree"]', { timeout: 4_000 });
+await shotPage(page, OUT, "04-right-rail-collapsed");
+
+console.log(`captured 4 screenshots to ${OUT}`);
+if (errors.length > 0) {
+  console.error("page errors during capture:", errors);
+}
+await browser.close();

--- a/web/src/components/wiki/Wiki.test.tsx
+++ b/web/src/components/wiki/Wiki.test.tsx
@@ -387,4 +387,71 @@ describe("<Wiki>", () => {
     // The load actually finished — "0 articles" is now honest.
     expect(screen.getByText(/0 articles/)).toBeInTheDocument();
   });
+
+  it("folds the left page tree to a rail and back, persisting the choice", async () => {
+    vi.spyOn(api, "fetchCatalogStrict").mockResolvedValue([]);
+    const { container } = render(
+      <Wiki articlePath={null} onNavigate={() => {}} />,
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId("wk-home")).toBeInTheDocument(),
+    );
+
+    const layout = container.querySelector(".wiki-layout");
+    expect(layout).toHaveAttribute("data-left-collapsed", "false");
+    expect(screen.getByTestId("wk-sidebar-home")).toBeInTheDocument();
+
+    // Collapse → the layout reports the fold and the menu yields to a rail.
+    fireEvent.click(
+      screen.getByRole("button", { name: "Collapse Pages panel" }),
+    );
+    expect(layout).toHaveAttribute("data-left-collapsed", "true");
+    expect(screen.queryByTestId("wk-sidebar-home")).not.toBeInTheDocument();
+    expect(globalThis.localStorage.getItem("wuphf:wiki:panels")).toContain(
+      '"left":true',
+    );
+
+    // Expand from the rail restores the full sidebar.
+    fireEvent.click(screen.getByRole("button", { name: "Expand Pages panel" }));
+    expect(layout).toHaveAttribute("data-left-collapsed", "false");
+    expect(screen.getByTestId("wk-sidebar-home")).toBeInTheDocument();
+  });
+
+  it("folds the right details rail on an article page", async () => {
+    vi.spyOn(api, "fetchCatalogStrict").mockResolvedValue([]);
+    vi.spyOn(api, "fetchArticle").mockResolvedValue({
+      path: "people/customer-x",
+      title: "Customer X",
+      content: "Body text.",
+      last_edited_by: "ceo",
+      last_edited_ts: new Date().toISOString(),
+      revisions: 1,
+      contributors: ["ceo"],
+      backlinks: [],
+      word_count: 10,
+      categories: [],
+    });
+    const { container } = render(
+      <Wiki articlePath="people/customer-x" onNavigate={() => {}} />,
+    );
+    await waitFor(() =>
+      expect(
+        screen.getByRole("heading", { name: "Customer X" }),
+      ).toBeInTheDocument(),
+    );
+
+    const layout = container.querySelector(".wiki-layout");
+    expect(layout).toHaveAttribute("data-right-collapsed", "false");
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Collapse Details panel" }),
+    );
+    expect(layout).toHaveAttribute("data-right-collapsed", "true");
+    expect(
+      screen.getByRole("button", { name: "Expand Details panel" }),
+    ).toBeInTheDocument();
+    expect(globalThis.localStorage.getItem("wuphf:wiki:panels")).toContain(
+      '"right":true',
+    );
+  });
 });

--- a/web/src/components/wiki/Wiki.tsx
+++ b/web/src/components/wiki/Wiki.tsx
@@ -7,6 +7,7 @@ import {
   subscribeSectionsUpdated,
   type WikiCatalogEntry,
 } from "../../api/wiki";
+import { useWikiPanels } from "../../hooks/useWikiPanels";
 import { track } from "../../lib/analytics";
 import EditLogFooter from "./EditLogFooter";
 import { APP_NAV_PREFIX } from "./tree/WikiTree";
@@ -124,6 +125,7 @@ export default function Wiki({
   const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [loadNonce, setLoadNonce] = useState(0);
+  const panels = useWikiPanels();
 
   // Resume where you left off: when the wiki opens with no explicit path,
   // navigate once to the last-viewed article. Guarded by a ref so it fires
@@ -225,10 +227,17 @@ export default function Wiki({
 
   return (
     <div className="wiki-root" data-testid="wiki-root">
-      <div className="wiki-layout" data-view={view}>
+      <div
+        className="wiki-layout"
+        data-view={view}
+        data-left-collapsed={panels.leftCollapsed}
+        data-right-collapsed={panels.rightCollapsed}
+      >
         <WikiSidebar
           currentPath={appPath ?? articlePath}
           onNavigate={(path) => onNavigate(path)}
+          collapsed={panels.leftCollapsed}
+          onToggleCollapse={panels.toggleLeft}
         />
         {view === "audit" ? (
           <WikiAudit onNavigate={(path) => onNavigate(path)} />
@@ -254,6 +263,8 @@ export default function Wiki({
             catalog={catalog}
             onNavigate={(path) => onNavigate(path)}
             externalRefreshNonce={externalRefreshNonce}
+            rightCollapsed={panels.rightCollapsed}
+            onToggleRightCollapse={panels.toggleRight}
           />
         ) : resuming ? (
           <main

--- a/web/src/components/wiki/WikiArticle.tsx
+++ b/web/src/components/wiki/WikiArticle.tsx
@@ -56,6 +56,7 @@ import { WIKI_TREE_QUERY_KEY } from "./tree/WikiTree";
 import VersionHistory from "./VersionHistory";
 import WikiEditor from "./WikiEditor";
 import WikiMaintenanceAssistant from "./WikiMaintenanceAssistant";
+import { CollapsedPanelRail, PanelCollapseButton } from "./WikiPanelChrome";
 import { categoryPath } from "./wikiPaths";
 
 const STALENESS_STALE_DAYS = 30;
@@ -201,6 +202,10 @@ interface WikiArticleProps {
    * additive trigger on top of the local refreshNonce used by inline edits.
    */
   externalRefreshNonce?: number;
+  /** Folds the right details rail to a thin strip when true. */
+  rightCollapsed?: boolean;
+  /** Toggles the right rail collapse. Omitted → no collapse affordance. */
+  onToggleRightCollapse?: () => void;
 }
 
 type DetectedEntity = { kind: EntityKind; slug: string };
@@ -300,6 +305,8 @@ export default function WikiArticle({
   catalog,
   onNavigate,
   externalRefreshNonce = 0,
+  rightCollapsed = false,
+  onToggleRightCollapse,
 }: WikiArticleProps) {
   const [tab, setTab] = useState<HatBarTab>("article");
   const [refreshNonce, setRefreshNonce] = useState(0);
@@ -638,6 +645,8 @@ export default function WikiArticle({
         toc={toc}
         onNavigate={onNavigate}
         onMaintenanceApplied={() => setRefreshNonce((n) => n + 1)}
+        collapsed={rightCollapsed}
+        onToggleCollapse={onToggleRightCollapse}
       />
     </>
   );
@@ -1053,11 +1062,15 @@ function ArticleRightSidebar({
   toc,
   onNavigate,
   onMaintenanceApplied,
+  collapsed = false,
+  onToggleCollapse,
 }: {
   article: WikiArticleT;
   toc: TocEntry[];
   onNavigate: (path: string) => void;
   onMaintenanceApplied: () => void;
+  collapsed?: boolean;
+  onToggleCollapse?: () => void;
 }) {
   // Consume the WikiLint "Suggest fix" hand-off exactly once per article
   // path. The consume call removes the slot from sessionStorage, so it is a
@@ -1078,8 +1091,30 @@ function ArticleRightSidebar({
       setInitialMaintenanceAction(target);
     }
   }, [article.path]);
+
+  if (collapsed && onToggleCollapse) {
+    return (
+      <aside className="wk-right-sidebar is-collapsed">
+        <CollapsedPanelRail
+          side="right"
+          label="Details"
+          onExpand={onToggleCollapse}
+        />
+      </aside>
+    );
+  }
+
   return (
     <aside className="wk-right-sidebar">
+      {onToggleCollapse ? (
+        <div className="wk-right-rail-head">
+          <PanelCollapseButton
+            side="right"
+            label="Details"
+            onClick={onToggleCollapse}
+          />
+        </div>
+      ) : null}
       <ArticleContents entries={toc} />
       <PageStatsPanel
         revisions={article.revisions}

--- a/web/src/components/wiki/WikiPanelChrome.stories.tsx
+++ b/web/src/components/wiki/WikiPanelChrome.stories.tsx
@@ -1,0 +1,66 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { CollapsedPanelRail, PanelCollapseButton } from "./WikiPanelChrome";
+import "../../styles/wiki.css";
+
+/**
+ * Fold-away chrome shared by the wiki's two flanking panels (left page tree,
+ * right details rail): a quiet in-panel collapse button, and the thin
+ * full-height rail the panel folds into. The lucide Panel{Left,Right} glyphs
+ * encode both which side and which direction, so no extra chevrons are needed.
+ */
+const meta: Meta = {
+  title: "Wiki / WikiPanelChrome",
+};
+export default meta;
+
+type Story = StoryObj;
+
+/** The in-panel collapse buttons for each side. */
+export const CollapseButtons: Story = {
+  render: () => (
+    <div
+      className="wiki-root"
+      style={{ display: "flex", gap: 24, padding: 24, alignItems: "center" }}
+    >
+      <PanelCollapseButton side="left" label="Pages" onClick={() => {}} />
+      <PanelCollapseButton side="right" label="Details" onClick={() => {}} />
+    </div>
+  ),
+};
+
+/** The collapsed rails as they sit in the layout — flanking the reading column. */
+export const Rails: Story = {
+  render: () => (
+    <div className="wiki-root" style={{ display: "flex", height: 320 }}>
+      <div
+        style={{
+          width: 44,
+          background: "var(--wk-sidebar-bg)",
+          borderRight: "1px solid var(--wk-border)",
+        }}
+      >
+        <CollapsedPanelRail side="left" label="Pages" onExpand={() => {}} />
+      </div>
+      <div
+        style={{
+          flex: 1,
+          padding: 24,
+          color: "var(--wk-text-muted)",
+          fontSize: 13,
+        }}
+      >
+        Reading column
+      </div>
+      <div
+        style={{
+          width: 44,
+          background: "var(--wk-sidebar-bg)",
+          borderLeft: "1px solid var(--wk-border)",
+        }}
+      >
+        <CollapsedPanelRail side="right" label="Details" onExpand={() => {}} />
+      </div>
+    </div>
+  ),
+};

--- a/web/src/components/wiki/WikiPanelChrome.tsx
+++ b/web/src/components/wiki/WikiPanelChrome.tsx
@@ -1,0 +1,76 @@
+import {
+  PanelLeftClose,
+  PanelLeftOpen,
+  PanelRightClose,
+  PanelRightOpen,
+} from "lucide-react";
+
+import type { WikiPanelSide } from "../../hooks/useWikiPanels";
+
+/**
+ * Shared chrome for the wiki's collapsible flanking panels. Both the left page
+ * tree and the right details rail reuse these two pieces so the collapse
+ * affordance reads identically on either side:
+ *
+ *   • PanelCollapseButton — a quiet icon button shown inside an open panel;
+ *     clicking it folds the panel away.
+ *   • CollapsedPanelRail — the panel reduced to a thin, full-height strip with
+ *     a vertical label; clicking anywhere on it restores the panel.
+ *
+ * The lucide Panel{Left,Right}{Open,Close} glyphs already encode "which side"
+ * and "which direction", so no extra chevrons are needed.
+ */
+
+interface PanelCollapseButtonProps {
+  side: WikiPanelSide;
+  /** Human label for the panel, used in the accessible name (e.g. "Pages"). */
+  label: string;
+  onClick: () => void;
+}
+
+export function PanelCollapseButton({
+  side,
+  label,
+  onClick,
+}: PanelCollapseButtonProps) {
+  const Icon = side === "left" ? PanelLeftClose : PanelRightClose;
+  return (
+    <button
+      type="button"
+      className={`wk-panel-collapse wk-panel-collapse--${side}`}
+      onClick={onClick}
+      aria-label={`Collapse ${label} panel`}
+      aria-expanded={true}
+      title={`Collapse ${label.toLowerCase()}`}
+    >
+      <Icon size={16} aria-hidden="true" />
+    </button>
+  );
+}
+
+interface CollapsedPanelRailProps {
+  side: WikiPanelSide;
+  label: string;
+  onExpand: () => void;
+}
+
+export function CollapsedPanelRail({
+  side,
+  label,
+  onExpand,
+}: CollapsedPanelRailProps) {
+  const Icon = side === "left" ? PanelLeftOpen : PanelRightOpen;
+  return (
+    <button
+      type="button"
+      className={`wk-panel-rail wk-panel-rail--${side}`}
+      onClick={onExpand}
+      aria-label={`Expand ${label} panel`}
+      aria-expanded={false}
+      title={`Expand ${label.toLowerCase()}`}
+    >
+      <Icon size={16} aria-hidden="true" className="wk-panel-rail-icon" />
+      <span className="wk-panel-rail-label">{label}</span>
+    </button>
+  );
+}

--- a/web/src/components/wiki/WikiSidebar.stories.tsx
+++ b/web/src/components/wiki/WikiSidebar.stories.tsx
@@ -119,17 +119,40 @@ function useTreeFetchStub(nodes: WikiFSTreeNode[]): boolean {
 
 interface HarnessProps {
   currentPath: string | null;
+  collapsed?: boolean;
 }
 
-function Harness({ currentPath }: HarnessProps) {
+function Harness({ currentPath, collapsed = false }: HarnessProps) {
   const ready = useTreeFetchStub(TREE);
+  const [isCollapsed, setIsCollapsed] = useState(collapsed);
+  useEffect(() => setIsCollapsed(collapsed), [collapsed]);
   if (!ready) return null;
+  // Emulate the real .wiki-layout grid so the collapse actually reclaims the
+  // track width — the same data-left-collapsed contract the app drives.
   return (
-    <div
-      className="wiki-root"
-      style={{ height: 560, width: 320, display: "flex" }}
-    >
-      <WikiSidebar currentPath={currentPath} onNavigate={() => {}} />
+    <div className="wiki-root" style={{ height: 560, width: 560 }}>
+      <div
+        className="wiki-layout"
+        data-view="home"
+        data-left-collapsed={isCollapsed}
+        style={{ height: "100%" }}
+      >
+        <WikiSidebar
+          currentPath={currentPath}
+          onNavigate={() => {}}
+          collapsed={isCollapsed}
+          onToggleCollapse={() => setIsCollapsed((v) => !v)}
+        />
+        <div
+          style={{
+            padding: 24,
+            color: "var(--wk-text-muted)",
+            fontSize: 13,
+          }}
+        >
+          Reading column — collapse the page tree to reclaim this width.
+        </div>
+      </div>
     </div>
   );
 }
@@ -150,4 +173,9 @@ export const Default: Story = {
 /** An article open: its branch highlights once expanded. */
 export const WithActiveArticle: Story = {
   args: { currentPath: "team/companies/acme.md" },
+};
+
+/** Folded to a rail: the page tree yields its width to the reading column. */
+export const Collapsed: Story = {
+  args: { currentPath: "", collapsed: true },
 };

--- a/web/src/components/wiki/WikiSidebar.test.tsx
+++ b/web/src/components/wiki/WikiSidebar.test.tsx
@@ -108,4 +108,50 @@ describe("<WikiSidebar>", () => {
     );
     expect(row).toHaveAttribute("aria-selected", "true");
   });
+
+  it("hides the collapse control when no toggle handler is provided", async () => {
+    render(<WikiSidebar currentPath={null} onNavigate={() => {}} />);
+    await waitFor(() =>
+      expect(screen.getByText("Companies")).toBeInTheDocument(),
+    );
+    expect(
+      screen.queryByRole("button", { name: "Collapse Pages panel" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows a collapse control that calls the toggle handler", async () => {
+    const onToggleCollapse = vi.fn();
+    render(
+      <WikiSidebar
+        currentPath={null}
+        onNavigate={() => {}}
+        collapsed={false}
+        onToggleCollapse={onToggleCollapse}
+      />,
+    );
+    await waitFor(() =>
+      expect(screen.getByText("Companies")).toBeInTheDocument(),
+    );
+    fireEvent.click(
+      screen.getByRole("button", { name: "Collapse Pages panel" }),
+    );
+    expect(onToggleCollapse).toHaveBeenCalledTimes(1);
+  });
+
+  it("folds to a rail when collapsed and expands again from it", () => {
+    const onToggleCollapse = vi.fn();
+    render(
+      <WikiSidebar
+        currentPath={null}
+        onNavigate={() => {}}
+        collapsed={true}
+        onToggleCollapse={onToggleCollapse}
+      />,
+    );
+    // The menu links + tree are replaced by the expand rail.
+    expect(screen.queryByTestId("wk-sidebar-home")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("wk-tree")).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Expand Pages panel" }));
+    expect(onToggleCollapse).toHaveBeenCalledTimes(1);
+  });
 });

--- a/web/src/components/wiki/WikiSidebar.tsx
+++ b/web/src/components/wiki/WikiSidebar.tsx
@@ -1,4 +1,5 @@
 import WikiTree from "./tree/WikiTree";
+import { CollapsedPanelRail, PanelCollapseButton } from "./WikiPanelChrome";
 import { AUDIT_PATH, LINT_PATH } from "./wikiPaths";
 
 /**
@@ -19,6 +20,13 @@ interface WikiSidebarProps {
   /** Currently-open article path (full team/...md), highlighted in the tree. */
   currentPath?: string | null;
   onNavigate: (path: string) => void;
+  /** Folds the sidebar to a thin rail when true. */
+  collapsed?: boolean;
+  /**
+   * Toggles collapse. When omitted, the collapse affordance is hidden entirely
+   * (the sidebar renders as before) — keeps standalone/test usage unchanged.
+   */
+  onToggleCollapse?: () => void;
 }
 
 interface SidebarLink {
@@ -36,10 +44,37 @@ const MENU_LINKS: SidebarLink[] = [
 export default function WikiSidebar({
   currentPath,
   onNavigate,
+  collapsed = false,
+  onToggleCollapse,
 }: WikiSidebarProps) {
   const current = currentPath ?? "";
+
+  if (collapsed && onToggleCollapse) {
+    return (
+      <aside
+        className="wk-nav-sidebar is-collapsed"
+        data-testid="wk-nav-sidebar"
+      >
+        <CollapsedPanelRail
+          side="left"
+          label="Pages"
+          onExpand={onToggleCollapse}
+        />
+      </aside>
+    );
+  }
+
   return (
     <aside className="wk-nav-sidebar" data-testid="wk-nav-sidebar">
+      {onToggleCollapse ? (
+        <div className="wk-sidebar-head">
+          <PanelCollapseButton
+            side="left"
+            label="Pages"
+            onClick={onToggleCollapse}
+          />
+        </div>
+      ) : null}
       <nav aria-label="Wiki navigation" className="wk-sidebar-menu">
         {MENU_LINKS.map((link) => {
           const isActive = current === link.path;

--- a/web/src/hooks/useWikiPanels.test.ts
+++ b/web/src/hooks/useWikiPanels.test.ts
@@ -1,0 +1,56 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { useWikiPanels } from "./useWikiPanels";
+
+const STORAGE_KEY = "wuphf:wiki:panels";
+
+describe("useWikiPanels", () => {
+  beforeEach(() => {
+    globalThis.localStorage?.clear();
+  });
+
+  it("defaults both flanking panels to open", () => {
+    const { result } = renderHook(() => useWikiPanels());
+    expect(result.current.leftCollapsed).toBe(false);
+    expect(result.current.rightCollapsed).toBe(false);
+  });
+
+  it("toggles and persists each side independently", () => {
+    const { result } = renderHook(() => useWikiPanels());
+
+    act(() => result.current.toggleLeft());
+    expect(result.current.leftCollapsed).toBe(true);
+    expect(result.current.rightCollapsed).toBe(false);
+
+    act(() => result.current.toggleRight());
+    expect(result.current.rightCollapsed).toBe(true);
+
+    expect(globalThis.localStorage.getItem(STORAGE_KEY)).toBe(
+      JSON.stringify({ left: true, right: true }),
+    );
+
+    act(() => result.current.toggleLeft());
+    expect(result.current.leftCollapsed).toBe(false);
+    expect(globalThis.localStorage.getItem(STORAGE_KEY)).toBe(
+      JSON.stringify({ left: false, right: true }),
+    );
+  });
+
+  it("restores the persisted collapse state on mount", () => {
+    globalThis.localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ left: true, right: false }),
+    );
+    const { result } = renderHook(() => useWikiPanels());
+    expect(result.current.leftCollapsed).toBe(true);
+    expect(result.current.rightCollapsed).toBe(false);
+  });
+
+  it("falls back to open panels when the stored value is malformed", () => {
+    globalThis.localStorage.setItem(STORAGE_KEY, "not json");
+    const { result } = renderHook(() => useWikiPanels());
+    expect(result.current.leftCollapsed).toBe(false);
+    expect(result.current.rightCollapsed).toBe(false);
+  });
+});

--- a/web/src/hooks/useWikiPanels.ts
+++ b/web/src/hooks/useWikiPanels.ts
@@ -1,0 +1,66 @@
+import { useCallback, useState } from "react";
+
+/**
+ * Collapse state for the wiki's two flanking panels — the left page tree and
+ * the right "details" rail. Either can be folded away to a thin rail so the
+ * reading column gets the full width, docmost/Notion-style. The preference is
+ * a durable, per-browser UI choice (like the app sidebar), so it persists to
+ * localStorage and survives reloads + navigations between articles.
+ */
+export type WikiPanelSide = "left" | "right";
+
+interface WikiPanelState {
+  left: boolean;
+  right: boolean;
+}
+
+const STORAGE_KEY = "wuphf:wiki:panels";
+
+function readState(): WikiPanelState {
+  try {
+    const raw = globalThis.localStorage?.getItem(STORAGE_KEY);
+    if (!raw) return { left: false, right: false };
+    const parsed = JSON.parse(raw) as Partial<WikiPanelState> | null;
+    return { left: parsed?.left === true, right: parsed?.right === true };
+  } catch {
+    // Private mode / malformed value — default to both panels open.
+    return { left: false, right: false };
+  }
+}
+
+function writeState(state: WikiPanelState): void {
+  try {
+    globalThis.localStorage?.setItem(STORAGE_KEY, JSON.stringify(state));
+  } catch {
+    // Private mode / quota — collapse preference is best-effort.
+  }
+}
+
+export interface WikiPanelsController {
+  leftCollapsed: boolean;
+  rightCollapsed: boolean;
+  toggleLeft: () => void;
+  toggleRight: () => void;
+}
+
+export function useWikiPanels(): WikiPanelsController {
+  const [state, setState] = useState<WikiPanelState>(readState);
+
+  const toggle = useCallback((side: WikiPanelSide) => {
+    setState((prev) => {
+      const next: WikiPanelState = { ...prev, [side]: !prev[side] };
+      writeState(next);
+      return next;
+    });
+  }, []);
+
+  const toggleLeft = useCallback(() => toggle("left"), [toggle]);
+  const toggleRight = useCallback(() => toggle("right"), [toggle]);
+
+  return {
+    leftCollapsed: state.left,
+    rightCollapsed: state.right,
+    toggleLeft,
+    toggleRight,
+  };
+}

--- a/web/src/styles/wiki.css
+++ b/web/src/styles/wiki.css
@@ -124,17 +124,30 @@
 
 /* ─── Layout: persistent page-tree sidebar + content (+ article right rail) ─── */
 .wiki-layout {
+  /* Either flanking panel can fold to a thin rail (--wk-panel-rail) so the
+     reading column reclaims the width. The active column widths live in
+     these custom props; the data-*-collapsed attributes below swap them, and
+     the grid templates simply consume them. */
+  --wk-panel-rail: 44px;
+  --wk-col-left: var(--wk-sidebar-left);
+  --wk-col-right: var(--wk-sidebar-right);
   display: grid;
-  grid-template-columns: var(--wk-sidebar-left) minmax(0, 1fr);
+  grid-template-columns: var(--wk-col-left) minmax(0, 1fr);
   flex: 1 1 auto;
   min-height: 0;
   overflow: hidden;
 }
 /* The article view adds docmost's right "details" rail. */
 .wiki-layout[data-view="article"] {
-  grid-template-columns: var(--wk-sidebar-left) minmax(0, 1fr) var(
-      --wk-sidebar-right
-    );
+  grid-template-columns: var(--wk-col-left) minmax(0, 1fr) var(--wk-col-right);
+}
+.wiki-layout[data-left-collapsed="true"] {
+  --wk-col-left: var(--wk-panel-rail);
+}
+/* The right rail only exists in the article view, so its collapse is scoped
+   there to avoid shrinking a column that other views never render. */
+.wiki-layout[data-view="article"][data-right-collapsed="true"] {
+  --wk-col-right: var(--wk-panel-rail);
 }
 .wiki-layout > .wk-article-col,
 .wiki-layout > .wk-home,
@@ -146,6 +159,112 @@
 /* Full-page editor spans the article + right-rail tracks. */
 .wk-article-col--editing {
   grid-column: 2 / -1;
+}
+
+/* ─── Collapsible panel chrome (left page tree + right details rail) ───
+   Both flanking panels share one fold-away vocabulary: a quiet icon button
+   inside the open panel, and — once folded — a thin full-height rail that
+   reads as a clickable strip with a vertical label. */
+
+/* Header row that hosts the in-panel collapse button. */
+.wk-sidebar-head {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  min-height: 24px;
+  margin-bottom: 4px;
+}
+.wk-right-rail-head {
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+  margin-bottom: 12px;
+}
+.wk-panel-collapse {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  padding: 0;
+  border: 0;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--wk-text-tertiary);
+  cursor: pointer;
+  transition:
+    background-color 0.12s ease,
+    color 0.12s ease;
+}
+.wk-panel-collapse:hover {
+  background: var(--wk-row-hover);
+  color: var(--wk-text);
+}
+.wk-panel-collapse:focus-visible {
+  outline: 2px solid var(--wk-accent);
+  outline-offset: -2px;
+}
+
+/* Folded state: the panel shrinks to the rail width and shows only the rail. */
+.wk-nav-sidebar.is-collapsed,
+.wk-right-sidebar.is-collapsed {
+  padding: 0;
+  overflow: hidden;
+}
+.wk-right-sidebar.is-collapsed {
+  /* Give the folded right rail the same offset surface as the left rail so
+     the two read as matching strips rather than a stray border on paper. */
+  background: var(--wk-sidebar-bg);
+}
+.wk-panel-rail {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  height: 100%;
+  padding: 14px 0;
+  border: 0;
+  background: transparent;
+  color: var(--wk-text-tertiary);
+  cursor: pointer;
+  transition:
+    background-color 0.12s ease,
+    color 0.12s ease;
+}
+.wk-panel-rail:hover {
+  background: var(--wk-row-hover);
+  color: var(--wk-text);
+}
+.wk-panel-rail:focus-visible {
+  outline: 2px solid var(--wk-accent);
+  outline-offset: -2px;
+}
+.wk-panel-rail-icon {
+  flex: none;
+}
+.wk-panel-rail-label {
+  writing-mode: vertical-rl;
+  text-orientation: mixed;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+/* Subtle arrival fade so the fold doesn't read as a hard cut. Opacity only —
+   compositor-friendly — and silenced under reduced-motion. */
+@media (prefers-reduced-motion: no-preference) {
+  .wk-panel-rail {
+    animation: wk-panel-rail-in 160ms ease;
+  }
+}
+@keyframes wk-panel-rail-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
 }
 
 /* ─── Article Contents panel (right rail, docmost "On this page") ─── */


### PR DESCRIPTION
## What

Two wiki UX changes:

1. **Collapsible flanking panels** — the left page tree and the right "details" rail each fold to a thin, clickable rail so the reading column reclaims the width. At common window sizes the two panels (300px + 280px) squeeze the article *below* its 800px reading measure; collapsing restores it and gives tables, code, visuals, and the editor real room. Collapse state persists per-browser in `localStorage` (`wuphf:wiki:panels`); each side toggles independently. Token-only styling, opacity-only motion (reduced-motion aware), faithful to the docmost-derived design system.

2. **Hide empty folders from the page tree** — `/wiki/tree` now prunes recursively-empty plain directories. A folder holding no pages/files anywhere beneath it is scaffolding noise, not navigation, so it never reaches the wire. Folders surface only once they hold content; the Librarian (or any writer) materializes a folder on demand by writing into it. Pruning is bottom-up; app/website dirs are content and never pruned.

## Why

Empty seeded scaffolding folders (`companies, decisions, learnings, …`) cluttered a fresh wiki tree, and the two flanking panels left little room for the article itself.

## How it works

- `useWikiPanels` hook owns the collapse state + persistence; `Wiki.tsx` sets `data-left-collapsed` / `data-right-collapsed` on `.wiki-layout`, which swap CSS custom props the grid templates consume. Shared `WikiPanelChrome` (button + rail) reused on both sides.
- `internal/team/wiki_fs.go` `buildTreeNodes` skips `dir` nodes whose recursive children are empty.

## Tests

- Go: `internal/team` full suite green (race); new `TestWikiTreeOmitsEmptyDirs` fails pre-fix / passes post-fix.
- Web: full wiki suite (525) + new `useWikiPanels` + Wiki/WikiSidebar collapse integration tests green; typecheck + production build clean; biome clean.

## Test plan

- [ ] Open an article; collapse/expand each panel; reload — state persists.
- [ ] A folder with no content does not appear in the tree; appears once a page is added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Collapsible left sidebar—users can now fold the page tree navigation into a compact rail and expand it on demand.
* Collapsible right details panel—article details sidebar can be collapsed to maximize reading space.
* Panel state persistence—collapse/expand preferences are saved and restored on return visits.

## Style
* Enhanced visual styling and smooth animations for collapsed panel states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->