### PR TITLE
feat(onboarding): two-column runtime picker — clip beside providers, grouped collapsible options

### DIFF
--- a/web/src/components/onboarding/PrePickScreen.test.tsx
+++ b/web/src/components/onboarding/PrePickScreen.test.tsx
@@ -387,6 +387,48 @@ describe("PrePickScreen runtime selection", () => {
 
 // ── New tests for Phase 5 ported sections ──────────────────────────────
 
+describe("config sections collapse", () => {
+  const SECTIONS = [
+    {
+      name: "API keys",
+      toggle: "pre-pick-api-keys-toggle",
+      body: "pre-pick-api-keys-body",
+    },
+    {
+      name: "Local model",
+      toggle: "pre-pick-local-toggle",
+      body: "pre-pick-local-body",
+    },
+    {
+      name: "Custom endpoint",
+      toggle: "pre-pick-oai-toggle",
+      body: "pre-pick-oai-body",
+    },
+  ];
+
+  for (const section of SECTIONS) {
+    it(`collapses "${section.name}" by default and toggles open/closed`, async () => {
+      mockPrereqs({});
+      render(<PrePickScreen onComplete={vi.fn()} />);
+      const toggle = await screen.findByTestId(section.toggle);
+      const body = document.getElementById(section.body);
+
+      // Collapsed by default — body kept mounted but hidden.
+      expect(toggle).toHaveAttribute("aria-expanded", "false");
+      expect(body).not.toBeNull();
+      expect(body).toHaveAttribute("hidden");
+
+      fireEvent.click(toggle);
+      expect(toggle).toHaveAttribute("aria-expanded", "true");
+      expect(body).not.toHaveAttribute("hidden");
+
+      fireEvent.click(toggle);
+      expect(toggle).toHaveAttribute("aria-expanded", "false");
+      expect(body).toHaveAttribute("hidden");
+    });
+  }
+});
+
 describe("API key row", () => {
   it("renders API key rows for Anthropic, OpenAI, and Google", async () => {
     mockPrereqs({});

--- a/web/src/components/onboarding/PrePickScreen.tsx
+++ b/web/src/components/onboarding/PrePickScreen.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
 import type { LLMRuntimeKind } from "../../api/client";
@@ -338,6 +339,177 @@ function VerifyClipFigure() {
   );
 }
 
+interface CollapsibleConfigSectionProps {
+  /** Stable testid for the <section> (kept to match existing tests). */
+  sectionTestId: string;
+  /** Prefix for the heading/body/toggle ids and the toggle testid. */
+  idBase: string;
+  title: string;
+  /** Short note shown to the right of the title in the collapsed header. */
+  toggleHint: string;
+  open: boolean;
+  onToggle: () => void;
+  children: ReactNode;
+}
+
+// Shared disclosure shell for the secondary config sections (API keys, local
+// model, custom endpoint). All three are fallbacks to CLI login, so each
+// starts collapsed. The body stays mounted (hidden) so in-progress field
+// state survives a collapse. Extracted to a module-level component so the
+// PrePickScreen render body stays within the per-function line budget.
+function CollapsibleConfigSection({
+  sectionTestId,
+  idBase,
+  title,
+  toggleHint,
+  open,
+  onToggle,
+  children,
+}: CollapsibleConfigSectionProps) {
+  return (
+    <section
+      className="pre-pick-section"
+      data-testid={sectionTestId}
+      aria-labelledby={`${idBase}-h`}
+    >
+      <button
+        type="button"
+        className={`pre-pick-section-toggle${open ? " open" : ""}`}
+        data-testid={`${idBase}-toggle`}
+        aria-expanded={open}
+        aria-controls={`${idBase}-body`}
+        onClick={onToggle}
+      >
+        <span className="pre-pick-section-toggle-chevron" aria-hidden="true">
+          &rsaquo;
+        </span>
+        <span className="pre-pick-section-heading" id={`${idBase}-h`}>
+          {title}
+        </span>
+        <span className="pre-pick-section-toggle-hint">{toggleHint}</span>
+      </button>
+      <div
+        className="pre-pick-section-collapse"
+        id={`${idBase}-body`}
+        hidden={!open}
+      >
+        {children}
+      </div>
+    </section>
+  );
+}
+
+interface ApiKeysSectionProps {
+  open: boolean;
+  onToggle: () => void;
+  apiKeys: Record<string, string>;
+  onChange: (key: string, value: string) => void;
+}
+
+function ApiKeysSection({
+  open,
+  onToggle,
+  apiKeys,
+  onChange,
+}: ApiKeysSectionProps) {
+  return (
+    <CollapsibleConfigSection
+      sectionTestId="pre-pick-api-keys"
+      idBase="pre-pick-api-keys"
+      title="API keys"
+      toggleHint="Optional — paste a key instead of CLI login"
+      open={open}
+      onToggle={onToggle}
+    >
+      <p className="pre-pick-section-hint">
+        Use CLI login or paste a key. CLI login is the primary path; keys are a
+        fallback or alternative.
+      </p>
+      <div className="key-group">
+        {API_KEY_FIELDS.map((field) => (
+          <PrePickApiKeyRow
+            key={field.key}
+            field={field}
+            value={apiKeys[field.key] ?? ""}
+            onChange={(v) => onChange(field.key, v)}
+          />
+        ))}
+      </div>
+    </CollapsibleConfigSection>
+  );
+}
+
+interface LocalModelSectionProps {
+  open: boolean;
+  onToggle: () => void;
+  selected: readonly string[];
+  onToggleProvider: (kind: string) => void;
+}
+
+function LocalModelSection({
+  open,
+  onToggle,
+  selected,
+  onToggleProvider,
+}: LocalModelSectionProps) {
+  return (
+    <CollapsibleConfigSection
+      sectionTestId="pre-pick-local-section"
+      idBase="pre-pick-local"
+      title="Local model"
+      toggleHint="Optional — run inference on this machine"
+      open={open}
+      onToggle={onToggle}
+    >
+      <p className="pre-pick-section-hint">
+        Run inference on this machine. No cloud key required.
+      </p>
+      <LocalProviderPicker selected={selected} onToggle={onToggleProvider} />
+    </CollapsibleConfigSection>
+  );
+}
+
+interface CustomEndpointSectionProps {
+  open: boolean;
+  onToggle: () => void;
+  oaiUrl: string;
+  oaiKey: string;
+  onChangeUrl: (value: string) => void;
+  onChangeKey: (value: string) => void;
+}
+
+function CustomEndpointSection({
+  open,
+  onToggle,
+  oaiUrl,
+  oaiKey,
+  onChangeUrl,
+  onChangeKey,
+}: CustomEndpointSectionProps) {
+  return (
+    <CollapsibleConfigSection
+      sectionTestId="pre-pick-oai-section"
+      idBase="pre-pick-oai"
+      title="Custom endpoint"
+      toggleHint="Optional — OpenAI-compatible server"
+      open={open}
+      onToggle={onToggle}
+    >
+      <p className="pre-pick-section-hint">
+        Any server that speaks the OpenAI REST protocol (LiteLLM, vLLM,
+        llama.cpp server, etc.). For OpenClaw or Hermes, use the Integrations
+        app after onboarding.
+      </p>
+      <OpenAICompatibleInput
+        endpointUrl={oaiUrl}
+        apiKey={oaiKey}
+        onChangeUrl={onChangeUrl}
+        onChangeKey={onChangeKey}
+      />
+    </CollapsibleConfigSection>
+  );
+}
+
 export function PrePickScreen({ onComplete }: PrePickScreenProps) {
   const [prereqs, setPrereqs] = useState<PrereqResult[]>([]);
   const [prereqsLoaded, setPrereqsLoaded] = useState(false);
@@ -350,6 +522,13 @@ export function PrePickScreen({ onComplete }: PrePickScreenProps) {
   // API key state (one entry per API_KEY_FIELDS entry)
   const [apiKeys, setApiKeys] =
     useState<Record<string, string>>(EMPTY_API_KEYS);
+
+  // The fallback config sections (keys / local / custom endpoint) are all
+  // secondary to CLI login, so each starts collapsed. Bodies stay mounted
+  // (hidden) when closed so in-progress field state survives a collapse.
+  const [apiKeysOpen, setApiKeysOpen] = useState(false);
+  const [localOpen, setLocalOpen] = useState(false);
+  const [oaiOpen, setOaiOpen] = useState(false);
 
   const [localProviders, setLocalProviders] = useState<LLMRuntimeKind[]>([]);
 
@@ -571,188 +750,160 @@ export function PrePickScreen({ onComplete }: PrePickScreenProps) {
   return (
     <div className="pre-pick-screen" data-testid="pre-pick-screen">
       <div className="pre-pick-body">
-        <div className="pre-pick-hero">
-          <div className="pre-pick-eyebrow">WUPHF</div>
-          <h1 className="pre-pick-headline">Pick a default runtime.</h1>
-          <p className="pre-pick-subhead">
-            This is the runtime new agents will inherit when they are created.
-            You can change it later in Settings, and most agents can be moved to
-            a different runtime one at a time from their profile. Agents
-            imported through a gateway (OpenClaw, Hermes) are managed from the
-            Integrations app instead.
-          </p>
-        </div>
+        {/* The hero, provider cards, and the grouped options card all live in
+            one left column so they read top-down on a single left edge. The
+            "Set up & verify" clip sits in the right column as a product-window
+            exhibit (stacking under the column on narrow viewports). */}
+        <div className="pre-pick-split">
+          <div className="pre-pick-left">
+            <div className="pre-pick-hero">
+              <div className="pre-pick-eyebrow">WUPHF</div>
+              <h1 className="pre-pick-headline">Pick a default runtime.</h1>
+              <p className="pre-pick-subhead">
+                New agents inherit this runtime when they're created — you can
+                change it later in Settings, one agent at a time. Gateway
+                imports (OpenClaw, Hermes) are managed from the Integrations
+                app.
+              </p>
+            </div>
 
-        {/* ── Section 1: CLI runtime cards ─────────────────────────────── */}
-        <div className="pre-pick-card-grid">
-          {runtimes.map((state) => (
-            <RuntimeCard
-              key={state.spec.label}
-              state={state}
-              prereqsLoaded={prereqsLoaded}
-              isSubmitting={submitting === state.spec.label}
-              anySubmitting={anySubmitting}
-              expanded={expandedGuide === state.spec.binary}
-              selected={
-                state.spec.provider !== null &&
-                selectedProviders.includes(state.spec.provider)
-              }
-              onToggle={(spec) => {
-                if (spec.provider) toggleProvider(spec.provider);
-              }}
-              onInstall={openInstallPage}
-              onCopySignIn={handleCopySignIn}
-              onToggleGuide={handleToggleGuide}
-            />
-          ))}
-        </div>
+            {/* ── Section 1: CLI runtime cards ─────────────────────────── */}
+            <div className="pre-pick-providers">
+              <div className="pre-pick-card-grid">
+                {runtimes.map((state) => (
+                  <RuntimeCard
+                    key={state.spec.label}
+                    state={state}
+                    prereqsLoaded={prereqsLoaded}
+                    isSubmitting={submitting === state.spec.label}
+                    anySubmitting={anySubmitting}
+                    expanded={expandedGuide === state.spec.binary}
+                    selected={
+                      state.spec.provider !== null &&
+                      selectedProviders.includes(state.spec.provider)
+                    }
+                    onToggle={(spec) => {
+                      if (spec.provider) toggleProvider(spec.provider);
+                    }}
+                    onInstall={openInstallPage}
+                    onCopySignIn={handleCopySignIn}
+                    onToggleGuide={handleToggleGuide}
+                  />
+                ))}
+              </div>
 
-        {/* ── Guided setup + verify panel for the expanded runtime ──────── */}
-        {expandedRuntime ? (
-          <RuntimeGuidePanel
-            key={expandedRuntime.spec.binary}
-            runtime={expandedRuntime.spec.binary}
-            label={expandedRuntime.spec.label}
-            onVerified={handleVerified}
-          />
-        ) : null}
+              {/* ── Guided setup + verify panel for the expanded runtime ── */}
+              {expandedRuntime ? (
+                <RuntimeGuidePanel
+                  key={expandedRuntime.spec.binary}
+                  runtime={expandedRuntime.spec.binary}
+                  label={expandedRuntime.spec.label}
+                  onVerified={handleVerified}
+                />
+              ) : null}
 
-        {/* ── Advance when a runtime has verified ready ─────────────────── */}
-        {anyRuntimeReady && expandedRuntime ? (
-          <div className="pre-pick-secondary-row">
-            <button
-              type="button"
-              className="btn btn-primary pre-pick-next-button"
-              data-testid="pre-pick-next"
-              disabled={anySubmitting}
-              onClick={() =>
-                void commitChoice(
-                  expandedRuntime.spec.provider,
-                  expandedRuntime.spec.label,
-                )
-              }
-            >
-              {submitting === expandedRuntime.spec.label
-                ? "Opening your office…"
-                : "Next  →"}
-            </button>
-          </div>
-        ) : null}
+              {/* ── Advance when a runtime has verified ready ───────────── */}
+              {anyRuntimeReady && expandedRuntime ? (
+                <div className="pre-pick-secondary-row">
+                  <button
+                    type="button"
+                    className="btn btn-primary pre-pick-next-button"
+                    data-testid="pre-pick-next"
+                    disabled={anySubmitting}
+                    onClick={() =>
+                      void commitChoice(
+                        expandedRuntime.spec.provider,
+                        expandedRuntime.spec.label,
+                      )
+                    }
+                  >
+                    {submitting === expandedRuntime.spec.label
+                      ? "Opening your office…"
+                      : "Next  →"}
+                  </button>
+                </div>
+              ) : null}
+            </div>
 
-        {/* What "Set up & verify" looks like. Sits BELOW the runtime cards so
-            the providers stay first; the clip illustrates the verify flow. */}
-        <VerifyClipFigure />
-
-        {/* ── Section 2: API keys ──────────────────────────────────────── */}
-        <section
-          className="pre-pick-section"
-          data-testid="pre-pick-api-keys"
-          aria-labelledby="pre-pick-api-keys-h"
-        >
-          <h2 className="pre-pick-section-heading" id="pre-pick-api-keys-h">
-            API keys
-          </h2>
-          <p className="pre-pick-section-hint">
-            Use CLI login or paste a key. CLI login is the primary path; keys
-            are a fallback or alternative.
-          </p>
-          <div className="key-group">
-            {API_KEY_FIELDS.map((field) => (
-              <PrePickApiKeyRow
-                key={field.key}
-                field={field}
-                value={apiKeys[field.key] ?? ""}
-                onChange={(v) => handleApiKeyChange(field.key, v)}
+            {/* ── Secondary config (one grouped card, all collapsed) ─────── */}
+            <div className="pre-pick-config-group">
+              <ApiKeysSection
+                open={apiKeysOpen}
+                onToggle={() => setApiKeysOpen((open) => !open)}
+                apiKeys={apiKeys}
+                onChange={handleApiKeyChange}
               />
-            ))}
-          </div>
-        </section>
+              <LocalModelSection
+                open={localOpen}
+                onToggle={() => setLocalOpen((open) => !open)}
+                selected={localProviders}
+                onToggleProvider={toggleLocalProvider}
+              />
+              <CustomEndpointSection
+                open={oaiOpen}
+                onToggle={() => setOaiOpen((open) => !open)}
+                oaiUrl={oaiUrl}
+                oaiKey={oaiKey}
+                onChangeUrl={setOaiUrl}
+                onChangeKey={setOaiKey}
+              />
+            </div>
 
-        {/* ── Section 3: Local provider picker ────────────────────────── */}
-        <section
-          className="pre-pick-section"
-          data-testid="pre-pick-local-section"
-          aria-labelledby="pre-pick-local-h"
-        >
-          <h2 className="pre-pick-section-heading" id="pre-pick-local-h">
-            Local model
-          </h2>
-          <p className="pre-pick-section-hint">
-            Run inference on this machine. No cloud key required.
-          </p>
-          <LocalProviderPicker
-            selected={localProviders}
-            onToggle={toggleLocalProvider}
-          />
-        </section>
+            {/* ── Submit from form sections ──────────────────────────────── */}
+            {canContinueFromForm ? (
+              <div className="pre-pick-secondary-row">
+                <button
+                  type="button"
+                  className="btn btn-primary pre-pick-form-submit"
+                  data-testid="pre-pick-form-submit"
+                  disabled={anySubmitting}
+                  onClick={() => void commitChoice("form", "form")}
+                >
+                  {submitting === "form"
+                    ? "Opening your office…"
+                    : "Continue  →"}
+                </button>
+                {selectedProviderLabels.length > 0 ? (
+                  <div className="pre-pick-selected-summary">
+                    Selected: {selectedProviderLabels.join(", ")}
+                  </div>
+                ) : null}
+              </div>
+            ) : null}
 
-        {/* ── Section 4: OpenAI-compatible endpoint ───────────────────── */}
-        <section
-          className="pre-pick-section"
-          data-testid="pre-pick-oai-section"
-          aria-labelledby="pre-pick-oai-h"
-        >
-          <h2 className="pre-pick-section-heading" id="pre-pick-oai-h">
-            Custom endpoint
-          </h2>
-          <p className="pre-pick-section-hint">
-            Any server that speaks the OpenAI REST protocol (LiteLLM, vLLM,
-            llama.cpp server, etc.). For OpenClaw or Hermes, use the
-            Integrations app after onboarding.
-          </p>
-          <OpenAICompatibleInput
-            endpointUrl={oaiUrl}
-            apiKey={oaiKey}
-            onChangeUrl={setOaiUrl}
-            onChangeKey={setOaiKey}
-          />
-        </section>
+            {/* ── Skip / sandbox affordance ──────────────────────────────── */}
+            <div className="pre-pick-secondary-row">
+              <button
+                type="button"
+                className="pre-pick-secondary-button"
+                data-testid="pre-pick-skip"
+                disabled={anySubmitting}
+                onClick={() => void commitChoice(null, "skip")}
+              >
+                {submitting === "skip"
+                  ? "Opening your office…"
+                  : "I will add one later  →"}
+              </button>
+            </div>
 
-        {/* ── Submit from form sections ────────────────────────────────── */}
-        {canContinueFromForm ? (
-          <div className="pre-pick-secondary-row">
-            <button
-              type="button"
-              className="btn btn-primary pre-pick-form-submit"
-              data-testid="pre-pick-form-submit"
-              disabled={anySubmitting}
-              onClick={() => void commitChoice("form", "form")}
-            >
-              {submitting === "form" ? "Opening your office…" : "Continue  →"}
-            </button>
-            {selectedProviderLabels.length > 0 ? (
-              <div className="pre-pick-selected-summary">
-                Selected: {selectedProviderLabels.join(", ")}
+            <p className="pre-pick-helper">
+              You can change this any time in{" "}
+              <strong>Settings &rarr; Runtimes</strong>.
+            </p>
+
+            {submitError ? (
+              <div role="alert" className="pre-pick-error">
+                {submitError}
               </div>
             ) : null}
           </div>
-        ) : null}
 
-        {/* ── Skip / sandbox affordance ────────────────────────────────── */}
-        <div className="pre-pick-secondary-row">
-          <button
-            type="button"
-            className="pre-pick-secondary-button"
-            data-testid="pre-pick-skip"
-            disabled={anySubmitting}
-            onClick={() => void commitChoice(null, "skip")}
-          >
-            {submitting === "skip"
-              ? "Opening your office…"
-              : "I will add one later  →"}
-          </button>
+          {/* What "Set up & verify" looks like — illustration of the verify
+              flow, kept beside the providers on the right. */}
+          <aside className="pre-pick-aside">
+            <VerifyClipFigure />
+          </aside>
         </div>
-
-        <p className="pre-pick-helper">
-          You can change this any time in{" "}
-          <strong>Settings &rarr; Runtimes</strong>.
-        </p>
-
-        {submitError ? (
-          <div role="alert" className="pre-pick-error">
-            {submitError}
-          </div>
-        ) : null}
       </div>
     </div>
   );

--- a/web/src/styles/onboarding.css
+++ b/web/src/styles/onboarding.css
@@ -2011,9 +2011,11 @@
 .pre-pick-screen {
   min-height: 100vh;
   display: flex;
-  align-items: center;
+  /* Top-anchored (not vertically centered) so the page reads top-down and
+     avoids a dead band above the hero on tall viewports. */
+  align-items: flex-start;
   justify-content: center;
-  padding: 40px 24px;
+  padding: clamp(48px, 9vh, 112px) 24px 64px;
   /* Token-based accent wash mirroring the wizard host (.onboarding-wizard):
      a faint accent radial over the theme base so it reads on light, dark, and
      noir without hardcoding a light gradient. */
@@ -2028,48 +2030,97 @@
 
 .pre-pick-body {
   width: 100%;
-  max-width: 640px;
+  max-width: 1000px;
   display: flex;
   flex-direction: column;
-  gap: 32px;
-  align-items: center;
+}
+
+/* Two-column band: the provider cards + every collapsible config section
+   share the left column (so they line up on one left edge); the verify clip
+   sits in the right column. Collapses to a single column on narrow viewports,
+   where the clip falls back under the left column. */
+.pre-pick-split {
+  display: grid;
+  grid-template-columns: minmax(0, 1.15fr) minmax(0, 0.85fr);
+  gap: 48px;
+  width: 100%;
+  align-items: start;
+}
+
+/* The shared left column: provider cards on top, then the config sections,
+   all stretched to the same width and aligned to the same left edge. */
+.pre-pick-left {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  min-width: 0;
+}
+
+.pre-pick-providers {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  min-width: 0;
+}
+
+/* The clip is centered vertically against the (taller) left column so the
+   right side reads as a balanced exhibit rather than top-aligned with empty
+   space beneath it. */
+.pre-pick-aside {
+  align-self: center;
+  display: flex;
+  justify-content: center;
+  min-width: 0;
+}
+
+@media (max-width: 880px) {
+  .pre-pick-split {
+    grid-template-columns: 1fr;
+    gap: 28px;
+  }
+
+  .pre-pick-aside {
+    align-self: stretch;
+  }
 }
 
 .pre-pick-hero {
-  text-align: center;
+  text-align: left;
+  margin-bottom: 4px;
 }
 
 .pre-pick-eyebrow {
   font-size: 11px;
-  letter-spacing: 0.16em;
+  font-weight: 600;
+  letter-spacing: 0.18em;
   text-transform: uppercase;
-  color: var(--text-secondary);
-  margin-bottom: 10px;
+  color: var(--accent);
+  margin-bottom: 12px;
 }
 
 .pre-pick-headline {
   font-family: var(--font-logo);
-  font-size: 36px;
+  font-size: 40px;
   font-weight: 700;
-  letter-spacing: -0.02em;
-  line-height: 1.1;
-  margin: 0 0 12px 0;
+  letter-spacing: -0.025em;
+  line-height: 1.05;
+  margin: 0 0 14px 0;
 }
 
 .pre-pick-subhead {
   font-size: 14px;
   line-height: 1.6;
   color: var(--text-secondary);
-  max-width: 480px;
-  margin: 0 auto;
-  text-wrap: balance;
+  max-width: 460px;
+  margin: 0;
+  text-wrap: pretty;
 }
 
 /* Rendered Remotion clip illustrating the verify pass (install / sign-in /
-   model-reachable checks resolving to Connected). It sits BELOW the runtime
-   cards so the providers stay the first actionable block. The clip is a
-   self-contained product window on its own soft backdrop, so it reads on any
-   theme. */
+   model-reachable checks resolving to Connected). It sits to the RIGHT of the
+   runtime cards (and under them on narrow viewports) so the providers stay the
+   first actionable block. The clip is a self-contained product window on its
+   own soft backdrop, so it reads on any theme. */
 .pre-pick-clip-figure {
   width: 100%;
   margin: 0;
@@ -2082,7 +2133,7 @@
 .pre-pick-clip {
   display: block;
   width: 100%;
-  max-width: 480px;
+  max-width: 440px;
   height: auto;
   border-radius: var(--radius-lg);
 }
@@ -2620,6 +2671,144 @@
   text-transform: uppercase;
   color: var(--text-secondary);
   margin: 0;
+}
+
+/* Disclosure header for a collapsible pre-pick section (e.g. API keys).
+   Borderless so it reads as a section label, not a button, while still
+   exposing the full keyboard/AT affordances of a real <button>. */
+.pre-pick-section-toggle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 2px 0;
+  border: none;
+  background: transparent;
+  text-align: left;
+  cursor: pointer;
+  color: var(--text-secondary);
+}
+
+.pre-pick-section-toggle-chevron {
+  display: inline-block;
+  font-size: 14px;
+  line-height: 1;
+  color: var(--text-secondary);
+  transition: transform 160ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.pre-pick-section-toggle-hint {
+  margin-left: auto;
+  font-size: 11px;
+  font-weight: 400;
+  letter-spacing: 0;
+  text-transform: none;
+  color: var(--text-secondary);
+}
+
+.pre-pick-section-collapse {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+/* Ordered after the base selectors above so specificity ascends and biome's
+   noDescendingSpecificity stays satisfied. */
+.pre-pick-section-toggle:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 3px;
+  border-radius: var(--radius-sm);
+}
+
+.pre-pick-section-toggle:hover .pre-pick-section-heading,
+.pre-pick-section-toggle:hover .pre-pick-section-toggle-chevron {
+  color: var(--text);
+}
+
+.pre-pick-section-toggle.open .pre-pick-section-toggle-chevron {
+  transform: rotate(90deg);
+  color: var(--accent);
+}
+
+/* Grouped "options" card — the three secondary config sections (API keys,
+   local model, custom endpoint) read as one settings group with hairline
+   dividers instead of three loose rows floating under the cards. */
+.pre-pick-config-group {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  background: var(--bg-card);
+  overflow: hidden;
+}
+
+.pre-pick-config-group .pre-pick-section {
+  gap: 0;
+}
+
+.pre-pick-config-group .pre-pick-section + .pre-pick-section {
+  border-top: 1px solid var(--border);
+}
+
+.pre-pick-config-group .pre-pick-section-toggle {
+  padding: 13px 16px;
+}
+
+.pre-pick-config-group .pre-pick-section-collapse {
+  padding: 2px 16px 16px;
+}
+
+.pre-pick-config-group .pre-pick-section-toggle:hover {
+  background: color-mix(in srgb, var(--text) 4%, transparent);
+}
+
+/* One-shot staggered entrance for the pick screen — a single directed load
+   sequence rather than scattered hover effects. Reduced-motion users get the
+   final state instantly (guarded by the no-preference query). */
+@media (prefers-reduced-motion: no-preference) {
+  .pre-pick-left > *,
+  .pre-pick-aside {
+    animation: pre-pick-rise 520ms cubic-bezier(0.22, 1, 0.36, 1) both;
+  }
+
+  .pre-pick-left > *:nth-child(1) {
+    animation-delay: 40ms;
+  }
+
+  .pre-pick-left > *:nth-child(2) {
+    animation-delay: 110ms;
+  }
+
+  .pre-pick-left > *:nth-child(3) {
+    animation-delay: 180ms;
+  }
+
+  .pre-pick-left > *:nth-child(n + 4) {
+    animation-delay: 240ms;
+  }
+
+  .pre-pick-aside {
+    animation-delay: 180ms;
+  }
+}
+
+@keyframes pre-pick-rise {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .pre-pick-section-toggle-chevron {
+    transition: none;
+  }
 }
 
 .pre-pick-section-hint {


### PR DESCRIPTION
## What

Reworks the PrePick **"Pick a default runtime"** onboarding screen.

- **Verify clip moved to the right column**, beside the provider cards (centered against the left column) instead of stacking below them.
- **One shared left column** for the hero, provider cards, and config sections, so everything lines up on a single left edge.
- **All three secondary config sections** (API keys, Local model, Custom endpoint) are now **collapsible and collapsed by default**, grouped into one settings card with hairline dividers. CLI login stays the primary path.
- **Editorial polish:** left-aligned accent eyebrow + larger headline, tightened subhead, top-anchored layout, and a single `prefers-reduced-motion`-gated load sequence.

## Notes

- Collapsed bodies stay mounted (`hidden`) so in-progress field state survives a collapse.
- Disclosure shells share a `CollapsibleConfigSection` component (+ three thin wrappers), which also drops the `PrePickScreen` per-function line count below `main`'s.
- Styling is token-only (`--accent`, `--bg-card`, `--border`, `--radius-*`, `color-mix`) — holds across Light/Dark/Noir.

## Test plan

- [x] `bunx tsc --noEmit` clean (app)
- [x] `biome check` clean (only the pre-existing function-length warning, below `main`'s 220)
- [x] `scripts/test-web.sh PrePickScreen.test.tsx` — **38 passing**, incl. new parametrized regression test asserting all three sections start collapsed and toggle open/closed
- [x] `bun run build` ✓
- [x] Live-verified against a real broker + screenshots below

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Screenshots

![01-prepick-gif-right-keys-collapsed](https://github.com/nex-crm/wuphf/raw/screenshots/pr-1085/01-prepick-gif-right-keys-collapsed.png)

![02-prepick-api-keys-expanded](https://github.com/nex-crm/wuphf/raw/screenshots/pr-1085/02-prepick-api-keys-expanded.png)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configuration sections are now collapsible, giving users flexibility to expand them as needed during setup.

* **Style**
  * Reorganized onboarding layout into a two-column design with the setup guide positioned alongside configuration options.
  * Enhanced responsive behavior for smaller screens and added smooth entrance animations.

* **Tests**
  * Added comprehensive test coverage for collapsible section functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->