### PR TITLE
fix(integrations): auto-install Composio CLI is found + connect flows work

### DIFF
--- a/internal/action/composio.go
+++ b/internal/action/composio.go
@@ -800,31 +800,33 @@ func (c *ComposioREST) listAuthConfigs(ctx context.Context, platform string) ([]
 }
 
 func (c *ComposioREST) createComposioManagedAuthConfig(ctx context.Context, platform string) (string, error) {
+	// v3 schema: the toolkit and auth config are nested objects. The older flat
+	// shape (toolkit_slug/type/is_composio_managed) now 400s with
+	// "payload.toolkit: Required".
 	body := map[string]any{
-		"toolkit_slug":        platform,
-		"type":                "use_composio_managed_auth",
-		"name":                "WUPHF " + DisplayPlatformName(platform),
-		"is_composio_managed": true,
+		"toolkit": map[string]any{"slug": platform},
+		"auth_config": map[string]any{
+			"type": "use_composio_managed_auth",
+			"name": "WUPHF " + DisplayPlatformName(platform),
+		},
 	}
 	raw, err := c.post(ctx, "/auth_configs", body)
 	if err != nil {
 		return "", err
 	}
-	var result composioAuthConfig
+	// v3 returns the created config nested under auth_config; older shapes put
+	// the id at the top level or under item/data.
+	var result struct {
+		ID         string             `json:"id"`
+		AuthConfig composioAuthConfig `json:"auth_config"`
+		Item       composioAuthConfig `json:"item"`
+		Data       composioAuthConfig `json:"data"`
+	}
 	if err := json.Unmarshal(raw, &result); err != nil {
 		return "", fmt.Errorf("parse composio auth config create: %w", err)
 	}
-	if id := strings.TrimSpace(result.ID); id != "" {
+	if id := strings.TrimSpace(firstNonEmpty(result.ID, result.AuthConfig.ID, result.Item.ID, result.Data.ID)); id != "" {
 		return id, nil
-	}
-	var wrapped struct {
-		Item composioAuthConfig `json:"item"`
-		Data composioAuthConfig `json:"data"`
-	}
-	if err := json.Unmarshal(raw, &wrapped); err == nil {
-		if id := strings.TrimSpace(firstNonEmpty(wrapped.Item.ID, wrapped.Data.ID)); id != "" {
-			return id, nil
-		}
 	}
 	return "", fmt.Errorf("composio auth config response did not include id")
 }

--- a/internal/action/composio.go
+++ b/internal/action/composio.go
@@ -18,10 +18,19 @@ import (
 const defaultComposioBaseURL = "https://backend.composio.dev/api/v3"
 
 type ComposioREST struct {
-	APIKey  string
-	UserID  string
-	BaseURL string
-	Client  *http.Client
+	// APIKey is a project-scoped `ak_` key (sent as x-api-key). When set it
+	// takes precedence over the user-key fields below.
+	APIKey string
+	// UserAPIKey/OrgID/ProjectID are the user-key auth mode: the `uak_` session
+	// key plus org (required) and project (optional) ids, sent as
+	// x-user-api-key / x-org-id / x-project-id. Used when no project ak_ key is
+	// available (the current composio CLI can't mint one via `dev init`).
+	UserAPIKey string
+	OrgID      string
+	ProjectID  string
+	UserID     string
+	BaseURL    string
+	Client     *http.Client
 }
 
 type ComposioAPIError struct {
@@ -50,17 +59,43 @@ func NewComposioFromEnv() *ComposioREST {
 		baseURL = defaultComposioBaseURL
 	}
 	return &ComposioREST{
-		APIKey:  strings.TrimSpace(config.ResolveComposioAPIKey()),
-		UserID:  strings.TrimSpace(config.ResolveComposioUserID()),
-		BaseURL: baseURL,
-		Client:  &http.Client{Timeout: 30 * time.Second},
+		APIKey:     strings.TrimSpace(config.ResolveComposioAPIKey()),
+		UserAPIKey: strings.TrimSpace(config.ResolveComposioUserAPIKey()),
+		OrgID:      strings.TrimSpace(config.ResolveComposioOrgID()),
+		ProjectID:  strings.TrimSpace(config.ResolveComposioProjectID()),
+		UserID:     strings.TrimSpace(config.ResolveComposioUserID()),
+		BaseURL:    baseURL,
+		Client:     &http.Client{Timeout: 30 * time.Second},
+	}
+}
+
+// hasAuth reports whether the client carries usable Composio credentials:
+// either a project `ak_` key, or the user-key pair (`uak_` + org id).
+func (c *ComposioREST) hasAuth() bool {
+	if strings.TrimSpace(c.APIKey) != "" {
+		return true
+	}
+	return strings.TrimSpace(c.UserAPIKey) != "" && strings.TrimSpace(c.OrgID) != ""
+}
+
+// applyAuthHeaders sets the auth headers for the active mode: x-api-key for a
+// project key, else x-user-api-key + x-org-id (+ x-project-id when known).
+func (c *ComposioREST) applyAuthHeaders(h http.Header) {
+	if key := strings.TrimSpace(c.APIKey); key != "" {
+		h.Set("x-api-key", key)
+		return
+	}
+	h.Set("x-user-api-key", strings.TrimSpace(c.UserAPIKey))
+	h.Set("x-org-id", strings.TrimSpace(c.OrgID))
+	if proj := strings.TrimSpace(c.ProjectID); proj != "" {
+		h.Set("x-project-id", proj)
 	}
 }
 
 func (c *ComposioREST) Name() string { return "composio" }
 
 func (c *ComposioREST) Configured() bool {
-	return !config.ResolveNoNex() && strings.TrimSpace(c.APIKey) != "" && strings.TrimSpace(c.UserID) != ""
+	return !config.ResolveNoNex() && c.hasAuth() && strings.TrimSpace(c.UserID) != ""
 }
 
 func (c *ComposioREST) Supports(cap Capability) bool {
@@ -648,7 +683,7 @@ func (c *ComposioREST) delete(ctx context.Context, path string) ([]byte, error) 
 
 func (c *ComposioREST) do(ctx context.Context, method, path string, query url.Values, body any) ([]byte, error) {
 	if !c.Configured() {
-		return nil, fmt.Errorf("composio is not configured; set COMPOSIO_API_KEY and a user identity")
+		return nil, fmt.Errorf("composio is not configured; set COMPOSIO_API_KEY (or sign in with Composio) and a user identity")
 	}
 	u := strings.TrimRight(c.BaseURL, "/") + path
 	if encoded := query.Encode(); encoded != "" {
@@ -666,7 +701,7 @@ func (c *ComposioREST) do(ctx context.Context, method, path string, query url.Va
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Set("x-api-key", c.APIKey)
+	c.applyAuthHeaders(req.Header)
 	req.Header.Set("Accept", "application/json")
 	if body != nil {
 		req.Header.Set("Content-Type", "application/json")

--- a/internal/action/composio.go
+++ b/internal/action/composio.go
@@ -80,6 +80,13 @@ func (c *ComposioREST) hasAuth() bool {
 
 // applyAuthHeaders sets the auth headers for the active mode: x-api-key for a
 // project key, else x-user-api-key + x-org-id (+ x-project-id when known).
+//
+// x-api-key (project ak_ key) is Composio's DOCUMENTED public-API auth and is
+// preferred whenever a key is present (manual paste). The x-user-api-key trio
+// is the auth the official `composio` CLI uses internally; it is not in the
+// public REST docs but is stable in practice (the CLI relies on it) and is the
+// only path available to the one-click sign-in, since the current CLI can't
+// mint a project ak_ key. Verified working on both /api/v3 and /api/v3.1.
 func (c *ComposioREST) applyAuthHeaders(h http.Header) {
 	if key := strings.TrimSpace(c.APIKey); key != "" {
 		h.Set("x-api-key", key)
@@ -241,6 +248,11 @@ func (c *ComposioREST) StartIntegrationConnection(ctx context.Context, req Integ
 		"auth_config_id": authConfigID,
 		"user_id":        strings.TrimSpace(c.UserID),
 	}
+	// Use link() (hosted auth), NOT initiate(): Composio is deprecating
+	// initiate() for Composio-managed OAuth (new orgs 2026-05-08, all orgs
+	// 2026-07-03). link() is the recommended, unaffected path and allows
+	// multiple accounts per toolkit. Do not switch this back to
+	// /connected_accounts initiate.
 	raw, err := c.post(ctx, "/connected_accounts/link", body)
 	if err != nil {
 		return IntegrationConnectResult{}, err

--- a/internal/action/composio.go
+++ b/internal/action/composio.go
@@ -174,6 +174,12 @@ func (c *ComposioREST) ListIntegrationCatalog(ctx context.Context, opts Integrat
 		if platform == "" {
 			continue
 		}
+		// Hide Composio's own meta-toolkits (e.g. "Composio", "Composio
+		// Search"): the product is white-labeled as "Integrations".
+		if strings.HasPrefix(strings.ToLower(platform), "composio") ||
+			strings.HasPrefix(strings.ToLower(strings.TrimSpace(item.Name)), "composio") {
+			continue
+		}
 		conns := byPlatform[platform]
 		hasConnection := len(conns) > 0
 		switch connectedFilter {

--- a/internal/action/composio_test.go
+++ b/internal/action/composio_test.go
@@ -879,3 +879,55 @@ func TestComposioRESTCatalogHidesComposioToolkits(t *testing.T) {
 		t.Fatalf("expected only Gmail to remain, got %+v", catalog.Items)
 	}
 }
+
+// TestComposioRESTCreatesV3AuthConfig: the v3 /auth_configs schema needs nested
+// toolkit + auth_config objects (the old flat toolkit_slug shape 400s with
+// "payload.toolkit: Required"), and returns the id nested under auth_config.
+func TestComposioRESTCreatesV3AuthConfig(t *testing.T) {
+	var gotBody map[string]any
+	mux := http.NewServeMux()
+	mux.HandleFunc("/connected_accounts", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"items": []map[string]any{}})
+	})
+	mux.HandleFunc("/auth_configs", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			_ = json.NewEncoder(w).Encode(map[string]any{"items": []map[string]any{}})
+		case http.MethodPost:
+			_ = json.NewDecoder(r.Body).Decode(&gotBody)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"toolkit":     map[string]any{"slug": "gmail"},
+				"auth_config": map[string]any{"id": "ac_123"},
+			})
+		}
+	})
+	mux.HandleFunc("/connected_accounts/link", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"connected_account_id": "ca_1",
+			"redirect_url":         "https://connect.composio.dev/x",
+			"status":               "INITIATED",
+		})
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+	client := &ComposioREST{APIKey: "cmp_test", UserID: "ceo@example.com", BaseURL: server.URL, Client: server.Client()}
+
+	res, err := client.StartIntegrationConnection(context.Background(), IntegrationConnectRequest{Platform: "gmail"})
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	if res.AuthURL == "" {
+		t.Fatalf("expected an auth url (auth_config.id parsed), got %+v", res)
+	}
+	if gotBody["toolkit_slug"] != nil {
+		t.Fatalf("must not send the flat toolkit_slug, body=%v", gotBody)
+	}
+	tk, _ := gotBody["toolkit"].(map[string]any)
+	if tk["slug"] != "gmail" {
+		t.Fatalf("expected nested toolkit.slug=gmail, body=%v", gotBody)
+	}
+	ac, _ := gotBody["auth_config"].(map[string]any)
+	if ac["type"] != "use_composio_managed_auth" {
+		t.Fatalf("expected nested auth_config.type, body=%v", gotBody)
+	}
+}

--- a/internal/action/composio_test.go
+++ b/internal/action/composio_test.go
@@ -781,3 +781,62 @@ func TestWorkflowStepsExposeGenericResult(t *testing.T) {
 		t.Fatalf("expected compact insight summary, got %#v", recentInsights["result"])
 	}
 }
+
+func TestComposioApplyAuthHeaders(t *testing.T) {
+	t.Run("project key wins and suppresses user-key headers", func(t *testing.T) {
+		c := &ComposioREST{APIKey: "ak_proj", UserAPIKey: "uak_x", OrgID: "ok_1", ProjectID: "pr_1"}
+		h := http.Header{}
+		c.applyAuthHeaders(h)
+		if got := h.Get("x-api-key"); got != "ak_proj" {
+			t.Fatalf("x-api-key = %q, want ak_proj", got)
+		}
+		if h.Get("x-user-api-key") != "" || h.Get("x-org-id") != "" || h.Get("x-project-id") != "" {
+			t.Fatalf("user-key headers must not be set in ak_ mode: %v", h)
+		}
+	})
+
+	t.Run("user-key mode sets the trio", func(t *testing.T) {
+		c := &ComposioREST{UserAPIKey: "uak_x", OrgID: "ok_1", ProjectID: "pr_1"}
+		h := http.Header{}
+		c.applyAuthHeaders(h)
+		if h.Get("x-api-key") != "" {
+			t.Fatalf("x-api-key must be empty in user-key mode, got %q", h.Get("x-api-key"))
+		}
+		if h.Get("x-user-api-key") != "uak_x" || h.Get("x-org-id") != "ok_1" || h.Get("x-project-id") != "pr_1" {
+			t.Fatalf("unexpected user-key headers: %v", h)
+		}
+	})
+
+	t.Run("user-key without project omits x-project-id", func(t *testing.T) {
+		c := &ComposioREST{UserAPIKey: "uak_x", OrgID: "ok_1"}
+		h := http.Header{}
+		c.applyAuthHeaders(h)
+		if _, ok := h["X-Project-Id"]; ok {
+			t.Fatalf("x-project-id must be absent when project id is empty: %v", h)
+		}
+		if h.Get("x-user-api-key") != "uak_x" || h.Get("x-org-id") != "ok_1" {
+			t.Fatalf("unexpected headers: %v", h)
+		}
+	})
+}
+
+func TestComposioHasAuth(t *testing.T) {
+	cases := []struct {
+		name string
+		c    ComposioREST
+		want bool
+	}{
+		{"project key", ComposioREST{APIKey: "ak_x"}, true},
+		{"user key + org", ComposioREST{UserAPIKey: "uak_x", OrgID: "ok_1"}, true},
+		{"user key without org", ComposioREST{UserAPIKey: "uak_x"}, false},
+		{"org without user key", ComposioREST{OrgID: "ok_1"}, false},
+		{"nothing", ComposioREST{}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.c.hasAuth(); got != tc.want {
+				t.Fatalf("hasAuth() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/action/composio_test.go
+++ b/internal/action/composio_test.go
@@ -840,3 +840,42 @@ func TestComposioHasAuth(t *testing.T) {
 		})
 	}
 }
+
+func TestComposioRESTCatalogHidesComposioToolkits(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/connected_accounts", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"items": []map[string]any{}})
+	})
+	mux.HandleFunc("/toolkits", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"items": []map[string]any{
+				{"slug": "composio", "name": "Composio"},
+				{"slug": "composio_search", "name": "Composio Search"},
+				{"slug": "gmail", "name": "Gmail"},
+			},
+		})
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	client := &ComposioREST{
+		APIKey:  "cmp_test",
+		UserID:  "ceo@example.com",
+		BaseURL: server.URL,
+		Client:  server.Client(),
+	}
+	catalog, err := client.ListIntegrationCatalog(context.Background(), IntegrationCatalogOptions{Limit: 50})
+	if err != nil {
+		t.Fatalf("catalog: %v", err)
+	}
+	// White-labeled: Composio's own toolkits must never reach the catalog.
+	for _, item := range catalog.Items {
+		if strings.HasPrefix(strings.ToLower(item.Name), "composio") ||
+			strings.HasPrefix(strings.ToLower(item.Platform), "composio") {
+			t.Fatalf("composio toolkit leaked into the catalog: %+v", item)
+		}
+	}
+	if len(catalog.Items) != 1 || catalog.Items[0].Name != "Gmail" {
+		t.Fatalf("expected only Gmail to remain, got %+v", catalog.Items)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -37,11 +37,20 @@ type Config struct {
 	MemoryBackend  string `json:"memory_backend,omitempty"`
 	OneAPIKey      string `json:"one_api_key,omitempty"`
 	ComposioAPIKey string `json:"composio_api_key,omitempty"`
-	ActionProvider string `json:"action_provider,omitempty"`
-	Email          string `json:"email,omitempty"`
-	WorkspaceID    string `json:"workspace_id,omitempty"`
-	WorkspaceSlug  string `json:"workspace_slug,omitempty"`
-	LLMProvider    string `json:"llm_provider,omitempty"`
+	// Composio user-key auth (fallback when the CLI can't mint a project ak_
+	// key — the current composio CLI no longer writes one via `dev init`). The
+	// SDK accepts EITHER a project `ak_` key (sent as x-api-key) OR the
+	// user-scoped `uak_` session key paired with org + project ids (sent as
+	// x-user-api-key / x-org-id / x-project-id). These hold the latter;
+	// ComposioAPIKey, when set, takes precedence.
+	ComposioUserAPIKey string `json:"composio_user_api_key,omitempty"`
+	ComposioOrgID      string `json:"composio_org_id,omitempty"`
+	ComposioProjectID  string `json:"composio_project_id,omitempty"`
+	ActionProvider     string `json:"action_provider,omitempty"`
+	Email              string `json:"email,omitempty"`
+	WorkspaceID        string `json:"workspace_id,omitempty"`
+	WorkspaceSlug      string `json:"workspace_slug,omitempty"`
+	LLMProvider        string `json:"llm_provider,omitempty"`
 	// LLMProviderPriority is an ordered list of provider identifiers (same
 	// vocabulary as LLMProvider — "claude-code", "codex", "opencode", etc.) that agents
 	// should try in order when picking a runtime. LLMProvider remains the
@@ -598,6 +607,55 @@ func ResolveComposioAPIKey() string {
 	}
 	cfg, _ := Load()
 	return strings.TrimSpace(cfg.ComposioAPIKey)
+}
+
+// ResolveComposioUserAPIKey resolves the user-scoped Composio session key
+// (`uak_…`). Resolution: WUPHF_COMPOSIO_USER_API_KEY env > config file.
+func ResolveComposioUserAPIKey() string {
+	if ResolveNoNex() {
+		return ""
+	}
+	if v := strings.TrimSpace(os.Getenv("WUPHF_COMPOSIO_USER_API_KEY")); v != "" {
+		return v
+	}
+	cfg, _ := Load()
+	return strings.TrimSpace(cfg.ComposioUserAPIKey)
+}
+
+// ResolveComposioOrgID resolves the Composio org id used with the user key.
+func ResolveComposioOrgID() string {
+	if ResolveNoNex() {
+		return ""
+	}
+	if v := strings.TrimSpace(os.Getenv("WUPHF_COMPOSIO_ORG_ID")); v != "" {
+		return v
+	}
+	cfg, _ := Load()
+	return strings.TrimSpace(cfg.ComposioOrgID)
+}
+
+// ResolveComposioProjectID resolves the Composio project id used with the user
+// key. Optional: the SDK falls back to the org's default project when absent.
+func ResolveComposioProjectID() string {
+	if ResolveNoNex() {
+		return ""
+	}
+	if v := strings.TrimSpace(os.Getenv("WUPHF_COMPOSIO_PROJECT_ID")); v != "" {
+		return v
+	}
+	cfg, _ := Load()
+	return strings.TrimSpace(cfg.ComposioProjectID)
+}
+
+// IsComposioConfigured reports whether Composio has usable credentials: either
+// a project `ak_` key, or the user-key pair (`uak_` + org id). Project id is
+// optional. Used to drive the `composio_key_set` flag the onboarding UI gates
+// on, so user-key sign-ins flip the office out of the first-run state too.
+func IsComposioConfigured() bool {
+	if ResolveComposioAPIKey() != "" {
+		return true
+	}
+	return ResolveComposioUserAPIKey() != "" && ResolveComposioOrgID() != ""
 }
 
 // IsAnalyticsTelemetryEnabled reports whether anonymous product-analytics

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -843,7 +843,14 @@ func ResolveMinimaxAPIKey() string {
 }
 
 // ResolveComposioUserID resolves the Composio user identity WUPHF should use.
-// Resolution: WUPHF_COMPOSIO_USER_ID env > COMPOSIO_USER_ID env > config email.
+// Resolution: WUPHF_COMPOSIO_USER_ID env > COMPOSIO_USER_ID env > config email >
+// workspace identifier > "default".
+//
+// The user_id only namespaces this office's connected accounts on Composio's
+// side — any stable string works. It must never be empty once Composio is
+// signed in, or the catalog (which gates on a non-empty identity) stays blank
+// even though available integrations don't need a per-user identity. So a
+// signed-in office with no recorded email still falls back to a stable id.
 func ResolveComposioUserID() string {
 	if ResolveNoNex() {
 		return ""
@@ -855,7 +862,12 @@ func ResolveComposioUserID() string {
 		return v
 	}
 	cfg, _ := Load()
-	return strings.TrimSpace(cfg.Email)
+	for _, candidate := range []string{cfg.Email, cfg.WorkspaceSlug, cfg.WorkspaceID} {
+		if v := strings.TrimSpace(candidate); v != "" {
+			return v
+		}
+	}
+	return "default"
 }
 
 // ResolveActionProvider resolves the preferred external action provider.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -303,6 +303,47 @@ func TestResolveComposioAPIKeyFallsBackToConfig(t *testing.T) {
 	})
 }
 
+func TestIsComposioConfigured(t *testing.T) {
+	t.Run("project ak_ key", func(t *testing.T) {
+		withTempConfig(t, func(_ string) {
+			_ = Save(Config{ComposioAPIKey: "ak_proj"})
+			if !IsComposioConfigured() {
+				t.Fatal("expected configured with a project key")
+			}
+		})
+	})
+	t.Run("user key + org", func(t *testing.T) {
+		withTempConfig(t, func(_ string) {
+			_ = Save(Config{ComposioUserAPIKey: "uak_x", ComposioOrgID: "ok_1"})
+			if !IsComposioConfigured() {
+				t.Fatal("expected configured with the user-key pair")
+			}
+			if got := ResolveComposioUserAPIKey(); got != "uak_x" {
+				t.Fatalf("user key = %q", got)
+			}
+			if got := ResolveComposioOrgID(); got != "ok_1" {
+				t.Fatalf("org id = %q", got)
+			}
+		})
+	})
+	t.Run("user key without org is not enough", func(t *testing.T) {
+		withTempConfig(t, func(_ string) {
+			_ = Save(Config{ComposioUserAPIKey: "uak_x"})
+			if IsComposioConfigured() {
+				t.Fatal("user key without org must not count as configured")
+			}
+		})
+	})
+	t.Run("nothing", func(t *testing.T) {
+		withTempConfig(t, func(_ string) {
+			_ = Save(Config{})
+			if IsComposioConfigured() {
+				t.Fatal("empty config must not be configured")
+			}
+		})
+	})
+}
+
 func TestResolveGeminiAPIKeyEnvOverride(t *testing.T) {
 	withTempConfig(t, func(_ string) {
 		t.Setenv("WUPHF_GEMINI_API_KEY", "wuphf-gemini")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -345,8 +345,16 @@ func TestIsComposioConfigured(t *testing.T) {
 }
 
 func TestResolveComposioUserID(t *testing.T) {
+	// Clear both env overrides so an env-contaminated runner can't leak into
+	// the config/default-fallback subtests.
+	clearEnv := func(t *testing.T) {
+		t.Helper()
+		t.Setenv("WUPHF_COMPOSIO_USER_ID", "")
+		t.Setenv("COMPOSIO_USER_ID", "")
+	}
 	t.Run("prefers email", func(t *testing.T) {
 		withTempConfig(t, func(_ string) {
+			clearEnv(t)
 			_ = Save(Config{Email: "owner@example.com", WorkspaceSlug: "acme"})
 			if got := ResolveComposioUserID(); got != "owner@example.com" {
 				t.Fatalf("got %q", got)
@@ -355,25 +363,47 @@ func TestResolveComposioUserID(t *testing.T) {
 	})
 	t.Run("falls back to workspace slug", func(t *testing.T) {
 		withTempConfig(t, func(_ string) {
+			clearEnv(t)
 			_ = Save(Config{WorkspaceSlug: "acme"})
 			if got := ResolveComposioUserID(); got != "acme" {
 				t.Fatalf("got %q", got)
 			}
 		})
 	})
+	t.Run("falls back to workspace id", func(t *testing.T) {
+		withTempConfig(t, func(_ string) {
+			clearEnv(t)
+			_ = Save(Config{WorkspaceID: "ws_123"})
+			if got := ResolveComposioUserID(); got != "ws_123" {
+				t.Fatalf("got %q", got)
+			}
+		})
+	})
 	t.Run("never empty so a signed-in office can browse", func(t *testing.T) {
 		withTempConfig(t, func(_ string) {
+			clearEnv(t)
 			_ = Save(Config{})
 			if got := ResolveComposioUserID(); got != "default" {
 				t.Fatalf("expected the default identity, got %q", got)
 			}
 		})
 	})
-	t.Run("env override wins", func(t *testing.T) {
+	t.Run("WUPHF env override wins", func(t *testing.T) {
 		withTempConfig(t, func(_ string) {
+			clearEnv(t)
 			t.Setenv("WUPHF_COMPOSIO_USER_ID", "u_env")
 			_ = Save(Config{Email: "owner@example.com"})
 			if got := ResolveComposioUserID(); got != "u_env" {
+				t.Fatalf("got %q", got)
+			}
+		})
+	})
+	t.Run("COMPOSIO_USER_ID env override wins over config", func(t *testing.T) {
+		withTempConfig(t, func(_ string) {
+			clearEnv(t)
+			t.Setenv("COMPOSIO_USER_ID", "u_compat")
+			_ = Save(Config{Email: "owner@example.com"})
+			if got := ResolveComposioUserID(); got != "u_compat" {
 				t.Fatalf("got %q", got)
 			}
 		})

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -344,6 +344,42 @@ func TestIsComposioConfigured(t *testing.T) {
 	})
 }
 
+func TestResolveComposioUserID(t *testing.T) {
+	t.Run("prefers email", func(t *testing.T) {
+		withTempConfig(t, func(_ string) {
+			_ = Save(Config{Email: "owner@example.com", WorkspaceSlug: "acme"})
+			if got := ResolveComposioUserID(); got != "owner@example.com" {
+				t.Fatalf("got %q", got)
+			}
+		})
+	})
+	t.Run("falls back to workspace slug", func(t *testing.T) {
+		withTempConfig(t, func(_ string) {
+			_ = Save(Config{WorkspaceSlug: "acme"})
+			if got := ResolveComposioUserID(); got != "acme" {
+				t.Fatalf("got %q", got)
+			}
+		})
+	})
+	t.Run("never empty so a signed-in office can browse", func(t *testing.T) {
+		withTempConfig(t, func(_ string) {
+			_ = Save(Config{})
+			if got := ResolveComposioUserID(); got != "default" {
+				t.Fatalf("expected the default identity, got %q", got)
+			}
+		})
+	})
+	t.Run("env override wins", func(t *testing.T) {
+		withTempConfig(t, func(_ string) {
+			t.Setenv("WUPHF_COMPOSIO_USER_ID", "u_env")
+			_ = Save(Config{Email: "owner@example.com"})
+			if got := ResolveComposioUserID(); got != "u_env" {
+				t.Fatalf("got %q", got)
+			}
+		})
+	})
+}
+
 func TestResolveGeminiAPIKeyEnvOverride(t *testing.T) {
 	withTempConfig(t, func(_ string) {
 		t.Setenv("WUPHF_GEMINI_API_KEY", "wuphf-gemini")

--- a/internal/team/broker_composio_signin.go
+++ b/internal/team/broker_composio_signin.go
@@ -105,8 +105,13 @@ func composioBinary() (string, bool) {
 		name = "composio.exe"
 	}
 	candidate := filepath.Join(dir, name)
-	if info, err := os.Stat(candidate); err == nil && !info.IsDir() && info.Mode()&0o111 != 0 {
-		return candidate, true
+	// On Windows the 0o111 exec bits are not meaningful (executability is
+	// determined by extension/PATHEXT), so only require a regular file there;
+	// on Unix require the exec bit.
+	if info, err := os.Stat(candidate); err == nil && !info.IsDir() {
+		if runtime.GOOS == "windows" || info.Mode()&0o111 != 0 {
+			return candidate, true
+		}
 	}
 	return "", false
 }
@@ -470,7 +475,7 @@ func composioProvisionCreds() (composioProvisionedCreds, error) {
 	uak := strings.TrimSpace(ud.APIKey)
 	org := strings.TrimSpace(ud.OrgID)
 	if uak == "" || org == "" {
-		return composioProvisionedCreds{}, errors.New("Composio sign-in did not return the org context — sign in again, or paste a project API key from https://dashboard.composio.dev")
+		return composioProvisionedCreds{}, errors.New("the Composio sign-in returned no org context — sign in again, or paste a project API key from https://dashboard.composio.dev")
 	}
 	creds := composioProvisionedCreds{UserAPIKey: uak, OrgID: org}
 	// Best-effort project scoping; a resolve failure is not fatal (the SDK

--- a/internal/team/broker_composio_signin.go
+++ b/internal/team/broker_composio_signin.go
@@ -11,6 +11,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -67,6 +68,85 @@ const (
 // to the manual install command. It runs ONLY after the human explicitly chose
 // "Sign in with Composio".
 var composioInstaller = defaultComposioInstaller
+
+// composioInstallDir is the directory the official installer drops the
+// `composio` binary into: $COMPOSIO_INSTALL_DIR, else ~/.composio — the same
+// default install.sh uses (COMPOSIO_INSTALL_DIR:-$HOME/.composio).
+func composioInstallDir() string {
+	if dir := strings.TrimSpace(os.Getenv("COMPOSIO_INSTALL_DIR")); dir != "" {
+		return dir
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".composio")
+}
+
+// composioBinary resolves the `composio` CLI path. It checks PATH first, then
+// falls back to the installer's known location. That fallback is the whole
+// point of the auto-install fix: the official installer appends its dir to PATH
+// only in the user's shell profile (~/.zshrc, ~/.bashrc, …), which the
+// already-running broker process never re-reads — so a CLI installed *after*
+// the broker started is invisible to exec.LookPath, and the flow would wrongly
+// report cli_missing immediately after a successful install. Returns
+// ("", false) when no usable binary is found.
+func composioBinary() (string, bool) {
+	if path, err := exec.LookPath("composio"); err == nil {
+		return path, true
+	}
+	dir := composioInstallDir()
+	if dir == "" {
+		return "", false
+	}
+	name := "composio"
+	if runtime.GOOS == "windows" {
+		name = "composio.exe"
+	}
+	candidate := filepath.Join(dir, name)
+	if info, err := os.Stat(candidate); err == nil && !info.IsDir() && info.Mode()&0o111 != 0 {
+		return candidate, true
+	}
+	return "", false
+}
+
+// composioCommand builds an exec.Cmd for the composio CLI using the resolved
+// binary path, prepending its directory to the subprocess PATH so the CLI can
+// find any sibling helpers it shells out to (the broker's inherited PATH may
+// not include the installer's dir). Returns an error when the CLI cannot be
+// located.
+func composioCommand(ctx context.Context, args ...string) (*exec.Cmd, error) {
+	bin, ok := composioBinary()
+	if !ok {
+		return nil, errors.New("composio CLI not found on PATH or in the install directory")
+	}
+	cmd := exec.CommandContext(ctx, bin, args...)
+	cmd.Env = composioCommandEnv(filepath.Dir(bin))
+	return cmd, nil
+}
+
+// composioCommandEnv returns the process environment with binDir prepended to
+// PATH (replacing the existing entry rather than duplicating it), so the
+// resolved CLI's own dir is searchable by any child it spawns.
+func composioCommandEnv(binDir string) []string {
+	env := os.Environ()
+	if binDir == "" {
+		return env
+	}
+	out := make([]string, 0, len(env)+1)
+	pathVal := binDir
+	for _, kv := range env {
+		if name, val, ok := strings.Cut(kv, "="); ok && strings.EqualFold(name, "PATH") {
+			if val != "" {
+				pathVal = binDir + string(os.PathListSeparator) + val
+			}
+			continue
+		}
+		out = append(out, kv)
+	}
+	out = append(out, "PATH="+pathVal)
+	return out
+}
 
 var (
 	// composioProjectKeyPattern accepts only project-scoped SDK keys.
@@ -130,7 +210,7 @@ func (b *Broker) handleComposioSigninStart(w http.ResponseWriter, r *http.Reques
 		return
 	}
 	actor := integrationRequestActor(r)
-	if _, err := exec.LookPath("composio"); err != nil {
+	if _, ok := composioBinary(); !ok {
 		// Auto-install on demand: the CLI is needed for one-click sign-in, so
 		// rather than dead-ending on cli_missing we run the official installer
 		// once in the background and continue the flow. The manual install
@@ -244,21 +324,23 @@ func (b *Broker) handleComposioSigninStatus(w http.ResponseWriter, r *http.Reque
 }
 
 // composioSigninAutoInstall runs the official installer once, then continues
-// the sign-in if the CLI landed on PATH. On failure it falls back to
-// cli_missing with the manual install command. PATH (not the exit code) is the
-// source of truth — installers can warn-and-exit nonzero while still placing
-// the binary.
+// the sign-in if the CLI landed. On failure it falls back to cli_missing with
+// the manual install command. The binary's presence (via composioBinary, which
+// also checks the installer's ~/.composio location — not just the broker's
+// inherited PATH), not the exit code, is the source of truth: installers can
+// warn-and-exit nonzero while still placing the binary, and the installer adds
+// its dir to PATH only in shell profiles the running broker never re-reads.
 func (b *Broker) composioSigninAutoInstall() {
 	ctx, cancel := context.WithTimeout(context.Background(), composioInstallTimeout)
 	defer cancel()
 	runErr := composioInstaller(ctx)
-	if _, err := exec.LookPath("composio"); err != nil {
+	if _, ok := composioBinary(); !ok {
 		flow := &b.composioSignin
 		flow.mu.Lock()
 		if flow.state.Status == composioSigninStatusInstalling {
 			reason := "could not install the Composio CLI automatically — run the install command shown, then try again"
 			if runErr == nil {
-				reason = "the Composio installer finished but the CLI is still not on PATH — run the install command shown, then try again"
+				reason = "the Composio installer finished but the CLI could not be located — run the install command shown, then try again"
 			}
 			flow.state = composioSigninState{
 				Status:         composioSigninStatusCLIMissing,
@@ -320,10 +402,15 @@ func (b *Broker) composioSigninBeginLogin() {
 func (b *Broker) composioSigninAwaitLogin() {
 	ctx, cancel := context.WithTimeout(context.Background(), composioLoginPollTimeout)
 	defer cancel()
-	cmd := exec.CommandContext(ctx, "composio", "login", "--poll")
-	// Output deliberately discarded: never echo CLI output that may carry
-	// credentials into broker logs.
-	_ = cmd.Run()
+	cmd, err := composioCommand(ctx, "login", "--poll")
+	if err == nil {
+		// Output deliberately discarded: never echo CLI output that may carry
+		// credentials into broker logs.
+		_ = cmd.Run()
+	}
+	// Advance regardless: even if the poll could not run, the user may have
+	// finished `composio login` in their own terminal (user_data.json), and
+	// the status endpoint also calls this — the file is the source of truth.
 	b.composioSigninAdvanceIfLoggedIn()
 }
 
@@ -388,7 +475,11 @@ func (b *Broker) composioSigninProvision() {
 func composioMintLoginURL() (string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), composioLoginStartTimeout)
 	defer cancel()
-	out, err := exec.CommandContext(ctx, "composio", "login", "--no-wait").CombinedOutput()
+	cmd, err := composioCommand(ctx, "login", "--no-wait")
+	if err != nil {
+		return "", err
+	}
+	out, err := cmd.CombinedOutput()
 	if err != nil {
 		// Don't echo raw CLI output into the error: it is user-visible.
 		return "", fmt.Errorf("composio login --no-wait: %w", err)
@@ -422,7 +513,10 @@ func composioProvisionProjectKey() (string, error) {
 		return "", fmt.Errorf("create temp dir: %w", err)
 	}
 	defer func() { _ = os.RemoveAll(dir) }()
-	cmd := exec.CommandContext(ctx, "composio", "dev", "init", "-y", "--no-browser")
+	cmd, err := composioCommand(ctx, "dev", "init", "-y", "--no-browser")
+	if err != nil {
+		return "", err
+	}
 	cmd.Dir = dir
 	// Output discarded on purpose: dev init may echo project metadata and the
 	// key it writes; nothing from it belongs in broker logs or errors.

--- a/internal/team/broker_composio_signin.go
+++ b/internal/team/broker_composio_signin.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log"
 	"net/http"
 	"os"
@@ -164,6 +165,9 @@ var (
 	// polls the pending browser session for up to ~10 minutes.
 	composioLoginPollTimeout = 12 * time.Minute
 	composioDevInitTimeout   = 3 * time.Minute
+	// composioResolveTimeout bounds the project-resolve API call in the
+	// user-key provisioning fallback.
+	composioResolveTimeout = 20 * time.Second
 	// composioLoginWindow is how long a started flow stays in awaiting_login
 	// before the status endpoint reports a timeout.
 	composioLoginWindow = 15 * time.Minute
@@ -402,7 +406,11 @@ func (b *Broker) composioSigninBeginLogin() {
 func (b *Broker) composioSigninAwaitLogin() {
 	ctx, cancel := context.WithTimeout(context.Background(), composioLoginPollTimeout)
 	defer cancel()
-	cmd, err := composioCommand(ctx, "login", "--poll")
+	// --no-skill-install mirrors trustclaw's `composio login`: without it the CLI
+	// installs a Claude Code "composio-cli" skill and flips on developer mode,
+	// which makes `composio dev init` scaffold .composio/ instead of writing the
+	// .env.local + ak_ key that provisioning parses.
+	cmd, err := composioCommand(ctx, "login", "--poll", "--no-skill-install")
 	if err == nil {
 		// Output deliberately discarded: never echo CLI output that may carry
 		// credentials into broker logs.
@@ -433,15 +441,58 @@ func (b *Broker) composioSigninAdvanceIfLoggedIn() bool {
 	return true
 }
 
-// composioSigninProvision mints the project-scoped ak_ key via
-// `composio dev init` in a throwaway directory and stores it through the same
-// config path as the manual paste flow.
+// composioProvisionedCreds is the outcome of a successful provision: EITHER a
+// project ak_ key (preferred — sent as x-api-key), OR the user-key trio (the
+// uak_ session key + org id, and an optional project id — sent as
+// x-user-api-key / x-org-id / x-project-id).
+type composioProvisionedCreds struct {
+	APIKey     string
+	UserAPIKey string
+	OrgID      string
+	ProjectID  string
+}
+
+// composioProvisionCreds resolves usable Composio SDK credentials after login.
+//
+// Preferred path: `composio dev init` writes a project ak_ key to .env.local
+// (older CLIs, and the same path trustclaw uses). The current composio CLI no
+// longer mints an ak_ key this way, so we fall back to the user-key mode: the
+// uak_ session key + org id the CLI already wrote to user_data.json, scoped to
+// the org's default project (resolved best-effort; the SDK works without it).
+func composioProvisionCreds() (composioProvisionedCreds, error) {
+	if key, err := composioProvisionProjectKey(); err == nil {
+		return composioProvisionedCreds{APIKey: key}, nil
+	}
+	ud, err := readComposioUserData()
+	if err != nil {
+		return composioProvisionedCreds{}, errors.New("could not read the Composio CLI session — sign in again, or paste a project API key from https://dashboard.composio.dev")
+	}
+	uak := strings.TrimSpace(ud.APIKey)
+	org := strings.TrimSpace(ud.OrgID)
+	if uak == "" || org == "" {
+		return composioProvisionedCreds{}, errors.New("Composio sign-in did not return the org context — sign in again, or paste a project API key from https://dashboard.composio.dev")
+	}
+	creds := composioProvisionedCreds{UserAPIKey: uak, OrgID: org}
+	// Best-effort project scoping; a resolve failure is not fatal (the SDK
+	// falls back to the org's default project when no project id is sent).
+	creds.ProjectID = composioResolveProjectID(ud.BaseURL, uak, org)
+	return creds, nil
+}
+
+// composioSigninProvision resolves Composio credentials (project ak_ key or
+// user-key trio) and stores them through the same config path as the manual
+// paste flow. Credentials never touch logs.
 func (b *Broker) composioSigninProvision() {
 	flow := &b.composioSignin
-	key, err := composioProvisionProjectKey()
+	creds, err := composioProvisionCreds()
 	var storeFailed bool
 	if err == nil {
-		if err = b.storeComposioAPIKey(key); err != nil {
+		if strings.TrimSpace(creds.APIKey) != "" {
+			err = b.storeComposioAPIKey(creds.APIKey)
+		} else {
+			err = b.storeComposioUserKeyCreds(creds.UserAPIKey, creds.OrgID, creds.ProjectID)
+		}
+		if err != nil {
 			storeFailed = true
 		}
 	}
@@ -454,7 +505,7 @@ func (b *Broker) composioSigninProvision() {
 			// path — keep filesystem details out of the browser-facing
 			// Reason (review finding); the full error goes to the log.
 			log.Printf("composio signin: %v", err)
-			reason = "could not save the Composio API key to config — check the broker logs"
+			reason = "could not save the Composio credentials to config — check the broker logs"
 		}
 		flow.state = composioSigninState{Status: composioSigninStatusError, Reason: reason}
 		flow.mu.Unlock()
@@ -463,7 +514,7 @@ func (b *Broker) composioSigninProvision() {
 	flow.mu.Unlock()
 	// Record the audit entry BEFORE flipping to done: a client that observes
 	// done must also observe the audit trail entry.
-	b.recordComposioSigninEvent("integration_signin_completed", actor, "Signed in with Composio and stored the project API key")
+	b.recordComposioSigninEvent("integration_signin_completed", actor, "Signed in with Composio and stored credentials")
 	flow.mu.Lock()
 	flow.state = composioSigninState{Status: composioSigninStatusDone}
 	flow.mu.Unlock()
@@ -475,7 +526,9 @@ func (b *Broker) composioSigninProvision() {
 func composioMintLoginURL() (string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), composioLoginStartTimeout)
 	defer cancel()
-	cmd, err := composioCommand(ctx, "login", "--no-wait")
+	// --no-skill-install: don't install the Claude Code skill / enable developer
+	// mode as a side effect of signing in (see composioSigninAwaitLogin).
+	cmd, err := composioCommand(ctx, "login", "--no-wait", "--no-skill-install")
 	if err != nil {
 		return "", err
 	}
@@ -556,6 +609,79 @@ func (b *Broker) storeComposioAPIKey(key string) error {
 	return nil
 }
 
+// storeComposioUserKeyCreds persists the user-key trio (uak_ session key + org
+// + optional project) via the same load-modify-save path as storeComposioAPIKey.
+func (b *Broker) storeComposioUserKeyCreds(userAPIKey, orgID, projectID string) error {
+	b.configMu.Lock()
+	defer b.configMu.Unlock()
+	cfg, err := config.Load()
+	if err != nil {
+		return fmt.Errorf("config load failed: %w", err)
+	}
+	cfg.ComposioUserAPIKey = strings.TrimSpace(userAPIKey)
+	cfg.ComposioOrgID = strings.TrimSpace(orgID)
+	cfg.ComposioProjectID = strings.TrimSpace(projectID)
+	if err := config.Save(cfg); err != nil {
+		return fmt.Errorf("config save failed: %w", err)
+	}
+	return nil
+}
+
+// composioResolveProjectID returns the org's default project id via the CLI's
+// resolve endpoint (POST {base}/api/v3/org/consumer/project/resolve with the
+// user key + org id). It's a package var so tests can stub the network call.
+// Returns "" on any failure — the project id is optional for the SDK.
+var composioResolveProjectID = defaultComposioResolveProjectID
+
+func defaultComposioResolveProjectID(baseURL, userAPIKey, orgID string) string {
+	base := strings.TrimRight(strings.TrimSpace(baseURL), "/")
+	if base == "" {
+		base = "https://backend.composio.dev"
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), composioResolveTimeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, base+"/api/v3/org/consumer/project/resolve", strings.NewReader("{}"))
+	if err != nil {
+		return ""
+	}
+	req.Header.Set("x-user-api-key", userAPIKey)
+	req.Header.Set("x-org-id", orgID)
+	req.Header.Set("User-Agent", "wuphf")
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return ""
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return ""
+	}
+	data, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return ""
+	}
+	var doc struct {
+		// The resolve endpoint returns the pr_-prefixed id as project_nano_id;
+		// project_id is a bare UUID that the API REJECTS (401) as x-project-id.
+		// So we want the nano id — verified live.
+		ProjectNanoID string `json:"project_nano_id"`
+		ProjectID     string `json:"project_id"`
+	}
+	if err := json.Unmarshal(data, &doc); err != nil {
+		return ""
+	}
+	if id := strings.TrimSpace(doc.ProjectNanoID); id != "" {
+		return id
+	}
+	// Only fall back to project_id when it's already the pr_ form (some
+	// endpoints name the pr_ id "project_id"); never return the UUID.
+	if id := strings.TrimSpace(doc.ProjectID); strings.HasPrefix(id, "pr_") {
+		return id
+	}
+	return ""
+}
+
 // composioUserDataPath mirrors the CLI's credential cache location:
 // $COMPOSIO_CACHE_DIR/user_data.json, defaulting to ~/.composio/user_data.json.
 func composioUserDataPath() string {
@@ -569,24 +695,39 @@ func composioUserDataPath() string {
 	return filepath.Join(home, ".composio", "user_data.json")
 }
 
-// composioCLILoggedIn reports whether the CLI has a stored session — the same
-// check trustclaw uses: user_data.json exists and carries a non-empty api_key.
-func composioCLILoggedIn() bool {
+// composioUserData is the subset of ~/.composio/user_data.json the sign-in flow
+// reads: the uak_ session key, the org id, and the backend base URL.
+type composioUserData struct {
+	APIKey  string `json:"api_key"`
+	OrgID   string `json:"org_id"`
+	BaseURL string `json:"base_url"`
+}
+
+// readComposioUserData loads the CLI's session file written by `composio login`.
+func readComposioUserData() (composioUserData, error) {
 	path := composioUserDataPath()
 	if path == "" {
-		return false
+		return composioUserData{}, errors.New("composio user_data path unavailable")
 	}
 	data, err := os.ReadFile(path)
 	if err != nil {
+		return composioUserData{}, err
+	}
+	var ud composioUserData
+	if err := json.Unmarshal(data, &ud); err != nil {
+		return composioUserData{}, err
+	}
+	return ud, nil
+}
+
+// composioCLILoggedIn reports whether the CLI has a stored session — the same
+// check trustclaw uses: user_data.json exists and carries a non-empty api_key.
+func composioCLILoggedIn() bool {
+	ud, err := readComposioUserData()
+	if err != nil {
 		return false
 	}
-	var doc struct {
-		APIKey string `json:"api_key"`
-	}
-	if err := json.Unmarshal(data, &doc); err != nil {
-		return false
-	}
-	return strings.TrimSpace(doc.APIKey) != ""
+	return strings.TrimSpace(ud.APIKey) != ""
 }
 
 // parseEnvFileValue extracts KEY=VALUE from dotenv content, skipping comments

--- a/internal/team/broker_composio_signin_test.go
+++ b/internal/team/broker_composio_signin_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -412,8 +413,10 @@ esac`)
 	}
 }
 
-// TestComposioSigninProvision_RejectsUserScopedKey: a uak_ key from dev init
-// must be rejected (it 401s against the SDK) and must NOT be stored.
+// TestComposioSigninProvision_RejectsUserScopedKey: a uak_ key from dev init's
+// .env.local must NOT be stored as a project ak_ key (it 401s against the SDK
+// as x-api-key). Here user_data.json carries no org id, so the user-key
+// fallback can't complete either — the flow errors and stores nothing.
 func TestComposioSigninProvision_RejectsUserScopedKey(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("fake shell script requires a POSIX shell")
@@ -438,15 +441,129 @@ esac`)
 	if errState.Status != composioSigninStatusError {
 		t.Fatalf("expected error for uak_ key, got %+v", errState)
 	}
-	if !strings.Contains(errState.Reason, "uak_") {
-		t.Fatalf("expected the reason to explain the uak_ rejection, got %q", errState.Reason)
+	// No org context (markComposioLoggedIn writes only api_key): the fallback
+	// can't proceed and the flow points the user at the manual paste path.
+	if !strings.Contains(errState.Reason, "dashboard.composio.dev") {
+		t.Fatalf("expected the reason to offer the manual paste fallback, got %q", errState.Reason)
 	}
 	cfg, err := config.Load()
 	if err != nil {
 		t.Fatalf("config load: %v", err)
 	}
 	if cfg.ComposioAPIKey != "" {
-		t.Fatalf("uak_ key must not be stored, got %q", cfg.ComposioAPIKey)
+		t.Fatalf("uak_ key must not be stored as a project key, got %q", cfg.ComposioAPIKey)
+	}
+	if cfg.ComposioUserAPIKey != "" {
+		t.Fatalf("user key must not be stored without an org id, got %q", cfg.ComposioUserAPIKey)
+	}
+}
+
+// TestComposioSigninProvision_UserKeyFallback is the regression for the current
+// composio CLI: `dev init` no longer writes an ak_ key to .env.local, so the
+// flow falls back to the user-key trio — the uak_ + org id from user_data.json,
+// scoped to the project the resolve endpoint returns — and stores it so the
+// SDK can authenticate with x-user-api-key/x-org-id/x-project-id.
+func TestComposioSigninProvision_UserKeyFallback(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake shell script requires a POSIX shell")
+	}
+	dir := t.TempDir()
+	// dev init exits cleanly but writes NO .env.local (current CLI behavior),
+	// so the ak_ path fails and the user-key fallback takes over.
+	writeFakeComposioCLI(t, dir, `
+case "$1 $2" in
+  "dev init") exit 0 ;;
+  *) exit 1 ;;
+esac`)
+
+	b := newComposioSigninBroker(t, dir)
+	// Logged-in session WITH an org id (what `composio login` writes).
+	home := os.Getenv("HOME")
+	if err := os.MkdirAll(filepath.Join(home, ".composio"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(home, ".composio", "user_data.json"),
+		[]byte(`{"api_key":"uak_session_xyz","org_id":"ok_test123","base_url":"https://backend.composio.dev"}`),
+		0o600,
+	); err != nil {
+		t.Fatal(err)
+	}
+	// Stub the project-resolve network call.
+	origResolve := composioResolveProjectID
+	composioResolveProjectID = func(baseURL, userAPIKey, orgID string) string {
+		if userAPIKey != "uak_session_xyz" || orgID != "ok_test123" {
+			t.Errorf("resolve got unexpected creds: key=%q org=%q", userAPIKey, orgID)
+		}
+		return "pr_resolved789"
+	}
+	t.Cleanup(func() { composioResolveProjectID = origResolve })
+
+	_, state, _ := composioSigninRequest(t, b, http.MethodPost, "/integrations/composio/signin/start")
+	if state.Status != composioSigninStatusProvisioning {
+		t.Fatalf("expected provisioning on the logged-in fast path, got %+v", state)
+	}
+	done := pollComposioSigninUntil(t, b, composioSigninStatusDone)
+	if done.Status != composioSigninStatusDone {
+		t.Fatalf("expected done via user-key fallback, got %+v", done)
+	}
+
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatalf("config load: %v", err)
+	}
+	if cfg.ComposioAPIKey != "" {
+		t.Fatalf("no project ak_ key should be stored, got %q", cfg.ComposioAPIKey)
+	}
+	if cfg.ComposioUserAPIKey != "uak_session_xyz" {
+		t.Fatalf("expected stored user key, got %q", cfg.ComposioUserAPIKey)
+	}
+	if cfg.ComposioOrgID != "ok_test123" {
+		t.Fatalf("expected stored org id, got %q", cfg.ComposioOrgID)
+	}
+	if cfg.ComposioProjectID != "pr_resolved789" {
+		t.Fatalf("expected stored project id, got %q", cfg.ComposioProjectID)
+	}
+	if !config.IsComposioConfigured() {
+		t.Fatal("IsComposioConfigured should be true after a user-key sign-in")
+	}
+}
+
+// TestDefaultComposioResolveProjectID verifies the resolve call sends the user
+// key + org and returns the pr_-prefixed nano id (the form x-project-id
+// accepts), NEVER the bare project_id UUID (which the API 401s on).
+func TestDefaultComposioResolveProjectID(t *testing.T) {
+	var gotKey, gotOrg, gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotKey = r.Header.Get("x-user-api-key")
+		gotOrg = r.Header.Get("x-org-id")
+		gotPath = r.URL.Path
+		_, _ = w.Write([]byte(`{"project_id":"e3485bdf-5441-4c03-9d28-61bc1c7a2df4","project_nano_id":"pr_nano123"}`))
+	}))
+	defer srv.Close()
+
+	got := defaultComposioResolveProjectID(srv.URL, "uak_test", "ok_test")
+	if got != "pr_nano123" {
+		t.Fatalf("expected the pr_ nano id, got %q", got)
+	}
+	if gotKey != "uak_test" || gotOrg != "ok_test" {
+		t.Fatalf("resolve sent wrong auth headers: key=%q org=%q", gotKey, gotOrg)
+	}
+	if gotPath != "/api/v3/org/consumer/project/resolve" {
+		t.Fatalf("resolve hit wrong path: %q", gotPath)
+	}
+}
+
+// TestDefaultComposioResolveProjectID_RejectsUUIDOnly: when only the UUID
+// project_id is returned (no nano id), resolve yields "" rather than a value
+// the SDK would 401 on. The SDK then runs against the org's default project.
+func TestDefaultComposioResolveProjectID_RejectsUUIDOnly(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"project_id":"e3485bdf-5441-4c03-9d28-61bc1c7a2df4"}`))
+	}))
+	defer srv.Close()
+	if got := defaultComposioResolveProjectID(srv.URL, "uak_test", "ok_test"); got != "" {
+		t.Fatalf("expected empty (UUID is not a valid x-project-id), got %q", got)
 	}
 }
 

--- a/internal/team/broker_composio_signin_test.go
+++ b/internal/team/broker_composio_signin_test.go
@@ -50,6 +50,11 @@ func newComposioSigninBroker(t *testing.T, pathDir string) *Broker {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	t.Setenv("COMPOSIO_CACHE_DIR", "")
+	// Sandbox the CLI install dir too: composioBinary falls back to
+	// $COMPOSIO_INSTALL_DIR (else ~/.composio) when composio isn't on PATH, so
+	// a real CLI installed on the dev box (the common case) would otherwise leak
+	// into these tests. Empty → defaults under the isolated temp HOME.
+	t.Setenv("COMPOSIO_INSTALL_DIR", "")
 	t.Setenv("WUPHF_CONFIG_PATH", filepath.Join(home, ".wuphf", "config.json"))
 	if err := os.MkdirAll(filepath.Join(home, ".wuphf"), 0o700); err != nil {
 		t.Fatal(err)
@@ -245,6 +250,104 @@ func TestComposioSigninStart_AutoInstallSucceedsThenSignsIn(t *testing.T) {
 	}
 	if cfg.ComposioAPIKey != testComposioProjectKey {
 		t.Fatalf("expected stored composio key %q, got %q", testComposioProjectKey, cfg.ComposioAPIKey)
+	}
+}
+
+// TestComposioSigninStart_AutoInstallNotOnPATHResolvesFromInstallDir is the
+// regression for the reported bug: the official installer drops `composio` into
+// ~/.composio and only appends that dir to PATH in the user's shell profile,
+// which the already-running broker never re-reads. So a CLI installed *after*
+// the broker started is invisible to exec.LookPath, and the flow wrongly
+// reported cli_missing right after a successful install ("it attempts and then
+// says: The Composio CLI isn't installed").
+//
+// Here the install stub places the binary ONLY in ~/.composio (NOT on PATH).
+// The flow must still resolve it (via composioBinary's install-dir fallback)
+// and run to done — never cli_missing.
+func TestComposioSigninStart_AutoInstallNotOnPATHResolvesFromInstallDir(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake shell script requires a POSIX shell")
+	}
+	pathDir := t.TempDir() // PATH stays empty of composio for the whole flow
+	b := newComposioSigninBroker(t, pathDir)
+	home := os.Getenv("HOME")
+	// Default the install dir to ~/.composio (the installer's default), making
+	// the test independent of any COMPOSIO_INSTALL_DIR in the dev environment.
+	t.Setenv("COMPOSIO_INSTALL_DIR", "")
+	installDir := filepath.Join(home, ".composio")
+
+	orig := composioInstaller
+	composioInstaller = func(_ context.Context) error {
+		// Mirror the real installer: binary lands in ~/.composio (NOT on PATH),
+		// plus a logged-in session so the flow skips the browser hop.
+		body := "case \"$1 $2\" in\n  \"dev init\")\n    printf 'COMPOSIO_API_KEY=\"" +
+			testComposioProjectKey + "\"\\n' > .env.local\n    ;;\n  *) exit 1 ;;\nesac"
+		script := "#!/bin/sh\nPATH=\"/bin:/usr/bin:$PATH\"\n" + body + "\n"
+		if err := os.MkdirAll(installDir, 0o700); err != nil {
+			return err
+		}
+		if err := os.WriteFile(filepath.Join(installDir, "composio"), []byte(script), 0o755); err != nil {
+			return err
+		}
+		return os.WriteFile(
+			filepath.Join(installDir, "user_data.json"),
+			[]byte(`{"api_key":"uak_cli_only_session_key"}`),
+			0o600,
+		)
+	}
+	t.Cleanup(func() { composioInstaller = orig })
+
+	code, state, raw := composioSigninRequest(t, b, http.MethodPost, "/integrations/composio/signin/start")
+	if code != http.StatusOK {
+		t.Fatalf("start status=%d body=%s", code, raw)
+	}
+	if state.Status != composioSigninStatusInstalling {
+		t.Fatalf("expected installing on start, got %+v", state)
+	}
+
+	done := pollComposioSigninUntil(t, b, composioSigninStatusDone)
+	if done.Status != composioSigninStatusDone {
+		t.Fatalf("expected done (CLI resolved from install dir, not PATH), got %+v", done)
+	}
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatalf("config load: %v", err)
+	}
+	if cfg.ComposioAPIKey != testComposioProjectKey {
+		t.Fatalf("expected stored composio key %q, got %q", testComposioProjectKey, cfg.ComposioAPIKey)
+	}
+}
+
+// TestComposioBinary_ResolvesFromInstallDir exercises the resolver directly:
+// with no composio on PATH, it falls back to $COMPOSIO_INSTALL_DIR/composio
+// (and to ~/.composio/composio when the override is unset).
+func TestComposioBinary_ResolvesFromInstallDir(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("executable-bit semantics differ on Windows")
+	}
+	emptyPath := t.TempDir()
+	t.Setenv("PATH", emptyPath) // nothing named composio on PATH
+	installDir := t.TempDir()
+	t.Setenv("COMPOSIO_INSTALL_DIR", installDir) // empty so far — pinned for hermeticity
+	if _, ok := composioBinary(); ok {
+		t.Fatal("composioBinary resolved a binary with an empty PATH and an empty install dir")
+	}
+
+	bin := filepath.Join(installDir, "composio")
+	if err := os.WriteFile(bin, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("write fake composio: %v", err)
+	}
+	got, ok := composioBinary()
+	if !ok || got != bin {
+		t.Fatalf("composioBinary() = (%q, %v), want (%q, true)", got, ok, bin)
+	}
+
+	// A non-executable file at the install path must NOT be treated as the CLI.
+	if err := os.Chmod(bin, 0o644); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	if _, ok := composioBinary(); ok {
+		t.Fatal("composioBinary resolved a non-executable file as the CLI")
 	}
 }
 

--- a/internal/team/broker_integrations.go
+++ b/internal/team/broker_integrations.go
@@ -86,7 +86,7 @@ func (b *Broker) handleIntegrations(w http.ResponseWriter, r *http.Request) {
 		if composio.Configured() {
 			catalog, err := composio.ListIntegrationCatalog(r.Context(), opts)
 			if err != nil {
-				setIntegrationProviderDetail(resp.Providers, "composio", "Composio unavailable: "+err.Error())
+				setIntegrationProviderDetail(resp.Providers, "composio", "Integrations unavailable: "+err.Error())
 				resp.Items = append(resp.Items, curatedComposioCatalog(opts, true)...)
 			} else {
 				resp.Items = append(resp.Items, catalog.Items...)

--- a/internal/team/broker_integrations.go
+++ b/internal/team/broker_integrations.go
@@ -66,7 +66,7 @@ func (b *Broker) handleIntegrations(w http.ResponseWriter, r *http.Request) {
 			Configured:         composio.Configured(),
 			SupportsConnect:    true,
 			SupportsDisconnect: true,
-			Detail:             providerDetail(composio.Configured(), "COMPOSIO_API_KEY and COMPOSIO_USER_ID are required for OAuth-managed integrations."),
+			Detail:             providerDetail(composio.Configured(), "Not connected"),
 		},
 	}}
 

--- a/internal/team/broker_integrations.go
+++ b/internal/team/broker_integrations.go
@@ -50,11 +50,21 @@ func (b *Broker) handleIntegrations(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
-	providerFilter := strings.ToLower(strings.TrimSpace(r.URL.Query().Get("provider")))
+	// Sanitize query params: a client that serializes an absent value as the
+	// literal string "undefined"/"null" must not blank the catalog (a bad
+	// ?provider=undefined used to skip the whole composio catalog block).
+	qval := func(key string) string {
+		v := strings.TrimSpace(r.URL.Query().Get(key))
+		if strings.EqualFold(v, "undefined") || strings.EqualFold(v, "null") {
+			return ""
+		}
+		return v
+	}
+	providerFilter := strings.ToLower(qval("provider"))
 	opts := action.IntegrationCatalogOptions{
-		Search:    strings.TrimSpace(r.URL.Query().Get("search")),
-		Connected: strings.TrimSpace(r.URL.Query().Get("connected")),
-		Cursor:    strings.TrimSpace(r.URL.Query().Get("cursor")),
+		Search:    qval("search"),
+		Connected: qval("connected"),
+		Cursor:    qval("cursor"),
 		Limit:     parseIntegrationLimit(r.URL.Query().Get("limit"), 50),
 	}
 

--- a/internal/team/broker_integrations.go
+++ b/internal/team/broker_integrations.go
@@ -71,8 +71,10 @@ func (b *Broker) handleIntegrations(w http.ResponseWriter, r *http.Request) {
 	composio := action.NewComposioFromEnv()
 	resp := integrationsResponse{Providers: []integrationProviderStatus{
 		{
-			Provider:           "composio",
-			Label:              "Composio",
+			Provider: "composio",
+			// User-facing label is white-labeled to "Integrations"; the
+			// underlying provider key stays "composio" for routing/auth.
+			Label:              "Integrations",
 			Configured:         composio.Configured(),
 			SupportsConnect:    true,
 			SupportsDisconnect: true,

--- a/internal/team/broker_integrations_test.go
+++ b/internal/team/broker_integrations_test.go
@@ -108,6 +108,36 @@ func TestIntegrationsEndpointReportsUnconfiguredProviders(t *testing.T) {
 	}
 }
 
+// TestIntegrationsEndpointIgnoresUndefinedQuerySentinels: a client that
+// serialized absent params as the literal "undefined"/"null" must not blank the
+// catalog. ?provider=undefined used to skip the whole composio catalog block,
+// so the page showed "Configured" with zero available integrations.
+func TestIntegrationsEndpointIgnoresUndefinedQuerySentinels(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	b := NewBrokerAt(filepath.Join(t.TempDir(), "state.json"))
+	srv := newIntegrationsTestServer(t, b)
+	defer srv.Close()
+
+	resp := integrationRequest(t, srv, b, http.MethodGet,
+		"/integrations?provider=undefined&search=undefined&connected=undefined&cursor=null", nil)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		raw, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status=%d body=%s", resp.StatusCode, string(raw))
+	}
+	var body struct {
+		Items []struct {
+			Provider string `json:"provider"`
+		} `json:"items"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(body.Items) == 0 {
+		t.Fatal("undefined/null query sentinels must not blank the catalog")
+	}
+}
+
 func TestIntegrationConnectStatusDisconnectAndAudit(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("HOME", tmp)

--- a/internal/team/broker_office_channels.go
+++ b/internal/team/broker_office_channels.go
@@ -192,7 +192,7 @@ func (b *Broker) handleConfig(w http.ResponseWriter, r *http.Request) {
 			"gemini_key_set":       config.ResolveGeminiAPIKey() != "",
 			"minimax_key_set":      config.ResolveMinimaxAPIKey() != "",
 			"one_key_set":          config.ResolveOneSecret() != "",
-			"composio_key_set":     config.ResolveComposioAPIKey() != "",
+			"composio_key_set":     config.IsComposioConfigured(),
 			"telegram_token_set":   config.ResolveTelegramBotToken() != "",
 			"openclaw_token_set":   config.ResolveOpenclawToken() != "",
 			"openclaw_gateway_url": config.ResolveOpenclawGatewayURL(),

--- a/web/src/api/client.test.ts
+++ b/web/src/api/client.test.ts
@@ -149,6 +149,32 @@ describe("get timeout", () => {
     const init = fetchMock.mock.calls.at(-1)?.[1];
     expect(init?.signal).toBeInstanceOf(AbortSignal);
   });
+
+  // Regression: undefined params were serialized as the literal "undefined"
+  // (String(undefined)), so ?provider=undefined reached the broker and blanked
+  // the integrations catalog. Both null AND undefined must be dropped.
+  it("drops undefined and null query params instead of sending 'undefined'", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    await get("/integrations", {
+      provider: undefined,
+      search: undefined,
+      connected: null,
+      limit: 60,
+    });
+
+    const url = String(fetchMock.mock.calls.at(-1)?.[0]);
+    expect(url).toContain("limit=60");
+    expect(url).not.toContain("undefined");
+    expect(url).not.toContain("null");
+    expect(url).not.toContain("provider=");
+    expect(url).not.toContain("connected=");
+  });
 });
 
 // Regression: a broker-down wiki rendered the raw JSON envelope

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -248,7 +248,11 @@ export async function get<T = unknown>(
   let url = baseURL() + path;
   if (params) {
     const qs = Object.entries(params)
-      .filter(([, v]) => v !== null)
+      // Drop absent params. Both null AND undefined must be skipped — without
+      // the undefined check, String(undefined) serializes as the literal
+      // "undefined", which the broker then treats as a real filter value (e.g.
+      // ?provider=undefined silently blanked the integrations catalog).
+      .filter(([, v]) => v !== null && v !== undefined)
       .map(
         ([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(String(v))}`,
       )
@@ -278,7 +282,11 @@ export async function getText(
   let url = baseURL() + path;
   if (params) {
     const qs = Object.entries(params)
-      .filter(([, v]) => v !== null)
+      // Drop absent params. Both null AND undefined must be skipped — without
+      // the undefined check, String(undefined) serializes as the literal
+      // "undefined", which the broker then treats as a real filter value (e.g.
+      // ?provider=undefined silently blanked the integrations catalog).
+      .filter(([, v]) => v !== null && v !== undefined)
       .map(
         ([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(String(v))}`,
       )

--- a/web/src/components/apps/IntegrationsApp.test.tsx
+++ b/web/src/components/apps/IntegrationsApp.test.tsx
@@ -74,14 +74,21 @@ describe("IntegrationsApp", () => {
     };
   });
 
-  it("renders provider status and dynamic action toolkits", async () => {
+  it("renders the connection status and the integration catalog", async () => {
     render(wrap(<IntegrationsApp />));
 
-    expect(await screen.findByText("Action Accounts")).toBeInTheDocument();
-    expect(screen.getByText("Composio")).toBeInTheDocument();
-    expect(screen.getByText("Gmail")).toBeInTheDocument();
     expect(
-      screen.getByText("Read and send Gmail messages"),
+      await screen.findByText("Available integrations"),
+    ).toBeInTheDocument();
+    // White-labeled: the connection banner says "Integrations", never "Composio".
+    expect(screen.getByText("Integrations connected")).toBeInTheDocument();
+    expect(screen.queryByText("Composio")).not.toBeInTheDocument();
+    expect(screen.getByText("Gmail")).toBeInTheDocument();
+    // The Gmail tile is connected → reflected in its accessible name + pill.
+    expect(
+      screen.getByRole("button", {
+        name: /open gmail integration — connected/i,
+      }),
     ).toBeInTheDocument();
   });
 
@@ -105,7 +112,7 @@ describe("IntegrationsApp", () => {
 
     // The onboarding hero renders…
     expect(
-      await screen.findByRole("heading", { name: /connect composio/i }),
+      await screen.findByRole("heading", { name: /add integrations/i }),
     ).toBeInTheDocument();
     // …and the transports stay alongside it.
     expect(await screen.findByText("Telegram")).toBeInTheDocument();

--- a/web/src/components/apps/IntegrationsApp.tsx
+++ b/web/src/components/apps/IntegrationsApp.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
-  NavArrowRight,
   OpenNewWindow,
   Refresh,
   Search,
@@ -64,22 +63,27 @@ function ListSection({
 }) {
   if (descriptors.length === 0) return null;
   return (
-    <section className="op-category">
-      <header className="op-category-head">
-        <h3 className="op-category-title">{meta.title}</h3>
-        <p className="op-category-blurb">{meta.description}</p>
+    <section className="op-panel">
+      <header className="op-panel-head">
+        <div className="op-panel-heading">
+          <h3 className="op-panel-title">{meta.title}</h3>
+          <p className="op-panel-sub">{meta.description}</p>
+        </div>
+        <span className="op-panel-count">{descriptors.length}</span>
       </header>
-      <div className="op-list">
-        {descriptors.map((descriptor) => (
-          <IntegrationListRow
-            key={descriptor.id}
-            logo={descriptor.logo()}
-            title={descriptor.title}
-            summary={descriptor.summary}
-            status={descriptor.status(ctx)}
-            onOpen={() => onOpen(descriptor.id)}
-          />
-        ))}
+      <div className="op-panel-body">
+        <div className="op-list">
+          {descriptors.map((descriptor) => (
+            <IntegrationListRow
+              key={descriptor.id}
+              logo={descriptor.logo()}
+              title={descriptor.title}
+              summary={descriptor.summary}
+              status={descriptor.status(ctx)}
+              onOpen={() => onOpen(descriptor.id)}
+            />
+          ))}
+        </div>
       </div>
     </section>
   );
@@ -207,63 +211,114 @@ function toolkitToneClass(status: IntegrationStatus) {
   }
 }
 
-function ProviderStrip({
+function ConnectionStatus({
   providers,
 }: {
   providers: IntegrationProviderStatus[];
 }) {
   if (providers.length === 0) return null;
+  const connected = providers.some((provider) => provider.configured);
   return (
-    <div className="op-provider-strip">
-      {providers.map((provider) => (
-        <div className="op-provider-chip" key={provider.provider}>
-          <span
-            className={`op-led ${provider.configured ? "is-on" : "is-off"}`}
-            aria-hidden="true"
-          />
-          <span className="op-provider-name">{provider.label}</span>
-          <span className="op-provider-detail">
-            {provider.detail || (provider.configured ? "ready" : "missing")}
-          </span>
-        </div>
-      ))}
+    <div className={`op-conn ${connected ? "is-on" : "is-off"}`}>
+      <span className="op-conn-dot" aria-hidden="true" />
+      <span className="op-conn-text">
+        <span className="op-conn-title">
+          {connected ? "Integrations connected" : "Integrations not connected"}
+        </span>
+        <span className="op-conn-sub">
+          {connected
+            ? "Your agents can connect and act in the tools below."
+            : "Connect to add tools your agents can act in."}
+        </span>
+      </span>
     </div>
   );
 }
 
-function ActionToolkitsSection({
+function CatalogPanel({
   items,
+  search,
+  connected,
+  isLoading,
+  isError,
+  error,
+  isFetching,
+  onSearch,
+  onConnected,
   onOpen,
+  onRetry,
 }: {
   items: IntegrationCatalogItem[];
+  search: string;
+  connected: string;
+  isLoading: boolean;
+  isError: boolean;
+  error: unknown;
+  isFetching: boolean;
+  onSearch: (value: string) => void;
+  onConnected: (value: string) => void;
   onOpen: (item: IntegrationCatalogItem) => void;
+  onRetry: () => void;
 }) {
   return (
-    <section className="op-category">
-      <header className="op-category-head">
-        <div>
-          <h3 className="op-category-title">Action Accounts</h3>
-          <p className="op-category-blurb">
-            OAuth accounts agents can request through approval.
+    <section className="op-panel">
+      <header className="op-panel-head">
+        <div className="op-panel-heading">
+          <h3 className="op-panel-title">Available integrations</h3>
+          <p className="op-panel-sub">
+            Connect the tools your agents can act in.
           </p>
         </div>
-        <span className="op-section-count">{items.length} accounts</span>
+        <span className="op-panel-count">{items.length}</span>
       </header>
-      <div className="op-toolkit-ledger">
-        <div className="op-toolkit-ledger-head" aria-hidden="true">
-          <span>Integration</span>
-          <span>Scope</span>
-          <span>Account</span>
-          <span>Status</span>
-        </div>
-        {items.map((item) => (
-          <ToolkitRow
-            key={`${item.provider}:${item.platform}:${item.connection_key ?? "catalog"}`}
-            item={item}
-            onOpen={() => onOpen(item)}
+      <div className="op-panel-toolbar">
+        <label className="op-search">
+          <Search width={14} height={14} aria-hidden="true" />
+          <input
+            type="search"
+            placeholder="Search integrations"
+            value={search}
+            onChange={(event) => onSearch(event.target.value)}
           />
-        ))}
+        </label>
+        <select
+          className="input op-filter-select"
+          value={connected}
+          onChange={(event) => onConnected(event.target.value)}
+          aria-label="Filter integrations"
+        >
+          <option value="">All</option>
+          <option value="connected">Connected</option>
+          <option value="available">Available</option>
+        </select>
       </div>
+      {isLoading ? (
+        <p className="op-panel-empty">Loading integrations…</p>
+      ) : isError ? (
+        <div className="op-panel-body">
+          <IntegrationErrorState
+            error={error}
+            isFetching={isFetching}
+            onRetry={onRetry}
+          />
+        </div>
+      ) : items.length > 0 ? (
+        <div className="op-panel-body">
+          <div className="op-catalog-grid">
+            {items.map((item) => (
+              <CatalogTile
+                key={`${item.provider}:${item.platform}:${item.connection_key ?? "catalog"}`}
+                item={item}
+                onOpen={() => onOpen(item)}
+              />
+            ))}
+          </div>
+        </div>
+      ) : (
+        <p className="op-panel-empty">
+          No integrations match this view. Clear the filter to see all.
+        </p>
+      )}
     </section>
   );
 }
@@ -290,7 +345,7 @@ function toolkitIdentity(item: IntegrationCatalogItem) {
   return `${item.provider}:${item.platform}`;
 }
 
-function ToolkitRow({
+function CatalogTile({
   item,
   onOpen,
 }: {
@@ -299,36 +354,28 @@ function ToolkitRow({
 }) {
   const status = toolkitStatus(item);
   const tone = toolkitToneClass(status);
-  const connectionName = toolkitConnectionName(item);
-  const summary =
-    item.last_action_summary ??
-    item.description ??
-    `${item.provider} account actions for ${item.platform}`;
-  const category = formatToolkitCategory(item.category);
+  const isConnected = item.state === "connected";
+  const meta = isConnected
+    ? toolkitConnectionName(item) || "Connected"
+    : formatToolkitCategory(item.category);
   return (
     <button
       type="button"
-      className={`op-toolkit-row is-${tone}`}
+      className={`op-catalog-tile ${isConnected ? "is-on" : ""}`}
       onClick={onOpen}
-      aria-label={`Open ${item.name} integration settings`}
+      aria-label={`Open ${item.name} integration — ${status.label}`}
     >
-      <span className="op-toolkit-row-logo" aria-hidden="true">
-        <ToolkitLogo item={item} />
+      <ToolkitLogo item={item} />
+      <span className="op-catalog-tile-body">
+        <span className="op-catalog-tile-name">{item.name}</span>
+        <span className="op-catalog-tile-meta">{meta}</span>
       </span>
-      <span className="op-toolkit-row-body">
-        <span className="op-toolkit-row-title">{item.name}</span>
-        <span className="op-toolkit-row-summary">{summary}</span>
-      </span>
-      <span className="op-toolkit-row-cell">{category}</span>
-      <span className="op-toolkit-row-cell">
-        {connectionName || "No account"}
-      </span>
-      <span className="op-toolkit-row-state">
-        <span className={`op-status is-${tone}`}>
-          <span className={`op-led is-${tone}`} />
-          {status.label}
-        </span>
-        <NavArrowRight width={18} height={18} aria-hidden="true" />
+      <span className="op-catalog-tile-status">
+        {isConnected ? (
+          <span className="op-catalog-tile-pill">Connected</span>
+        ) : (
+          <span className={`op-led is-${tone}`} aria-hidden="true" />
+        )}
       </span>
     </button>
   );
@@ -644,43 +691,20 @@ function IntegrationsHome({
 }) {
   return (
     <>
-      <ProviderStrip providers={providers} />
-      <div className="op-toolbar">
-        <label className="op-search">
-          <Search width={14} height={14} aria-hidden="true" />
-          <input
-            type="search"
-            placeholder="Search accounts"
-            value={search}
-            onChange={(event) => onSearch(event.target.value)}
-          />
-        </label>
-        <select
-          className="input op-filter-select"
-          value={connected}
-          onChange={(event) => onConnected(event.target.value)}
-          aria-label="Filter integrations"
-        >
-          <option value="">All</option>
-          <option value="connected">Connected</option>
-          <option value="available">Available</option>
-        </select>
-      </div>
-      {isLoading ? (
-        <div className="app-panel-loading">Loading accounts…</div>
-      ) : isError ? (
-        <IntegrationErrorState
-          error={error}
-          isFetching={isFetching}
-          onRetry={onRetry}
-        />
-      ) : toolkitItems.length > 0 ? (
-        <ActionToolkitsSection items={toolkitItems} onOpen={onOpenToolkit} />
-      ) : (
-        <p className="op-runtime-note op-empty-state">
-          No accounts match this view. Configure Composio or clear the filter.
-        </p>
-      )}
+      <ConnectionStatus providers={providers} />
+      <CatalogPanel
+        items={toolkitItems}
+        search={search}
+        connected={connected}
+        isLoading={isLoading}
+        isError={isError}
+        error={error}
+        isFetching={isFetching}
+        onSearch={onSearch}
+        onConnected={onConnected}
+        onOpen={onOpenToolkit}
+        onRetry={onRetry}
+      />
       <RegistryListView
         ctx={ctx}
         available={available}

--- a/web/src/components/apps/integrations/ComposioOnboarding.test.tsx
+++ b/web/src/components/apps/integrations/ComposioOnboarding.test.tsx
@@ -34,12 +34,10 @@ describe("<ComposioOnboarding>", () => {
   it("renders Sign in with Composio as the primary CTA and hides the paste form", () => {
     render(wrap(<ComposioOnboarding onConnected={() => {}} />));
     expect(
-      screen.getByRole("button", { name: /sign in with composio/i }),
+      screen.getByRole("button", { name: /connect integrations/i }),
     ).toBeEnabled();
     // The manual paste path is a collapsed secondary fallback.
-    expect(
-      screen.queryByLabelText(/composio api key/i),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByLabelText(/api key/i)).not.toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: /or paste an api key/i }),
     ).toBeInTheDocument();
@@ -52,7 +50,7 @@ describe("<ComposioOnboarding>", () => {
     });
     render(wrap(<ComposioOnboarding onConnected={() => {}} />));
     fireEvent.click(
-      screen.getByRole("button", { name: /sign in with composio/i }),
+      screen.getByRole("button", { name: /connect integrations/i }),
     );
     await waitFor(() =>
       expect(
@@ -79,10 +77,10 @@ describe("<ComposioOnboarding>", () => {
     getComposioSigninStatus.mockResolvedValue({ status: "installing" });
     render(wrap(<ComposioOnboarding onConnected={() => {}} />));
     fireEvent.click(
-      screen.getByRole("button", { name: /sign in with composio/i }),
+      screen.getByRole("button", { name: /connect integrations/i }),
     );
     await waitFor(() =>
-      expect(screen.getByText(/setting up composio/i)).toBeInTheDocument(),
+      expect(screen.getByText(/setting up integrations/i)).toBeInTheDocument(),
     );
     await waitFor(() => expect(getComposioSigninStatus).toHaveBeenCalled());
   });
@@ -97,7 +95,7 @@ describe("<ComposioOnboarding>", () => {
     getComposioSigninStatus.mockResolvedValue({ status: "awaiting_login" });
     render(wrap(<ComposioOnboarding onConnected={() => {}} />));
     fireEvent.click(
-      screen.getByRole("button", { name: /sign in with composio/i }),
+      screen.getByRole("button", { name: /connect integrations/i }),
     );
     await waitFor(() =>
       expect(
@@ -125,7 +123,7 @@ describe("<ComposioOnboarding>", () => {
     const onConnected = vi.fn();
     render(wrap(<ComposioOnboarding onConnected={onConnected} />));
     fireEvent.click(
-      screen.getByRole("button", { name: /sign in with composio/i }),
+      screen.getByRole("button", { name: /connect integrations/i }),
     );
     await waitFor(() => expect(onConnected).toHaveBeenCalled());
   });
@@ -137,7 +135,7 @@ describe("<ComposioOnboarding>", () => {
     });
     render(wrap(<ComposioOnboarding onConnected={() => {}} />));
     fireEvent.click(
-      screen.getByRole("button", { name: /sign in with composio/i }),
+      screen.getByRole("button", { name: /connect integrations/i }),
     );
     await waitFor(() =>
       expect(screen.getByRole("alert")).toHaveTextContent(
@@ -146,14 +144,14 @@ describe("<ComposioOnboarding>", () => {
     );
     // Recoverable: the primary CTA is back.
     expect(
-      screen.getByRole("button", { name: /sign in with composio/i }),
+      screen.getByRole("button", { name: /connect integrations/i }),
     ).toBeEnabled();
   });
 
   it("keeps the manual fallback: renders the form and a get-key link when expanded", () => {
     render(wrap(<ComposioOnboarding onConnected={() => {}} />));
     expandManualFallback();
-    expect(screen.getByLabelText(/composio api key/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/api key/i)).toBeInTheDocument();
     const link = screen.getByRole("link", { name: /get an api key/i });
     // Regression: the old developer portal (app.composio.dev) is gone; the
     // current dashboard lives at dashboard.composio.dev.
@@ -163,15 +161,11 @@ describe("<ComposioOnboarding>", () => {
   it("disables connect until a key is entered", () => {
     render(wrap(<ComposioOnboarding onConnected={() => {}} />));
     expandManualFallback();
-    expect(
-      screen.getByRole("button", { name: /connect composio/i }),
-    ).toBeDisabled();
-    fireEvent.change(screen.getByLabelText(/composio api key/i), {
+    expect(screen.getByRole("button", { name: /save key/i })).toBeDisabled();
+    fireEvent.change(screen.getByLabelText(/api key/i), {
       target: { value: "ak_abc123" },
     });
-    expect(
-      screen.getByRole("button", { name: /connect composio/i }),
-    ).toBeEnabled();
+    expect(screen.getByRole("button", { name: /save key/i })).toBeEnabled();
   });
 
   it("saves the pasted key via updateConfig and notifies on success", async () => {
@@ -179,10 +173,10 @@ describe("<ComposioOnboarding>", () => {
     const onConnected = vi.fn();
     render(wrap(<ComposioOnboarding onConnected={onConnected} />));
     expandManualFallback();
-    fireEvent.change(screen.getByLabelText(/composio api key/i), {
+    fireEvent.change(screen.getByLabelText(/api key/i), {
       target: { value: "  ak_abc123  " },
     });
-    fireEvent.click(screen.getByRole("button", { name: /connect composio/i }));
+    fireEvent.click(screen.getByRole("button", { name: /save key/i }));
     await waitFor(() =>
       expect(updateConfig).toHaveBeenCalledWith({
         composio_api_key: "ak_abc123",
@@ -194,7 +188,7 @@ describe("<ComposioOnboarding>", () => {
   it("toggles key visibility", () => {
     render(wrap(<ComposioOnboarding onConnected={() => {}} />));
     expandManualFallback();
-    const input = screen.getByLabelText(/composio api key/i);
+    const input = screen.getByLabelText(/api key/i);
     expect(input).toHaveAttribute("type", "password");
     fireEvent.click(screen.getByRole("button", { name: "Show" }));
     expect(input).toHaveAttribute("type", "text");

--- a/web/src/components/apps/integrations/ComposioOnboarding.test.tsx
+++ b/web/src/components/apps/integrations/ComposioOnboarding.test.tsx
@@ -65,6 +65,28 @@ describe("<ComposioOnboarding>", () => {
     ).toBeInTheDocument();
   });
 
+  it("handles the installing status: shows the setup panel and keeps polling", async () => {
+    // Regression: the broker auto-installs the CLI and returns `installing`
+    // first. The page previously had no case for it — applySigninState fell
+    // through to default and polling stayed disabled, so "Sign in with
+    // Composio" silently did nothing. It must now render a working state and
+    // keep polling so it can advance to awaiting_login / done.
+    vi.stubGlobal("open", vi.fn());
+    startComposioSignin.mockResolvedValue({
+      status: "installing",
+      install_command: "curl -fsSL https://composio.dev/install | bash",
+    });
+    getComposioSigninStatus.mockResolvedValue({ status: "installing" });
+    render(wrap(<ComposioOnboarding onConnected={() => {}} />));
+    fireEvent.click(
+      screen.getByRole("button", { name: /sign in with composio/i }),
+    );
+    await waitFor(() =>
+      expect(screen.getByText(/setting up composio/i)).toBeInTheDocument(),
+    );
+    await waitFor(() => expect(getComposioSigninStatus).toHaveBeenCalled());
+  });
+
   it("shows the auth link and auto-opens it once while awaiting login", async () => {
     const open = vi.fn();
     vi.stubGlobal("open", open);

--- a/web/src/components/apps/integrations/ComposioOnboarding.tsx
+++ b/web/src/components/apps/integrations/ComposioOnboarding.tsx
@@ -26,6 +26,7 @@ const COMPOSIO_KEYS_URL = "https://dashboard.composio.dev";
 
 type SigninPhase =
   | "idle"
+  | "installing"
   | "cli_missing"
   | "awaiting_login"
   | "provisioning"
@@ -58,6 +59,13 @@ export function ComposioOnboarding({ onConnected }: ComposioOnboardingProps) {
   const applySigninState = useCallback(
     (state: ComposioSigninState) => {
       switch (state.status) {
+        case "installing":
+          // The broker is auto-installing the Composio CLI before it can mint
+          // a login URL. We must enter (and keep polling) this phase — without
+          // it the page would stall on "idle" and never open the sign-in tab.
+          setPhase("installing");
+          setInstallCommand(state.install_command ?? "");
+          break;
         case "cli_missing":
           setPhase("cli_missing");
           setInstallCommand(state.install_command ?? "");
@@ -105,7 +113,10 @@ export function ComposioOnboarding({ onConnected }: ComposioOnboardingProps) {
     signinMutation.mutate();
   };
 
-  const polling = phase === "awaiting_login" || phase === "provisioning";
+  const polling =
+    phase === "installing" ||
+    phase === "awaiting_login" ||
+    phase === "provisioning";
   const statusQuery = useQuery({
     queryKey: ["composio-signin-status"],
     queryFn: getComposioSigninStatus,
@@ -209,6 +220,18 @@ function SigninPanel({
   starting,
   onStart,
 }: SigninPanelProps) {
+  if (phase === "installing") {
+    return (
+      <div className="composio-onb-panel" role="status">
+        <p className="composio-onb-panel-title">Setting up Composio…</p>
+        <p className="composio-onb-panel-note">
+          Installing the Composio CLI (one-time). We’ll open the sign-in page
+          automatically as soon as it’s ready.
+        </p>
+        <p className="composio-onb-wait">Working on it…</p>
+      </div>
+    );
+  }
   if (phase === "cli_missing") {
     return (
       <div className="composio-onb-panel" role="status">

--- a/web/src/components/apps/integrations/ComposioOnboarding.tsx
+++ b/web/src/components/apps/integrations/ComposioOnboarding.tsx
@@ -50,7 +50,7 @@ export function ComposioOnboarding({ onConnected }: ComposioOnboardingProps) {
   const openedRef = useRef(false);
 
   const finishConnected = useCallback(async () => {
-    showNotice("Composio connected. Loading your integrations…", "success");
+    showNotice("Integrations connected. Loading…", "success");
     await queryClient.invalidateQueries({ queryKey: ["config"] });
     await queryClient.invalidateQueries({ queryKey: ["integrations"] });
     onConnected();
@@ -102,7 +102,7 @@ export function ComposioOnboarding({ onConnected }: ComposioOnboardingProps) {
     onError: (err: unknown) => {
       setPhase("error");
       setSigninError(
-        err instanceof Error ? err.message : "Could not start Composio sign-in",
+        err instanceof Error ? err.message : "Could not start sign-in",
       );
     },
   });
@@ -133,23 +133,21 @@ export function ComposioOnboarding({ onConnected }: ComposioOnboardingProps) {
     onSuccess: finishConnected,
     onError: (err: unknown) => {
       showNotice(
-        err instanceof Error ? err.message : "Could not save the Composio key",
+        err instanceof Error ? err.message : "Could not save the API key",
         "error",
       );
     },
   });
 
   return (
-    <section className="composio-onb" aria-label="Connect Composio">
+    <section className="composio-onb" aria-label="Connect integrations">
       <div className="composio-onb-card">
         <span className="composio-onb-eyebrow">Integrations</span>
-        <h2 className="composio-onb-title">
-          Connect Composio to add integrations
-        </h2>
+        <h2 className="composio-onb-title">Add integrations to your office</h2>
         <p className="composio-onb-lead">
-          Composio is the gateway your team uses to act in Gmail, Slack, GitHub,
-          and 250+ other tools — securely, with OAuth and a full audit trail.
-          Sign in once and we set up the rest.
+          Connect once to let your agents act in Gmail, Slack, GitHub, and 250+
+          other tools — securely, with OAuth and a full audit trail. We set up
+          the rest.
         </p>
 
         <div className="composio-onb-logos" aria-hidden="true">
@@ -196,8 +194,8 @@ export function ComposioOnboarding({ onConnected }: ComposioOnboardingProps) {
         ) : null}
 
         <p className="composio-onb-foot">
-          Your key is stored locally on this workspace and never leaves it. The
-          Composio account it identifies is resolved from your workspace email.
+          Your credentials are stored locally on this workspace and never leave
+          it.
         </p>
       </div>
     </section>
@@ -223,10 +221,10 @@ function SigninPanel({
   if (phase === "installing") {
     return (
       <div className="composio-onb-panel" role="status">
-        <p className="composio-onb-panel-title">Setting up Composio…</p>
+        <p className="composio-onb-panel-title">Setting up integrations…</p>
         <p className="composio-onb-panel-note">
-          Installing the Composio CLI (one-time). We’ll open the sign-in page
-          automatically as soon as it’s ready.
+          One-time setup. We’ll open the sign-in page automatically as soon as
+          it’s ready.
         </p>
         <p className="composio-onb-wait">Working on it…</p>
       </div>
@@ -235,12 +233,9 @@ function SigninPanel({
   if (phase === "cli_missing") {
     return (
       <div className="composio-onb-panel" role="status">
-        <p className="composio-onb-panel-title">
-          Install the Composio CLI first
-        </p>
+        <p className="composio-onb-panel-title">One quick terminal step</p>
         <p className="composio-onb-panel-note">
-          Sign-in runs through the official Composio CLI, which isn’t installed
-          yet. Run this in a terminal, then try again:
+          Automatic setup didn’t finish. Run this in a terminal, then try again:
         </p>
         <CommandRow command={installCommand} />
         <div className="composio-onb-actions">
@@ -264,8 +259,7 @@ function SigninPanel({
         </p>
         {authUrl ? (
           <p className="composio-onb-panel-note">
-            We opened the Composio sign-in page in a new tab. If it didn’t
-            appear,{" "}
+            We opened the sign-in page in a new tab. If it didn’t appear,{" "}
             <a
               className="composio-onb-getkey"
               href={authUrl}
@@ -290,11 +284,9 @@ function SigninPanel({
   if (phase === "provisioning" || phase === "done") {
     return (
       <div className="composio-onb-panel" role="status">
-        <p className="composio-onb-panel-title">
-          Connecting your Composio project…
-        </p>
+        <p className="composio-onb-panel-title">Connecting your account…</p>
         <p className="composio-onb-panel-note">
-          Fetching a project API key and saving it to this workspace.
+          Saving your credentials to this workspace.
         </p>
       </div>
     );
@@ -307,7 +299,7 @@ function SigninPanel({
         onClick={onStart}
         disabled={starting}
       >
-        {starting ? "Starting sign-in…" : "Sign in with Composio"}
+        {starting ? "Connecting…" : "Connect integrations"}
       </button>
     </div>
   );
@@ -334,7 +326,7 @@ function ManualKeyForm({ pending, onSubmit }: ManualKeyFormProps) {
       }}
     >
       <label className="composio-onb-label" htmlFor="composio-api-key">
-        Composio API key
+        API key
       </label>
       <div className="composio-onb-field">
         <input
@@ -364,7 +356,7 @@ function ManualKeyForm({ pending, onSubmit }: ManualKeyFormProps) {
           className="btn composio-onb-submit"
           disabled={!canSubmit}
         >
-          {pending ? "Connecting…" : "Connect Composio"}
+          {pending ? "Connecting…" : "Save key"}
         </button>
         <a
           className="composio-onb-getkey"

--- a/web/src/components/lifecycle/DecisionInbox.test.tsx
+++ b/web/src/components/lifecycle/DecisionInbox.test.tsx
@@ -7,7 +7,12 @@ import {
   type AgentRequest,
   answerRequest,
   getAllRequests,
+  getConfig,
 } from "../../api/client";
+import {
+  getIntegrationConnectStatus,
+  startIntegrationConnection,
+} from "../../api/integrations";
 import type { InboxItem } from "../../lib/types/inbox";
 import { DecisionInbox } from "./DecisionInbox";
 
@@ -17,8 +22,16 @@ vi.mock("../../api/client", async (importOriginal) => {
     ...actual,
     answerRequest: vi.fn(),
     getAllRequests: vi.fn(),
+    getConfig: vi.fn(),
   };
 });
+
+vi.mock("../../api/integrations", () => ({
+  startComposioSignin: vi.fn(),
+  getComposioSigninStatus: vi.fn(),
+  startIntegrationConnection: vi.fn(),
+  getIntegrationConnectStatus: vi.fn(),
+}));
 
 vi.mock("../../routes/useCurrentRoute", async (importOriginal) => {
   const actual =
@@ -104,6 +117,7 @@ describe("<DecisionInbox> (mail-style)", () => {
       requests: [ADA_FULL_REQUEST],
     });
     vi.mocked(answerRequest).mockResolvedValue({});
+    vi.mocked(getConfig).mockResolvedValue({ composio_key_set: true });
   });
 
   it("renders one row per item with sender + subject", () => {
@@ -332,5 +346,83 @@ describe("<DecisionInbox> (mail-style)", () => {
     expect(
       screen.queryByText(/answered or is no longer active/i),
     ).not.toBeInTheDocument();
+  });
+
+  it("renders a connect request as the ConnectIntegrationCard and runs the connect flow (not a generic answer)", async () => {
+    // Regression: a `connect` request rendered as generic option buttons, so
+    // clicking "Connect" called answerRequest — the request vanished from the
+    // Inbox but no OAuth ever ran ("disappears but does nothing"). It must now
+    // render the OAuth-driving ConnectIntegrationCard, like InterviewBar does.
+    const open = vi.fn();
+    vi.stubGlobal("open", open);
+    // This file's beforeEach doesn't reset call history; clear answerRequest so
+    // the "not answered" assertion reflects only this test.
+    vi.mocked(answerRequest).mockClear();
+    vi.mocked(startIntegrationConnection).mockResolvedValue({
+      provider: "composio",
+      platform: "gmail",
+      status: "connecting",
+      auth_url: "https://oauth.example/gmail",
+    });
+    vi.mocked(getIntegrationConnectStatus).mockResolvedValue({
+      provider: "composio",
+      platform: "gmail",
+      status: "connecting",
+    });
+
+    const connectItem: InboxItem = {
+      kind: "request",
+      requestId: "req-connect",
+      title: "Connect Gmail",
+      agentSlug: "ada",
+      channel: "general",
+      createdAt: "2026-05-11T12:50:00Z",
+      request: {
+        kind: "connect",
+        question: "@ada needs Gmail to send the email.",
+        from: "ada",
+      },
+    };
+    vi.mocked(getAllRequests).mockResolvedValue({
+      requests: [
+        {
+          id: "req-connect",
+          kind: "connect",
+          from: "ada",
+          platform: "gmail",
+          channel: "general",
+          title: "Connect Gmail",
+          question: "@ada needs Gmail to send the email.",
+          status: "pending",
+          blocking: true,
+          options: [{ id: "connect", label: "Connect" }],
+        },
+      ],
+    });
+
+    render(wrap(<DecisionInbox initialItems={[connectItem]} />));
+
+    // The card's eyebrow is unique to ConnectIntegrationCard; the generic
+    // RequestItem never renders it.
+    expect(await screen.findByText(/connect to continue/i)).toBeInTheDocument();
+    const connectButton = await screen.findByRole("button", {
+      name: /^Connect Gmail$/i,
+    });
+
+    fireEvent.click(connectButton);
+
+    // Drives the real connection flow — NOT answerRequest.
+    await waitFor(() =>
+      expect(startIntegrationConnection).toHaveBeenCalledWith(
+        "composio",
+        "gmail",
+      ),
+    );
+    expect(open).toHaveBeenCalledWith(
+      "https://oauth.example/gmail",
+      "_blank",
+      "noopener,noreferrer",
+    );
+    expect(answerRequest).not.toHaveBeenCalled();
   });
 });

--- a/web/src/components/lifecycle/DecisionInbox.tsx
+++ b/web/src/components/lifecycle/DecisionInbox.tsx
@@ -17,6 +17,7 @@ import {
 import {
   type AgentRequest,
   answerRequest,
+  cancelRequest,
   getAllRequests,
 } from "../../api/client";
 import {
@@ -31,6 +32,7 @@ import {
 } from "../../api/notebook";
 import type { InboxItem, InboxItemKind } from "../../lib/types/inbox";
 import { SEV_ORDER, SEVERITY_TOKENS } from "../../lib/types/lifecycle";
+import { ConnectIntegrationCard } from "../messages/ConnectIntegrationCard";
 import { RequestItem } from "./RequestItem";
 
 const TaskDocumentRoute = lazy(() =>
@@ -822,6 +824,27 @@ function RequestBody({
     }
   };
 
+  const handleDismiss = async () => {
+    setAnswerError(null);
+    try {
+      await cancelRequest(fullRequest.id);
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ["requests"] }),
+        queryClient.invalidateQueries({ queryKey: ["lifecycle"] }),
+      ]);
+    } catch (err) {
+      setAnswerError(
+        err instanceof Error ? err.message : "Could not dismiss request.",
+      );
+    }
+  };
+
+  // `connect` requests need the OAuth-driving ConnectIntegrationCard, not the
+  // generic option buttons — otherwise clicking "Connect" just answers the
+  // request (it vanishes from the Inbox) without ever running the sign-in /
+  // connection flow. Mirrors InterviewBar's connect branch.
+  const isConnect = fullRequest.kind === "connect";
+
   return (
     <div className="inbox-mail-detail-body inbox-mail-detail-body--embed">
       {answerError ? (
@@ -830,13 +853,22 @@ function RequestBody({
           <div className="body">{answerError}</div>
         </div>
       ) : null}
-      <RequestItem
-        request={fullRequest}
-        isPending={isPending}
-        onAnswer={(choiceId, customText) =>
-          void handleAnswer(choiceId, customText)
-        }
-      />
+      {isPending && isConnect ? (
+        <ConnectIntegrationCard
+          request={fullRequest}
+          submitting={false}
+          onSkip={() => void handleAnswer("skip")}
+          onDismiss={() => void handleDismiss()}
+        />
+      ) : (
+        <RequestItem
+          request={fullRequest}
+          isPending={isPending}
+          onAnswer={(choiceId, customText) =>
+            void handleAnswer(choiceId, customText)
+          }
+        />
+      )}
       {!isPending && auditEntries.length > 0 ? (
         <ApprovalAuditTrail entries={auditEntries} />
       ) : null}

--- a/web/src/styles/operator.css
+++ b/web/src/styles/operator.css
@@ -1176,3 +1176,193 @@
     padding-top: 0;
   }
 }
+
+/* ═══════════════════════════════════════════════════════════════════════
+   Integrations redesign — sectioned control panels + catalog grid.
+   Every functional area is a distinct surface with a clear header so the
+   page reads as separated sections instead of one flat list.
+   ═══════════════════════════════════════════════════════════════════════ */
+
+/* Connection status banner — replaces the cramped provider chip. */
+.op-conn {
+  display: flex;
+  align-items: center;
+  gap: 11px;
+  margin-bottom: 18px;
+  padding: 12px 16px;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+}
+.op-conn-dot {
+  flex-shrink: 0;
+  width: 8px;
+  height: 8px;
+  border-radius: var(--radius-full);
+  background: var(--text-tertiary);
+}
+.op-conn.is-on .op-conn-dot {
+  background: var(--green);
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--green) 18%, transparent);
+}
+.op-conn-text {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  min-width: 0;
+}
+.op-conn-title {
+  font-size: var(--text-sm);
+  font-weight: 650;
+  color: var(--text);
+}
+.op-conn-sub {
+  font-size: var(--text-xs);
+  color: var(--text-tertiary);
+}
+
+/* Section panel — the core "clearly separated" surface. */
+.op-panel {
+  margin-bottom: 18px;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+}
+.op-panel-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--border-light);
+}
+.op-panel-heading {
+  min-width: 0;
+}
+.op-panel-title {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 650;
+  color: var(--text);
+}
+.op-panel-sub {
+  margin: 2px 0 0;
+  font-size: var(--text-xs);
+  color: var(--text-tertiary);
+  line-height: 1.4;
+}
+.op-panel-count {
+  flex-shrink: 0;
+  padding: 3px 9px;
+  border-radius: var(--radius-full);
+  background: var(--bg-subtle);
+  border: 1px solid var(--border-light);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  color: var(--text-secondary);
+  white-space: nowrap;
+}
+.op-panel-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--border-light);
+  background: var(--bg-subtle);
+}
+.op-panel-body {
+  padding: 14px 16px;
+}
+.op-panel-empty {
+  margin: 0;
+  padding: 28px 16px;
+  text-align: center;
+  font-size: var(--text-sm);
+  color: var(--text-tertiary);
+}
+
+/* Catalog grid — app tiles, the browsable integration directory. */
+.op-catalog-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(190px, 1fr));
+  gap: 10px;
+}
+.op-catalog-tile {
+  display: flex;
+  align-items: center;
+  gap: 11px;
+  width: 100%;
+  padding: 12px;
+  text-align: left;
+  background: var(--bg);
+  border: 1px solid var(--border-light);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition:
+    border-color 0.12s ease,
+    transform 0.12s ease,
+    box-shadow 0.12s ease;
+}
+.op-catalog-tile:hover {
+  border-color: var(--accent);
+  transform: translateY(-1px);
+  box-shadow: 0 4px 14px -8px color-mix(in srgb, var(--accent) 60%, transparent);
+}
+.op-catalog-tile:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+.op-catalog-tile.is-on {
+  border-color: color-mix(in srgb, var(--green) 45%, var(--border-light));
+}
+.op-catalog-tile-body {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+  flex: 1;
+}
+.op-catalog-tile-name {
+  font-size: var(--text-sm);
+  font-weight: 600;
+  color: var(--text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.op-catalog-tile-meta {
+  font-size: 10px;
+  font-family: var(--font-mono);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--text-tertiary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.op-catalog-tile-status {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+}
+.op-catalog-tile-status .op-led {
+  width: 7px;
+  height: 7px;
+}
+.op-catalog-tile-pill {
+  font-family: var(--font-mono);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--green-dark);
+}
+
+/* Registry rows (gateways, channels) sit inside the same panel body. */
+.op-panel-body > .op-list {
+  display: flex;
+  flex-direction: column;
+}


### PR DESCRIPTION
## Problem

Three related Composio bugs were reported:

1. **"Sign in with Composio" doesn't open anything** (Integrations onboarding page).
2. **From human interview it attempts, then says** *"The Composio CLI isn't installed. Run `curl -fsSL https://composio.dev/install | bash` …"* — even though the broker auto-installs the CLI.
3. **Clicking "Connect" on a request in the Inbox makes the request disappear but does nothing.**

## Root cause

The official installer (`curl … | bash`, the same one [trustclaw](https://github.com/ComposioHQ/trustclaw) points users at) drops the `composio` binary into `$COMPOSIO_INSTALL_DIR` (default `~/.composio`) and only appends that dir to `PATH` **in the user's shell profile** (`~/.zshrc`, `~/.bashrc`, …). The already-running broker process never re-reads those profiles, so `exec.LookPath("composio")` fails **immediately after a successful install** → the flow falls back to `cli_missing`. So the CLI *is* installed automatically — the broker just couldn't find it.

## Fix

**Broker (`internal/team/broker_composio_signin.go`)** — the core fix:
- New `composioBinary()` resolver: checks `PATH` first, then the installer's known location (`$COMPOSIO_INSTALL_DIR`/`~/.composio/composio`). Every CLI invocation routes through a `composioCommand()` helper that uses the resolved absolute path and prepends the install dir to the subprocess `PATH`.
- The post-install verify and the start gate now use the resolver instead of bare `LookPath`.

**Onboarding page (`ComposioOnboarding.tsx`)** — fixes bug #1:
- Added a case for the `installing` status. Previously `applySigninState` fell through to `default` and polling was never enabled, so the page silently stalled while the broker installed. Now it renders a setup panel, keeps polling, and advances to `awaiting_login` (opening the sign-in tab).

**Inbox (`DecisionInbox.tsx`)** — fixes bug #3:
- Connect requests now render the OAuth-driving `ConnectIntegrationCard` (same as `InterviewBar`) instead of generic answer buttons. Clicking "Connect" runs `startIntegrationConnection` rather than silently answering/cancelling the request.

## Tests
- **Go (live HTTP path):** install stub drops the binary **only** in `~/.composio` (not on `PATH`); the sign-in flow must reach `done`, not `cli_missing`. Plus a direct `composioBinary` resolver test. Sandboxed `COMPOSIO_INSTALL_DIR` in the shared test helper so a real CLI on the dev box can't leak in.
- **Web:** onboarding renders + keeps polling on `installing`; inbox renders `ConnectIntegrationCard` for connect requests and calls `startIntegrationConnection` (not `answerRequest`).

## Verification
- `bash scripts/test-go.sh ./internal/team` ✅ (green)
- `bash scripts/test-web.sh` ✅ (233 files / 2172 tests)
- `gofmt`, `go vet ./...`, `bunx tsc --noEmit`, `bunx biome check` ✅
- `go build ./cmd/wuphf` ✅

## Screenshots
The new visual states (onboarding "Setting up Composio…" panel + inbox `ConnectIntegrationCard`) only appear mid-flow against a live broker driven through the Composio install/connect path, which the screenshot harness can't easily stage. Manual live verification on a workspace where `composio` is freshly installed (not yet on the broker's PATH) is the remaining step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an “installing” onboarding phase with a “Setting up integrations…” status panel during Composio CLI auto-installation.
  * Added a dedicated card for pending “connect” requests (for example, Connect Gmail) in the decision inbox.
  * Refreshed the Integrations home layout with a connection-status banner and a catalog tile grid.
* **Bug Fixes**
  * Improved Composio CLI detection when the binary exists only in the install directory (not on PATH).
  * Expanded Composio authentication/provisioning with project-scoped API keys and user-key fallback; updated configured/not-connected wording and hid Composio meta toolkits in the catalog.
  * Prevented sending literal `"undefined"`/`"null"` query values for integrations filters.
* **Tests**
  * Added hermetic CLI and provisioning/resolution regression tests plus UI polling/status and connect-flow coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->