### PR TITLE
fix(tasks): remove channel selection from the new-task modal

### DIFF
--- a/web/src/components/tasks/TaskCreateDialog.stories.tsx
+++ b/web/src/components/tasks/TaskCreateDialog.stories.tsx
@@ -2,16 +2,9 @@ import { useEffect, useState } from "react";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
-import type { Channel, OfficeMember } from "../../api/client";
+import type { OfficeMember } from "../../api/client";
 import { Button } from "../ui/Button";
 import { TaskCreateDialog } from "./TaskCreateDialog";
-
-const SAMPLE_CHANNELS: Channel[] = [
-  { slug: "general", name: "General" },
-  { slug: "bookkeeping", name: "Bookkeeping" },
-  { slug: "sales-pipeline", name: "Sales pipeline" },
-  { slug: "ops-week", name: "Ops week" },
-];
 
 const SAMPLE_MEMBERS: OfficeMember[] = [
   { slug: "ceo", name: "CEO", role: "supervisor", emoji: "👔" },
@@ -20,17 +13,11 @@ const SAMPLE_MEMBERS: OfficeMember[] = [
   { slug: "researcher", name: "Researcher", role: "specialist", emoji: "🔍" },
 ];
 
-function buildClient(opts?: {
-  channels?: Channel[];
-  members?: OfficeMember[];
-}) {
+function buildClient(opts?: { members?: OfficeMember[] }) {
   const client = new QueryClient({
     defaultOptions: {
       queries: { retry: false, staleTime: Number.POSITIVE_INFINITY },
     },
-  });
-  client.setQueryData(["channels"], {
-    channels: opts?.channels ?? SAMPLE_CHANNELS,
   });
   client.setQueryData(["office-members"], {
     members: opts?.members ?? SAMPLE_MEMBERS,
@@ -39,18 +26,12 @@ function buildClient(opts?: {
 }
 
 interface HarnessProps {
-  defaultChannel?: string;
   defaultAssignee?: string;
   startOpen?: boolean;
   client?: QueryClient;
 }
 
-function Harness({
-  defaultChannel,
-  defaultAssignee,
-  startOpen = true,
-  client,
-}: HarnessProps) {
+function Harness({ defaultAssignee, startOpen = true, client }: HarnessProps) {
   const [open, setOpen] = useState(startOpen);
   const queryClient = client ?? buildClient();
   // Reflect the prop into local state when the story re-mounts so toggling
@@ -84,7 +65,6 @@ function Harness({
         <TaskCreateDialog
           open={open}
           onOpenChange={setOpen}
-          defaultChannel={defaultChannel}
           defaultAssignee={defaultAssignee}
           navigateOnCreate={false}
         />
@@ -101,7 +81,7 @@ const meta: Meta<typeof Harness> = {
     docs: {
       description: {
         component:
-          "Linear-inspired task creation dialog. Title is the hero input, description is a markdown textarea, channel + assignee live as chip-style pickers in the footer. Cmd/Ctrl+Enter submits.",
+          "Linear-inspired task creation dialog. Title is the hero input, description is a markdown textarea, the assignee lives as a chip-style picker in the footer. Cmd/Ctrl+Enter submits.",
       },
     },
   },
@@ -114,17 +94,11 @@ export const Default: Story = {
   args: { startOpen: true },
 };
 
-export const PreselectedChannel: Story = {
-  args: { startOpen: true, defaultChannel: "bookkeeping" },
-};
-
 export const PreselectedAssignee: Story = {
   args: { startOpen: true, defaultAssignee: "bookkeeper" },
 };
 
-export const NoChannelsYet: Story = {
+export const NoMembersYet: Story = {
   args: { startOpen: true },
-  render: (args) => (
-    <Harness {...args} client={buildClient({ channels: [], members: [] })} />
-  ),
+  render: (args) => <Harness {...args} client={buildClient({ members: [] })} />,
 };

--- a/web/src/components/tasks/TaskCreateDialog.test.tsx
+++ b/web/src/components/tasks/TaskCreateDialog.test.tsx
@@ -1,0 +1,76 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { OfficeMember } from "../../api/client";
+
+const mutateAsync = vi.fn(
+  async (_input: Record<string, unknown>) => ({ task: { id: "task-1" } }),
+);
+
+vi.mock("../../hooks/useCreateTask", () => ({
+  useCreateTask: () => ({ mutateAsync, isPending: false }),
+}));
+
+const SAMPLE_MEMBERS: OfficeMember[] = [
+  { slug: "ceo", name: "CEO", role: "supervisor", emoji: "👔" },
+  { slug: "bookkeeper", name: "Bookkeeper", role: "specialist", emoji: "📒" },
+];
+
+vi.mock("../../hooks/useMembers", () => ({
+  useOfficeMembers: () => ({ data: SAMPLE_MEMBERS, isPending: false }),
+}));
+
+vi.mock("../../api/client", () => ({
+  getConfig: async () => ({ team_lead_slug: "ceo" }),
+}));
+
+vi.mock("../../lib/router", () => ({
+  router: { navigate: vi.fn() },
+}));
+
+import { TaskCreateDialog } from "./TaskCreateDialog";
+
+function renderDialog() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <TaskCreateDialog open={true} onOpenChange={() => {}} />
+    </QueryClientProvider>,
+  );
+}
+
+describe("<TaskCreateDialog>", () => {
+  beforeEach(() => {
+    mutateAsync.mockClear();
+  });
+
+  it("does not render a channel selector (channels are no longer user-facing)", () => {
+    renderDialog();
+
+    // Regression: the modal used to expose a "#channel" picker chip. Channels
+    // are no longer a creation-time choice — every task gets its own channel.
+    expect(screen.queryByTestId("issue-create-channel")).toBeNull();
+    expect(
+      screen.queryByRole("combobox", { name: /channel/i }),
+    ).toBeNull();
+    // The assignee chip is still the one remaining property control.
+    expect(screen.getByTestId("issue-create-assignee")).toBeInTheDocument();
+  });
+
+  it("creates a task without sending a user-chosen channel", async () => {
+    renderDialog();
+
+    fireEvent.change(screen.getByTestId("issue-create-title"), {
+      target: { value: "Reconcile the books" },
+    });
+    fireEvent.click(screen.getByTestId("issue-create-submit"));
+
+    await waitFor(() => expect(mutateAsync).toHaveBeenCalledTimes(1));
+    const payload = mutateAsync.mock.calls[0][0] as Record<string, unknown>;
+    expect(payload).not.toHaveProperty("channel");
+    expect(payload.title).toBe("Reconcile the books");
+  });
+});

--- a/web/src/components/tasks/TaskCreateDialog.tsx
+++ b/web/src/components/tasks/TaskCreateDialog.tsx
@@ -9,10 +9,9 @@ import {
   useState,
 } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { FastArrowDown, Hashtag, KeyframeSolid, User } from "iconoir-react";
+import { FastArrowDown, KeyframeSolid, User } from "iconoir-react";
 
 import { getConfig } from "../../api/client";
-import { useChannels } from "../../hooks/useChannels";
 import { useCreateTask } from "../../hooks/useCreateTask";
 import { useOfficeMembers } from "../../hooks/useMembers";
 import { router } from "../../lib/router";
@@ -25,14 +24,11 @@ import {
 } from "../ui/Dialog";
 import { Kbd, MOD_KEY } from "../ui/Kbd";
 
-const DEFAULT_CHANNEL = "general";
 const AUTO_ASSIGN = "";
 
 export interface TaskCreateDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  /** Pre-select a channel — used when opened from a channel header. */
-  defaultChannel?: string;
   /** Pre-select an assignee — used when opened from an agent subspace. */
   defaultAssignee?: string;
   /** Navigate to the new task's detail page on success. Default: true. */
@@ -50,24 +46,20 @@ export interface TaskCreateDialogProps {
 export function TaskCreateDialog({
   open,
   onOpenChange,
-  defaultChannel,
   defaultAssignee,
   navigateOnCreate = true,
 }: TaskCreateDialogProps) {
   const titleId = useId();
   const detailsId = useId();
-  const channelId = useId();
   const assigneeId = useId();
 
   const [title, setTitle] = useState("");
   const [details, setDetails] = useState("");
-  const [channel, setChannel] = useState(defaultChannel ?? DEFAULT_CHANNEL);
   const [assignee, setAssignee] = useState(defaultAssignee ?? AUTO_ASSIGN);
   const [createMore, setCreateMore] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const titleRef = useRef<HTMLInputElement | null>(null);
 
-  const channelsQuery = useChannels();
   const membersQuery = useOfficeMembers();
   const createTask = useCreateTask();
   const { data: cfg } = useQuery({
@@ -76,7 +68,6 @@ export function TaskCreateDialog({
     staleTime: 60_000,
   });
 
-  const channels = channelsQuery.data ?? [];
   const members = membersQuery.data ?? [];
   const leadSlug = useMemo(
     () => resolveLeadSlug(cfg?.team_lead_slug, members),
@@ -87,12 +78,11 @@ export function TaskCreateDialog({
     if (open) {
       setTitle("");
       setDetails("");
-      setChannel(defaultChannel ?? DEFAULT_CHANNEL);
       setAssignee(defaultAssignee ?? AUTO_ASSIGN);
       setError(null);
       queueMicrotask(() => titleRef.current?.focus());
     }
-  }, [open, defaultChannel, defaultAssignee]);
+  }, [open, defaultAssignee]);
 
   const canSubmit = title.trim().length > 0 && !createTask.isPending;
 
@@ -105,11 +95,6 @@ export function TaskCreateDialog({
     return member ? member.name : assignee;
   }, [assignee, members, leadSlug]);
 
-  const channelLabel = useMemo(() => {
-    const c = channels.find((entry) => entry.slug === channel);
-    return c ? c.slug : channel;
-  }, [channel, channels]);
-
   const handleSubmit = useCallback(async () => {
     if (!canSubmit) return;
     setError(null);
@@ -117,7 +102,6 @@ export function TaskCreateDialog({
       const result = await createTask.mutateAsync({
         title,
         details,
-        channel,
         // Empty selection routes to the office lead so the CEO's scoping
         // interview fires and picks a specialist owner.
         assignee: assignee || leadSlug || undefined,
@@ -143,7 +127,6 @@ export function TaskCreateDialog({
     createTask,
     title,
     details,
-    channel,
     assignee,
     leadSlug,
     createMore,
@@ -182,10 +165,6 @@ export function TaskCreateDialog({
             <KeyframeSolid width={14} height={14} aria-hidden="true" />
           </span>
           <span className="issue-create-eyebrow-label">New task</span>
-          <span className="issue-create-eyebrow-sep" aria-hidden="true">
-            ·
-          </span>
-          <span>#{channelLabel}</span>
           {defaultAssignee ? (
             <>
               <span className="issue-create-eyebrow-sep" aria-hidden="true">
@@ -228,31 +207,6 @@ export function TaskCreateDialog({
         </div>
 
         <div className="issue-create-chips">
-          <PropertyChip
-            icon={<Hashtag width={14} height={14} aria-hidden="true" />}
-            label={channelLabel}
-            htmlFor={channelId}
-            disabled={channelsQuery.isPending}
-          >
-            <select
-              id={channelId}
-              value={channel}
-              onChange={(e) => setChannel(e.target.value)}
-              className="issue-create-chip-select"
-              data-testid="issue-create-channel"
-              aria-label="Channel"
-            >
-              {!channels.some((c) => c.slug === channel) ? (
-                <option value={channel}>#{channel}</option>
-              ) : null}
-              {channels.map((c) => (
-                <option key={c.slug} value={c.slug}>
-                  #{c.slug}
-                </option>
-              ))}
-            </select>
-          </PropertyChip>
-
           <PropertyChip
             icon={<User width={14} height={14} aria-hidden="true" />}
             label={assigneeLabel}

--- a/web/src/hooks/useCreateTask.ts
+++ b/web/src/hooks/useCreateTask.ts
@@ -7,7 +7,12 @@ import { track } from "../lib/analytics";
 export interface CreateTaskFormInput {
   title: string;
   details?: string;
-  channel: string;
+  /**
+   * Channel slug to file the task under. Optional: channels are no longer a
+   * user-facing concept (every task gets its own channel), so creation
+   * surfaces omit this and the broker defaults it to "general".
+   */
+  channel?: string;
   assignee?: string;
   createdBy?: string;
 }
@@ -32,7 +37,7 @@ export function useCreateTask() {
     mutationFn: async (input) => {
       const response = await post<TaskResponse>("/tasks", {
         action: "create",
-        channel: input.channel.trim() || "general",
+        channel: input.channel?.trim() || "general",
         title: input.title.trim(),
         details: input.details?.trim() || "",
         owner: input.assignee?.trim() || "",


### PR DESCRIPTION
## What

The task creation modal (`TaskCreateDialog`, opened from the **+ New task** button on the tasks page) still exposed a `#channel` picker chip. Channels are no longer a user-facing concept — every task gets its own channel — so this control was stale and confusing.

This PR removes the channel selection:

- Drop the `#channel` PropertyChip, the eyebrow `· #channel` segment, the `defaultChannel` prop, and all channel state from `TaskCreateDialog`.
- `useCreateTask` now treats `channel` as **optional**; the broker still defaults it to `"general"` under the hood, so the wire shape is unchanged.
- Update the Storybook stories (drop the channel sample data / `PreselectedChannel` / `NoChannelsYet` stories).

## Tests

- New `TaskCreateDialog.test.tsx` regression guard:
  - asserts the modal renders **no** channel selector
  - asserts submit no longer sends a user-chosen `channel`
  - both assertions **fail** against the pre-fix modal and pass with the fix
- Full web suite green: **234 files / 2172 passed, 14 skipped**.
- `tsc --noEmit` clean, `biome check` clean.

## Screenshots

⏳ Pending — needs a running broker + web instance to capture the modal before/after. Will add via `web/e2e/screenshots/publish.sh` before marking ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Task creation dialog simplified: Channel selection removed; tasks now default to the general channel.

* **Tests**
  * Added test coverage for the updated task creation flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->