### PR TITLE
fix(team): derive task id prefix from workspace name, not just OFFICE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,17 @@ All notable changes to WUPHF will be documented in this file.
 
 ### Fixed
 
+- **Task/Issue ids are now personal to each workspace instead of always reading
+  `OFFICE-N`.** The Linear-style prefix is minted from the workspace's company
+  name, but that field is optional and stays blank unless the human picks a
+  brand during onboarding — so `refreshIDPrefixFromWorkspaceLocked` fell through
+  to the hardcoded `OFFICE` default for every workspace, even though each
+  workspace always has a required Name. The prefix is now derived from the
+  company name, then the workspace name (`acme-revops` → `ACMER-1`), then the
+  local config's company name, only falling back to `OFFICE` when none is
+  usable. A new `workspaceIDPrefix` helper skips letter-free candidates so a
+  symbol-only company name can't mask a usable workspace name. Adds table tests
+  plus a live-path regression test that seeds the workspace registry.
 - **Agent runner correctness across provider routing, event ordering, terminal
   races, resume expiry, and receipt reconciliation.** Broker-resolved
   `providerKind` now flows into runner cost and receipt attribution, runner

--- a/internal/team/broker_id_prefix.go
+++ b/internal/team/broker_id_prefix.go
@@ -1,8 +1,10 @@
 package team
 
 // broker_id_prefix.go derives the Linear-style ID prefix used for new
-// Issue IDs (e.g. "NEX" → NEX-1, NEX-2). The prefix comes from the
-// workspace's company name; if absent, falls back to a neutral default.
+// Issue IDs (e.g. "NEX" → NEX-1, NEX-2). The prefix is personal to each
+// workspace: it comes from the workspace's company name, falling back to
+// the workspace's own name, and only then to a neutral default. This keeps
+// every workspace's task ids distinct instead of all reading "OFFICE-N".
 
 import (
 	"fmt"
@@ -49,33 +51,52 @@ func deriveIDPrefix(companyName string) string {
 	return out
 }
 
-// refreshIDPrefixFromWorkspaceLocked re-reads the workspace registry and
-// updates b.idPrefix based on the current company name for this broker's
-// runtime home. Called on init and after onboarding company-name writes.
-// Failures are non-fatal — keeps the existing prefix (which falls back to
-// defaultIDPrefix on first miss).
-func (b *Broker) refreshIDPrefixFromWorkspaceLocked() {
-	runtimeHome := config.RuntimeHomeDir()
-	reg, err := workspaces.Read()
-	if err != nil || reg == nil {
-		if b.idPrefix == "" {
-			b.idPrefix = defaultIDPrefix
-		}
-		return
-	}
-	for _, ws := range reg.Workspaces {
-		if ws == nil {
+// workspaceIDPrefix picks a Linear-style prefix for a workspace, preferring
+// the explicit company name (the brand the human picks during onboarding,
+// e.g. "Nex" → NEX) and falling back to the workspace's own name so each
+// workspace still gets a personal, scannable prefix. Candidates that carry
+// no letters (and would only resolve to defaultIDPrefix) are skipped so a
+// blank or symbol-only company name doesn't mask a usable workspace name.
+// Returns "" when neither yields a real prefix, letting callers fall through.
+func workspaceIDPrefix(companyName, workspaceName string) string {
+	for _, candidate := range []string{companyName, workspaceName} {
+		if strings.TrimSpace(candidate) == "" {
 			continue
 		}
-		if ws.RuntimeHome == runtimeHome {
-			name := strings.TrimSpace(ws.CompanyName)
-			if name == "" {
-				if b.idPrefix == "" {
-					b.idPrefix = defaultIDPrefix
-				}
+		if p := deriveIDPrefix(candidate); p != defaultIDPrefix {
+			return p
+		}
+	}
+	return ""
+}
+
+// refreshIDPrefixFromWorkspaceLocked re-reads the workspace registry and
+// updates b.idPrefix for this broker's runtime home. The prefix is derived
+// from the workspace's company name, then its workspace name, then the local
+// config's company name — only falling back to defaultIDPrefix when none is
+// usable. Called on init and after onboarding company-name writes. Failures
+// are non-fatal: a registry read error keeps the existing prefix (which falls
+// back to defaultIDPrefix on first miss).
+func (b *Broker) refreshIDPrefixFromWorkspaceLocked() {
+	runtimeHome := config.RuntimeHomeDir()
+	if reg, err := workspaces.Read(); err == nil && reg != nil {
+		for _, ws := range reg.Workspaces {
+			if ws == nil || ws.RuntimeHome != runtimeHome {
+				continue
+			}
+			if p := workspaceIDPrefix(ws.CompanyName, ws.Name); p != "" {
+				b.idPrefix = p
 				return
 			}
-			b.idPrefix = deriveIDPrefix(name)
+			break
+		}
+	}
+	// No registry match (e.g. a single default instance not created through
+	// the spaces orchestrator): derive from the local config's company name
+	// before giving up on the neutral default.
+	if cfg, err := config.Load(); err == nil {
+		if p := workspaceIDPrefix(cfg.CompanyName, ""); p != "" {
+			b.idPrefix = p
 			return
 		}
 	}

--- a/internal/team/broker_id_prefix.go
+++ b/internal/team/broker_id_prefix.go
@@ -57,6 +57,9 @@ func deriveIDPrefix(companyName string) string {
 // workspace still gets a personal, scannable prefix. Candidates that carry
 // no letters (and would only resolve to defaultIDPrefix) are skipped so a
 // blank or symbol-only company name doesn't mask a usable workspace name.
+// deriveIDPrefix can only return defaultIDPrefix for letter-free input — a
+// real word like "Office" truncates to "OFFIC" at idPrefixMaxLen — so this
+// guard never skips a legitimately-named workspace, only junk candidates.
 // Returns "" when neither yields a real prefix, letting callers fall through.
 func workspaceIDPrefix(companyName, workspaceName string) string {
 	for _, candidate := range []string{companyName, workspaceName} {
@@ -91,9 +94,10 @@ func (b *Broker) refreshIDPrefixFromWorkspaceLocked() {
 			break
 		}
 	}
-	// No registry match (e.g. a single default instance not created through
-	// the spaces orchestrator): derive from the local config's company name
-	// before giving up on the neutral default.
+	// No usable prefix from the registry — either no row matched this runtime
+	// home (e.g. a single default instance not created through the spaces
+	// orchestrator) or the matched row had only symbol-only names. Derive from
+	// the local config's company name before giving up on the neutral default.
 	if cfg, err := config.Load(); err == nil {
 		if p := workspaceIDPrefix(cfg.CompanyName, ""); p != "" {
 			b.idPrefix = p

--- a/internal/team/broker_id_prefix_test.go
+++ b/internal/team/broker_id_prefix_test.go
@@ -1,0 +1,128 @@
+package team
+
+import (
+	"testing"
+	"time"
+
+	"github.com/nex-crm/wuphf/internal/workspaces"
+)
+
+func TestDeriveIDPrefix(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"Nex", "NEX"},
+		{"Acme Corp", "ACMEC"},
+		{"a.b.c", "ABC"},
+		{"  ", defaultIDPrefix},
+		{"!@#", defaultIDPrefix},
+		{"", defaultIDPrefix},
+	}
+	for _, c := range cases {
+		if got := deriveIDPrefix(c.in); got != c.want {
+			t.Errorf("deriveIDPrefix(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestWorkspaceIDPrefix(t *testing.T) {
+	cases := []struct {
+		name          string
+		company       string
+		workspaceName string
+		want          string
+	}{
+		{"company name wins when set", "Nex", "acme-revops", "NEX"},
+		{"blank company falls back to workspace name", "", "acme-revops", "ACMER"},
+		{"symbol-only company falls back to workspace name", "!!!", "beta-team", "BETAT"},
+		{"both blank yields empty", "", "", ""},
+		{"symbol-only company and blank name yields empty", "###", "", ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := workspaceIDPrefix(c.company, c.workspaceName); got != c.want {
+				t.Errorf("workspaceIDPrefix(%q, %q) = %q, want %q",
+					c.company, c.workspaceName, got, c.want)
+			}
+		})
+	}
+}
+
+// TestRefreshIDPrefixUsesWorkspaceNameWhenCompanyNameEmpty pins the bug fix:
+// a workspace that has a Name but no CompanyName must mint task ids from its
+// own name (e.g. "acme-revops" → ACMER-1) instead of the shared OFFICE-N
+// default. This drives the live refresh path against a seeded registry.
+func TestRefreshIDPrefixUsesWorkspaceNameWhenCompanyNameEmpty(t *testing.T) {
+	home := t.TempDir()
+	// spacesDir() reads the real HOME; RuntimeHomeDir() reads
+	// WUPHF_RUNTIME_HOME. Point both at the temp dir so the seeded
+	// registry row matches this broker's runtime home.
+	t.Setenv("HOME", home)
+	t.Setenv("WUPHF_RUNTIME_HOME", home)
+
+	now := time.Now().UTC()
+	reg := &workspaces.Registry{
+		Version: 1,
+		Workspaces: []*workspaces.Workspace{{
+			Name:        "acme-revops",
+			RuntimeHome: home,
+			State:       workspaces.StateRunning,
+			CreatedAt:   now,
+			LastUsedAt:  now,
+			// CompanyName intentionally left empty — the workspace was
+			// created without a brand name, the exact "all OFFICE-N" case.
+		}},
+	}
+	if err := workspaces.Write(reg); err != nil {
+		t.Fatalf("seed registry: %v", err)
+	}
+
+	b := &Broker{}
+	b.mu.Lock()
+	b.refreshIDPrefixFromWorkspaceLocked()
+	b.mu.Unlock()
+
+	if got := b.idPrefix; got != "ACMER" {
+		t.Fatalf("IDPrefix = %q, want ACMER (derived from workspace name)", got)
+	}
+
+	b.mu.Lock()
+	b.counter = 1
+	id := b.allocateIssueIDLocked()
+	b.mu.Unlock()
+	if id != "ACMER-1" {
+		t.Fatalf("allocateIssueIDLocked = %q, want ACMER-1", id)
+	}
+}
+
+// TestRefreshIDPrefixCompanyNameWins confirms an explicit company name still
+// takes precedence over the workspace name, preserving the "Nex" → NEX-1
+// behaviour for onboarded workspaces.
+func TestRefreshIDPrefixCompanyNameWins(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("WUPHF_RUNTIME_HOME", home)
+
+	now := time.Now().UTC()
+	reg := &workspaces.Registry{
+		Version: 1,
+		Workspaces: []*workspaces.Workspace{{
+			Name:        "acme-revops",
+			RuntimeHome: home,
+			CompanyName: "Nex",
+			State:       workspaces.StateRunning,
+			CreatedAt:   now,
+			LastUsedAt:  now,
+		}},
+	}
+	if err := workspaces.Write(reg); err != nil {
+		t.Fatalf("seed registry: %v", err)
+	}
+
+	b := &Broker{}
+	b.mu.Lock()
+	b.refreshIDPrefixFromWorkspaceLocked()
+	b.mu.Unlock()
+
+	if got := b.idPrefix; got != "NEX" {
+		t.Fatalf("IDPrefix = %q, want NEX (company name should win)", got)
+	}
+}

--- a/internal/team/broker_id_prefix_test.go
+++ b/internal/team/broker_id_prefix_test.go
@@ -17,9 +17,11 @@ func TestDeriveIDPrefix(t *testing.T) {
 		{"", defaultIDPrefix},
 	}
 	for _, c := range cases {
-		if got := deriveIDPrefix(c.in); got != c.want {
-			t.Errorf("deriveIDPrefix(%q) = %q, want %q", c.in, got, c.want)
-		}
+		t.Run(c.in, func(t *testing.T) {
+			if got := deriveIDPrefix(c.in); got != c.want {
+				t.Errorf("deriveIDPrefix(%q) = %q, want %q", c.in, got, c.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Problem

Every workspace's task/issue IDs read `OFFICE-1`, `OFFICE-2`, … regardless of the workspace. IDs are minted by `allocateIssueIDLocked()` using a Linear-style prefix derived in `refreshIDPrefixFromWorkspaceLocked` (`internal/team/broker_id_prefix.go`).

That derivation read **only** the workspace's optional `CompanyName`. Every workspace always has a *required* `Name`, but `CompanyName` stays blank unless the human picks a brand during onboarding — so the derivation fell through to the hardcoded `defaultIDPrefix = "OFFICE"`, and the per-workspace prefix never materialized.

## Fix

The prefix is now personal to each workspace, derived in order:

1. `CompanyName` — preserves `Nex → NEX-1` for onboarded workspaces.
2. The workspace `Name` — `acme-revops → ACMER-1`. **This is the new fallback that fixes the OFFICE-everywhere problem.**
3. Local `config.CompanyName` — covers a single default instance not created through the spaces orchestrator (no registry row).
4. `OFFICE` only when none of the above is usable.

A new `workspaceIDPrefix` helper also skips letterless/symbol-only candidates, so a junk company name (e.g. `"!!!"`) can't mask a usable workspace name.

## Tests

- `internal/team/broker_id_prefix_test.go` (new): pure-helper table tests for `deriveIDPrefix` / `workspaceIDPrefix`, plus a **live-path regression test** that seeds the workspace registry and asserts `acme-revops → ACMER-1`, and a test confirming an explicit company name still wins.
- The regression test **fails pre-fix** with `IDPrefix = "OFFICE"`.

## Verification

- `gofmt` clean, `go vet ./internal/team` clean.
- Full `internal/team` suite green with `-race` (193s).

No `web/` files changed — no screenshots needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)