### PR TITLE
feat(desktop): build desktop on every v* release + website hero cleanup [release]

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -92,3 +92,16 @@ jobs:
           VERSION: ${{ steps.bump.outputs.version }}
         run: |
           gh workflow run release.yml --ref "$VERSION"
+
+      - name: Dispatch desktop-release workflow at the new tag
+        # Same GITHUB_TOKEN limitation as the Release dispatch above: a tag pushed
+        # with GITHUB_TOKEN never fires desktop-release.yml's `on: push: tags`, so
+        # dispatch it explicitly. Every product release then also builds + attaches
+        # the signed desktop apps. --ref points the run at the new tag (so its
+        # github.ref_name is the v* tag → draft:false → append to the release);
+        # the bare version is passed as the stamping input.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.bump.outputs.version }}
+        run: |
+          gh workflow run desktop-release.yml --ref "$VERSION" -f version="${VERSION#v}"

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -4,9 +4,13 @@
 # Windows builds and signs via Azure Trusted Signing IF its secrets exist; without
 # them it still produces an (unsigned) installer so the pipeline isn't blocked.
 #
-# Trigger: a `desktop-v*` tag (e.g. desktop-v0.1.0) or manual dispatch. Switch the
-# tag filter to `v*` once the desktop ships on the main release cadence (every
-# product release needs a new dmg — the app is a fat self-contained binary).
+# Trigger: every product release tag `v*` (e.g. v0.226.0) — the desktop app rides
+# the main release cadence, so each release also cuts a signed dmg + Windows
+# installer (the app is a fat self-contained binary, so every release needs a new
+# one). `desktop-v*` and manual dispatch remain for desktop-only / out-of-band
+# builds. On a `v*` tag the signed artifacts are APPENDED to the published GitHub
+# Release that `release.yml`/goreleaser creates for the same tag; on a standalone
+# `desktop-v*` tag (or manual dispatch) they go to a DRAFT for review first.
 #
 # Required repo secrets (Settings → Secrets and variables → Actions):
 #   macOS:
@@ -27,7 +31,7 @@ name: desktop-release
 
 on:
   push:
-    tags: ["desktop-v*"]
+    tags: ["v*", "desktop-v*"]
   workflow_dispatch:
     inputs:
       version:
@@ -54,7 +58,9 @@ jobs:
           REF_NAME: ${{ github.ref_name }}
           INPUT_VERSION: ${{ github.event.inputs.version }}
         run: |
-          if [ -n "$INPUT_VERSION" ]; then V="$INPUT_VERSION"; else V="${REF_NAME#desktop-v}"; fi
+          # Accept both the main-cadence `v*` tag and a standalone `desktop-v*`
+          # tag: strip whichever prefix is present (desktop-v first, then v).
+          if [ -n "$INPUT_VERSION" ]; then V="$INPUT_VERSION"; else V="${REF_NAME#desktop-v}"; V="${V#v}"; fi
           # Reject anything that isn't a clean version so a crafted tag can't
           # smuggle shell metacharacters into later filename/volname uses.
           if ! printf '%s' "$V" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.]+)?$'; then
@@ -150,7 +156,10 @@ jobs:
       - uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # ratchet:softprops/action-gh-release@v2
         with:
           files: dist/WUPHF-*.dmg
-          draft: true # review before publishing
+          # On a `v*` tag, append to the published release goreleaser made for the
+          # same tag (draft:false keeps it published). On a standalone `desktop-v*`
+          # tag or manual dispatch, ship a draft to review first.
+          draft: ${{ !startsWith(github.ref_name, 'v') }}
 
   # -------------------------------------------------------------- Windows ----
   windows:
@@ -171,7 +180,9 @@ jobs:
           REF_NAME: ${{ github.ref_name }}
           INPUT_VERSION: ${{ github.event.inputs.version }}
         run: |
-          if [ -n "$INPUT_VERSION" ]; then V="$INPUT_VERSION"; else V="${REF_NAME#desktop-v}"; fi
+          # Accept both the main-cadence `v*` tag and a standalone `desktop-v*`
+          # tag: strip whichever prefix is present (desktop-v first, then v).
+          if [ -n "$INPUT_VERSION" ]; then V="$INPUT_VERSION"; else V="${REF_NAME#desktop-v}"; V="${V#v}"; fi
           # Reject anything that isn't a clean version so a crafted tag can't
           # smuggle shell metacharacters into later filename/volname uses.
           if ! printf '%s' "$V" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.]+)?$'; then
@@ -237,4 +248,5 @@ jobs:
       - uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # ratchet:softprops/action-gh-release@v2
         with:
           files: dist/WUPHF-*-setup.exe
-          draft: true
+          # Same draft logic as macOS: append on `v*`, draft on `desktop-v*`/dispatch.
+          draft: ${{ !startsWith(github.ref_name, 'v') }}

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -4,13 +4,15 @@
 # Windows builds and signs via Azure Trusted Signing IF its secrets exist; without
 # them it still produces an (unsigned) installer so the pipeline isn't blocked.
 #
-# Trigger: every product release tag `v*` (e.g. v0.226.0) — the desktop app rides
-# the main release cadence, so each release also cuts a signed dmg + Windows
-# installer (the app is a fat self-contained binary, so every release needs a new
-# one). `desktop-v*` and manual dispatch remain for desktop-only / out-of-band
-# builds. On a `v*` tag the signed artifacts are APPENDED to the published GitHub
-# Release that `release.yml`/goreleaser creates for the same tag; on a standalone
-# `desktop-v*` tag (or manual dispatch) they go to a DRAFT for review first.
+# Trigger: every product release. auto-release.yml dispatches this workflow at the
+# new `v*` tag — a tag pushed with GITHUB_TOKEN does NOT fire `on: push: tags`
+# (the same limitation release.yml works around), so the dispatch is the real path
+# for the main cadence. `push: tags` still covers a manually pushed `v*`/`desktop-v*`
+# tag, and workflow_dispatch covers out-of-band builds. The app is a fat
+# self-contained binary, so every release needs a fresh dmg + Windows installer.
+# On a `v*` tag this job WAITS for the published Release that release.yml/goreleaser
+# creates for the tag, then APPENDS its signed artifacts to it; on a standalone
+# `desktop-v*` tag (or manual dispatch) it owns a DRAFT release for review first.
 #
 # Required repo secrets (Settings → Secrets and variables → Actions):
 #   macOS:
@@ -58,8 +60,9 @@ jobs:
           REF_NAME: ${{ github.ref_name }}
           INPUT_VERSION: ${{ github.event.inputs.version }}
         run: |
-          # Accept both the main-cadence `v*` tag and a standalone `desktop-v*`
-          # tag: strip whichever prefix is present (desktop-v first, then v).
+          # Resolve the bare version. INPUT_VERSION (manual dispatch, or the
+          # auto-release.yml dispatch) is used verbatim; a tag push strips its
+          # prefix (desktop-v first, then v).
           if [ -n "$INPUT_VERSION" ]; then V="$INPUT_VERSION"; else V="${REF_NAME#desktop-v}"; V="${V#v}"; fi
           # Reject anything that isn't a clean version so a crafted tag can't
           # smuggle shell metacharacters into later filename/volname uses.
@@ -67,6 +70,14 @@ jobs:
             echo "::error::invalid version '$V' (expected semver-like, e.g. 0.1.0)"; exit 1
           fi
           echo "version=$V" >> "$GITHUB_OUTPUT"
+          # Resolve the release TAG this run targets so softprops never falls back
+          # to github.ref (a branch on a UI dispatch). A v*/desktop-v* tag ref is
+          # used as-is; a branch dispatch synthesizes desktop-v<version>.
+          case "$REF_NAME" in
+            v*|desktop-v*) TAG="$REF_NAME" ;;
+            *) TAG="desktop-v$V" ;;
+          esac
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # ratchet:actions/setup-go@v5
         with:
@@ -153,8 +164,28 @@ jobs:
           # releases/latest/download/WUPHF-mac.dmg URL (same signed+stapled bytes).
           cp "dist/WUPHF-$VERSION.dmg" "dist/WUPHF-mac.dmg"
 
+      - name: Wait for the product release to exist
+        # On the v* cadence the published Release is created by release.yml/
+        # goreleaser (auto-release.yml dispatches both in parallel). Wait for it so
+        # softprops APPENDS to that release instead of racing ahead and creating a
+        # partial one. Skipped on desktop-v*/dispatch, where this job owns a draft.
+        if: startsWith(github.ref_name, 'v')
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.ver.outputs.tag }}
+        run: |
+          for i in $(seq 1 60); do
+            if gh release view "$TAG" -R "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+              echo "release $TAG exists — appending desktop assets"; exit 0
+            fi
+            echo "waiting for release $TAG ($i/60)"; sleep 15
+          done
+          echo "::error::release $TAG not created within 15m; refusing to upload a partial release"; exit 1
+
       - uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # ratchet:softprops/action-gh-release@v2
         with:
+          tag_name: ${{ steps.ver.outputs.tag }}
           files: dist/WUPHF-*.dmg
           # On a `v*` tag, append to the published release goreleaser made for the
           # same tag (draft:false keeps it published). On a standalone `desktop-v*`
@@ -180,8 +211,9 @@ jobs:
           REF_NAME: ${{ github.ref_name }}
           INPUT_VERSION: ${{ github.event.inputs.version }}
         run: |
-          # Accept both the main-cadence `v*` tag and a standalone `desktop-v*`
-          # tag: strip whichever prefix is present (desktop-v first, then v).
+          # Resolve the bare version. INPUT_VERSION (manual dispatch, or the
+          # auto-release.yml dispatch) is used verbatim; a tag push strips its
+          # prefix (desktop-v first, then v).
           if [ -n "$INPUT_VERSION" ]; then V="$INPUT_VERSION"; else V="${REF_NAME#desktop-v}"; V="${V#v}"; fi
           # Reject anything that isn't a clean version so a crafted tag can't
           # smuggle shell metacharacters into later filename/volname uses.
@@ -189,6 +221,14 @@ jobs:
             echo "::error::invalid version '$V' (expected semver-like, e.g. 0.1.0)"; exit 1
           fi
           echo "version=$V" >> "$GITHUB_OUTPUT"
+          # Resolve the release TAG this run targets so softprops never falls back
+          # to github.ref (a branch on a UI dispatch). A v*/desktop-v* tag ref is
+          # used as-is; a branch dispatch synthesizes desktop-v<version>.
+          case "$REF_NAME" in
+            v*|desktop-v*) TAG="$REF_NAME" ;;
+            *) TAG="desktop-v$V" ;;
+          esac
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 
       - name: Build embedded web bundle
         shell: bash
@@ -232,6 +272,19 @@ jobs:
           timestamp-rfc3161: http://timestamp.acs.microsoft.com
           timestamp-digest: SHA256
 
+      - name: Flag unsigned Windows installer
+        # If Azure signing was skipped (secrets absent), the installer ships
+        # unsigned. Surface it loudly — a green run otherwise hides that users
+        # will hit a SmartScreen warning, and that a secret may have lapsed.
+        if: steps.azure.outputs.enabled != 'true'
+        shell: bash
+        run: |
+          echo "::warning::Azure Trusted Signing secrets absent — WUPHF-windows-setup.exe is UNSIGNED (users hit a SmartScreen warning). Set AZURE_CLIENT_ID + siblings to sign."
+          {
+            echo "### ⚠️ Unsigned Windows installer"
+            echo "Azure Trusted Signing secrets were absent, so \`WUPHF-windows-setup.exe\` is NOT code-signed."
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Rename artifact with version
         shell: bash
         env:
@@ -245,8 +298,26 @@ jobs:
           # Version-less alias for the stable releases/latest/download URL.
           cp "$exe" "dist/WUPHF-windows-setup.exe"
 
+      - name: Wait for the product release to exist
+        # Same coordination as macOS: append to goreleaser's published release on
+        # the v* cadence instead of racing it; skipped on desktop-v*/dispatch.
+        if: startsWith(github.ref_name, 'v')
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.ver.outputs.tag }}
+        run: |
+          for i in $(seq 1 60); do
+            if gh release view "$TAG" -R "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+              echo "release $TAG exists — appending desktop assets"; exit 0
+            fi
+            echo "waiting for release $TAG ($i/60)"; sleep 15
+          done
+          echo "::error::release $TAG not created within 15m; refusing to upload a partial release"; exit 1
+
       - uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # ratchet:softprops/action-gh-release@v2
         with:
+          tag_name: ${{ steps.ver.outputs.tag }}
           files: dist/WUPHF-*-setup.exe
           # Same draft logic as macOS: append on `v*`, draft on `desktop-v*`/dispatch.
           draft: ${{ !startsWith(github.ref_name, 'v') }}

--- a/docs/desktop-signing.md
+++ b/docs/desktop-signing.md
@@ -6,10 +6,14 @@ needs a new build**: a change to `web/`, `internal/`, `desktop/oswails/`, or the
 Go deps ships only when a fresh signed artifact is cut. Docs/website/test/CI
 changes do not.
 
-Automated by `.github/workflows/desktop-release.yml` (tag `desktop-v*` or manual
-dispatch → build → sign → notarize → draft GitHub Release). The
-`desktop-build-check.yml` PR gate builds it unsigned on any PR touching those
-paths, so a desktop-breaking change fails the PR, not the release.
+Automated by `.github/workflows/desktop-release.yml`. It fires on every product
+release tag `v*` (the desktop app rides the main release cadence) and on a
+standalone `desktop-v*` tag or manual dispatch → build → sign → notarize. On a
+`v*` tag the signed dmg + Windows installer are APPENDED to the published GitHub
+Release goreleaser creates for that tag; on a `desktop-v*` tag / dispatch they go
+to a DRAFT to review first. The `desktop-build-check.yml` PR gate builds it
+unsigned on any PR touching those paths, so a desktop-breaking change fails the
+PR, not the release.
 
 ## One-time setup
 
@@ -43,13 +47,15 @@ Signing account + certificate profile, then add: `AZURE_TENANT_ID`,
 
 ## Cut a release
 
+The desktop app rides the main `v*` cadence, so every product release already
+cuts a signed dmg + Windows installer and appends them to that tag's GitHub
+Release — no separate step. For an out-of-band desktop-only build:
+
 ```bash
-git tag desktop-v0.1.0 && git push origin desktop-v0.1.0
+git tag desktop-v0.1.1 && git push origin desktop-v0.1.1
 # → desktop-release.yml builds, signs, notarizes, and drafts a GitHub Release.
 # Review the draft, then publish. Link the .dmg / .exe on the website.
 ```
-Switch the release trigger from `desktop-v*` to `v*` once the desktop ships on
-the main product cadence (so every `wuphf` release also cuts a dmg).
 
 ## Manual macOS build (local, validated 2026-06-14)
 

--- a/docs/desktop-signing.md
+++ b/docs/desktop-signing.md
@@ -6,14 +6,18 @@ needs a new build**: a change to `web/`, `internal/`, `desktop/oswails/`, or the
 Go deps ships only when a fresh signed artifact is cut. Docs/website/test/CI
 changes do not.
 
-Automated by `.github/workflows/desktop-release.yml`. It fires on every product
-release tag `v*` (the desktop app rides the main release cadence) and on a
-standalone `desktop-v*` tag or manual dispatch → build → sign → notarize. On a
-`v*` tag the signed dmg + Windows installer are APPENDED to the published GitHub
-Release goreleaser creates for that tag; on a `desktop-v*` tag / dispatch they go
-to a DRAFT to review first. The `desktop-build-check.yml` PR gate builds it
-unsigned on any PR touching those paths, so a desktop-breaking change fails the
-PR, not the release.
+Automated by `.github/workflows/desktop-release.yml`. The desktop app rides the
+main release cadence: `auto-release.yml` dispatches it at each new `v*` tag (a
+GITHUB_TOKEN tag push can't fire `on: push: tags`, so the dispatch is the real
+trigger — same reason it dispatches `release.yml`). It also runs on a manually
+pushed `v*`/`desktop-v*` tag and on manual dispatch → build → sign → notarize. On
+a `v*` tag the job WAITS for the published GitHub Release that
+`release.yml`/goreleaser creates for the tag, then APPENDS the signed dmg +
+Windows installer to it; on a `desktop-v*` tag / dispatch it owns a DRAFT to
+review first. If Azure signing secrets are absent the Windows installer ships
+unsigned and the run logs a `::warning::` plus a job-summary note. The
+`desktop-build-check.yml` PR gate builds it unsigned on any PR touching those
+paths, so a desktop-breaking change fails the PR, not the release.
 
 ## One-time setup
 

--- a/website/index.html
+++ b/website/index.html
@@ -312,6 +312,18 @@
     vertical-align: middle;
   }
 
+  /* ── CREDS ROW: Backed by YC + Featured on HN, side by side ─ */
+  .hero-creds {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 20px;
+    flex-wrap: wrap;
+    margin: 4px 0 28px;
+  }
+  .hero-creds .yc-badge { margin: 0; }
+  .hero-creds .hn-badge img { height: 44px; }
+
   /* ── BACKED BY Y COMBINATOR (official badge) ───────── */
   .yc-badge {
     display: inline-flex;
@@ -464,14 +476,25 @@
   .cloud-cta-link:hover {
     text-decoration: underline;
   }
-  .hero-badges {
-    display: flex; gap: 16px; align-items: center; flex-wrap: wrap; justify-content: center;
-    margin-top: 24px;
-  }
-  .ph-badge { display: inline-flex; line-height: 0; }
-  .ph-badge img { height: 48px; width: auto; display: block; }
   .hn-badge { display: inline-flex; line-height: 0; }
   .hn-badge img { height: 48px; width: auto; display: block; }
+
+  /* Discord — a quiet text link under the CTAs, not a button */
+  .hero-discord {
+    margin: 14px 0 0;
+    font-family: var(--font-mono);
+    font-size: 12px;
+  }
+  .hero-discord a {
+    display: inline-flex; align-items: center; gap: 7px;
+    color: var(--text-dim);
+    text-decoration: none;
+    letter-spacing: 0.02em;
+    min-height: 44px;
+    transition: color 0.15s;
+  }
+  .hero-discord a:hover { color: var(--yellow); }
+  .hero-discord svg { flex-shrink: 0; }
 
   .btn-primary {
     font-family: var(--font-display);
@@ -1301,9 +1324,12 @@
     <h1 class="hero-title">WUPHF<span class="visually-hidden"> — Your personal office of AI teammates</span></h1>
     <a class="hero-by" href="https://nex.ai" target="_blank" rel="noopener" aria-label="Nex.ai">by <svg class="hero-nex-logo" width="95" height="22" viewBox="0 0 95 22" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M11.4968 9.1124C10.2339 7.84948 9.98851 5.898 9.48601 4.18411C9.26753 3.43896 8.86469 2.73685 8.27738 2.14953C6.40286 0.275011 3.35898 0.279701 1.47868 2.16C-0.401626 4.0403 -0.406316 7.08419 1.4682 8.9587C2.05551 9.54601 2.75761 9.94885 3.50275 10.1673C5.21664 10.6698 7.16813 10.9152 8.43106 12.1782C9.69399 13.4411 9.93939 15.3926 10.4419 17.1065C10.6604 17.8516 11.0632 18.5537 11.6505 19.141C13.525 21.0155 16.5689 21.0109 18.4492 19.1306C20.3295 17.2503 20.3342 14.2064 18.4597 12.3319C17.8724 11.7445 17.1703 11.3417 16.4251 11.1232C14.7112 10.6207 12.7597 10.3753 11.4968 9.1124Z" fill="currentColor"/><path d="M7.25926 17.0471C7.25926 19.0517 5.63422 20.6768 3.62963 20.6768C1.62504 20.6768 0 19.0517 0 17.0471C0 15.0425 1.62504 13.4175 3.62963 13.4175C5.63422 13.4175 7.25926 15.0425 7.25926 17.0471Z" fill="currentColor"/><path d="M20 4.30639C20 6.31098 18.375 7.93602 16.3704 7.93602C14.3658 7.93602 12.7407 6.31098 12.7407 4.30639C12.7407 2.3018 14.3658 0.676758 16.3704 0.676758C18.375 0.676758 20 2.3018 20 4.30639Z" fill="currentColor"/><path d="M29.5211 7.15435V20.5967H26.25V1.92676H29.7915L37.4421 14.9957V1.92676H40.7132V20.5967H37.415L29.5211 7.15435Z" fill="currentColor"/><path d="M55.8786 14.5423H45.5787C45.9572 16.356 47.444 17.6896 49.2012 17.6896C50.5259 17.6896 51.6884 16.9428 52.3372 15.7959H55.6083C54.7432 18.6231 52.202 20.6768 49.2012 20.6768C45.4705 20.6768 42.4698 17.5029 42.4698 13.6088C42.4698 9.71481 45.4705 6.54091 49.2012 6.54091C52.202 6.54091 54.7432 8.59461 55.6083 11.4218C55.8246 12.1152 55.9327 12.8354 55.9327 13.6088C55.9327 13.9289 55.9327 14.2223 55.8786 14.5423ZM46.0653 11.4218H52.3372C51.6884 10.2749 50.5259 9.52811 49.2012 9.52811C47.8766 9.52811 46.7141 10.2749 46.0653 11.4218Z" fill="currentColor"/><path d="M68.75 6.32754L63.965 13.4755L68.75 20.5967H64.9652L62.0726 16.276L59.1529 20.5967H55.3952L60.1802 13.4755L55.3952 6.32754H59.1529L62.0726 10.6483L64.9652 6.32754H68.75Z" fill="currentColor"/><circle cx="72" cy="18.6768" r="2" fill="currentColor"/><path d="M94.3129 3.422C93.9263 3.80867 93.4623 4.002 92.9209 4.002C92.3796 4.002 91.9059 3.80867 91.4999 3.422C91.1133 3.016 90.9199 2.54233 90.9199 2.001C90.9199 1.45967 91.1133 0.995667 91.4999 0.609001C91.8866 0.203 92.3603 0 92.9209 0C93.4816 0 93.9553 0.203 94.3419 0.609001C94.7286 0.995667 94.9219 1.45967 94.9219 2.001C94.9219 2.54233 94.7189 3.016 94.3129 3.422ZM91.3549 20.677V6.177H94.4869V20.677H91.3549Z" fill="currentColor"/><path d="M85.5131 6.17681H88.7697V20.6768H85.5131V18.5888C84.4699 20.2321 82.9736 21.0538 81.024 21.0538C79.2626 21.0538 77.7577 20.3191 76.5093 18.8498C75.2609 17.3611 74.6367 15.5535 74.6367 13.4268C74.6367 11.2808 75.2609 9.47314 76.5093 8.0038C77.7577 6.53447 79.2626 5.7998 81.024 5.7998C82.9736 5.7998 84.4699 6.6118 85.5131 8.2358V6.17681ZM78.5614 16.7618C79.331 17.6318 80.2972 18.0668 81.4601 18.0668C82.623 18.0668 83.5892 17.6318 84.3587 16.7618C85.1283 15.8725 85.5131 14.7608 85.5131 13.4268C85.5131 12.0928 85.1283 10.9908 84.3587 10.1208C83.5892 9.23147 82.623 8.7868 81.4601 8.7868C80.2972 8.7868 79.331 9.23147 78.5614 10.1208C77.7919 10.9908 77.4071 12.0928 77.4071 13.4268C77.4071 14.7608 77.7919 15.8725 78.5614 16.7618Z" fill="currentColor"/></svg></a>
 
-    <a class="yc-badge" href="https://www.ycombinator.com/" target="_blank" rel="noopener noreferrer" aria-label="Backed by Y Combinator">
-      <img src="yc-badge.svg" alt="Backed by Y Combinator" width="543" height="102">
-    </a>
+    <div class="hero-creds">
+      <a class="yc-badge" href="https://www.ycombinator.com/" target="_blank" rel="noopener noreferrer" aria-label="Backed by Y Combinator">
+        <img src="yc-badge.svg" alt="Backed by Y Combinator" width="543" height="102">
+      </a>
+      <a href="https://news.ycombinator.com/item?id=47899844" target="_blank" rel="noopener noreferrer" class="hn-badge" aria-label="Featured on Hacker News — Life of Product Week's #1"><img src="hn-badge.svg" alt="Featured on Hacker News — Life of Product Week's #1" width="223" height="48"></a>
+    </div>
 
     <p class="hero-tagline" data-pretext>
       A team of AI agents who build their own knowledge base, playbooks, skills and policies to collaborate with each other and accomplish tasks usually done by 10+ SaaS subscriptions.
@@ -1343,18 +1369,20 @@
         <svg viewBox="0 0 16 16" width="14" height="14" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg>
         GitHub &nbsp;<span id="heroStars">★ 21</span>
       </a>
-      <a href="https://discord.gg/gjSySC3PzV" class="btn-ghost" target="_blank" rel="noopener">
-        <svg viewBox="0 0 24 24" width="12" height="12" fill="currentColor" style="vertical-align:middle;margin-right:4px"><path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057.101 18.079.111 18.1.127 18.116a19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028 14.09 14.09 0 0 0 1.226-1.994.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z"/></svg>
-        Discord
+      <a href="/download.html" class="btn-ghost">
+        <svg viewBox="0 0 16 16" width="13" height="13" fill="currentColor" style="vertical-align:middle;margin-right:5px"><path d="M7 1h2v6h3l-4 5-4-5h3V1zM2 13h12v2H2z"/></svg>
+        Download
       </a>
     </div>
 
-    <p class="hero-cloud-cta">Want to invite more human teammates? <a class="cloud-cta-link" href="https://nex.ai" target="_blank" rel="noopener">Get Nex Cloud →</a></p>
+    <p class="hero-discord">
+      <a href="https://discord.gg/gjSySC3PzV" target="_blank" rel="noopener">
+        <svg viewBox="0 0 24 24" width="15" height="15" fill="currentColor"><path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057.101 18.079.111 18.1.127 18.116a19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028 14.09 14.09 0 0 0 1.226-1.994.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z"/></svg>
+        Join our Discord community
+      </a>
+    </p>
 
-    <div class="hero-badges">
-      <a href="https://news.ycombinator.com/item?id=47899844" target="_blank" rel="noopener noreferrer" class="hn-badge" aria-label="Hacker News Life of Product Week's #1"><img src="hn-badge.svg" alt="Hacker News Life of Product Week's #1" width="223" height="48"></a>
-      <a href="https://www.producthunt.com/products/wuphf-2?embed=true&amp;utm_source=badge-featured&amp;utm_medium=badge&amp;utm_campaign=badge-wuphf-by-nex-ai" target="_blank" rel="noopener noreferrer" class="ph-badge"><img alt="WUPHF by Nex.ai - AI employees who build their own knowledge base | Product Hunt" width="250" height="54" src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1132040&amp;theme=neutral&amp;t=1777385299660"></a>
-    </div>
+    <p class="hero-cloud-cta">Want to invite more human teammates? <a class="cloud-cta-link" href="https://nex.ai" target="_blank" rel="noopener">Get Nex Cloud →</a></p>
 
   </div>
 

--- a/website/index.html
+++ b/website/index.html
@@ -312,18 +312,6 @@
     vertical-align: middle;
   }
 
-  /* ── CREDS ROW: Backed by YC + Featured on HN, side by side ─ */
-  .hero-creds {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 20px;
-    flex-wrap: wrap;
-    margin: 4px 0 28px;
-  }
-  .hero-creds .yc-badge { margin: 0; }
-  .hero-creds .hn-badge img { height: 44px; }
-
   /* ── BACKED BY Y COMBINATOR (official badge) ───────── */
   .yc-badge {
     display: inline-flex;
@@ -476,25 +464,6 @@
   .cloud-cta-link:hover {
     text-decoration: underline;
   }
-  .hn-badge { display: inline-flex; line-height: 0; }
-  .hn-badge img { height: 48px; width: auto; display: block; }
-
-  /* Discord — a quiet text link under the CTAs, not a button */
-  .hero-discord {
-    margin: 14px 0 0;
-    font-family: var(--font-mono);
-    font-size: 12px;
-  }
-  .hero-discord a {
-    display: inline-flex; align-items: center; gap: 7px;
-    color: var(--text-dim);
-    text-decoration: none;
-    letter-spacing: 0.02em;
-    min-height: 44px;
-    transition: color 0.15s;
-  }
-  .hero-discord a:hover { color: var(--yellow); }
-  .hero-discord svg { flex-shrink: 0; }
 
   .btn-primary {
     font-family: var(--font-display);
@@ -1324,12 +1293,9 @@
     <h1 class="hero-title">WUPHF<span class="visually-hidden"> — Your personal office of AI teammates</span></h1>
     <a class="hero-by" href="https://nex.ai" target="_blank" rel="noopener" aria-label="Nex.ai">by <svg class="hero-nex-logo" width="95" height="22" viewBox="0 0 95 22" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M11.4968 9.1124C10.2339 7.84948 9.98851 5.898 9.48601 4.18411C9.26753 3.43896 8.86469 2.73685 8.27738 2.14953C6.40286 0.275011 3.35898 0.279701 1.47868 2.16C-0.401626 4.0403 -0.406316 7.08419 1.4682 8.9587C2.05551 9.54601 2.75761 9.94885 3.50275 10.1673C5.21664 10.6698 7.16813 10.9152 8.43106 12.1782C9.69399 13.4411 9.93939 15.3926 10.4419 17.1065C10.6604 17.8516 11.0632 18.5537 11.6505 19.141C13.525 21.0155 16.5689 21.0109 18.4492 19.1306C20.3295 17.2503 20.3342 14.2064 18.4597 12.3319C17.8724 11.7445 17.1703 11.3417 16.4251 11.1232C14.7112 10.6207 12.7597 10.3753 11.4968 9.1124Z" fill="currentColor"/><path d="M7.25926 17.0471C7.25926 19.0517 5.63422 20.6768 3.62963 20.6768C1.62504 20.6768 0 19.0517 0 17.0471C0 15.0425 1.62504 13.4175 3.62963 13.4175C5.63422 13.4175 7.25926 15.0425 7.25926 17.0471Z" fill="currentColor"/><path d="M20 4.30639C20 6.31098 18.375 7.93602 16.3704 7.93602C14.3658 7.93602 12.7407 6.31098 12.7407 4.30639C12.7407 2.3018 14.3658 0.676758 16.3704 0.676758C18.375 0.676758 20 2.3018 20 4.30639Z" fill="currentColor"/><path d="M29.5211 7.15435V20.5967H26.25V1.92676H29.7915L37.4421 14.9957V1.92676H40.7132V20.5967H37.415L29.5211 7.15435Z" fill="currentColor"/><path d="M55.8786 14.5423H45.5787C45.9572 16.356 47.444 17.6896 49.2012 17.6896C50.5259 17.6896 51.6884 16.9428 52.3372 15.7959H55.6083C54.7432 18.6231 52.202 20.6768 49.2012 20.6768C45.4705 20.6768 42.4698 17.5029 42.4698 13.6088C42.4698 9.71481 45.4705 6.54091 49.2012 6.54091C52.202 6.54091 54.7432 8.59461 55.6083 11.4218C55.8246 12.1152 55.9327 12.8354 55.9327 13.6088C55.9327 13.9289 55.9327 14.2223 55.8786 14.5423ZM46.0653 11.4218H52.3372C51.6884 10.2749 50.5259 9.52811 49.2012 9.52811C47.8766 9.52811 46.7141 10.2749 46.0653 11.4218Z" fill="currentColor"/><path d="M68.75 6.32754L63.965 13.4755L68.75 20.5967H64.9652L62.0726 16.276L59.1529 20.5967H55.3952L60.1802 13.4755L55.3952 6.32754H59.1529L62.0726 10.6483L64.9652 6.32754H68.75Z" fill="currentColor"/><circle cx="72" cy="18.6768" r="2" fill="currentColor"/><path d="M94.3129 3.422C93.9263 3.80867 93.4623 4.002 92.9209 4.002C92.3796 4.002 91.9059 3.80867 91.4999 3.422C91.1133 3.016 90.9199 2.54233 90.9199 2.001C90.9199 1.45967 91.1133 0.995667 91.4999 0.609001C91.8866 0.203 92.3603 0 92.9209 0C93.4816 0 93.9553 0.203 94.3419 0.609001C94.7286 0.995667 94.9219 1.45967 94.9219 2.001C94.9219 2.54233 94.7189 3.016 94.3129 3.422ZM91.3549 20.677V6.177H94.4869V20.677H91.3549Z" fill="currentColor"/><path d="M85.5131 6.17681H88.7697V20.6768H85.5131V18.5888C84.4699 20.2321 82.9736 21.0538 81.024 21.0538C79.2626 21.0538 77.7577 20.3191 76.5093 18.8498C75.2609 17.3611 74.6367 15.5535 74.6367 13.4268C74.6367 11.2808 75.2609 9.47314 76.5093 8.0038C77.7577 6.53447 79.2626 5.7998 81.024 5.7998C82.9736 5.7998 84.4699 6.6118 85.5131 8.2358V6.17681ZM78.5614 16.7618C79.331 17.6318 80.2972 18.0668 81.4601 18.0668C82.623 18.0668 83.5892 17.6318 84.3587 16.7618C85.1283 15.8725 85.5131 14.7608 85.5131 13.4268C85.5131 12.0928 85.1283 10.9908 84.3587 10.1208C83.5892 9.23147 82.623 8.7868 81.4601 8.7868C80.2972 8.7868 79.331 9.23147 78.5614 10.1208C77.7919 10.9908 77.4071 12.0928 77.4071 13.4268C77.4071 14.7608 77.7919 15.8725 78.5614 16.7618Z" fill="currentColor"/></svg></a>
 
-    <div class="hero-creds">
-      <a class="yc-badge" href="https://www.ycombinator.com/" target="_blank" rel="noopener noreferrer" aria-label="Backed by Y Combinator">
-        <img src="yc-badge.svg" alt="Backed by Y Combinator" width="543" height="102">
-      </a>
-      <a href="https://news.ycombinator.com/item?id=47899844" target="_blank" rel="noopener noreferrer" class="hn-badge" aria-label="Featured on Hacker News — Life of Product Week's #1"><img src="hn-badge.svg" alt="Featured on Hacker News — Life of Product Week's #1" width="223" height="48"></a>
-    </div>
+    <a class="yc-badge" href="https://www.ycombinator.com/" target="_blank" rel="noopener noreferrer" aria-label="Backed by Y Combinator">
+      <img src="yc-badge.svg" alt="Backed by Y Combinator" width="543" height="102">
+    </a>
 
     <p class="hero-tagline" data-pretext>
       A team of AI agents who build their own knowledge base, playbooks, skills and policies to collaborate with each other and accomplish tasks usually done by 10+ SaaS subscriptions.
@@ -1361,7 +1327,6 @@
       </div>
       <div class="visually-hidden" id="copyStatus" aria-live="polite" aria-atomic="true"></div>
       <p class="install-note">Free to self-host. Runs local. No account, no cloud, no per-seat pricing. Source-available (Sustainable Use License).</p>
-      <p class="install-note" style="margin-top:8px"><a href="/download.html" style="color:var(--yellow);text-decoration:none">⬇ Prefer a native app? Download WUPHF Desktop for macOS &amp; Windows →</a></p>
     </div>
 
     <div class="hero-ctas">
@@ -1374,13 +1339,6 @@
         Download
       </a>
     </div>
-
-    <p class="hero-discord">
-      <a href="https://discord.gg/gjSySC3PzV" target="_blank" rel="noopener">
-        <svg viewBox="0 0 24 24" width="15" height="15" fill="currentColor"><path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057.101 18.079.111 18.1.127 18.116a19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028 14.09 14.09 0 0 0 1.226-1.994.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z"/></svg>
-        Join our Discord community
-      </a>
-    </p>
 
     <p class="hero-cloud-cta">Want to invite more human teammates? <a class="cloud-cta-link" href="https://nex.ai" target="_blank" rel="noopener">Get Nex Cloud →</a></p>
 


### PR DESCRIPTION
## What

Two related changes from the "desktop ships with every release + website polish" ask.

### 1. Desktop builds on every `v*` release
`desktop-release.yml` now triggers on the main product release tags (`v*`) in addition to `desktop-v*` / manual dispatch. So every `npx wuphf` release also cuts a **signed + notarized macOS dmg** and a **Windows installer**, with no separate step.

- On a **`v*`** tag → artifacts are **appended** to the published GitHub Release goreleaser creates for that tag (`draft: false` keeps it published). Timing is safe: goreleaser finishes well before the ~12-min notarized desktop build, and goreleaser's default `keep-existing` mode never deletes the appended assets.
- On a standalone **`desktop-v*`** tag or manual dispatch → ships a **draft** to review first (unchanged behavior).
- Version resolution now strips both `v` and `desktop-v` prefixes.

### 2. Website hero cleanup (`website/index.html`)
- **Download button** replaces the Discord button in the CTA row → links to `/download.html`.
- **Discord** becomes a quiet text link: *"Join our Discord community"* (with the Discord logo), under the CTAs.
- **Featured-on-HN** badge moved up next to the **Backed by YC** badge (new `.hero-creds` flex row).
- **Product Hunt** badge removed (dead `.ph-badge`/`.hero-badges` CSS pruned).

## Screenshot (hero)
Verified via headless Chrome — YC + HN side by side, Download in the CTA row, Discord as a text link, no Product Hunt badge.

## Test plan
- [x] `desktop-release.yml` YAML validates; trigger + draft expressions render
- [x] `go build ./...` (no Go changes here, but desktop tag boundary unaffected)
- [x] Hero renders correctly in headless Chrome
- [ ] First real `v*` release after merge confirms the dmg/exe append to the published release

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Website Updates**
  * Removed Product Hunt and Hacker News hero badges
  * Updated the hero call-to-action to feature a **Download** button (with icon) alongside the existing GitHub button

* **Documentation**
  * Updated desktop signing/runbook guidance for `v*` vs `desktop-v*` flows, including draft/review behavior and Windows unsigned installer notes

* **Chores**
  * Enhanced desktop release automation for both tag types, including safer asset upload sequencing and draft/publish behavior
  * Auto-release now triggers the desktop release workflow after creating version tags
<!-- end of auto-generated comment: release notes by coderabbit.ai -->