### PR TITLE
feat(apps): App Builder — agent-generated internal tools + live dev-server preview

### DIFF
--- a/docs/specs/app-builder-live-preview.md
+++ b/docs/specs/app-builder-live-preview.md
@@ -1,0 +1,172 @@
+# App Builder — Live Dev-Server Preview (SOTA)
+
+Status: **planned, gated on PR #1096 merge + rebase.** Architecture approved by
+the founder (2026-06-15): live dev-server-per-app behind a broker proxy; the
+single-file build stays as the sealed "ship" artifact.
+
+## Why
+
+Today the App Builder runs a full `bun install && bun run build` to a single
+self-contained `index.html` *before anything is shown*, so the preview sits on a
+"Building…" placeholder for minutes — the worst weakness of the feature
+(observed live: 0 apps registered across a whole test, preview never populated).
+
+The dyad research (`/tmp/dyad-research-report.md`) found that dyad's preview is
+instant for one reason: **it does not build for preview.** It runs a real Vite
+**dev server per app**, reverse-proxies it (tunneling Vite's HMR WebSocket), and
+loads that *live origin* in the iframe. Edits hot-reload in milliseconds.
+
+We adopt the same model, adapted to our Go broker + headless-agent + sandbox:
+
+- **Preview = live dev server** (`bun run dev`) behind a broker reverse-proxy.
+  Boots in ~1–2s after deps install; reflects every agent edit via HMR with no
+  rebuild. This is what the human watches.
+- **Ship artifact = the single-file build** (`vite-plugin-singlefile`), produced
+  on "seal/publish". This is what gets stored, versioned, listed under Apps, and
+  rendered in the fully-sealed sandbox for non-build viewing. Unchanged.
+
+The data model does **not** change: dyad lets the app talk to Supabase/Neon
+directly (`allow-same-origin`, no CSP). We keep our whitelisted-postMessage
+bridge as the only data path, and inject a dev-mode CSP that blocks all network
+except the HMR WebSocket (see Security).
+
+## Architecture
+
+```
+App Builder edits src/  ──HMR──▶  bun run dev (:Pdev)
+                                       │
+runtime-home/.wuphf/apps/<id>/src/     │  scrape "Local: http://localhost:Pdev"
+                                       ▼
+            broker:  appDevManager  ── httputil.ReverseProxy + WS upgrade ──▶ :Pdev
+                                       │  inject dev-mode CSP header
+                                       ▼
+            GET /apps/<id>/dev/*  (proxy route, stable per app)
+                                       │
+web:  CustomAppFrame (dev mode)  iframe src=/api/apps/<id>/dev/  (NOT srcDoc)
+                                  + live boot-log overlay while starting
+```
+
+## Backend (Go, `internal/team`)
+
+### `appDevManager` (new: `custom_app_dev.go`)
+A process manager mirroring dyad's `process_manager.ts` / `runningApps`.
+
+- `runningAppServers map[string]*appDevServer` keyed by app id; own mutex.
+- `appDevServer{ id, port, cmd *exec.Cmd, proxy *httputil.ReverseProxy, startedAt, lastUsed, bootLog *ringBuffer, ready bool, readyURL string }`.
+- `EnsureDevServer(id) (*appDevServer, error)`:
+  1. Warm fast-path: if a server for `id` is running and healthy, bump `lastUsed`
+     and return it (zero rebuild — dyad `app_handlers.ts:642`).
+  2. Else: `bun install` in `…/apps/<id>/src/` if `node_modules` absent (warm
+     shared cache — see Perf), then spawn `bun run dev --port <free>` with cwd =
+     the app's src dir. Stream stdout/stderr into `bootLog` (ring buffer, last N
+     KB) AND classify readiness by scraping `/(https?:\/\/(?:localhost|127\.0\.0\.1):\d+)/`
+     (dyad `app_runtime_service.ts:588`). Mark `ready=true` + `readyURL` on match.
+  3. Build the `httputil.ReverseProxy` to `readyURL` with a `Director` that
+     strips the `/apps/<id>/dev` prefix, and a `ModifyResponse` that injects the
+     dev-mode CSP header. WebSocket upgrade must pass through (Vite HMR): detect
+     `Connection: Upgrade` and hijack/bidi-copy, or use a proxy that supports it.
+- `StopDevServer(id)`: kill the process group, close the proxy, delete the entry.
+- Idle GC: a ticker stops servers idle > 10 min (dyad `process_manager.ts:247`).
+- Shutdown: kill all on broker stop (no orphaned `bun` processes).
+
+### Broker routes (`broker_apps.go`)
+- `GET  /apps/{id}/dev/*` → `EnsureDevServer(id)` then `proxy.ServeHTTP`. The
+  first request blocks until ready (or streams the boot screen — see FE). Gated
+  by the existing app read auth.
+- `GET  /apps/{id}/dev/status` → `{ ready, bootLog, error }` for the FE overlay
+  to poll/stream while starting.
+- `POST /apps/{id}/dev/stop` (app-builder/human) → `StopDevServer`.
+- Reuse `appWriterAllowed` semantics for stop; reads follow app read auth.
+
+### Build/seal path (unchanged surface)
+`register_app` (the ship artifact) stays exactly as today: the agent runs
+`bun run build` → single-file `index.html` → `POST /apps`. The dev server is
+purely the preview; sealing is still the durable, versioned, shareable artifact.
+
+## Frontend (`web/src`)
+
+- `CustomAppFrame`: add a `mode: "dev" | "sealed"` prop.
+  - `sealed` (today): `srcDoc={withAppCsp(html)}`, `sandbox="allow-scripts"`.
+  - `dev`: `src="/api/apps/<id>/dev/"`, `sandbox="allow-scripts allow-same-origin"`
+    (HMR + Vite client need same-origin to the proxy; the injected dev CSP is the
+    real network boundary — see Security). The bridge (`postMessage`) still works.
+- `AppBuildPreview` (the task pane): default to **dev mode while the task is
+  active** so the human watches the live build; switch to the sealed artifact
+  once the app is published/the task is done.
+- **Live boot-log overlay** (port dyad `PreviewLoadingScreen.tsx`): while
+  `dev/status.ready === false`, show the streaming install/boot log with the
+  sticky latest line — NOT a frozen "Building…". On error, show the tail + a
+  "Fix with App Builder" action (Phase 3).
+- `CustomAppView` (standalone app screen): a "Live"/"Sealed" toggle; Live ensures
+  the dev server, Sealed shows the published single-file.
+
+## Security (the load-bearing part)
+
+The sealed artifact is unchanged: opaque-origin `allow-scripts`-only iframe +
+injected `connect-src 'none'` CSP + whitelisted postMessage bridge.
+
+The **dev preview loosens the iframe to a localhost proxy origin**, so it must
+re-establish the no-exfiltration guarantee at the proxy:
+
+- The proxy injects, on every dev response, a **dev-mode CSP**:
+  `default-src 'self'; connect-src 'self' ws://<proxy-host> wss://<proxy-host>;
+  img-src 'self' data: blob:; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline'`.
+  This permits Vite's HMR WS to the proxy origin and blocks all other network —
+  so a generated app still cannot `fetch()` the internet, even in dev.
+- Data access stays through the parent bridge (postMessage), never the network.
+- `allow-same-origin` is scoped to the proxy origin only (the dev server is
+  served from the broker's own origin via the `/apps/<id>/dev` path, so the app
+  cannot reach the parent app's cookies/storage — it's a different path on the
+  same origin; evaluate whether to serve dev previews from a **distinct port**
+  to get a true separate origin, which is stronger). **Decision needed at build
+  time:** distinct-port origin (stronger isolation, more infra) vs same-origin
+  path (simpler). Default: distinct ephemeral port per broker, documented.
+- Trust model: the dev server runs the agent's own source on the user's machine —
+  the same code we already `bun build`. The CSP keeps the *rendered app* unable
+  to exfiltrate; the dev server itself is local-only (bind 127.0.0.1).
+- Pin `event.origin` on the host bridge listener to the proxy origin in dev mode.
+
+Run `security-reviewer` + an orthogonal triangulation pass on the proxy + the
+dev CSP + the WS tunnel before marking ready (new wire/serving surface, per
+repo rules).
+
+## Perf
+
+- Warm dep cache: a shared bun cache dir so `bun install` resolves from cache
+  (the scaffold already commits `bun.lock`). Optionally a pre-warmed
+  `node_modules` template copied on scaffold to skip install entirely on first
+  run (dyad does NOT do this — it's our chance to beat dyad's first-run latency).
+- Warm-reuse + idle-GC bound the number of live `bun` processes.
+
+## Phasing (after #1096 rebase)
+
+1. **Dev-server preview + proxy + live boot-log** — the headline win (fixes
+   time-to-first-preview). Effort L.
+2. **Structured tool-activity cards in the chat** (port `DyadCardPrimitives` +
+   `getState` so spinners resolve to ✓/✗, no zombies). Broker emits
+   write/bash/edit start/done events interleaved with prose. Effort M.
+3. **Pre-commit `tsc --noEmit` + `vite build` gate + bounded ~2-round auto-fix**
+   re-prompt with `file:line:col` (dyad `chat_stream_handlers.ts` auto-fix loop).
+   Auto-loop build errors (ground truth); human-gate runtime errors. Effort M.
+4. **Git-commit-per-response version timeline** (we already commit to git):
+   non-destructive preview of a past version + forward-preserving "Restore".
+   Effort M.
+5. **Select-to-edit** (`data-dyad-id="file:line:col"` JSX tagging + injected
+   selector → source map) **+ iframe error capture** via postMessage — the magic
+   moment; works under our sandbox. Effort S–M.
+
+## Open questions for build time
+
+- Distinct-port vs same-origin-path for the dev preview (security vs infra).
+- WebSocket passthrough mechanics for the Go reverse proxy (HMR).
+- Windows process-group kill + port allocation parity.
+- Resource ceiling: cap concurrent live dev servers; queue/evict policy.
+- Does the dev server need the bridge, or only the sealed artifact? (Keep the
+  bridge in both so data-reading apps work live.)
+
+## Reuse, not rebuild
+
+Reverse proxy = Go stdlib `httputil.ReverseProxy`. Process mgmt = `os/exec` +
+existing patterns. Sandbox/CSP/bridge = the rich-artifact + custom-app
+primitives already in the tree. Version timeline = the wiki/app git worker.
+Nothing new is invented that the stdlib or the existing kernel already provides.

--- a/internal/commands/slash.go
+++ b/internal/commands/slash.go
@@ -61,6 +61,10 @@ func RegisterAllCommands(r *Registry) {
 	// Wiki intelligence
 	r.Register(SlashCommand{Name: "lint", Description: "Run wiki lint — checks contradictions, orphans, stale claims, cross-refs", WebSupported: true})
 
+	// Apps — agent-generated internal tools, built by the App Builder agent.
+	r.Register(SlashCommand{Name: "create-app", Description: "Build a new internal tool (App Builder)", WebSupported: true})
+	r.Register(SlashCommand{Name: "update-app", Description: "Improve an existing app (App Builder)", WebSupported: true})
+
 	// Channel workflows
 	r.Register(SlashCommand{Name: "request", Description: "Request commands (focus/answer/dismiss)"})
 	r.Register(SlashCommand{Name: "reply", Description: "Reply in thread"})

--- a/internal/company/manifest.go
+++ b/internal/company/manifest.go
@@ -222,6 +222,29 @@ func SaveManifest(manifest Manifest) error {
 	return os.WriteFile(path, data, 0o600)
 }
 
+// AppBuilderSlug is the canonical slug of the built-in App Builder agent — the
+// special teammate that turns repeatable workflows into Apps (internal tools).
+// It is seeded into every office (see ensureAppBuilderMember) and is immutable
+// like the CEO.
+const AppBuilderSlug = "app-builder"
+
+func appBuilderMemberSpec() MemberSpec {
+	return MemberSpec{Slug: AppBuilderSlug, Name: "App Builder", Role: "App Builder", System: true}
+}
+
+// ensureAppBuilderMember guarantees the App Builder is present in the roster.
+// Runs inside normalizeManifest so it covers the default, from-scratch, AND
+// blueprint-materialized paths — and back-fills existing offices on next load
+// (legacy-safe migration, the same shape used to roll out the Librarian).
+func ensureAppBuilderMember(members []MemberSpec) []MemberSpec {
+	for _, m := range members {
+		if normalizeSlug(m.Slug) == AppBuilderSlug {
+			return members
+		}
+	}
+	return append(members, appBuilderMemberSpec())
+}
+
 func DefaultManifest() Manifest {
 	now := time.Now().UTC().Format(time.RFC3339)
 	cfg, _ := config.Load()
@@ -248,6 +271,7 @@ func DefaultManifest() Manifest {
 	}
 	manifest.Members = []MemberSpec{
 		{Slug: "ceo", Name: "CEO", Role: "CEO", System: true},
+		appBuilderMemberSpec(),
 		{Slug: "planner", Name: "Planner", Role: "Planner"},
 		{Slug: "executor", Name: "Executor", Role: "Executor"},
 		{Slug: "reviewer", Name: "Reviewer", Role: "Reviewer"},
@@ -278,6 +302,7 @@ func fromScratchDefaultManifest(now string) Manifest {
 	members := []MemberSpec{
 		{Slug: "founder", Name: "Founder", Role: "Founder", System: true},
 		{Slug: "operator", Name: "Operator", Role: "Operator", System: true},
+		appBuilderMemberSpec(),
 		{Slug: "builder", Name: "Builder", Role: "Builder"},
 		{Slug: "reviewer", Name: "Reviewer", Role: "Reviewer"},
 	}
@@ -339,6 +364,10 @@ func normalizeManifest(manifest Manifest) Manifest {
 		}
 		return DefaultManifest()
 	}
+	// Guarantee the built-in App Builder exists in every office — including
+	// blueprint-materialized ones — and back-fill it for existing offices on
+	// load. Appended last so it never displaces the lead or a blueprint roster.
+	members = ensureAppBuilderMember(members)
 	manifest.Members = members
 
 	seenChannels := make(map[string]struct{}, len(manifest.Channels))

--- a/internal/team/app_builder_agent.go
+++ b/internal/team/app_builder_agent.go
@@ -1,0 +1,61 @@
+package team
+
+import (
+	"strings"
+	"time"
+)
+
+// app_builder_agent.go — the App Builder is a first-class, always-present agent
+// (slug "app-builder", display name "App Builder") that turns repeatable
+// workflows into Apps (internal tools). Like the CEO and the Librarian it is
+// BUILT-IN: present in every new workspace regardless of blueprint or selected
+// agents, and back-filled onto existing rosters on load.
+//
+// The roster-seed chokepoints live in broker_defaults.go: defaultOfficeMembers
+// (fresh offices) and normalizeLoadedStateLocked (persisted offices loaded from
+// disk that predate the agent). Both call ensureAppBuilderOfficeMember so the
+// App Builder shows up in the sidebar and can own App-build tasks. This mirrors
+// the Librarian rollout (librarian.go) exactly so the two stay consistent.
+//
+// appBuilderSlug itself is defined in broker_apps_proposal.go (the proposal
+// path needed it first); persona/expertise come from the shared inference in
+// broker_member_construction.go so the strings live in one place.
+
+const appBuilderRole = "App Builder"
+
+// isAppBuilderSlug reports whether slug is the App Builder (case-insensitive).
+func isAppBuilderSlug(slug string) bool {
+	return strings.EqualFold(strings.TrimSpace(slug), appBuilderSlug)
+}
+
+// appBuilderOfficeMember builds the App Builder's officeMember record. Expertise
+// and personality reuse the shared inference (broker_member_construction.go) so
+// the back-filled member matches one constructed from the manifest spec.
+func appBuilderOfficeMember(createdAt string) officeMember {
+	if strings.TrimSpace(createdAt) == "" {
+		createdAt = time.Now().UTC().Format(time.RFC3339)
+	}
+	return officeMember{
+		Slug:        appBuilderSlug,
+		Name:        appBuilderRole,
+		Role:        appBuilderRole,
+		Expertise:   inferOfficeExpertise(appBuilderSlug, appBuilderRole),
+		Personality: inferOfficePersonality(appBuilderSlug, appBuilderRole),
+		BuiltIn:     true,
+		CreatedBy:   "wuphf",
+		CreatedAt:   createdAt,
+	}
+}
+
+// ensureAppBuilderOfficeMember returns members with the App Builder present,
+// appending it when absent (matched case-insensitively by slug). Used at every
+// roster-seed chokepoint so the App Builder is always in the office, like the
+// CEO and the Librarian.
+func ensureAppBuilderOfficeMember(members []officeMember) []officeMember {
+	for i := range members {
+		if isAppBuilderSlug(members[i].Slug) {
+			return members
+		}
+	}
+	return append(members, appBuilderOfficeMember(""))
+}

--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -163,6 +163,8 @@ type Broker struct {
 	wikiWorker              *WikiWorker
 	wikiInitMu              sync.Mutex
 	wikiInitErr             error
+	customApps              *customAppStore
+	customAppOnce           sync.Once
 	autoNotebookWriter      *AutoNotebookWriter
 	humanWikiWriter         *HumanWikiIntentWriter
 	obsidianWatcher         *ObsidianWatcher
@@ -639,6 +641,10 @@ func (b *Broker) StartOnPort(port int) error {
 	mux.HandleFunc("/notebook/promote", b.requireAuth(b.handleNotebookPromote))
 	mux.HandleFunc("/notebook/visual-artifacts", b.requireAuth(b.handleNotebookVisualArtifacts))
 	mux.HandleFunc("/notebook/visual-artifacts/", b.requireAuth(b.handleNotebookVisualArtifactSubpath))
+	// Apps: agent-generated internal tools. Reached only via the /api proxy, so
+	// these never shadow the SPA's client-side /apps/<id> route.
+	mux.HandleFunc("/apps", b.requireAuth(b.handleApps))
+	mux.HandleFunc("/apps/", b.requireAuth(b.handleAppByID))
 	mux.HandleFunc("/article-attribution", b.requireAuth(b.handleArticleAttribution))
 	mux.HandleFunc("/notebook/review-candidates", b.requireAuth(b.handleNotebookReviewCandidates))
 	mux.HandleFunc("/review/list", b.requireAuth(b.handleReviewList))

--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -165,6 +165,8 @@ type Broker struct {
 	wikiInitErr             error
 	customApps              *customAppStore
 	customAppOnce           sync.Once
+	appDev                  *appDevManager
+	appDevOnce              sync.Once
 	autoNotebookWriter      *AutoNotebookWriter
 	humanWikiWriter         *HumanWikiIntentWriter
 	obsidianWatcher         *ObsidianWatcher
@@ -806,9 +808,15 @@ func (b *Broker) Stop() {
 	// pending WaitGroup, so this is the only correct order.
 	b.mu.Lock()
 	obsidianWatcher := b.obsidianWatcher
+	appDev := b.appDev
 	b.mu.Unlock()
 	if obsidianWatcher != nil {
 		_ = obsidianWatcher.Stop()
+	}
+	// Tear down any live app-preview dev servers (bun processes + proxies) so
+	// they don't outlive the broker.
+	if appDev != nil {
+		appDev.StopAll()
 	}
 
 	if b.lifecycleCancel != nil {

--- a/internal/team/broker_apps.go
+++ b/internal/team/broker_apps.go
@@ -100,8 +100,65 @@ func (b *Broker) handleAppByID(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusOK, map[string]any{"versions": versions})
 	case "rollback":
 		b.handleAppRollback(w, r, id)
+	case "dev":
+		b.handleAppDev(w, r, id, parts)
 	default:
 		writeJSON(w, http.StatusNotFound, map[string]string{"error": "not found"})
+	}
+}
+
+// appDevManager lazily constructs the live-preview dev-server manager on first
+// use (mirrors appStore). It shares the same custom-app store.
+func (b *Broker) appDevManager() *appDevManager {
+	b.appDevOnce.Do(func() {
+		b.appDev = newAppDevManager(b.appStore())
+	})
+	return b.appDev
+}
+
+// handleAppDev is the CONTROL plane for live previews: ensure/status/stop. The
+// preview content itself is served by a per-app reverse proxy on its own
+// ephemeral 127.0.0.1 port (see custom_app_dev.go); these endpoints just manage
+// its lifecycle and hand the FE the proxy origin to load.
+//
+//	GET  /apps/{id}/dev         -> ensure running, returns {ready,url,boot_log,error}
+//	GET  /apps/{id}/dev/status  -> current status without (re)starting
+//	POST /apps/{id}/dev/stop    -> tear down (App Builder / human only)
+func (b *Broker) handleAppDev(w http.ResponseWriter, r *http.Request, id string, parts []string) {
+	action := ""
+	if len(parts) > 2 {
+		action = parts[2]
+	}
+	mgr := b.appDevManager()
+	switch {
+	case r.Method == http.MethodGet && action == "":
+		st, err := mgr.Ensure(id)
+		if err != nil {
+			writeAppError(w, err)
+			return
+		}
+		writeJSON(w, http.StatusOK, st)
+	case r.Method == http.MethodGet && action == "status":
+		st, ok := mgr.Status(id)
+		if !ok {
+			writeJSON(w, http.StatusNotFound, map[string]string{"error": "no preview running"})
+			return
+		}
+		writeJSON(w, http.StatusOK, st)
+	case r.Method == http.MethodPost && action == "stop":
+		actor, status, err := richArtifactAuthenticatedSlug(r, "", "actor")
+		if err != nil {
+			writeJSON(w, status, map[string]string{"error": err.Error()})
+			return
+		}
+		if !b.appWriterAllowed(r, actor) {
+			writeJSON(w, http.StatusForbidden, map[string]string{"error": "only a human or the App Builder may stop a preview"})
+			return
+		}
+		mgr.Stop(id)
+		writeJSON(w, http.StatusOK, map[string]any{"ok": true})
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 	}
 }
 

--- a/internal/team/broker_apps.go
+++ b/internal/team/broker_apps.go
@@ -1,0 +1,215 @@
+package team
+
+// broker_apps.go owns the HTTP surface for agent-generated internal tools
+// ("Apps"). Routes are reached only via the /api proxy (ServeWebUI strips /api
+// and forwards to this mux), so they never collide with the SPA's client-side
+// /apps/<id> route — the browser navigation hits the SPA fallback, the data
+// fetch hits these handlers.
+//
+//	GET    /apps          -> { apps: [...] }            (sidebar listing)
+//	POST   /apps          -> { app }                    (App Builder register/update)
+//	GET    /apps/{id}      -> { app, html }             (render in sandboxed iframe)
+//	DELETE /apps/{id}      -> { ok: true }              (remove an app)
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// appStore lazily constructs the custom-app store on first use so we avoid
+// constructor surgery on NewBroker. Safe for concurrent callers via sync.Once.
+func (b *Broker) appStore() *customAppStore {
+	b.customAppOnce.Do(func() {
+		b.customApps = newCustomAppStore(CustomAppsRootDir())
+	})
+	return b.customApps
+}
+
+func (b *Broker) handleApps(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		apps, err := b.appStore().List()
+		if err != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"apps": apps})
+	case http.MethodPost:
+		var body CustomAppWriteRequest
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid json"})
+			return
+		}
+		// Resolve the writer the same way rich artifacts do: prefer the
+		// authenticated agent slug, fall back to the human session identity.
+		actor, status, err := richArtifactAuthenticatedSlug(r, body.Actor, "actor")
+		if err != nil {
+			writeJSON(w, status, map[string]string{"error": err.Error()})
+			return
+		}
+		// Only the App Builder (the lone agent with register_app) or a human
+		// session may write app bytes. A random agent holding the broker token
+		// must not register apps directly and bypass the build path.
+		if !b.appWriterAllowed(r, actor) {
+			writeJSON(w, http.StatusForbidden, map[string]string{"error": "only the App Builder may register apps"})
+			return
+		}
+		body.Actor = actor
+		app, err := b.appStore().Save(body, time.Now())
+		if err != nil {
+			writeAppError(w, err)
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"app": app})
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+func (b *Broker) handleAppByID(w http.ResponseWriter, r *http.Request) {
+	rest := strings.Trim(strings.TrimPrefix(r.URL.Path, "/apps/"), "/")
+	parts := strings.Split(rest, "/")
+	id := parts[0]
+	sub := ""
+	if len(parts) > 1 {
+		sub = parts[1]
+	}
+	if err := validateCustomAppID(id); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
+
+	switch sub {
+	case "":
+		b.handleAppRoot(w, r, id)
+	case "versions":
+		if r.Method != http.MethodGet {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		versions, err := b.appStore().ListVersions(id)
+		if err != nil {
+			writeAppError(w, err)
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"versions": versions})
+	case "rollback":
+		b.handleAppRollback(w, r, id)
+	default:
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "not found"})
+	}
+}
+
+func (b *Broker) handleAppRoot(w http.ResponseWriter, r *http.Request, id string) {
+	switch r.Method {
+	case http.MethodGet:
+		app, htmlBody, err := b.appStore().Get(id)
+		if err != nil {
+			writeAppError(w, err)
+			return
+		}
+		out := map[string]any{"app": app, "html": htmlBody}
+		// ?source=1 includes the app's source project — only the App Builder
+		// needs it (to edit), so the FE view never asks for it.
+		if r.URL.Query().Get("source") == "1" {
+			source, err := b.appStore().Source(id)
+			if err != nil {
+				writeAppError(w, err)
+				return
+			}
+			out["source"] = source
+		}
+		writeJSON(w, http.StatusOK, out)
+	case http.MethodDelete:
+		actor, _, _ := richArtifactAuthenticatedSlug(r, "", "actor")
+		if !b.appWriterAllowed(r, actor) {
+			writeJSON(w, http.StatusForbidden, map[string]string{"error": "only a human or the App Builder may delete apps"})
+			return
+		}
+		if err := b.appStore().Delete(id); err != nil {
+			writeAppError(w, err)
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"ok": true})
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+func (b *Broker) handleAppRollback(w http.ResponseWriter, r *http.Request, id string) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	var body struct {
+		Version int    `json:"version"`
+		Actor   string `json:"actor"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid json"})
+		return
+	}
+	actor, status, err := richArtifactAuthenticatedSlug(r, body.Actor, "actor")
+	if err != nil {
+		writeJSON(w, status, map[string]string{"error": err.Error()})
+		return
+	}
+	if !b.appWriterAllowed(r, actor) {
+		writeJSON(w, http.StatusForbidden, map[string]string{"error": "only a human or the App Builder may roll back apps"})
+		return
+	}
+	app, err := b.appStore().Rollback(id, body.Version, actor, time.Now())
+	if err != nil {
+		writeAppError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"app": app})
+}
+
+// appWriterAllowed reports whether the request may write/delete app bytes:
+// either the authenticated agent is the App Builder, or the caller is a human
+// session. Other agents (which all hold the broker token) are rejected so they
+// cannot register or remove apps directly outside the build path.
+func (b *Broker) appWriterAllowed(r *http.Request, actor string) bool {
+	if strings.EqualFold(strings.TrimSpace(actor), appBuilderSlug) {
+		return true
+	}
+	if a, ok := requestActorFromContext(r.Context()); ok && a.Kind == requestActorKindHuman {
+		return true
+	}
+	return false
+}
+
+func writeAppError(w http.ResponseWriter, err error) {
+	switch {
+	case isCustomAppCallerError(err):
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+	case errors.Is(err, os.ErrNotExist):
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": err.Error()})
+	default:
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+	}
+}
+
+// Delete removes an app directory. Returns a caller error for an unknown id so
+// the handler maps it to 404 rather than 500.
+func (s *customAppStore) Delete(id string) error {
+	if err := validateCustomAppID(id); err != nil {
+		return err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	dir := s.appDir(id)
+	if _, err := os.Stat(filepath.Join(dir, customAppManifestFile)); err != nil {
+		if os.IsNotExist(err) {
+			return newCustomAppCallerError("app: %s not found", id)
+		}
+		return err
+	}
+	return os.RemoveAll(dir)
+}

--- a/internal/team/broker_apps_integration_test.go
+++ b/internal/team/broker_apps_integration_test.go
@@ -1,0 +1,176 @@
+package team
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+)
+
+// TestProposeAppApprovalSpawnsAppBuilderTask locks in the implicit-intent gate:
+// an agent's propose_app raises a NON-BLOCKING approval, and only on approve
+// does the broker spawn a task owned by the App Builder. Drives the real HTTP
+// handlers end-to-end (POST /requests -> POST /requests/answer).
+func TestProposeAppApprovalSpawnsAppBuilderTask(t *testing.T) {
+	b := newTestBroker(t)
+	if err := b.StartOnPort(0); err != nil {
+		t.Fatalf("start broker: %v", err)
+	}
+	defer b.Stop()
+	base := fmt.Sprintf("http://%s", b.Addr())
+
+	// 1. propose_app -> POST /requests with an app_proposal payload.
+	body, _ := json.Marshal(map[string]any{
+		"kind":     "approval",
+		"from":     "ceo",
+		"channel":  "general",
+		"title":    "Build a new internal tool: Lead Scorer?",
+		"question": "Build a new internal tool: Lead Scorer?",
+		"blocking": false,
+		"required": false,
+		"app_proposal": map[string]any{
+			"name":        "Lead Scorer",
+			"icon":        "🎯",
+			"summary":     "Score inbound leads",
+			"description": "Rank inbound leads against our ICP weights.",
+		},
+	})
+	created := postAppsJSON(t, base+"/requests", b.Token(), body)
+	reqObj, _ := created["request"].(map[string]any)
+	if reqObj == nil {
+		t.Fatalf("no request in create response: %v", created)
+	}
+	// Non-blocking exemption: an app proposal keeps the approval options but
+	// must NOT freeze the channel even though kind=approval.
+	if blocking, _ := reqObj["blocking"].(bool); blocking {
+		t.Fatalf("app proposal should be non-blocking, got blocking=true: %v", reqObj)
+	}
+	reqID, _ := reqObj["id"].(string)
+	if reqID == "" {
+		t.Fatalf("no request id: %v", reqObj)
+	}
+
+	// 2. Human approves -> POST /requests/answer with choice_id=approve.
+	answer, _ := json.Marshal(map[string]any{"id": reqID, "choice_id": "approve"})
+	postAppsJSON(t, base+"/requests/answer", b.Token(), answer)
+
+	// 3. A task owned by the App Builder must now exist.
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	var found *teamTask
+	for i := range b.tasks {
+		if b.tasks[i].Owner == appBuilderSlug {
+			found = &b.tasks[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("expected an app-builder task after approval; tasks=%+v", b.tasks)
+	}
+	if found.Title != "Build app: Lead Scorer" {
+		t.Fatalf("task title = %q, want %q", found.Title, "Build app: Lead Scorer")
+	}
+}
+
+// TestProposeAppRejectionSpawnsNoTask is the negative path: reject must not
+// build anything.
+func TestProposeAppRejectionSpawnsNoTask(t *testing.T) {
+	b := newTestBroker(t)
+	if err := b.StartOnPort(0); err != nil {
+		t.Fatalf("start broker: %v", err)
+	}
+	defer b.Stop()
+	base := fmt.Sprintf("http://%s", b.Addr())
+
+	body, _ := json.Marshal(map[string]any{
+		"kind":     "approval",
+		"from":     "ceo",
+		"channel":  "general",
+		"question": "Build a new internal tool: Throwaway?",
+		"blocking": false,
+		"app_proposal": map[string]any{
+			"name":        "Throwaway",
+			"description": "Nope.",
+		},
+	})
+	created := postAppsJSON(t, base+"/requests", b.Token(), body)
+	reqObj, _ := created["request"].(map[string]any)
+	reqID, _ := reqObj["id"].(string)
+
+	answer, _ := json.Marshal(map[string]any{"id": reqID, "choice_id": "reject"})
+	postAppsJSON(t, base+"/requests/answer", b.Token(), answer)
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	for i := range b.tasks {
+		if b.tasks[i].Owner == appBuilderSlug {
+			t.Fatalf("rejected proposal must not create an app-builder task: %+v", b.tasks[i])
+		}
+	}
+}
+
+// TestRegisterAppRestrictedToAppBuilder locks the write gate: a random agent
+// holding the broker token must not register apps directly; only the App Builder
+// (or a human session) may. Drives POST /apps with the X-WUPHF-Agent header.
+func TestRegisterAppRestrictedToAppBuilder(t *testing.T) {
+	b := newTestBroker(t)
+	if err := b.StartOnPort(0); err != nil {
+		t.Fatalf("start broker: %v", err)
+	}
+	defer b.Stop()
+	base := fmt.Sprintf("http://%s", b.Addr())
+
+	body, _ := json.Marshal(map[string]any{
+		"name": "Sneaky Tool",
+		"html": validAppHTML,
+	})
+
+	// A non-app-builder agent is forbidden.
+	if code := postAppsStatus(t, base+"/apps", b.Token(), "ceo", body); code != http.StatusForbidden {
+		t.Fatalf("non-app-builder register: got %d, want 403", code)
+	}
+	// The App Builder is allowed.
+	if code := postAppsStatus(t, base+"/apps", b.Token(), appBuilderSlug, body); code != http.StatusOK {
+		t.Fatalf("app-builder register: got %d, want 200", code)
+	}
+}
+
+func postAppsStatus(t *testing.T, url, token, agentSlug string, body []byte) int {
+	t.Helper()
+	req, _ := http.NewRequest(http.MethodPost, url, bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	if agentSlug != "" {
+		req.Header.Set("X-WUPHF-Agent", agentSlug)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST %s: %v", url, err)
+	}
+	defer resp.Body.Close()
+	_, _ = io.ReadAll(resp.Body)
+	return resp.StatusCode
+}
+
+func postAppsJSON(t *testing.T, url, token string, body []byte) map[string]any {
+	t.Helper()
+	req, _ := http.NewRequest(http.MethodPost, url, bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST %s: %v", url, err)
+	}
+	defer resp.Body.Close()
+	raw, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("POST %s -> %d: %s", url, resp.StatusCode, raw)
+	}
+	var out map[string]any
+	if len(raw) > 0 {
+		_ = json.Unmarshal(raw, &out)
+	}
+	return out
+}

--- a/internal/team/broker_apps_proposal.go
+++ b/internal/team/broker_apps_proposal.go
@@ -1,0 +1,159 @@
+package team
+
+// broker_apps_proposal.go — the implicit-intent permission gate for Apps.
+//
+// When an agent notices a repeatable workflow it does NOT build silently. It
+// raises a non-blocking approval request (propose_app -> POST /requests with an
+// app_proposal payload). The human can approve, reject, or "add context and
+// approve" (approve_with_note). Only on an approve does the broker spawn a task
+// owned by the App Builder agent to actually build (or improve) the app.
+//
+// Explicit paths (the /create-app, /update-app slash commands and the Edit
+// button on an app screen) skip this gate — the human initiated the build — and
+// post the App Builder task directly via the normal task surface.
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// appBuilderSlug is the team-package mirror of company.AppBuilderSlug — the
+// slug of the built-in App Builder agent. Kept as a local const so the hot
+// broker paths don't import the company package just for one identifier; the
+// two MUST stay in sync.
+const appBuilderSlug = "app-builder"
+
+// appProposalSpec is the structured app request carried on an approval request
+// (humanInterview.AppProposal) and unpacked into the App Builder task when the
+// human approves.
+type appProposalSpec struct {
+	Name        string `json:"name"`
+	Icon        string `json:"icon,omitempty"`
+	Summary     string `json:"summary,omitempty"`
+	Description string `json:"description"`
+	// AppID is set when the proposal improves an EXISTING app rather than
+	// creating a new one — the agent is expected to have checked list_apps
+	// first and found a related app to extend instead of duplicating.
+	AppID string `json:"app_id,omitempty"`
+}
+
+// sanitizeAppProposalSpec trims the proposal and drops it entirely when it has
+// no usable name — a proposal with nothing to build should not mark the request.
+func sanitizeAppProposalSpec(in *appProposalSpec) *appProposalSpec {
+	if in == nil {
+		return nil
+	}
+	out := appProposalSpec{
+		Name:        strings.TrimSpace(in.Name),
+		Icon:        strings.TrimSpace(in.Icon),
+		Summary:     strings.TrimSpace(in.Summary),
+		Description: strings.TrimSpace(in.Description),
+		AppID:       strings.TrimSpace(in.AppID),
+	}
+	if out.Name == "" {
+		return nil
+	}
+	return &out
+}
+
+// appProposalApproved reports whether an answer choice green-lights the build.
+// "approve" and "approve_with_note" (= add context and approve) both proceed;
+// reject / reject_with_steer / needs_more_info do not.
+func appProposalApproved(choiceID string) bool {
+	switch strings.ToLower(strings.TrimSpace(choiceID)) {
+	case "approve", "approve_with_note":
+		return true
+	default:
+		return false
+	}
+}
+
+// maybeSpawnAppBuilderTaskFromProposal inspects a just-answered request and, if
+// it was an approved App Builder proposal, creates the App Builder task. Called
+// from handlePostRequestAnswer OUTSIDE b.mu because MutateTask locks internally.
+func (b *Broker) maybeSpawnAppBuilderTaskFromProposal(requestID string) {
+	requestID = strings.TrimSpace(requestID)
+	if requestID == "" {
+		return
+	}
+	b.mu.Lock()
+	var snapshot humanInterview
+	found := false
+	for i := range b.requests {
+		if b.requests[i].ID == requestID {
+			snapshot = cloneHumanInterview(b.requests[i])
+			found = true
+			break
+		}
+	}
+	b.mu.Unlock()
+	if !found || snapshot.AppProposal == nil || snapshot.Answered == nil {
+		return
+	}
+	if !appProposalApproved(snapshot.Answered.GetChoiceID()) {
+		return
+	}
+
+	note := snapshot.Answered.GetCustomText()
+	title, details := appBuilderTaskBrief(*snapshot.AppProposal, note)
+	channel := normalizeChannelSlug(snapshot.Channel)
+	if channel == "" {
+		channel = "general"
+	}
+	if _, err := b.MutateTask(TaskPostRequest{
+		Action:    "create",
+		Channel:   channel,
+		Title:     title,
+		Details:   details,
+		Owner:     appBuilderSlug,
+		CreatedBy: "system",
+		TaskType:  "issue",
+	}); err != nil {
+		b.mu.Lock()
+		b.counter++
+		b.appendMessageLocked(channelMessage{
+			ID:        fmt.Sprintf("msg-%d", b.counter),
+			From:      "system",
+			Channel:   channel,
+			Content:   fmt.Sprintf("Could not start the App Builder task for \"%s\": %s", snapshot.AppProposal.Name, strings.TrimSpace(err.Error())),
+			Tagged:    uniqueSlugs([]string{appBuilderSlug}),
+			Timestamp: time.Now().UTC().Format(time.RFC3339),
+		})
+		_ = b.saveLocked()
+		b.mu.Unlock()
+	}
+}
+
+// appBuilderTaskBrief composes the task title + details handed to the App
+// Builder. The brief tells it exactly what to ship and how to register it.
+func appBuilderTaskBrief(spec appProposalSpec, humanNote string) (string, string) {
+	verb := "Build"
+	if spec.AppID != "" {
+		verb = "Improve"
+	}
+	title := fmt.Sprintf("%s app: %s", verb, spec.Name)
+
+	var d strings.Builder
+	if spec.AppID != "" {
+		fmt.Fprintf(&d, "Improve the existing app `%s` (\"%s\").\n\n", spec.AppID, spec.Name)
+		d.WriteString("First call get_app to read its current source and manifest, then apply the change below.\n\n")
+	} else {
+		fmt.Fprintf(&d, "Build a new internal tool named \"%s\".\n\n", spec.Name)
+	}
+	if spec.Summary != "" {
+		fmt.Fprintf(&d, "Summary: %s\n\n", spec.Summary)
+	}
+	d.WriteString("What it should do:\n")
+	d.WriteString(spec.Description)
+	d.WriteString("\n")
+	if note := strings.TrimSpace(humanNote); note != "" {
+		fmt.Fprintf(&d, "\nHuman constraints / added context:\n%s\n", note)
+	}
+	d.WriteString("\nWhen the build passes, register it with register_app")
+	if spec.AppID != "" {
+		fmt.Fprintf(&d, " (app_id=%s)", spec.AppID)
+	}
+	d.WriteString(" so it appears under Apps.")
+	return title, d.String()
+}

--- a/internal/team/broker_defaults.go
+++ b/internal/team/broker_defaults.go
@@ -38,8 +38,9 @@ func defaultOfficeMembers() []officeMember {
 		builtIn := cfg.System || cfg.Slug == manifest.Lead || cfg.Slug == "ceo"
 		members = append(members, memberFromSpec(cfg, "wuphf", now, builtIn))
 	}
-	// The Librarian is built-in, present in every workspace alongside the lead.
-	return ensureLibrarianMember(members)
+	// The Librarian and App Builder are built-in, present in every workspace
+	// alongside the lead.
+	return ensureAppBuilderOfficeMember(ensureLibrarianMember(members))
 }
 
 func defaultOfficeMemberSlugs() []string {
@@ -228,7 +229,7 @@ func (b *Broker) normalizeLoadedStateLocked() {
 		if member.Role == "" {
 			member.Role = member.Name
 		}
-		member.BuiltIn = member.Slug == "ceo" || isLibrarianSlug(member.Slug)
+		member.BuiltIn = member.Slug == "ceo" || isLibrarianSlug(member.Slug) || isAppBuilderSlug(member.Slug)
 		member.Expertise = normalizeStringList(member.Expertise)
 		member.AllowedTools = normalizeStringList(member.AllowedTools)
 		normalizedMembers = append(normalizedMembers, member)
@@ -238,7 +239,9 @@ func (b *Broker) normalizeLoadedStateLocked() {
 	// disk predate her, and ensureDefaultOfficeMembersLocked only seeds when the
 	// roster is empty — so append her here on every load. Idempotent (no-op once
 	// present); the BuiltIn line above keeps her flag set on subsequent loads.
-	b.members = ensureLibrarianMember(normalizedMembers)
+	// The App Builder is back-filled the same way so it shows in the roster of
+	// offices created before the Apps feature.
+	b.members = ensureAppBuilderOfficeMember(ensureLibrarianMember(normalizedMembers))
 	for i := range b.channels {
 		b.channels[i].Slug = normalizeChannelSlug(b.channels[i].Slug)
 		if strings.TrimSpace(b.channels[i].Name) == "" {

--- a/internal/team/broker_member_construction.go
+++ b/internal/team/broker_member_construction.go
@@ -59,6 +59,8 @@ func applyOfficeMemberDefaults(member *officeMember) {
 func inferOfficeExpertise(slug, role string) []string {
 	text := strings.ToLower(strings.TrimSpace(slug + " " + role))
 	switch {
+	case strings.Contains(text, "app build"), strings.Contains(text, "app-build"):
+		return []string{"internal tools", "React", "TypeScript", "Vite", "app generation"}
 	case strings.Contains(text, "front"), strings.Contains(text, "ui"), strings.Contains(text, "design eng"):
 		return []string{"frontend", "UI", "interaction design", "components", "accessibility"}
 	case strings.Contains(text, "back"), strings.Contains(text, "api"), strings.Contains(text, "infra"):
@@ -81,6 +83,8 @@ func inferOfficeExpertise(slug, role string) []string {
 func inferOfficePersonality(slug, role string) string {
 	text := strings.ToLower(strings.TrimSpace(slug + " " + role))
 	switch {
+	case strings.Contains(text, "app build"), strings.Contains(text, "app-build"):
+		return "Pragmatic tool-smith who turns repeatable workflows into small, dependable internal apps and ships the simplest thing that works."
 	case strings.Contains(text, "front"):
 		return "Frontend specialist focused on polished user-facing work and sharp interaction details."
 	case strings.Contains(text, "back"):

--- a/internal/team/broker_office_channels_test.go
+++ b/internal/team/broker_office_channels_test.go
@@ -747,10 +747,10 @@ func TestLoadDoesNotAppendDefaultsAfterBlueprintSeed(t *testing.T) {
 
 	// The curated blueprint roster must survive reload with NO generic
 	// default-manifest agents (ceo/planner/executor/reviewer) leaking back in.
-	// The one exception is the Librarian (Pam): a universal built-in, added to
-	// every roster on load by the Phase 6 migration — like the CEO is meant to
-	// be — so she is expected here, appended last.
-	want := []string{"operator", "planner", "builder", "growth", "reviewer", LibrarianSlug}
+	// The exceptions are the universal built-ins added to every roster on load:
+	// the Librarian (Pam) and the App Builder — like the CEO is meant to be — so
+	// both are expected here, appended last (Librarian first, App Builder after).
+	want := []string{"operator", "planner", "builder", "growth", "reviewer", LibrarianSlug, appBuilderSlug}
 	if len(slugs) != len(want) {
 		t.Fatalf("expected blueprint roster %v to survive reload, got %v", want, slugs)
 	}

--- a/internal/team/broker_phase6_migration_test.go
+++ b/internal/team/broker_phase6_migration_test.go
@@ -171,6 +171,21 @@ func TestPhase6MigrationLoadsLegacyWorkspaceClean(t *testing.T) {
 	if pam.Name != librarianName {
 		t.Fatalf("Librarian name = %q, want %q", pam.Name, librarianName)
 	}
+
+	// --- App Builder back-filled onto the existing roster, built-in. The
+	// roster was persisted before the Apps feature, so this is the same
+	// load-time migration as the Librarian: the agent must appear in the
+	// office (and therefore the sidebar) without re-onboarding. ---
+	ab, ok := memberBySlug(t, b, appBuilderSlug)
+	if !ok {
+		t.Fatalf("App Builder (%q) was not added to the legacy roster", appBuilderSlug)
+	}
+	if !ab.BuiltIn {
+		t.Fatalf("App Builder should be built-in after migration, got BuiltIn=false")
+	}
+	if ab.Name != appBuilderRole {
+		t.Fatalf("App Builder name = %q, want %q", ab.Name, appBuilderRole)
+	}
 	// The pre-existing specialists must still be present (no roster clobber).
 	for _, slug := range []string{"ceo", "dwight", "angela"} {
 		if _, found := memberBySlug(t, b, slug); !found {

--- a/internal/team/broker_requests_interviews.go
+++ b/internal/team/broker_requests_interviews.go
@@ -566,6 +566,8 @@ func (b *Broker) handlePostRequest(w http.ResponseWriter, r *http.Request) {
 		// (slice 4b) for approval cards: typed fields + the masked raw envelope.
 		IntegrationAction    *approvalActionPayload `json:"integration_action,omitempty"`
 		ConnectionUnverified bool                   `json:"connection_unverified,omitempty"`
+		// AppProposal marks the request as an App Builder proposal (propose_app).
+		AppProposal *appProposalSpec `json:"app_proposal,omitempty"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		http.Error(w, "invalid json", http.StatusBadRequest)
@@ -738,6 +740,7 @@ func (b *Broker) handlePostRequest(w http.ResponseWriter, r *http.Request) {
 			IssueID:              strings.TrimSpace(body.IssueID),
 			Action:               sanitizeApprovalActionPayload(body.IntegrationAction),
 			ConnectionUnverified: body.ConnectionUnverified,
+			AppProposal:          sanitizeAppProposalSpec(body.AppProposal),
 			CreatedAt:            time.Now().UTC().Format(time.RFC3339),
 			UpdatedAt:            time.Now().UTC().Format(time.RFC3339),
 		}
@@ -747,6 +750,14 @@ func (b *Broker) handlePostRequest(w http.ResponseWriter, r *http.Request) {
 			req.Required = true
 		}
 		if requestIsHumanInterview(req) {
+			req.Blocking = false
+			req.Required = false
+		}
+		// App Builder proposals keep the approval option set (approve /
+		// approve_with_note / reject) but are non-blocking by design: the human
+		// decides at leisure while the team keeps working. Never freeze a
+		// channel just because an agent suggested building a tool.
+		if req.AppProposal != nil {
 			req.Blocking = false
 			req.Required = false
 		}
@@ -845,6 +856,11 @@ func (b *Broker) handlePostRequestAnswer(w http.ResponseWriter, r *http.Request)
 		http.Error(w, msg, status)
 		return
 	}
+	// App Builder proposal hook: if the just-answered request was a propose_app
+	// approval and the human approved, spawn the App Builder task now. Runs
+	// AFTER answerRequestFromActor releases b.mu because MutateTask locks
+	// internally (mirrors how the integration gate proceeds post-answer).
+	b.maybeSpawnAppBuilderTaskFromProposal(body.ID)
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(map[string]any{"ok": true})
 }

--- a/internal/team/broker_types.go
+++ b/internal/team/broker_types.go
@@ -168,14 +168,18 @@ type humanInterview struct {
 	// ConnectionUnverified is set when the action gate could not reach the
 	// resolver and degraded to approval-only, so the connection state is
 	// unconfirmed. The card surfaces a warning (review LOW #5).
-	ConnectionUnverified bool             `json:"connection_unverified,omitempty"`
-	DueAt                string           `json:"due_at,omitempty"`
-	FollowUpAt           string           `json:"follow_up_at,omitempty"`
-	ReminderAt           string           `json:"reminder_at,omitempty"`
-	RecheckAt            string           `json:"recheck_at,omitempty"`
-	CreatedAt            string           `json:"created_at"`
-	UpdatedAt            string           `json:"updated_at,omitempty"`
-	Answered             *interviewAnswer `json:"answered,omitempty"`
+	ConnectionUnverified bool `json:"connection_unverified,omitempty"`
+	// AppProposal marks this approval request as an App Builder proposal. On
+	// approve / approve_with_note the broker spawns a task owned by the App
+	// Builder agent to build (or improve) the app. Nil for every other request.
+	AppProposal *appProposalSpec `json:"app_proposal,omitempty"`
+	DueAt       string           `json:"due_at,omitempty"`
+	FollowUpAt  string           `json:"follow_up_at,omitempty"`
+	ReminderAt  string           `json:"reminder_at,omitempty"`
+	RecheckAt   string           `json:"recheck_at,omitempty"`
+	CreatedAt   string           `json:"created_at"`
+	UpdatedAt   string           `json:"updated_at,omitempty"`
+	Answered    *interviewAnswer `json:"answered,omitempty"`
 }
 
 type humanInvite struct {

--- a/internal/team/custom_app.go
+++ b/internal/team/custom_app.go
@@ -1,0 +1,530 @@
+package team
+
+// custom_app.go owns the storage + validation for agent-generated internal
+// tools ("Apps"). An App is a small, self-contained single-file web app — the
+// built output of a real Vite/React/TS project (inlined via
+// vite-plugin-singlefile by the App Builder agent) — that lives under
+// <runtime-home>/.wuphf/apps/<id>/ and renders inside a sandboxed iframe.
+//
+// Why a dedicated store instead of the wiki git worker:
+//   - Apps are a distinct concern from the curated wiki; coupling them to the
+//     wiki write queue would entangle two unrelated serializers.
+//   - v1 versioning is a monotonic counter on the manifest, not git history.
+//
+// Security model: the rendered iframe is the real boundary (sandbox=
+// "allow-scripts" with no allow-same-origin, CSP connect-src 'none'). The
+// write-time validator below is defense-in-depth: it mirrors the proven
+// rich-artifact sandbox policy (no external script/style/base, no nested
+// browsing contexts, no inline event handlers, no off-origin URLs) but ALLOWS
+// <form> because a form is inert under the app sandbox and real tools need it.
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/nex-crm/wuphf/internal/config"
+)
+
+const (
+	customAppEntry = "index.html"
+	// Singlefile React bundles run larger than rich artifacts (the whole app +
+	// inlined CSS lives in one document), so the ceiling is higher.
+	customAppMaxHTMLBytes = 4 * 1024 * 1024
+	customAppDefaultIcon  = "🧩"
+	customAppManifestFile = "app.json"
+	customAppMaxNameBytes = 120
+	// Version snapshots + source live next to the manifest so an edit can roll
+	// back to a known-good build, and the App Builder can edit real source
+	// instead of regenerating from prose.
+	customAppVersionsDir        = "versions"
+	customAppSourceDir          = "src"
+	customAppMaxSourceFiles     = 300
+	customAppMaxSourceFileBytes = 512 * 1024
+)
+
+// CustomApp is the durable manifest for an agent-generated internal tool. The
+// built HTML bundle lives next to it on disk (Entry) so listings stay cheap.
+type CustomApp struct {
+	ID          string `json:"id"`
+	Slug        string `json:"slug"`
+	Name        string `json:"name"`
+	Icon        string `json:"icon"`
+	Summary     string `json:"summary,omitempty"`
+	Description string `json:"description,omitempty"`
+	Entry       string `json:"entry"`
+	Version     int    `json:"version"`
+	CreatedBy   string `json:"createdBy"`
+	UpdatedBy   string `json:"updatedBy,omitempty"`
+	CreatedAt   string `json:"createdAt"`
+	UpdatedAt   string `json:"updatedAt"`
+	ContentHash string `json:"contentHash"`
+}
+
+// CustomAppWriteRequest is the create/update payload. An empty ID creates a new
+// app; a populated ID updates the existing one in place (bumping Version).
+type CustomAppWriteRequest struct {
+	ID          string `json:"id,omitempty"`
+	Name        string `json:"name"`
+	Icon        string `json:"icon,omitempty"`
+	Summary     string `json:"summary,omitempty"`
+	Description string `json:"description,omitempty"`
+	HTML        string `json:"html"`
+	Actor       string `json:"actor,omitempty"`
+	// Files is the app's source project (relative path -> content), persisted
+	// under src/ so a later edit modifies real files instead of regenerating
+	// from prose. Optional; nil leaves any existing source untouched. Build
+	// artifacts (node_modules/, dist/) are rejected.
+	Files map[string]string `json:"files,omitempty"`
+}
+
+var errCustomAppCaller = errors.New("app: caller error")
+
+type customAppCallerError struct{ err error }
+
+func (e customAppCallerError) Error() string   { return e.err.Error() }
+func (e customAppCallerError) Unwrap() []error { return []error{errCustomAppCaller, e.err} }
+
+func newCustomAppCallerError(format string, args ...any) error {
+	return customAppCallerError{err: fmt.Errorf(format, args...)}
+}
+
+func isCustomAppCallerError(err error) bool { return errors.Is(err, errCustomAppCaller) }
+
+// CustomAppsRootDir returns <runtime-home>/.wuphf/apps, honouring
+// config.RuntimeHomeDir so dev runs stay isolated from prod (same discipline as
+// WikiRootDir).
+func CustomAppsRootDir() string {
+	home := strings.TrimSpace(config.RuntimeHomeDir())
+	if home == "" {
+		return filepath.Join(".wuphf", "apps")
+	}
+	return filepath.Join(home, ".wuphf", "apps")
+}
+
+// customAppStore is the standalone persistence layer for Apps. All operations
+// serialize on mu; reads and writes both lock so a listing never observes a
+// half-written manifest.
+type customAppStore struct {
+	root string
+	mu   sync.Mutex
+}
+
+func newCustomAppStore(root string) *customAppStore {
+	return &customAppStore{root: root}
+}
+
+func validateCustomAppID(id string) error {
+	id = strings.TrimSpace(id)
+	if len(id) != len("app_")+16 || !strings.HasPrefix(id, "app_") {
+		return newCustomAppCallerError("app: invalid id %q", id)
+	}
+	for _, ch := range strings.TrimPrefix(id, "app_") {
+		if !((ch >= 'a' && ch <= 'f') || (ch >= '0' && ch <= '9')) {
+			return newCustomAppCallerError("app: invalid id %q", id)
+		}
+	}
+	return nil
+}
+
+func customAppID(slug, name, createdAt string) string {
+	sum := sha256.Sum256([]byte(strings.Join([]string{slug, name, createdAt}, "\x00")))
+	return "app_" + hex.EncodeToString(sum[:])[:16]
+}
+
+func customAppContentHash(htmlBody string) string {
+	sum := sha256.Sum256([]byte(htmlBody))
+	return hex.EncodeToString(sum[:])
+}
+
+func (s *customAppStore) appDir(id string) string {
+	return filepath.Join(s.root, id)
+}
+
+// List returns all apps, most-recently-updated first.
+func (s *customAppStore) List() ([]CustomApp, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	entries, err := os.ReadDir(s.root)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return []CustomApp{}, nil
+		}
+		return nil, fmt.Errorf("app: read registry: %w", err)
+	}
+	out := make([]CustomApp, 0, len(entries))
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		// Only iterate well-formed app ids so a stray/foreign directory name can
+		// never be joined onto the apps root (defense in depth — os.ReadDir never
+		// returns ".."/absolute names, but the id shape is the contract).
+		if err := validateCustomAppID(entry.Name()); err != nil {
+			continue
+		}
+		app, err := s.readManifestLocked(entry.Name())
+		if err != nil {
+			continue // skip unreadable/foreign dirs rather than fail the whole list
+		}
+		out = append(out, app)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].UpdatedAt == out[j].UpdatedAt {
+			return out[i].ID > out[j].ID
+		}
+		return out[i].UpdatedAt > out[j].UpdatedAt
+	})
+	return out, nil
+}
+
+// Get returns the manifest plus the built HTML bundle for an app.
+func (s *customAppStore) Get(id string) (CustomApp, string, error) {
+	if err := validateCustomAppID(id); err != nil {
+		return CustomApp{}, "", err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	app, err := s.readManifestLocked(id)
+	if err != nil {
+		return CustomApp{}, "", err
+	}
+	body, err := os.ReadFile(filepath.Join(s.appDir(id), customAppEntry))
+	if err != nil {
+		return CustomApp{}, "", fmt.Errorf("app: read entry: %w", err)
+	}
+	return app, string(body), nil
+}
+
+func (s *customAppStore) readManifestLocked(id string) (CustomApp, error) {
+	raw, err := os.ReadFile(filepath.Join(s.appDir(id), customAppManifestFile))
+	if err != nil {
+		return CustomApp{}, fmt.Errorf("app: read manifest: %w", err)
+	}
+	var app CustomApp
+	if err := json.Unmarshal(raw, &app); err != nil {
+		return CustomApp{}, fmt.Errorf("app: decode manifest: %w", err)
+	}
+	if app.ID != id {
+		return CustomApp{}, fmt.Errorf("app: manifest id mismatch")
+	}
+	return app, nil
+}
+
+// Save creates a new app (empty req.ID) or updates an existing one. It
+// validates the HTML against the app sandbox policy, writes the manifest +
+// entry bundle, and returns the stored manifest.
+func (s *customAppStore) Save(req CustomAppWriteRequest, now time.Time) (CustomApp, error) {
+	name := strings.TrimSpace(req.Name)
+	if name == "" {
+		return CustomApp{}, newCustomAppCallerError("app: name is required")
+	}
+	if len(name) > customAppMaxNameBytes {
+		return CustomApp{}, newCustomAppCallerError("app: name exceeds %d bytes", customAppMaxNameBytes)
+	}
+	if strings.ContainsRune(name, '\x00') {
+		return CustomApp{}, newCustomAppCallerError("app: name must not contain NUL bytes")
+	}
+	htmlBody := req.HTML
+	if err := validateCustomAppHTML(htmlBody); err != nil {
+		return CustomApp{}, err
+	}
+	actor := strings.TrimSpace(req.Actor)
+	if actor == "" {
+		actor = "app-builder"
+	}
+	icon := strings.TrimSpace(req.Icon)
+	if icon == "" {
+		icon = customAppDefaultIcon
+	}
+	stamp := now.UTC().Format(time.RFC3339Nano)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	var app CustomApp
+	if id := strings.TrimSpace(req.ID); id != "" {
+		if err := validateCustomAppID(id); err != nil {
+			return CustomApp{}, err
+		}
+		existing, err := s.readManifestLocked(id)
+		if err != nil {
+			return CustomApp{}, newCustomAppCallerError("app: %s not found", id)
+		}
+		app = existing
+		app.Name = name
+		app.Icon = icon
+		app.Summary = strings.TrimSpace(req.Summary)
+		if desc := strings.TrimSpace(req.Description); desc != "" {
+			app.Description = desc
+		}
+		app.Version = existing.Version + 1
+		app.UpdatedBy = actor
+		app.UpdatedAt = stamp
+		app.ContentHash = customAppContentHash(htmlBody)
+	} else {
+		slug := slugifyNotebookEntry(name)
+		if slug == "" {
+			slug = "app"
+		}
+		app = CustomApp{
+			ID:          customAppID(slug, name, stamp),
+			Slug:        slug,
+			Name:        name,
+			Icon:        icon,
+			Summary:     strings.TrimSpace(req.Summary),
+			Description: strings.TrimSpace(req.Description),
+			Entry:       customAppEntry,
+			Version:     1,
+			CreatedBy:   actor,
+			UpdatedBy:   actor,
+			CreatedAt:   stamp,
+			UpdatedAt:   stamp,
+			ContentHash: customAppContentHash(htmlBody),
+		}
+	}
+	app.Entry = customAppEntry
+
+	dir := s.appDir(app.ID)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return CustomApp{}, fmt.Errorf("app: mkdir: %w", err)
+	}
+	if err := writeFileAtomic(filepath.Join(dir, customAppEntry), []byte(htmlBody), 0o600); err != nil {
+		return CustomApp{}, fmt.Errorf("app: write entry: %w", err)
+	}
+	manifestBytes, err := json.MarshalIndent(app, "", "  ")
+	if err != nil {
+		return CustomApp{}, fmt.Errorf("app: marshal manifest: %w", err)
+	}
+	manifestBytes = append(manifestBytes, '\n')
+	if err := writeFileAtomic(filepath.Join(dir, customAppManifestFile), manifestBytes, 0o600); err != nil {
+		return CustomApp{}, fmt.Errorf("app: write manifest: %w", err)
+	}
+	// Retain this version's built bytes (append-only history) so a later edit
+	// can roll back to a known-good build. Without this the version counter is
+	// a false affordance — it promises an undo that cannot happen.
+	if err := s.snapshotVersionLocked(dir, app.Version, htmlBody); err != nil {
+		return CustomApp{}, err
+	}
+	// Persist the source project when provided so edits modify real files.
+	if err := s.writeAppSourceLocked(dir, req.Files); err != nil {
+		return CustomApp{}, err
+	}
+	return app, nil
+}
+
+func (s *customAppStore) snapshotVersionLocked(dir string, version int, htmlBody string) error {
+	if version < 1 {
+		return nil
+	}
+	vdir := filepath.Join(dir, customAppVersionsDir, fmt.Sprintf("v%d", version))
+	if err := os.MkdirAll(vdir, 0o700); err != nil {
+		return fmt.Errorf("app: mkdir version: %w", err)
+	}
+	if err := writeFileAtomic(filepath.Join(vdir, customAppEntry), []byte(htmlBody), 0o600); err != nil {
+		return fmt.Errorf("app: write version snapshot: %w", err)
+	}
+	return nil
+}
+
+// writeAppSourceLocked replaces src/ with the provided files (so deletes
+// propagate). Each path is sanitized against traversal; build artifacts are
+// rejected. A nil/empty map leaves any existing source untouched.
+func (s *customAppStore) writeAppSourceLocked(dir string, files map[string]string) error {
+	if len(files) == 0 {
+		return nil
+	}
+	if len(files) > customAppMaxSourceFiles {
+		return newCustomAppCallerError("app: too many source files (%d > %d)", len(files), customAppMaxSourceFiles)
+	}
+	srcRoot := filepath.Join(dir, customAppSourceDir)
+	if err := os.RemoveAll(srcRoot); err != nil {
+		return fmt.Errorf("app: clear source: %w", err)
+	}
+	for rel, content := range files {
+		clean, err := sanitizeAppSourcePath(rel)
+		if err != nil {
+			return err
+		}
+		if len(content) > customAppMaxSourceFileBytes {
+			return newCustomAppCallerError("app: source file %q exceeds %d bytes", rel, customAppMaxSourceFileBytes)
+		}
+		full := filepath.Join(srcRoot, clean)
+		if err := os.MkdirAll(filepath.Dir(full), 0o700); err != nil {
+			return fmt.Errorf("app: mkdir source dir: %w", err)
+		}
+		if err := writeFileAtomic(full, []byte(content), 0o600); err != nil {
+			return fmt.Errorf("app: write source: %w", err)
+		}
+	}
+	return nil
+}
+
+// sanitizeAppSourcePath returns a cleaned relative path under src/, or a caller
+// error if it would escape the app dir or names a build artifact.
+func sanitizeAppSourcePath(rel string) (string, error) {
+	rel = filepath.ToSlash(strings.TrimSpace(rel))
+	if rel == "" {
+		return "", newCustomAppCallerError("app: empty source path")
+	}
+	if strings.HasPrefix(rel, "/") || strings.Contains(rel, "..") || strings.ContainsRune(rel, '\x00') {
+		return "", newCustomAppCallerError("app: invalid source path %q", rel)
+	}
+	clean := filepath.Clean(rel)
+	if clean == "." || filepath.IsAbs(clean) || strings.HasPrefix(filepath.ToSlash(clean), "../") {
+		return "", newCustomAppCallerError("app: invalid source path %q", rel)
+	}
+	switch first := strings.SplitN(filepath.ToSlash(clean), "/", 2)[0]; first {
+	case "node_modules", "dist":
+		return "", newCustomAppCallerError("app: source path %q is a build artifact; exclude node_modules and dist", rel)
+	}
+	return clean, nil
+}
+
+// Source returns the persisted source project (relative path -> content). Empty
+// when an app has no source (html-only). Used by the App Builder via get_app.
+func (s *customAppStore) Source(id string) (map[string]string, error) {
+	if err := validateCustomAppID(id); err != nil {
+		return nil, err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	srcRoot := filepath.Join(s.appDir(id), customAppSourceDir)
+	out := map[string]string{}
+	err := filepath.WalkDir(srcRoot, func(p string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			if os.IsNotExist(walkErr) {
+				return nil
+			}
+			return walkErr
+		}
+		if d.IsDir() {
+			return nil
+		}
+		rel, err := filepath.Rel(srcRoot, p)
+		if err != nil {
+			return err
+		}
+		body, err := os.ReadFile(p)
+		if err != nil {
+			return err
+		}
+		out[filepath.ToSlash(rel)] = string(body)
+		return nil
+	})
+	if err != nil && !os.IsNotExist(err) {
+		return nil, fmt.Errorf("app: read source: %w", err)
+	}
+	return out, nil
+}
+
+// ListVersions returns the retained version numbers, newest first.
+func (s *customAppStore) ListVersions(id string) ([]int, error) {
+	if err := validateCustomAppID(id); err != nil {
+		return nil, err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	dir := filepath.Join(s.appDir(id), customAppVersionsDir)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return []int{}, nil
+		}
+		return nil, fmt.Errorf("app: read versions: %w", err)
+	}
+	out := []int{}
+	for _, e := range entries {
+		if !e.IsDir() || !strings.HasPrefix(e.Name(), "v") {
+			continue
+		}
+		n, err := strconv.Atoi(strings.TrimPrefix(e.Name(), "v"))
+		if err != nil || n < 1 {
+			continue
+		}
+		out = append(out, n)
+	}
+	sort.Sort(sort.Reverse(sort.IntSlice(out)))
+	return out, nil
+}
+
+// Rollback restores a prior version's built bytes as a NEW forward version.
+// History stays append-only, so a rollback is itself reversible.
+func (s *customAppStore) Rollback(id string, version int, actor string, now time.Time) (CustomApp, error) {
+	if err := validateCustomAppID(id); err != nil {
+		return CustomApp{}, err
+	}
+	if version < 1 {
+		return CustomApp{}, newCustomAppCallerError("app: invalid version %d", version)
+	}
+	s.mu.Lock()
+	app, err := s.readManifestLocked(id)
+	if err != nil {
+		s.mu.Unlock()
+		return CustomApp{}, newCustomAppCallerError("app: %s not found", id)
+	}
+	if version == app.Version {
+		s.mu.Unlock()
+		return CustomApp{}, newCustomAppCallerError("app: v%d is already current", version)
+	}
+	snap := filepath.Join(s.appDir(id), customAppVersionsDir, fmt.Sprintf("v%d", version), customAppEntry)
+	body, readErr := os.ReadFile(snap)
+	s.mu.Unlock()
+	if readErr != nil {
+		return CustomApp{}, newCustomAppCallerError("app: version v%d not found", version)
+	}
+	// Save() re-locks and snapshots the restored bytes as a new version.
+	return s.Save(CustomAppWriteRequest{
+		ID:          id,
+		Name:        app.Name,
+		Icon:        app.Icon,
+		Summary:     app.Summary,
+		Description: app.Description,
+		HTML:        string(body),
+		Actor:       actor,
+	}, now)
+}
+
+// validateCustomAppHTML enforces the app sandbox policy at write time. It is
+// intentionally close to validateRichArtifactSandboxPolicy but permits <form>.
+func validateCustomAppHTML(raw string) error {
+	if strings.TrimSpace(raw) == "" {
+		return newCustomAppCallerError("app: html is required")
+	}
+	if len([]byte(raw)) > customAppMaxHTMLBytes {
+		return newCustomAppCallerError("app: html exceeds %d bytes", customAppMaxHTMLBytes)
+	}
+	if strings.ContainsRune(raw, '\x00') {
+		return newCustomAppCallerError("app: html must not contain NUL bytes")
+	}
+	return validateSandboxHTML(raw, sandboxHTMLPolicy{
+		label:          "app",
+		blockedElement: customAppBlockedElementReason,
+		newErr:         newCustomAppCallerError,
+	})
+}
+
+func customAppBlockedElementReason(tag string) (string, bool) {
+	switch tag {
+	case "base":
+		return "base URLs can rewrite link targets inside the sandbox", true
+	case "embed", "iframe", "object":
+		return "nested browsing contexts and plugins are not part of the app sandbox", true
+	case "link":
+		return "external stylesheets and preloads are not allowed; inline your styles", true
+	default:
+		// NB: <form> is intentionally allowed — it is inert under the app
+		// sandbox (no allow-forms / allow-same-origin) and real tools use it.
+		return "", false
+	}
+}

--- a/internal/team/custom_app_dev.go
+++ b/internal/team/custom_app_dev.go
@@ -1,0 +1,520 @@
+package team
+
+// custom_app_dev.go — live dev-server preview for App Builder apps (SOTA, the
+// dyad model adapted to our boundary; see docs/specs/app-builder-live-preview.md).
+//
+// Instead of waiting minutes for `bun run build` → single-file before showing
+// anything, the broker runs a real Vite dev server per app and previews it live
+// with HMR: edits hot-reload in milliseconds. The single-file build stays as the
+// sealed "ship" artifact (register_app); this is purely the live preview.
+//
+// Security: the dev server runs the agent's own source on 127.0.0.1, but a
+// generated app must still be unable to exfiltrate. We do NOT trust the app's
+// own vite.config for that — the CSP is injected by a broker-owned reverse proxy
+// (httputil.ReverseProxy, which also tunnels Vite's HMR WebSocket for free), so
+// a generated config cannot strip it. The iframe loads the proxy origin (a
+// distinct ephemeral 127.0.0.1 port), so allow-same-origin grants the app only
+// its OWN origin, never the parent app's session. connect-src 'self' blocks all
+// network except the same-origin HMR WS; data still flows only via the parent
+// postMessage bridge.
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	appDevIdleTimeout = 10 * time.Minute
+	appDevBootLogMax  = 16 * 1024
+	appDevGCInterval  = 1 * time.Minute
+)
+
+// appDevCSP builds the CSP the proxy injects on every dev response. connect-src
+// is restricted to the SAME-ORIGIN HMR WebSocket only (the proxy port) — no
+// wildcard `ws:`/`wss:` (exfil to any host) and no `'self'` for fetch/XHR (the
+// app reads data only through the parent postMessage bridge, never the network;
+// Vite loads modules via <script>, governed by script-src). Every other network
+// destination is blocked.
+func appDevCSP(proxyPort int) string {
+	hmr := fmt.Sprintf("ws://127.0.0.1:%d wss://127.0.0.1:%d", proxyPort, proxyPort)
+	return "default-src 'self'; " +
+		"script-src 'self' 'unsafe-inline' 'unsafe-eval'; " +
+		"style-src 'self' 'unsafe-inline'; " +
+		"img-src 'self' data: blob:; " +
+		"font-src 'self' data:; " +
+		"media-src 'self' data: blob:; " +
+		"connect-src " + hmr + "; " +
+		"frame-src 'none'; " +
+		"base-uri 'self'"
+}
+
+// appDevURLRe scrapes the local dev URL from Vite's "Local:" line specifically
+// (capture group 1), not any URL anywhere in stdout — so a generated vite.config
+// can't print a decoy "http://127.0.0.1:<attacker-port>" earlier and redirect
+// the proxy's target to a server it controls.
+var appDevURLRe = regexp.MustCompile(`(?i)Local:\s+(https?://(?:localhost|127\.0\.0\.1):\d+)`)
+
+// cspMetaRe matches a <meta http-equiv="Content-Security-Policy" …> tag (any
+// attribute order/quoting) so the proxy can strip it from served HTML.
+var cspMetaRe = regexp.MustCompile(`(?is)<meta\b[^>]*http-equiv\s*=\s*["']?content-security-policy["']?[^>]*>`)
+
+// appDevStatus is the FE-facing snapshot (GET /apps/{id}/dev[/status]).
+type appDevStatus struct {
+	Ready   bool   `json:"ready"`
+	URL     string `json:"url,omitempty"`      // proxy origin to load in the iframe
+	BootLog string `json:"boot_log,omitempty"` // streaming install/boot output
+	Error   string `json:"error,omitempty"`
+}
+
+// appDevServer is one running app preview: a `bun run dev` process plus a
+// broker-owned reverse proxy that fronts it (CSP injection + HMR WS passthrough).
+type appDevServer struct {
+	id     string
+	srcDir string
+
+	mu        sync.Mutex
+	cmd       *exec.Cmd // current child (install, then dev) — killed on shutdown
+	devURL    string    // scraped Vite origin, e.g. http://127.0.0.1:5173
+	proxyPort int       // the origin the iframe loads
+	proxySrv  *http.Server
+	target    *url.URL
+	proxy     *httputil.ReverseProxy // built once when ready (not per request)
+	ready     bool
+	exited    bool
+	errMsg    string
+	bootLog   appDevRing
+	startedAt time.Time
+	lastUsed  time.Time
+}
+
+// appDevManager owns the lifecycle of every running app dev server. Methods are
+// safe for concurrent use; per-server state is guarded by the server's own mu.
+type appDevManager struct {
+	store   *customAppStore
+	mu      sync.Mutex
+	servers map[string]*appDevServer
+	gcOnce  sync.Once
+	stopGC  chan struct{}
+}
+
+func newAppDevManager(store *customAppStore) *appDevManager {
+	return &appDevManager{
+		store:   store,
+		servers: make(map[string]*appDevServer),
+		stopGC:  make(chan struct{}),
+	}
+}
+
+// Ensure starts (or reuses) the dev server for an app and returns its current
+// status. Booting is asynchronous: the first call returns ready=false with a
+// streaming boot log; callers poll Status until ready, then load status.URL.
+func (m *appDevManager) Ensure(id string) (appDevStatus, error) {
+	if m == nil || m.store == nil {
+		return appDevStatus{}, errors.New("app dev manager not initialised")
+	}
+	if err := validateCustomAppID(id); err != nil {
+		return appDevStatus{}, err
+	}
+	srcDir := filepath.Join(m.store.appDir(id), customAppSourceDir)
+	if info, err := os.Stat(srcDir); err != nil || !info.IsDir() {
+		return appDevStatus{}, newCustomAppCallerError("app %q has no editable source to preview", id)
+	}
+
+	m.mu.Lock()
+	srv, ok := m.servers[id]
+	if ok && srv.alive() {
+		srv.touch()
+		m.mu.Unlock()
+		return srv.status(), nil
+	}
+	srv = &appDevServer{id: id, srcDir: srcDir, startedAt: time.Now(), lastUsed: time.Now()}
+	m.servers[id] = srv
+	m.mu.Unlock()
+
+	m.gcOnce.Do(func() { go m.gcLoop() })
+
+	if err := srv.start(); err != nil {
+		srv.fail(err.Error())
+		return srv.status(), nil
+	}
+	go srv.run()
+	return srv.status(), nil
+}
+
+// Status returns the current snapshot without starting anything.
+func (m *appDevManager) Status(id string) (appDevStatus, bool) {
+	m.mu.Lock()
+	srv, ok := m.servers[id]
+	m.mu.Unlock()
+	if !ok {
+		return appDevStatus{}, false
+	}
+	srv.touch()
+	return srv.status(), true
+}
+
+// Stop tears down one app's dev server (process group + proxy).
+func (m *appDevManager) Stop(id string) {
+	m.mu.Lock()
+	srv, ok := m.servers[id]
+	if ok {
+		delete(m.servers, id)
+	}
+	m.mu.Unlock()
+	if ok {
+		srv.shutdown()
+	}
+}
+
+// StopAll tears down every running dev server (broker shutdown).
+func (m *appDevManager) StopAll() {
+	if m == nil {
+		return
+	}
+	select {
+	case <-m.stopGC:
+	default:
+		close(m.stopGC)
+	}
+	m.mu.Lock()
+	servers := make([]*appDevServer, 0, len(m.servers))
+	for _, srv := range m.servers {
+		servers = append(servers, srv)
+	}
+	m.servers = make(map[string]*appDevServer)
+	m.mu.Unlock()
+	for _, srv := range servers {
+		srv.shutdown()
+	}
+}
+
+func (m *appDevManager) gcLoop() {
+	ticker := time.NewTicker(appDevGCInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-m.stopGC:
+			return
+		case <-ticker.C:
+			now := time.Now()
+			m.mu.Lock()
+			var idle []*appDevServer
+			for id, srv := range m.servers {
+				if now.Sub(srv.lastUsedAt()) > appDevIdleTimeout {
+					idle = append(idle, srv)
+					delete(m.servers, id)
+				}
+			}
+			m.mu.Unlock()
+			for _, srv := range idle {
+				srv.shutdown()
+			}
+		}
+	}
+}
+
+// ── per-server lifecycle ────────────────────────────────────────────────────
+
+// start allocates the proxy listener synchronously (so the iframe origin is
+// known before the dev server — or even its install — is done) and serves it.
+// The dev process is spawned in run().
+func (s *appDevServer) start() error {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return fmt.Errorf("allocate preview port: %w", err)
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", s.serveProxy)
+	srv := &http.Server{Handler: mux}
+	s.mu.Lock()
+	s.proxyPort = port
+	s.proxySrv = srv
+	s.mu.Unlock()
+	go func() { _ = srv.Serve(ln) }()
+	return nil
+}
+
+// run installs dependencies if the project is cold, spawns the Vite dev server,
+// scrapes its origin (flipping ready), and blocks until it exits. Runs in its
+// own goroutine so Ensure returns immediately with a streaming boot log.
+func (s *appDevServer) run() {
+	if err := s.installIfNeeded(); err != nil {
+		s.fail("dependency install failed: " + err.Error())
+		s.markExited()
+		return
+	}
+	s.runDev()
+	s.markExited()
+}
+
+// installIfNeeded runs `bun install` when node_modules is absent, streaming to
+// the boot log. No-ops on a warm tree (the scaffold commits bun.lock so this is
+// fast/cache-resolved).
+func (s *appDevServer) installIfNeeded() error {
+	if _, err := os.Stat(filepath.Join(s.srcDir, "node_modules")); err == nil {
+		return nil
+	}
+	cmd := exec.Command("bun", "install")
+	cmd.Dir = s.srcDir
+	configureHeadlessProcess(cmd)
+	return s.pipeAndWait(cmd, nil)
+}
+
+// runDev spawns `bun run dev`, scrapes the Vite origin (flips ready), and waits.
+func (s *appDevServer) runDev() {
+	cmd := exec.Command("bun", "run", "dev")
+	cmd.Dir = s.srcDir
+	cmd.Env = append(os.Environ(), fmt.Sprintf("WUPHF_HMR_CLIENT_PORT=%d", s.proxyPortValue()))
+	configureHeadlessProcess(cmd)
+	if err := s.pipeAndWait(cmd, s.onDevChunk); err != nil {
+		s.mu.Lock()
+		if !s.ready && s.errMsg == "" {
+			s.errMsg = "dev server exited: " + err.Error()
+		}
+		s.mu.Unlock()
+	}
+}
+
+// pipeAndWait runs cmd with stdout+stderr folded into the boot log; onChunk (if
+// non-nil) is also called per chunk (used to scrape the dev URL). It records cmd
+// as the current process (so shutdown can kill it), starts it, and blocks until
+// it exits.
+func (s *appDevServer) pipeAndWait(cmd *exec.Cmd, onChunk func([]byte)) error {
+	pr, pw := io.Pipe()
+	cmd.Stdout = pw
+	cmd.Stderr = pw
+	if err := cmd.Start(); err != nil {
+		_ = pw.Close()
+		return err
+	}
+	s.mu.Lock()
+	s.cmd = cmd
+	s.mu.Unlock()
+	done := make(chan struct{})
+	go func() {
+		buf := make([]byte, 4096)
+		for {
+			n, rerr := pr.Read(buf)
+			if n > 0 {
+				chunk := buf[:n]
+				s.appendBootLog(chunk)
+				if onChunk != nil {
+					onChunk(chunk)
+				}
+			}
+			if rerr != nil {
+				break
+			}
+		}
+		close(done)
+	}()
+	werr := cmd.Wait()
+	_ = pw.Close()
+	<-done
+	return werr
+}
+
+func (s *appDevServer) onDevChunk(_ []byte) {
+	if s.isReady() {
+		return
+	}
+	// Match against the ACCUMULATED log (the chunk was already appended) so a
+	// "Local:" header and its URL split across read boundaries still match.
+	s.mu.Lock()
+	log := s.bootLog.String()
+	s.mu.Unlock()
+	if m := appDevURLRe.FindStringSubmatch(log); m != nil {
+		s.setReady(m[1])
+	}
+}
+
+// serveProxy fronts the Vite dev server, injecting the agent-proof CSP. Returns
+// 503 while the dev server is still starting (target not yet scraped).
+func (s *appDevServer) serveProxy(w http.ResponseWriter, r *http.Request) {
+	// DNS-rebinding guard: the ephemeral preview proxy is loopback-only, so a
+	// request whose Host isn't 127.0.0.1/localhost is a rebinding attempt.
+	host := r.Host
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		host = h
+	}
+	if host != "127.0.0.1" && host != "localhost" {
+		http.Error(w, "forbidden", http.StatusForbidden)
+		return
+	}
+	s.mu.Lock()
+	proxy := s.proxy
+	s.lastUsed = time.Now()
+	s.mu.Unlock()
+	if proxy == nil {
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write([]byte("preview starting…\n"))
+		return
+	}
+	proxy.ServeHTTP(w, r)
+}
+
+// stripCSPMeta removes any CSP <meta> from an HTML response body so the proxy's
+// header CSP stays authoritative (the browser would otherwise intersect a meta
+// CSP with it). No-ops on non-HTML and on encoded bodies — Vite dev serves
+// uncompressed, so that is the common path.
+func stripCSPMeta(resp *http.Response) error {
+	if resp == nil || resp.Body == nil {
+		return nil
+	}
+	if !strings.Contains(strings.ToLower(resp.Header.Get("Content-Type")), "text/html") {
+		return nil
+	}
+	if resp.Header.Get("Content-Encoding") != "" {
+		return nil
+	}
+	body, err := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if err != nil {
+		return err
+	}
+	cleaned := cspMetaRe.ReplaceAll(body, nil)
+	resp.Body = io.NopCloser(bytes.NewReader(cleaned))
+	resp.ContentLength = int64(len(cleaned))
+	resp.Header.Set("Content-Length", strconv.Itoa(len(cleaned)))
+	return nil
+}
+
+func (s *appDevServer) setReady(devURL string) {
+	target, err := url.Parse(devURL)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if err != nil {
+		if s.errMsg == "" {
+			s.errMsg = "could not parse dev url: " + err.Error()
+		}
+		return
+	}
+	// Build the reverse proxy ONCE (not per request — that leaked a fresh
+	// Transport + connection pool each time). The CSP is fixed for this server.
+	csp := appDevCSP(s.proxyPort)
+	proxy := httputil.NewSingleHostReverseProxy(target)
+	proxy.ModifyResponse = func(resp *http.Response) error {
+		// We own the CSP — a generated vite.config cannot weaken it. Strip any
+		// CSP <meta> so the browser can't intersect it with (and break) ours.
+		resp.Header.Set("Content-Security-Policy", csp)
+		resp.Header.Del("X-Frame-Options")
+		return stripCSPMeta(resp)
+	}
+	proxy.ErrorHandler = func(rw http.ResponseWriter, _ *http.Request, _ error) {
+		rw.WriteHeader(http.StatusBadGateway)
+	}
+	s.devURL = devURL
+	s.target = target
+	s.proxy = proxy
+	s.ready = true
+}
+
+func (s *appDevServer) appendBootLog(chunk []byte) {
+	s.mu.Lock()
+	s.bootLog.Write(chunk)
+	s.mu.Unlock()
+}
+
+func (s *appDevServer) isReady() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.ready
+}
+
+func (s *appDevServer) proxyPortValue() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.proxyPort
+}
+
+func (s *appDevServer) fail(msg string) {
+	s.mu.Lock()
+	if s.errMsg == "" {
+		s.errMsg = msg
+	}
+	s.mu.Unlock()
+}
+
+func (s *appDevServer) markExited() {
+	s.mu.Lock()
+	s.exited = true
+	s.mu.Unlock()
+}
+
+func (s *appDevServer) touch() {
+	s.mu.Lock()
+	s.lastUsed = time.Now()
+	s.mu.Unlock()
+}
+
+func (s *appDevServer) lastUsedAt() time.Time {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.lastUsed
+}
+
+// alive reports whether the preview is still usable (not exited or failed).
+func (s *appDevServer) alive() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return !s.exited && s.errMsg == ""
+}
+
+func (s *appDevServer) status() appDevStatus {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	st := appDevStatus{Ready: s.ready, BootLog: s.bootLog.String(), Error: s.errMsg}
+	if s.ready && s.proxyPort > 0 {
+		st.URL = fmt.Sprintf("http://127.0.0.1:%d/", s.proxyPort)
+	}
+	return st
+}
+
+func (s *appDevServer) shutdown() {
+	s.mu.Lock()
+	srv := s.proxySrv
+	cmd := s.cmd
+	s.proxySrv = nil
+	s.exited = true
+	s.mu.Unlock()
+	if srv != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		_ = srv.Shutdown(ctx)
+		cancel()
+	}
+	terminateHeadlessProcess(cmd)
+}
+
+// ── appDevRing: a small capped boot-log buffer ──────────────────────────────
+
+type appDevRing struct {
+	buf []byte
+}
+
+func (r *appDevRing) Write(p []byte) {
+	r.buf = append(r.buf, p...)
+	if len(r.buf) > appDevBootLogMax {
+		r.buf = r.buf[len(r.buf)-appDevBootLogMax:]
+	}
+}
+
+func (r *appDevRing) String() string {
+	return strings.TrimRight(string(r.buf), "\x00")
+}

--- a/internal/team/custom_app_dev_test.go
+++ b/internal/team/custom_app_dev_test.go
@@ -1,0 +1,149 @@
+package team
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestStripCSPMetaFromHTML is the regression for the blank-preview bug: the
+// scaffold's sealed-mode <meta> CSP (script-src 'unsafe-inline', no 'self')
+// intersected with the proxy header CSP and blocked Vite's own /src modules. The
+// proxy must strip the meta so its header CSP is the sole authority.
+func TestStripCSPMetaFromHTML(t *testing.T) {
+	html := `<!doctype html><html><head>` +
+		`<meta http-equiv="Content-Security-Policy" content="script-src 'unsafe-inline'">` +
+		`<title>x</title></head><body><div id="root"></div></body></html>`
+	resp := &http.Response{
+		Header: http.Header{"Content-Type": []string{"text/html"}},
+		Body:   io.NopCloser(strings.NewReader(html)),
+	}
+	if err := stripCSPMeta(resp); err != nil {
+		t.Fatal(err)
+	}
+	out, _ := io.ReadAll(resp.Body)
+	if strings.Contains(strings.ToLower(string(out)), "content-security-policy") {
+		t.Fatalf("CSP meta not stripped: %s", out)
+	}
+	if !strings.Contains(string(out), "<title>x</title>") {
+		t.Fatalf("stripping removed unrelated content: %s", out)
+	}
+}
+
+func TestStripCSPMetaSkipsNonHTML(t *testing.T) {
+	js := `const x = 1 // content-security-policy mention in a comment`
+	resp := &http.Response{
+		Header: http.Header{"Content-Type": []string{"text/javascript"}},
+		Body:   io.NopCloser(strings.NewReader(js)),
+	}
+	if err := stripCSPMeta(resp); err != nil {
+		t.Fatal(err)
+	}
+	out, _ := io.ReadAll(resp.Body)
+	if string(out) != js {
+		t.Fatalf("non-HTML body was modified: %s", out)
+	}
+}
+
+func TestAppDevRingCapsBootLog(t *testing.T) {
+	var r appDevRing
+	r.Write([]byte(strings.Repeat("a", appDevBootLogMax+500)))
+	if len(r.String()) > appDevBootLogMax {
+		t.Fatalf("ring exceeded cap: %d > %d", len(r.String()), appDevBootLogMax)
+	}
+}
+
+func TestAppDevURLScrape(t *testing.T) {
+	cases := map[string]string{
+		"  ➜  Local:   http://localhost:5173/": "http://localhost:5173",
+		"➜  Local:   http://127.0.0.1:5199/":   "http://127.0.0.1:5199",
+		// A decoy URL NOT on a Vite "Local:" line must NOT match — an agent's
+		// vite.config plugin could print one early to redirect the proxy.
+		"plugin printed http://127.0.0.1:9999/ early": "",
+		"no url in this line":                         "",
+	}
+	for in, want := range cases {
+		got := ""
+		if m := appDevURLRe.FindStringSubmatch(in); m != nil {
+			got = m[1]
+		}
+		if got != want {
+			t.Fatalf("scrape(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// TestAppDevProxyEnforcesCSP locks the security invariant: the broker-owned
+// proxy injects the App-Builder CSP on every dev response and strips
+// X-Frame-Options, REGARDLESS of what the (agent-controlled) dev server sent —
+// so a generated vite.config cannot weaken the no-exfiltration guarantee.
+func TestAppDevProxyEnforcesCSP(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		// A hostile/loose dev server tries to open the CSP and block framing.
+		w.Header().Set("Content-Security-Policy", "default-src *")
+		w.Header().Set("X-Frame-Options", "DENY")
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer backend.Close()
+	s := &appDevServer{id: "app_0000000000000000", proxyPort: 4321}
+	s.setReady(backend.URL) // builds the proxy + injects the CSP
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Host = "127.0.0.1:4321"
+	rec := httptest.NewRecorder()
+	s.serveProxy(rec, req)
+	res := rec.Result()
+
+	want := appDevCSP(4321)
+	if got := res.Header.Get("Content-Security-Policy"); got != want {
+		t.Fatalf("proxy did not enforce the App Builder CSP; got %q want %q", got, want)
+	}
+	if got := res.Header.Get("X-Frame-Options"); got != "" {
+		t.Fatalf("X-Frame-Options must be stripped so the preview can be framed; got %q", got)
+	}
+	// connect-src must be the same-origin HMR socket ONLY — no wildcard ws/wss
+	// and no 'self' (no arbitrary fetch/XHR), so the app can't reach the network.
+	if strings.Contains(want, "ws: wss:") || strings.Contains(want, "connect-src *") || strings.Contains(want, "connect-src 'self'") {
+		t.Fatalf("dev CSP connect-src too permissive: %q", want)
+	}
+	if !strings.Contains(want, "connect-src ws://127.0.0.1:4321 wss://127.0.0.1:4321") {
+		t.Fatalf("dev CSP must allow only the same-origin HMR socket: %q", want)
+	}
+}
+
+func TestAppDevProxyRejectsForeignHost(t *testing.T) {
+	s := &appDevServer{id: "app_0000000000000000", proxyPort: 4321}
+	s.setReady("http://127.0.0.1:5173")
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Host = "evil.example.com" // DNS-rebinding attempt
+	rec := httptest.NewRecorder()
+	s.serveProxy(rec, req)
+	if rec.Result().StatusCode != http.StatusForbidden {
+		t.Fatalf("foreign Host must be rejected (DNS-rebind guard), got %d", rec.Result().StatusCode)
+	}
+}
+
+func TestAppDevProxy503BeforeReady(t *testing.T) {
+	s := &appDevServer{id: "app_0000000000000000", proxyPort: 4321} // not ready, no proxy
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Host = "127.0.0.1:4321"
+	rec := httptest.NewRecorder()
+	s.serveProxy(rec, req)
+	if rec.Result().StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503 before the dev server is ready, got %d", rec.Result().StatusCode)
+	}
+}
+
+func TestAppDevStatusURLOnlyWhenReady(t *testing.T) {
+	s := &appDevServer{id: "app_0000000000000000", proxyPort: 4321}
+	if st := s.status(); st.Ready || st.URL != "" {
+		t.Fatalf("not-ready status must omit the url, got %+v", st)
+	}
+	s.setReady("http://127.0.0.1:5173")
+	st := s.status()
+	if !st.Ready || st.URL != "http://127.0.0.1:4321/" {
+		t.Fatalf("ready status should expose the proxy origin, got %+v", st)
+	}
+}

--- a/internal/team/custom_app_test.go
+++ b/internal/team/custom_app_test.go
@@ -1,0 +1,279 @@
+package team
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+const validAppHTML = `<!doctype html><html><head><style>body{font-family:Georgia}</style></head><body><div id="root"></div><form><input/></form><script>var x=1;</script></body></html>`
+
+func TestCustomAppStoreCreateGetListUpdateDelete(t *testing.T) {
+	store := newCustomAppStore(t.TempDir())
+	now := time.Unix(1_700_000_000, 0).UTC()
+
+	created, err := store.Save(CustomAppWriteRequest{
+		Name:        "Standup Digest",
+		Icon:        "📊",
+		Summary:     "Daily standup",
+		Description: "Lists each agent's open tasks grouped by status.",
+		HTML:        validAppHTML,
+		Actor:       "app-builder",
+	}, now)
+	if err != nil {
+		t.Fatalf("Save create: %v", err)
+	}
+	if !strings.HasPrefix(created.ID, "app_") {
+		t.Fatalf("unexpected id %q", created.ID)
+	}
+	if created.Version != 1 {
+		t.Fatalf("version = %d, want 1", created.Version)
+	}
+	if created.Slug != "standup-digest" {
+		t.Fatalf("slug = %q, want standup-digest", created.Slug)
+	}
+	if created.Entry != customAppEntry {
+		t.Fatalf("entry = %q, want %q", created.Entry, customAppEntry)
+	}
+
+	gotApp, gotHTML, err := store.Get(created.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if gotHTML != validAppHTML {
+		t.Fatalf("Get html mismatch")
+	}
+	if gotApp.Name != "Standup Digest" {
+		t.Fatalf("Get name = %q", gotApp.Name)
+	}
+
+	list, err := store.List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(list) != 1 || list[0].ID != created.ID {
+		t.Fatalf("List = %+v, want one app %s", list, created.ID)
+	}
+
+	// Update in place keeps the id and bumps the version.
+	updated, err := store.Save(CustomAppWriteRequest{
+		ID:          created.ID,
+		Name:        "Standup Digest",
+		Description: "Now also shows blocked tasks.",
+		HTML:        validAppHTML,
+		Actor:       "app-builder",
+	}, now.Add(time.Minute))
+	if err != nil {
+		t.Fatalf("Save update: %v", err)
+	}
+	if updated.ID != created.ID {
+		t.Fatalf("update changed id: %q -> %q", created.ID, updated.ID)
+	}
+	if updated.Version != 2 {
+		t.Fatalf("update version = %d, want 2", updated.Version)
+	}
+	if updated.CreatedAt != created.CreatedAt {
+		t.Fatalf("update changed createdAt")
+	}
+
+	if err := store.Delete(created.ID); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if _, _, err := store.Get(created.ID); err == nil {
+		t.Fatalf("Get after delete: expected error")
+	}
+	if got, _ := store.List(); len(got) != 0 {
+		t.Fatalf("List after delete = %+v, want empty", got)
+	}
+}
+
+func TestCustomAppStoreUpdateMissingIsCallerError(t *testing.T) {
+	store := newCustomAppStore(t.TempDir())
+	_, err := store.Save(CustomAppWriteRequest{
+		ID:   "app_0123456789abcdef",
+		Name: "Ghost",
+		HTML: validAppHTML,
+	}, time.Now())
+	if err == nil || !isCustomAppCallerError(err) {
+		t.Fatalf("update of missing app: got %v, want caller error", err)
+	}
+}
+
+func TestValidateCustomAppHTML(t *testing.T) {
+	cases := []struct {
+		name    string
+		html    string
+		wantErr bool
+	}{
+		{"valid singlefile-ish", validAppHTML, false},
+		{"form allowed", `<form><button>go</button></form>`, false},
+		{"inline svg img data uri", `<img src="data:image/png;base64,AAAA">`, false},
+		{"empty", "", true},
+		{"external script", `<script src="https://evil.example/x.js"></script>`, true},
+		{"external stylesheet link", `<link rel="stylesheet" href="data:,">`, true},
+		{"base tag", `<base href="https://evil.example/">`, true},
+		{"iframe", `<iframe src="data:,"></iframe>`, true},
+		{"object", `<object data="data:,"></object>`, true},
+		{"inline event handler", `<div onclick="steal()">x</div>`, true},
+		{"css import", `<style>@import url('x.css');</style>`, true},
+		{"external image url", `<img src="https://evil.example/x.png">`, true},
+		{"meta refresh", `<meta http-equiv="refresh" content="0;url=https://x">`, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateCustomAppHTML(tc.html)
+			if tc.wantErr && err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tc.wantErr && err != nil && !isCustomAppCallerError(err) {
+				t.Fatalf("error is not a caller error: %v", err)
+			}
+		})
+	}
+}
+
+// TestCustomAppVersionRetentionAndRollback is the IRON RULE regression for the
+// modify loop: an update must NOT destroy the prior version, and rollback must
+// restore its exact bytes as a new forward version. Before this, Save
+// overwrote index.html in place and the version counter was a false affordance.
+func TestCustomAppVersionRetentionAndRollback(t *testing.T) {
+	store := newCustomAppStore(t.TempDir())
+	now := time.Unix(1_700_000_000, 0).UTC()
+	htmlA := validAppHTML
+	htmlB := `<!doctype html><html><head></head><body><div id="root">B</div><script>var b=2;</script></body></html>`
+
+	a, err := store.Save(CustomAppWriteRequest{Name: "Tool", HTML: htmlA, Actor: "app-builder"}, now)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	id := a.ID
+
+	b2, err := store.Save(CustomAppWriteRequest{ID: id, Name: "Tool", HTML: htmlB, Actor: "app-builder"}, now.Add(time.Minute))
+	if err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	if b2.Version != 2 {
+		t.Fatalf("update version = %d, want 2", b2.Version)
+	}
+
+	_, cur, err := store.Get(id)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if cur != htmlB {
+		t.Fatalf("current bytes are not htmlB after update")
+	}
+
+	vs, err := store.ListVersions(id)
+	if err != nil {
+		t.Fatalf("versions: %v", err)
+	}
+	if len(vs) != 2 || vs[0] != 2 || vs[1] != 1 {
+		t.Fatalf("versions = %v, want [2 1]", vs)
+	}
+
+	// Rollback to v1 restores htmlA's exact bytes as a NEW version (append-only).
+	r, err := store.Rollback(id, 1, "human", now.Add(2*time.Minute))
+	if err != nil {
+		t.Fatalf("rollback: %v", err)
+	}
+	if r.Version != 3 {
+		t.Fatalf("rollback version = %d, want 3", r.Version)
+	}
+	_, cur2, _ := store.Get(id)
+	if cur2 != htmlA {
+		t.Fatalf("rollback did not restore htmlA bytes")
+	}
+	if vs2, _ := store.ListVersions(id); len(vs2) != 3 {
+		t.Fatalf("versions after rollback = %v, want 3 entries", vs2)
+	}
+}
+
+func TestCustomAppSourcePersistence(t *testing.T) {
+	store := newCustomAppStore(t.TempDir())
+	now := time.Unix(1_700_000_000, 0).UTC()
+	a, err := store.Save(CustomAppWriteRequest{
+		Name: "Tool", HTML: validAppHTML, Actor: "app-builder",
+		Files: map[string]string{"src/App.tsx": "export const App = () => null", "package.json": "{}"},
+	}, now)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	src, err := store.Source(a.ID)
+	if err != nil {
+		t.Fatalf("source: %v", err)
+	}
+	if src["src/App.tsx"] == "" || src["package.json"] != "{}" {
+		t.Fatalf("source not persisted: %v", src)
+	}
+	// Update replaces the source set wholesale (deletes propagate).
+	if _, err := store.Save(CustomAppWriteRequest{
+		ID: a.ID, Name: "Tool", HTML: validAppHTML, Actor: "app-builder",
+		Files: map[string]string{"src/App.tsx": "v2"},
+	}, now.Add(time.Minute)); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	src2, _ := store.Source(a.ID)
+	if src2["src/App.tsx"] != "v2" || len(src2) != 1 {
+		t.Fatalf("source not replaced: %v", src2)
+	}
+}
+
+func TestCustomAppSourcePathRejection(t *testing.T) {
+	store := newCustomAppStore(t.TempDir())
+	for _, bad := range []string{"../escape.txt", "/abs.txt", "node_modules/x", "dist/index.html", "a/../../b"} {
+		_, err := store.Save(CustomAppWriteRequest{
+			Name: "T", HTML: validAppHTML, Files: map[string]string{bad: "x"},
+		}, time.Now())
+		if err == nil || !isCustomAppCallerError(err) {
+			t.Fatalf("path %q: expected caller error, got %v", bad, err)
+		}
+	}
+}
+
+func TestCustomAppIDValidation(t *testing.T) {
+	good := []string{"app_0123456789abcdef", "app_ffffffffffffffff"}
+	bad := []string{"", "app_short", "ra_0123456789abcdef", "app_0123456789ABCDEF", "app_0123456789abcdeg"}
+	for _, id := range good {
+		if err := validateCustomAppID(id); err != nil {
+			t.Fatalf("valid id %q rejected: %v", id, err)
+		}
+	}
+	for _, id := range bad {
+		if err := validateCustomAppID(id); err == nil {
+			t.Fatalf("bad id %q accepted", id)
+		}
+	}
+}
+
+func TestAppProposalApprovedAndBrief(t *testing.T) {
+	if !appProposalApproved("approve") || !appProposalApproved("approve_with_note") {
+		t.Fatalf("approve choices should be approved")
+	}
+	for _, c := range []string{"reject", "reject_with_steer", "needs_more_info", ""} {
+		if appProposalApproved(c) {
+			t.Fatalf("%q should NOT be approved", c)
+		}
+	}
+	title, details := appBuilderTaskBrief(appProposalSpec{
+		Name: "Lead Scorer", Description: "Score inbound leads.", AppID: "",
+	}, "use our ICP weights")
+	if title != "Build app: Lead Scorer" {
+		t.Fatalf("title = %q", title)
+	}
+	if !strings.Contains(details, "Score inbound leads.") || !strings.Contains(details, "use our ICP weights") || !strings.Contains(details, "register_app") {
+		t.Fatalf("brief missing parts: %q", details)
+	}
+	upTitle, upDetails := appBuilderTaskBrief(appProposalSpec{
+		Name: "Lead Scorer", Description: "Add CSV export.", AppID: "app_0123456789abcdef",
+	}, "")
+	if upTitle != "Improve app: Lead Scorer" {
+		t.Fatalf("update title = %q", upTitle)
+	}
+	if !strings.Contains(upDetails, "app_0123456789abcdef") || !strings.Contains(upDetails, "get_app") {
+		t.Fatalf("update brief missing parts: %q", upDetails)
+	}
+}

--- a/internal/team/launcher_test.go
+++ b/internal/team/launcher_test.go
@@ -109,11 +109,12 @@ func TestNewLauncherFromScratchUsesGenericOffice(t *testing.T) {
 	if got := l.PackName(); got != "WUPHF Office" {
 		t.Fatalf("PackName: got %q, want %q", got, "WUPHF Office")
 	}
-	if got := l.AgentCount(); got != 4 {
-		t.Fatalf("AgentCount: got %d, want 4", got)
+	if got := l.AgentCount(); got != 5 {
+		t.Fatalf("AgentCount: got %d, want 5", got)
 	}
 	got := l.officeMembersSnapshot()
-	want := []string{"founder", "operator", "builder", "reviewer"}
+	// app-builder is the built-in App Builder agent, seeded into every office.
+	want := []string{"founder", "operator", "app-builder", "builder", "reviewer"}
 	if len(got) != len(want) {
 		t.Fatalf("officeMembersSnapshot: got %d members, want %d (%+v)", len(got), len(want), got)
 	}

--- a/internal/team/operation_matrix_test.go
+++ b/internal/team/operation_matrix_test.go
@@ -151,10 +151,10 @@ func TestOperationBlueprintMatrixSeedsBrokerOffice(t *testing.T) {
 
 			b := newTestBroker(t)
 			members := b.OfficeMembers()
-			// Roster = the blueprint's starter agents PLUS the always-present
-			// built-in Librarian.
-			if len(members) != len(blueprint.Starter.Agents)+1 {
-				t.Fatalf("expected broker office roster to match starter agents + librarian, got %d want %d", len(members), len(blueprint.Starter.Agents)+1)
+			// Roster = the blueprint's starter agents PLUS the two always-present
+			// built-ins: the Librarian and the App Builder.
+			if len(members) != len(blueprint.Starter.Agents)+2 {
+				t.Fatalf("expected broker office roster to match starter agents + librarian + app-builder, got %d want %d", len(members), len(blueprint.Starter.Agents)+2)
 			}
 
 			memberBySlug := make(map[string]officeMember, len(members))
@@ -163,6 +163,9 @@ func TestOperationBlueprintMatrixSeedsBrokerOffice(t *testing.T) {
 			}
 			if _, ok := memberBySlug[LibrarianSlug]; !ok {
 				t.Fatalf("expected built-in librarian in office roster, got %+v", members)
+			}
+			if _, ok := memberBySlug[company.AppBuilderSlug]; !ok {
+				t.Fatalf("expected built-in app-builder in office roster, got %+v", members)
 			}
 			for _, starter := range blueprint.Starter.Agents {
 				member, ok := memberBySlug[starter.Slug]

--- a/internal/team/prompt_apps.go
+++ b/internal/team/prompt_apps.go
@@ -1,0 +1,38 @@
+package team
+
+import "strings"
+
+// prompt_apps.go — the Apps guidance injected into office-mode agent prompts.
+// Every agent gets the awareness rule (notice repetition -> propose_app); the
+// App Builder gets the full build-and-publish playbook.
+
+func isAppBuilderAgent(slug, role string) bool {
+	if strings.EqualFold(strings.TrimSpace(slug), appBuilderSlug) {
+		return true
+	}
+	return strings.Contains(strings.ToLower(role), "app build")
+}
+
+func appsPromptBlock(slug, role string) string {
+	if isAppBuilderAgent(slug, role) {
+		return appBuilderPromptBlock()
+	}
+	return appsAwarenessPromptBlock()
+}
+
+func appsAwarenessPromptBlock() string {
+	return "APPS: When a workflow is repeatable — you or the human have done the same multi-step thing two or three times, or the human asks for something recurring — consider turning it into an App (a small internal tool). FIRST call list_apps to see what already exists; if a related app is there, propose improving it (propose_app with its app_id) instead of duplicating. Then call propose_app with a clear name, a description of what it does and the workflow it automates, and why it helps. That raises a NON-BLOCKING approval the human can Approve, Approve-with-note, or Reject; on approval the App Builder builds it automatically — you do not build it yourself and you do not block waiting. Do NOT call propose_app when the human used /create-app, /update-app, or explicitly told you to build it — that work is already authorized; just confirm it is underway.\n"
+}
+
+func appBuilderPromptBlock() string {
+	return "YOU ARE THE APP BUILDER. You turn approved app requests into small, dependable internal tools and publish them so they appear under Apps. Your work arrives as Issues owned by you, titled \"Build app: …\" or \"Improve app: …\".\n" +
+		"BUILD IN THE OPEN — NARRATE LIKE A LIVESTREAM. The human is watching your task channel in real time, with a live preview of the app beside it. Think out loud in plain first-person prose as you work: say what you are about to do and why, the design decisions you are weighing and the call you make (\"I'll group tasks by status, not owner, because the digest is scanned top-down\"), what you just learned from reading the data, and each milestone as you hit it (\"Scaffold copied\", \"Wiring the table to getTasks…\", \"Running the build…\", \"Build passed — publishing v1\"). This narration is your normal message text — it streams straight to the channel — so keep it flowing and conversational, a sentence or two at each step, not one silent stretch then a summary. Surface surprises and course-corrections honestly (\"the first layout felt cramped, switching to a two-column split\"). Do NOT paste raw tool output, code dumps, or file contents into the chat — describe what you are doing, not the bytes.\n" +
+		"How to build one:\n" +
+		"1. Read the task brief and say back, in a sentence, what you are going to build and your plan. For an \"Improve\" task, call get_app(app_id) first to read the current source and manifest, and note what you found.\n" +
+		"2. Copy the scaffold at templates/app-scaffold/ to a scratch dir (if it is missing, run `bun create vite@latest . --template react-ts`, add vite-plugin-singlefile, and set base:'./'). READ templates/app-scaffold/AI_RULES.md — it is the build contract.\n" +
+		"3. Implement the tool in src/, narrating the structure and the key choices as you go. Read workspace data ONLY through src/wuphf-bridge.ts (callBroker / getOfficeMembers / getTasks). NEVER use fetch/XHR/WebSocket — the sandbox blocks all network except the bridge.\n" +
+		"4. Build ONE self-contained file: `bun install && bun run build` produces dist/index.html with all JS and CSS inlined. The scaffold ships a committed bun.lock, so `bun install` is fast and resolves from cache. No external scripts, styles, fonts, or images; inline data: images only; no @import. Say when the build is running and whether it passed; if it fails, say what broke and how you are fixing it.\n" +
+		"5. Publish with register_app: pass the COMPLETE contents of dist/index.html as `html`, AND the source project as `files` (src/*, package.json, vite.config.ts, index.html, tsconfig.json — EXCLUDE node_modules and dist), plus a clear name, emoji icon, summary, and description. Persisting source is what makes the next edit reliable instead of a from-scratch rebuild. For an improvement, pass the existing app_id so it updates in place; every publish keeps a rollback snapshot. Publishing early and iterating is good — the live preview updates on every publish, so a rough first version the human can see beats a long silent build.\n" +
+		"6. Tell the human it is live (or what changed) and where to look, then complete the task.\n" +
+		"Keep apps simple and focused, with strong defaults and real empty/loading/error states. Never invent secrets or login flows — the bridge uses the signed-in user's own session.\n"
+}

--- a/internal/team/prompt_builder.go
+++ b/internal/team/prompt_builder.go
@@ -458,6 +458,11 @@ func (p *promptBuilder) Build(slug string) string {
 		sb.WriteString("Never launch another WUPHF office from inside your turn (`wuphf`, `./wuphf`, `/reset`, or a new browser instance). The office is already running; inspect the current repo and UI instead.\n")
 	}
 
+	// Apps guidance for every office agent: awareness of propose_app for most,
+	// the full build playbook for the App Builder.
+	sb.WriteString("\n")
+	sb.WriteString(appsPromptBlock(slug, member.Role))
+
 	return sb.String()
 }
 

--- a/internal/team/rich_artifact.go
+++ b/internal/team/rich_artifact.go
@@ -7,14 +7,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"sort"
 	"strings"
 	"time"
-
-	"golang.org/x/net/html"
 )
 
 const (
@@ -362,41 +359,11 @@ func validateRichArtifactHTMLPolicy(html string) error {
 }
 
 func validateRichArtifactSandboxPolicy(raw string) error {
-	tokenizer := html.NewTokenizer(strings.NewReader(raw))
-	styleDepth := 0
-	for {
-		tt := tokenizer.Next()
-		switch tt {
-		case html.ErrorToken:
-			if errors.Is(tokenizer.Err(), io.EOF) {
-				return nil
-			}
-			return newRichArtifactCallerError("visual artifact: html parse failed: %v", tokenizer.Err())
-		case html.StartTagToken, html.SelfClosingTagToken:
-			token := tokenizer.Token()
-			tag := strings.ToLower(token.Data)
-			if reason, blocked := richArtifactBlockedElementReason(tag); blocked {
-				return newRichArtifactCallerError("visual artifact: html element <%s> is not allowed: %s", tag, reason)
-			}
-			if tag == "style" && tt == html.StartTagToken {
-				styleDepth++
-			}
-			if err := validateRichArtifactAttributes(tag, token.Attr); err != nil {
-				return err
-			}
-		case html.EndTagToken:
-			token := tokenizer.Token()
-			if strings.EqualFold(token.Data, "style") && styleDepth > 0 {
-				styleDepth--
-			}
-		case html.TextToken:
-			if styleDepth > 0 {
-				if err := validateRichArtifactCSS(tokenizer.Token().Data); err != nil {
-					return err
-				}
-			}
-		}
-	}
+	return validateSandboxHTML(raw, sandboxHTMLPolicy{
+		label:          "visual artifact",
+		blockedElement: richArtifactBlockedElementReason,
+		newErr:         newRichArtifactCallerError,
+	})
 }
 
 func richArtifactBlockedElementReason(tag string) (string, bool) {
@@ -411,85 +378,6 @@ func richArtifactBlockedElementReason(tag string) (string, bool) {
 		return "external stylesheets and preloads are not allowed", true
 	default:
 		return "", false
-	}
-}
-
-func validateRichArtifactAttributes(tag string, attrs []html.Attribute) error {
-	metaRefresh := false
-	for _, attr := range attrs {
-		key := strings.ToLower(strings.TrimSpace(attr.Key))
-		value := strings.TrimSpace(attr.Val)
-		if strings.HasPrefix(key, "on") && len(key) > 2 {
-			return newRichArtifactCallerError("visual artifact: html attribute %s on <%s> is not allowed", key, tag)
-		}
-		switch key {
-		case "srcset":
-			return newRichArtifactCallerError("visual artifact: html attribute %s on <%s> is not allowed", key, tag)
-		case "style":
-			if err := validateRichArtifactCSS(value); err != nil {
-				return err
-			}
-		case "http-equiv":
-			metaRefresh = tag == "meta" && strings.EqualFold(value, "refresh")
-		}
-		if tag == "script" && key == "src" {
-			return newRichArtifactCallerError("visual artifact: external script src is not allowed")
-		}
-		if richArtifactURLAttribute(key) {
-			if err := validateRichArtifactURL(tag, key, value); err != nil {
-				return err
-			}
-		}
-	}
-	if metaRefresh {
-		return newRichArtifactCallerError("visual artifact: meta refresh is not allowed")
-	}
-	return nil
-}
-
-func richArtifactURLAttribute(attr string) bool {
-	switch attr {
-	case "action", "formaction", "href", "poster", "src", "xlink:href":
-		return true
-	default:
-		return false
-	}
-}
-
-func validateRichArtifactURL(tag, attr, value string) error {
-	if value == "" || strings.HasPrefix(value, "#") {
-		return nil
-	}
-	lower := strings.ToLower(value)
-	if strings.HasPrefix(lower, "data:") || strings.HasPrefix(lower, "blob:") {
-		return nil
-	}
-	return newRichArtifactCallerError("visual artifact: <%s> %s must use a data/blob URL or fragment reference", tag, attr)
-}
-
-func validateRichArtifactCSS(css string) error {
-	if containsASCIIFold(css, "@import") {
-		return newRichArtifactCallerError("visual artifact: css @import is not allowed (including empty data: URLs); use system fonts like Georgia, Times, Cambria, or Courier directly in font-family")
-	}
-	if containsASCIIFold(css, "expression(") {
-		return newRichArtifactCallerError("visual artifact: css expression() is not allowed")
-	}
-	for offset := 0; ; {
-		idx := indexASCIIFold(css[offset:], "url(")
-		if idx < 0 {
-			return nil
-		}
-		start := offset + idx + len("url(")
-		endRel := strings.Index(css[start:], ")")
-		if endRel < 0 {
-			return newRichArtifactCallerError("visual artifact: css url() is malformed")
-		}
-		end := start + endRel
-		value := strings.Trim(strings.TrimSpace(css[start:end]), `"'`)
-		if err := validateRichArtifactURL("style", "url()", value); err != nil {
-			return err
-		}
-		offset = end + 1
 	}
 }
 

--- a/internal/team/sandbox_html_policy.go
+++ b/internal/team/sandbox_html_policy.go
@@ -1,0 +1,144 @@
+package team
+
+// sandbox_html_policy.go is the single write-time HTML sandbox validator shared
+// by rich artifacts and Apps. The two are identical except for which elements
+// are blocked (Apps permit <form>) and the error label/constructor, so the walk,
+// attribute checks, URL checks, and CSS checks live here once. Keeping one copy
+// of a security boundary means a future tightening can't be applied to one and
+// forgotten on the other.
+
+import (
+	"errors"
+	"io"
+	"strings"
+
+	"golang.org/x/net/html"
+)
+
+// sandboxHTMLPolicy parameterizes the shared validator. blockedElement decides
+// per-tag rejection (the one real divergence: <form>), label + newErr shape the
+// caller-facing error. The error messages preserve the substrings asserted by
+// existing tests ("external script src is not allowed", "css @import is not
+// allowed").
+type sandboxHTMLPolicy struct {
+	label          string
+	blockedElement func(tag string) (string, bool)
+	newErr         func(format string, args ...any) error
+}
+
+func validateSandboxHTML(raw string, p sandboxHTMLPolicy) error {
+	tokenizer := html.NewTokenizer(strings.NewReader(raw))
+	styleDepth := 0
+	for {
+		tt := tokenizer.Next()
+		switch tt {
+		case html.ErrorToken:
+			if errors.Is(tokenizer.Err(), io.EOF) {
+				return nil
+			}
+			return p.newErr("%s: html parse failed: %v", p.label, tokenizer.Err())
+		case html.StartTagToken, html.SelfClosingTagToken:
+			token := tokenizer.Token()
+			tag := strings.ToLower(token.Data)
+			if reason, blocked := p.blockedElement(tag); blocked {
+				return p.newErr("%s: html element <%s> is not allowed: %s", p.label, tag, reason)
+			}
+			if tag == "style" && tt == html.StartTagToken {
+				styleDepth++
+			}
+			if err := validateSandboxAttributes(tag, token.Attr, p); err != nil {
+				return err
+			}
+		case html.EndTagToken:
+			token := tokenizer.Token()
+			if strings.EqualFold(token.Data, "style") && styleDepth > 0 {
+				styleDepth--
+			}
+		case html.TextToken:
+			if styleDepth > 0 {
+				if err := validateSandboxCSS(tokenizer.Token().Data, p); err != nil {
+					return err
+				}
+			}
+		}
+	}
+}
+
+func validateSandboxAttributes(tag string, attrs []html.Attribute, p sandboxHTMLPolicy) error {
+	metaRefresh := false
+	for _, attr := range attrs {
+		key := strings.ToLower(strings.TrimSpace(attr.Key))
+		value := strings.TrimSpace(attr.Val)
+		if strings.HasPrefix(key, "on") && len(key) > 2 {
+			return p.newErr("%s: html attribute %s on <%s> is not allowed", p.label, key, tag)
+		}
+		switch key {
+		case "srcset":
+			return p.newErr("%s: html attribute %s on <%s> is not allowed", p.label, key, tag)
+		case "style":
+			if err := validateSandboxCSS(value, p); err != nil {
+				return err
+			}
+		case "http-equiv":
+			metaRefresh = tag == "meta" && strings.EqualFold(value, "refresh")
+		}
+		if tag == "script" && key == "src" {
+			return p.newErr("%s: external script src is not allowed", p.label)
+		}
+		if sandboxURLAttribute(key) {
+			if err := validateSandboxURL(tag, key, value, p); err != nil {
+				return err
+			}
+		}
+	}
+	if metaRefresh {
+		return p.newErr("%s: meta refresh is not allowed", p.label)
+	}
+	return nil
+}
+
+func sandboxURLAttribute(attr string) bool {
+	switch attr {
+	case "action", "formaction", "href", "poster", "src", "xlink:href":
+		return true
+	default:
+		return false
+	}
+}
+
+func validateSandboxURL(tag, attr, value string, p sandboxHTMLPolicy) error {
+	if value == "" || strings.HasPrefix(value, "#") {
+		return nil
+	}
+	lower := strings.ToLower(value)
+	if strings.HasPrefix(lower, "data:") || strings.HasPrefix(lower, "blob:") {
+		return nil
+	}
+	return p.newErr("%s: <%s> %s must use a data/blob URL or fragment reference (no network access)", p.label, tag, attr)
+}
+
+func validateSandboxCSS(css string, p sandboxHTMLPolicy) error {
+	if containsASCIIFold(css, "@import") {
+		return p.newErr("%s: css @import is not allowed; inline fonts/styles or use system fonts (Georgia, Times, Cambria, Courier)", p.label)
+	}
+	if containsASCIIFold(css, "expression(") {
+		return p.newErr("%s: css expression() is not allowed", p.label)
+	}
+	for offset := 0; ; {
+		idx := indexASCIIFold(css[offset:], "url(")
+		if idx < 0 {
+			return nil
+		}
+		start := offset + idx + len("url(")
+		endRel := strings.Index(css[start:], ")")
+		if endRel < 0 {
+			return p.newErr("%s: css url() is malformed", p.label)
+		}
+		end := start + endRel
+		value := strings.Trim(strings.TrimSpace(css[start:end]), `"'`)
+		if err := validateSandboxURL("style", "url()", value, p); err != nil {
+			return err
+		}
+		offset = end + 1
+	}
+}

--- a/internal/teammcp/app_tools.go
+++ b/internal/teammcp/app_tools.go
@@ -1,0 +1,245 @@
+package teammcp
+
+// app_tools.go — MCP tools for Apps (agent-generated internal tools).
+//
+//   list_apps     (all agents)      check what already exists before proposing
+//   propose_app   (all agents)      raise a NON-BLOCKING approval to build/improve
+//   get_app       (App Builder)     read an app's current source before editing
+//   register_app  (App Builder)     publish the built single-file app
+//
+// The build itself is the App Builder agent's job — it scaffolds a real
+// Vite/React/TS project, builds a single self-contained index.html, and calls
+// register_app. Other agents only ever discover (list_apps) and propose
+// (propose_app); they never write app bytes.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// appBuilderSlug mirrors company.AppBuilderSlug / team's appBuilderSlug. Kept
+// local so this package gates on the slug without importing the broker just for
+// one identifier; the three MUST stay in sync.
+const appBuilderSlug = "app-builder"
+
+// ListAppsArgs has no inputs — it returns every app in the office.
+type ListAppsArgs struct{}
+
+// GetAppArgs identifies one app to read.
+type GetAppArgs struct {
+	AppID string `json:"app_id" jsonschema:"The app id (app_0123456789abcdef) from list_apps."`
+}
+
+// ProposeAppArgs raises a non-blocking approval to build or improve an app.
+type ProposeAppArgs struct {
+	MySlug      string `json:"my_slug,omitempty" jsonschema:"Your agent slug. Defaults to WUPHF_AGENT_SLUG."`
+	Channel     string `json:"channel,omitempty" jsonschema:"Channel to raise the proposal in. Defaults to your current channel."`
+	Name        string `json:"name" jsonschema:"Short product name for the tool, e.g. 'Lead Scorer'."`
+	Icon        string `json:"icon,omitempty" jsonschema:"Optional emoji icon for the app."`
+	Summary     string `json:"summary,omitempty" jsonschema:"One-line summary of what the tool does."`
+	Description string `json:"description" jsonschema:"What the app should do, the repeatable workflow it automates, and why it is worth building."`
+	AppID       string `json:"app_id,omitempty" jsonschema:"Set ONLY when improving an EXISTING app you found via list_apps, instead of creating a duplicate."`
+}
+
+// RegisterAppArgs publishes the built single-file app. App Builder only.
+type RegisterAppArgs struct {
+	MySlug      string `json:"my_slug,omitempty" jsonschema:"Your agent slug. Defaults to WUPHF_AGENT_SLUG."`
+	AppID       string `json:"app_id,omitempty" jsonschema:"Set to update an existing app in place; leave empty to create a new one."`
+	Name        string `json:"name" jsonschema:"The app's display name."`
+	Icon        string `json:"icon,omitempty" jsonschema:"Optional emoji icon."`
+	Summary     string `json:"summary,omitempty" jsonschema:"One-line summary shown in the sidebar."`
+	Description string `json:"description,omitempty" jsonschema:"What the app does — keep this current as it evolves."`
+	HTML        string `json:"html" jsonschema:"The COMPLETE self-contained index.html: all JS/CSS inlined (vite-plugin-singlefile). No external scripts/styles/fonts and no network fetches — read workspace data only through the injected WUPHF bridge (window.parent postMessage)."`
+	// Files is the source project so future edits modify real files instead of
+	// regenerating from prose. Strongly recommended.
+	Files map[string]string `json:"files,omitempty" jsonschema:"The app's SOURCE project as a map of relative path -> file content (e.g. src/App.tsx, package.json, vite.config.ts). EXCLUDE node_modules and dist. Persisting source is how an operator's later edit is reliable instead of a from-scratch regeneration."`
+}
+
+// registerAppTools wires the Apps tools. Discovery + proposal are open to every
+// agent; the build/publish tools are gated to the App Builder.
+func registerAppTools(server *mcp.Server, slug string) {
+	mcp.AddTool(server, readOnlyTool(
+		"list_apps",
+		"List the internal tools (Apps) that already exist in this office. ALWAYS call this before proposing a new app: if a related app exists, propose improving it (propose_app with app_id) instead of creating a duplicate.",
+	), handleListApps)
+	mcp.AddTool(server, officeWriteTool(
+		"propose_app",
+		"Propose building (or improving) an internal tool when you notice a repeatable workflow. Raises a NON-BLOCKING approval card the human can Approve, Approve-with-note, or Reject. Do NOT use this when the human used /create-app, /update-app, or explicitly asked you to build — in that case the build is already authorized. After proposing, keep working; do not block waiting for the answer. On approval the App Builder builds it automatically.",
+	), handleProposeApp)
+	if strings.EqualFold(strings.TrimSpace(slug), appBuilderSlug) {
+		mcp.AddTool(server, readOnlyTool(
+			"get_app",
+			"Read an existing app's manifest and current HTML so you can edit it. App Builder only.",
+		), handleGetApp)
+		mcp.AddTool(server, officeWriteTool(
+			"register_app",
+			"Publish a built app so it appears under Apps. Pass the COMPLETE self-contained index.html. Set app_id to update an existing app in place. App Builder only.",
+		), handleRegisterApp)
+	}
+}
+
+func handleListApps(ctx context.Context, _ *mcp.CallToolRequest, _ ListAppsArgs) (*mcp.CallToolResult, any, error) {
+	var result struct {
+		Apps []map[string]any `json:"apps"`
+	}
+	if err := brokerGetJSON(ctx, "/apps", &result); err != nil {
+		return toolError(err), nil, nil
+	}
+	if result.Apps == nil {
+		result.Apps = []map[string]any{}
+	}
+	payload, err := json.Marshal(result.Apps)
+	if err != nil {
+		return toolError(fmt.Errorf("marshal apps list: %w", err)), nil, nil
+	}
+	return textResult(string(payload)), nil, nil
+}
+
+func handleGetApp(ctx context.Context, _ *mcp.CallToolRequest, args GetAppArgs) (*mcp.CallToolResult, any, error) {
+	id := strings.TrimSpace(args.AppID)
+	if err := validateCustomAppIDLocal(id); err != nil {
+		return toolError(err), nil, nil
+	}
+	var result map[string]any
+	// ?source=1 so the App Builder gets the editable source project back, not
+	// just the built bundle — this is what makes an edit reliable.
+	if err := brokerGetJSON(ctx, "/apps/"+url.PathEscape(id)+"?source=1", &result); err != nil {
+		return toolError(err), nil, nil
+	}
+	payload, err := json.Marshal(result)
+	if err != nil {
+		return toolError(fmt.Errorf("marshal app: %w", err)), nil, nil
+	}
+	return textResult(string(payload)), nil, nil
+}
+
+func handleProposeApp(ctx context.Context, _ *mcp.CallToolRequest, args ProposeAppArgs) (*mcp.CallToolResult, any, error) {
+	slug, err := resolveSlug(args.MySlug)
+	if err != nil {
+		return toolError(err), nil, nil
+	}
+	name := strings.TrimSpace(args.Name)
+	if name == "" {
+		return toolError(fmt.Errorf("name is required")), nil, nil
+	}
+	description := strings.TrimSpace(args.Description)
+	if description == "" {
+		return toolError(fmt.Errorf("description is required: explain what the app does and the workflow it automates")), nil, nil
+	}
+	appID := strings.TrimSpace(args.AppID)
+	if appID != "" {
+		if err := validateCustomAppIDLocal(appID); err != nil {
+			return toolError(err), nil, nil
+		}
+	}
+	location := resolveConversationContext(ctx, slug, args.Channel, "")
+	channel := location.Channel
+
+	verb := "Build a new internal tool"
+	if appID != "" {
+		verb = "Improve the app"
+	}
+	question := fmt.Sprintf("%s: %s?", verb, name)
+	var contextText strings.Builder
+	if summary := strings.TrimSpace(args.Summary); summary != "" {
+		contextText.WriteString(summary)
+		contextText.WriteString("\n\n")
+	}
+	contextText.WriteString("What it does:\n")
+	contextText.WriteString(description)
+	contextText.WriteString("\n\nOn approval, the App Builder will scaffold a small React/TypeScript app and register it under Apps. Approve, Approve with note (to add constraints), or Reject.")
+
+	dedupeKey := "app-proposal:" + slug + ":" + strings.ToLower(name)
+	if appID != "" {
+		dedupeKey += ":" + appID
+	}
+
+	var created struct {
+		ID      string `json:"id"`
+		Deduped bool   `json:"deduped"`
+	}
+	if err := brokerPostJSON(ctx, "/requests", map[string]any{
+		"kind":       "approval",
+		"channel":    channel,
+		"from":       slug,
+		"title":      question,
+		"question":   question,
+		"context":    contextText.String(),
+		"blocking":   false,
+		"required":   false,
+		"dedupe_key": dedupeKey,
+		"app_proposal": map[string]any{
+			"name":        name,
+			"icon":        strings.TrimSpace(args.Icon),
+			"summary":     strings.TrimSpace(args.Summary),
+			"description": description,
+			"app_id":      appID,
+		},
+	}, &created); err != nil {
+		return toolError(err), nil, nil
+	}
+	if strings.TrimSpace(created.ID) == "" {
+		return toolError(fmt.Errorf("proposal did not return an ID")), nil, nil
+	}
+	return textResult(fmt.Sprintf(
+		"Raised a non-blocking app proposal (%s) in #%s. The human can Approve, Approve-with-note, or Reject; on approval the App Builder builds it. Keep working — do not block waiting for the decision.",
+		created.ID, channel,
+	)), nil, nil
+}
+
+func handleRegisterApp(ctx context.Context, _ *mcp.CallToolRequest, args RegisterAppArgs) (*mcp.CallToolResult, any, error) {
+	slug, err := resolveSlug(args.MySlug)
+	if err != nil {
+		return toolError(err), nil, nil
+	}
+	name := strings.TrimSpace(args.Name)
+	if name == "" {
+		return toolError(fmt.Errorf("name is required")), nil, nil
+	}
+	if strings.TrimSpace(args.HTML) == "" {
+		return toolError(fmt.Errorf("html is required: pass the complete self-contained index.html")), nil, nil
+	}
+	appID := strings.TrimSpace(args.AppID)
+	if appID != "" {
+		if err := validateCustomAppIDLocal(appID); err != nil {
+			return toolError(err), nil, nil
+		}
+	}
+	var result map[string]any
+	if err := brokerPostJSON(ctx, "/apps", map[string]any{
+		"id":          appID,
+		"name":        name,
+		"icon":        strings.TrimSpace(args.Icon),
+		"summary":     strings.TrimSpace(args.Summary),
+		"description": strings.TrimSpace(args.Description),
+		"html":        args.HTML,
+		"files":       args.Files,
+		"actor":       slug,
+	}, &result); err != nil {
+		return toolError(err), nil, nil
+	}
+	payload, err := json.Marshal(result)
+	if err != nil {
+		return toolError(fmt.Errorf("marshal register_app response: %w", err)), nil, nil
+	}
+	return textResult(string(payload)), nil, nil
+}
+
+// validateCustomAppIDLocal mirrors the broker's validateCustomAppID so the tool
+// rejects a malformed id before a round-trip.
+func validateCustomAppIDLocal(id string) error {
+	if len(id) != len("app_")+16 || !strings.HasPrefix(id, "app_") {
+		return fmt.Errorf("app_id must look like app_0123456789abcdef; got %q", id)
+	}
+	for _, ch := range strings.TrimPrefix(id, "app_") {
+		if !((ch >= 'a' && ch <= 'f') || (ch >= '0' && ch <= '9')) {
+			return fmt.Errorf("app_id must look like app_0123456789abcdef; got %q", id)
+		}
+	}
+	return nil
+}

--- a/internal/teammcp/server.go
+++ b/internal/teammcp/server.go
@@ -332,6 +332,9 @@ func configureServerTools(server *mcp.Server, slug string, channel string, oneOn
 	), handleTeamSkillRun)
 	registerSkillTools(server)
 	registerRoutineTools(server)
+	// Apps: every agent can discover (list_apps) and propose (propose_app); the
+	// build/publish tools (get_app, register_app) are gated to the App Builder.
+	registerAppTools(server, slug)
 
 	// Gate external-action tools behind a configured provider. Registering 14
 	// empty action tools inflates the MCP tool schema and pushes the total

--- a/templates/app-scaffold/.gitignore
+++ b/templates/app-scaffold/.gitignore
@@ -1,0 +1,7 @@
+node_modules/
+dist/
+*.tsbuildinfo
+
+# bun.lock is intentionally committed: it pins the scaffold's dependencies so
+# every App build is deterministic and `bun install` resolves from cache
+# (fast + offline) instead of re-resolving from the network each time.

--- a/templates/app-scaffold/AI_RULES.md
+++ b/templates/app-scaffold/AI_RULES.md
@@ -1,0 +1,42 @@
+# AI_RULES — building a WUPHF App
+
+These rules are the contract for any App Builder work on this project. Read them
+before editing and keep them satisfied; the publish step (`register_app`) and the
+sandbox enforce most of them, so breaking one means a broken or rejected app.
+
+## Stack (do not swap)
+
+- React 19 + TypeScript, built with Vite + `vite-plugin-singlefile`.
+- Plain CSS in `src/styles.css` using the system font stack. No Tailwind, no UI
+  kit, no CSS framework, no icon font — keep the bundle small and self-contained.
+
+## Hard rules
+
+1. **Self-contained output.** `bun run build` must emit ONE `dist/index.html`
+   with all JS and CSS inlined. No external scripts, stylesheets, fonts, or
+   images. No `@import`. Images must be inline `data:`/`blob:` URLs.
+2. **No direct network.** The app runs in a sandbox with `connect-src 'none'`.
+   NEVER use `fetch`, `XMLHttpRequest`, or `WebSocket`. Read workspace data ONLY
+   through `src/wuphf-bridge.ts` (`callBroker` / `getOfficeMembers` / `getTasks`).
+   The bridge is read-only and limited to an allowlist of broker GET paths.
+3. **No secrets, no auth.** The app never holds a token; the host bridge uses the
+   signed-in user's session. Do not invent API keys or login flows.
+4. **Keep it one app.** Single SPA, no router needed for a focused tool. Don't add
+   server code, databases, or build steps beyond Vite.
+5. **Protected files.** Do not change the bridge wire contract in
+   `src/wuphf-bridge.ts` (the `wuphf-app` / `wuphf-host` message shape) or
+   `vite.config.ts`'s singlefile setup — they must match the WUPHF host.
+
+## Style
+
+- Clear hierarchy, legible defaults, real empty/loading/error states.
+- Light surface; the app renders on white inside WUPHF.
+- camelCase variables, PascalCase components, `is/has/should` booleans.
+
+## Build & publish
+
+```bash
+bun install
+bun run build          # produces dist/index.html (single file)
+# then call the register_app MCP tool with the contents of dist/index.html
+```

--- a/templates/app-scaffold/README.md
+++ b/templates/app-scaffold/README.md
@@ -1,0 +1,25 @@
+# WUPHF App scaffold
+
+A minimal Vite + React + TypeScript project that builds to a single
+self-contained `index.html`. The built-in **App Builder** agent copies this
+scaffold to build internal tools ("Apps") for an office.
+
+## How the App Builder uses it
+
+1. Copy this directory to a scratch workspace.
+2. Read `AI_RULES.md` — it is the build contract.
+3. Edit `src/App.tsx` (and add components/styles) to implement the requested tool.
+   Read workspace data through `src/wuphf-bridge.ts`, never `fetch`.
+4. `bun install && bun run build` → `dist/index.html` (one self-contained file).
+5. Call the `register_app` MCP tool with the contents of `dist/index.html` to
+   publish it under **Apps**.
+
+If this scaffold is not present (e.g. an `npx wuphf` install with no repo
+checkout), create the equivalent with `bun create vite@latest . --template
+react-ts`, add `vite-plugin-singlefile`, set `base: "./"`, and copy
+`src/wuphf-bridge.ts` + `AI_RULES.md` from this template's documented contract.
+
+## Local preview
+
+`bun run dev` serves it at the Vite dev URL. The office roster panel is a live
+demo of the bridge; replace it with the real tool.

--- a/templates/app-scaffold/bun.lock
+++ b/templates/app-scaffold/bun.lock
@@ -1,0 +1,272 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "wuphf-app",
+      "dependencies": {
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0",
+      },
+      "devDependencies": {
+        "@types/react": "^19.0.0",
+        "@types/react-dom": "^19.0.0",
+        "@vitejs/plugin-react": "^4.3.4",
+        "typescript": "^5.7.0",
+        "vite": "^6.0.0",
+        "vite-plugin-singlefile": "^2.1.0",
+      },
+    },
+  },
+  "packages": {
+    "@babel/code-frame": ["@babel/code-frame@7.29.7", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.29.7", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw=="],
+
+    "@babel/compat-data": ["@babel/compat-data@7.29.7", "", {}, "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg=="],
+
+    "@babel/core": ["@babel/core@7.29.7", "", { "dependencies": { "@babel/code-frame": "^7.29.7", "@babel/generator": "^7.29.7", "@babel/helper-compilation-targets": "^7.29.7", "@babel/helper-module-transforms": "^7.29.7", "@babel/helpers": "^7.29.7", "@babel/parser": "^7.29.7", "@babel/template": "^7.29.7", "@babel/traverse": "^7.29.7", "@babel/types": "^7.29.7", "@jridgewell/remapping": "^2.3.5", "convert-source-map": "^2.0.0", "debug": "^4.1.0", "gensync": "^1.0.0-beta.2", "json5": "^2.2.3", "semver": "^6.3.1" } }, "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA=="],
+
+    "@babel/generator": ["@babel/generator@7.29.7", "", { "dependencies": { "@babel/parser": "^7.29.7", "@babel/types": "^7.29.7", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "jsesc": "^3.0.2" } }, "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ=="],
+
+    "@babel/helper-compilation-targets": ["@babel/helper-compilation-targets@7.29.7", "", { "dependencies": { "@babel/compat-data": "^7.29.7", "@babel/helper-validator-option": "^7.29.7", "browserslist": "^4.24.0", "lru-cache": "^5.1.1", "semver": "^6.3.1" } }, "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g=="],
+
+    "@babel/helper-globals": ["@babel/helper-globals@7.29.7", "", {}, "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA=="],
+
+    "@babel/helper-module-imports": ["@babel/helper-module-imports@7.29.7", "", { "dependencies": { "@babel/traverse": "^7.29.7", "@babel/types": "^7.29.7" } }, "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g=="],
+
+    "@babel/helper-module-transforms": ["@babel/helper-module-transforms@7.29.7", "", { "dependencies": { "@babel/helper-module-imports": "^7.29.7", "@babel/helper-validator-identifier": "^7.29.7", "@babel/traverse": "^7.29.7" }, "peerDependencies": { "@babel/core": "^7.0.0" } }, "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg=="],
+
+    "@babel/helper-plugin-utils": ["@babel/helper-plugin-utils@7.29.7", "", {}, "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw=="],
+
+    "@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
+
+    "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
+    "@babel/helper-validator-option": ["@babel/helper-validator-option@7.29.7", "", {}, "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw=="],
+
+    "@babel/helpers": ["@babel/helpers@7.29.7", "", { "dependencies": { "@babel/template": "^7.29.7", "@babel/types": "^7.29.7" } }, "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg=="],
+
+    "@babel/parser": ["@babel/parser@7.29.7", "", { "dependencies": { "@babel/types": "^7.29.7" }, "bin": "./bin/babel-parser.js" }, "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg=="],
+
+    "@babel/plugin-transform-react-jsx-self": ["@babel/plugin-transform-react-jsx-self@7.29.7", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.29.7" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw=="],
+
+    "@babel/plugin-transform-react-jsx-source": ["@babel/plugin-transform-react-jsx-source@7.29.7", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.29.7" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q=="],
+
+    "@babel/template": ["@babel/template@7.29.7", "", { "dependencies": { "@babel/code-frame": "^7.29.7", "@babel/parser": "^7.29.7", "@babel/types": "^7.29.7" } }, "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg=="],
+
+    "@babel/traverse": ["@babel/traverse@7.29.7", "", { "dependencies": { "@babel/code-frame": "^7.29.7", "@babel/generator": "^7.29.7", "@babel/helper-globals": "^7.29.7", "@babel/parser": "^7.29.7", "@babel/template": "^7.29.7", "@babel/types": "^7.29.7", "debug": "^4.3.1" } }, "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw=="],
+
+    "@babel/types": ["@babel/types@7.29.7", "", { "dependencies": { "@babel/helper-string-parser": "^7.29.7", "@babel/helper-validator-identifier": "^7.29.7" } }, "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA=="],
+
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.12", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA=="],
+
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.25.12", "", { "os": "android", "cpu": "arm" }, "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg=="],
+
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.25.12", "", { "os": "android", "cpu": "arm64" }, "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg=="],
+
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.25.12", "", { "os": "android", "cpu": "x64" }, "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg=="],
+
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.25.12", "", { "os": "darwin", "cpu": "arm64" }, "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg=="],
+
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.25.12", "", { "os": "darwin", "cpu": "x64" }, "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA=="],
+
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.25.12", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg=="],
+
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.25.12", "", { "os": "freebsd", "cpu": "x64" }, "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ=="],
+
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.25.12", "", { "os": "linux", "cpu": "arm" }, "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw=="],
+
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.25.12", "", { "os": "linux", "cpu": "arm64" }, "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ=="],
+
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.25.12", "", { "os": "linux", "cpu": "ia32" }, "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA=="],
+
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng=="],
+
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw=="],
+
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.25.12", "", { "os": "linux", "cpu": "ppc64" }, "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA=="],
+
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w=="],
+
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.25.12", "", { "os": "linux", "cpu": "s390x" }, "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg=="],
+
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.25.12", "", { "os": "linux", "cpu": "x64" }, "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw=="],
+
+    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.25.12", "", { "os": "none", "cpu": "arm64" }, "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg=="],
+
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.25.12", "", { "os": "none", "cpu": "x64" }, "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ=="],
+
+    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.25.12", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A=="],
+
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.25.12", "", { "os": "openbsd", "cpu": "x64" }, "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw=="],
+
+    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.25.12", "", { "os": "none", "cpu": "arm64" }, "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg=="],
+
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.25.12", "", { "os": "sunos", "cpu": "x64" }, "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w=="],
+
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.25.12", "", { "os": "win32", "cpu": "arm64" }, "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg=="],
+
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.25.12", "", { "os": "win32", "cpu": "ia32" }, "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ=="],
+
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.12", "", { "os": "win32", "cpu": "x64" }, "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA=="],
+
+    "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
+
+    "@jridgewell/remapping": ["@jridgewell/remapping@2.3.5", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ=="],
+
+    "@jridgewell/resolve-uri": ["@jridgewell/resolve-uri@3.1.2", "", {}, "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw=="],
+
+    "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
+
+    "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-beta.27", "", {}, "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA=="],
+
+    "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.62.0", "", { "os": "android", "cpu": "arm" }, "sha512-IPIQ55ythEHkfEd9jMEi32OQ7SxURsGA43JI22lj01OLZNt2NUbJX8YUHxkVWyQ6daHPNn0truF5nSj3DQp6YQ=="],
+
+    "@rollup/rollup-android-arm64": ["@rollup/rollup-android-arm64@4.62.0", "", { "os": "android", "cpu": "arm64" }, "sha512-M6s9cr10MibETyo8JsOkq+Lo1+lU6hcvb1MApnUql5qte/5hMEgzlN8/ReIKNfRV8rrqX50W1BX9zoUhC192RA=="],
+
+    "@rollup/rollup-darwin-arm64": ["@rollup/rollup-darwin-arm64@4.62.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-BqCoMoIbn0keKys+dEAdBa70EtOwV1bEsQCUgU9FdiZmmMge/Zk7LlkYGqbrdHR+Frnt0E1FOanly+rlwvvQzw=="],
+
+    "@rollup/rollup-darwin-x64": ["@rollup/rollup-darwin-x64@4.62.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-SIMzST3VFNXDAbeIWDWiFCNM5qncUBDWaEV7NfE7oZbDt2mgfW4MvbKdbYiGOLoM32gbTv608UMd0XktEYSD7w=="],
+
+    "@rollup/rollup-freebsd-arm64": ["@rollup/rollup-freebsd-arm64@4.62.0", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-ezjfSQMP7ArdUsbBwbQIfwAlhE84I2iVnzQNCFSveqV42q+BmKlzVpf7mxv5EchLcoWU4y6/heFzVg1F+hodUQ=="],
+
+    "@rollup/rollup-freebsd-x64": ["@rollup/rollup-freebsd-x64@4.62.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-9+qTWGW9AZRhnUgwtTwzNwcPlL87ngkeN0LA+q1bADvmY9aNvWaF2TFW8BZgnQPYxpDI7+rMVLivcd4V737TAQ=="],
+
+    "@rollup/rollup-linux-arm-gnueabihf": ["@rollup/rollup-linux-arm-gnueabihf@4.62.0", "", { "os": "linux", "cpu": "arm" }, "sha512-T1dMEQhXA/jkJ/jyMIw9IovK8bSUq7A8kLIlvZTb/6YIVsp2zLavr4F3oyllHWo7eIVJRyE5n3tUjQJEbE1IuQ=="],
+
+    "@rollup/rollup-linux-arm-musleabihf": ["@rollup/rollup-linux-arm-musleabihf@4.62.0", "", { "os": "linux", "cpu": "arm" }, "sha512-2as0LgT7qQpyceQq6VUJYnumUMUrgGQCWIiDIN9DE0/tglsk6o66uCB4f3djRawAltvfCNLyZZrsqbPA6inCsA=="],
+
+    "@rollup/rollup-linux-arm64-gnu": ["@rollup/rollup-linux-arm64-gnu@4.62.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-bVURMg+6eNN9C/yc0aVjooZcwTTtYF4YW3xta5pP0//r3o1V8gXEHXWCndj47w/HhwsFroZrFhR+6uQP5T0n0g=="],
+
+    "@rollup/rollup-linux-arm64-musl": ["@rollup/rollup-linux-arm64-musl@4.62.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-Ful8pM/2yYI83PViWdFdpZhdI8HJ5qsXANe5atypbHDf+KIBBDsZsbyy8hbXnULVvW9NsTh5DHwbcBftyLTfiw=="],
+
+    "@rollup/rollup-linux-loong64-gnu": ["@rollup/rollup-linux-loong64-gnu@4.62.0", "", { "os": "linux", "cpu": "none" }, "sha512-9Gp/DgrkzfUBmNPVTyPTvay+4xEP7M/clXpj3efXBcm6uTIVIgDg4rqUpqKXvLEuFRVuEpSAOkhgNeecvaZ4Cg=="],
+
+    "@rollup/rollup-linux-loong64-musl": ["@rollup/rollup-linux-loong64-musl@4.62.0", "", { "os": "linux", "cpu": "none" }, "sha512-m9tsJz54LUXkSYM8+8PG81B9IKK5r+2T0clMq4QrS16xFosufU7firBDAZEsDheDs7wTlP7h3++S7lMsU955HA=="],
+
+    "@rollup/rollup-linux-ppc64-gnu": ["@rollup/rollup-linux-ppc64-gnu@4.62.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-3UvJ5PNVU16aJf6M3tFI24pWzAl2/ynfbyRN3ICyQajK1lSkrnVYNnLz3v04J32qKa0FczJc22zeToc0lr2A3w=="],
+
+    "@rollup/rollup-linux-ppc64-musl": ["@rollup/rollup-linux-ppc64-musl@4.62.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-vRWUAbYLGHBZS6Q8Msb2sfnf1fvJf+47t8l/TwOerM2qArzy+IeNMTHrYLHXh95h8MoatPHI5hhSZNs+mGXKPg=="],
+
+    "@rollup/rollup-linux-riscv64-gnu": ["@rollup/rollup-linux-riscv64-gnu@4.62.0", "", { "os": "linux", "cpu": "none" }, "sha512-c00T5SYENHAt86cfW47URaP3Us5vLC/4QO7GYud1G5VNRffCwwCuBspwqYrriuJB+5m0WFzClCn9wed0FBjKvg=="],
+
+    "@rollup/rollup-linux-riscv64-musl": ["@rollup/rollup-linux-riscv64-musl@4.62.0", "", { "os": "linux", "cpu": "none" }, "sha512-krrCDilhXOwFkSkO3Wm9I/f9H0L92XHHwy2fwxjukxIbh0dem8gZqOW5Y8BsHrpJv5qwlRBV+Wl4ZFyRWhUpwg=="],
+
+    "@rollup/rollup-linux-s390x-gnu": ["@rollup/rollup-linux-s390x-gnu@4.62.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-7pfYFSTc4/rUC/FtAI0Qp6QthDBCIi6/AuP1xYqFk5vanI6KnL5dWKP60OM/05LOsbwTmIcvr6eXC4CJuJ75IA=="],
+
+    "@rollup/rollup-linux-x64-gnu": ["@rollup/rollup-linux-x64-gnu@4.62.0", "", { "os": "linux", "cpu": "x64" }, "sha512-7SDIalKeIpG0Ifogbbdn58HmSotYMlf23K3dCJEmiVd9Fg36Vmni82iPQec27N3wY4Bvbxftkxz6vSx9OcouTg=="],
+
+    "@rollup/rollup-linux-x64-musl": ["@rollup/rollup-linux-x64-musl@4.62.0", "", { "os": "linux", "cpu": "x64" }, "sha512-eRZevouTH2i1HeAVLqJuLnt256krQkGY0TN6WsTmsIhuzbh457HuWDMakKwmi0Cjadux983CoSr8Lim2QhUIFw=="],
+
+    "@rollup/rollup-openbsd-x64": ["@rollup/rollup-openbsd-x64@4.62.0", "", { "os": "openbsd", "cpu": "x64" }, "sha512-3oVS7FLGa4U1qcvao9ylGxrjXZyUQqR8UwxEcnUEyPX53O/C/mKDZegNXTdHCP+h3e6ta/f1EN38Yif1mmZHYg=="],
+
+    "@rollup/rollup-openharmony-arm64": ["@rollup/rollup-openharmony-arm64@4.62.0", "", { "os": "none", "cpu": "arm64" }, "sha512-yTB9TgfWj5wHe5QgktAgXTLLot1gvEjl1NiPPAUiCs4oPrIWFl5V4nC3GrkNdj9LaAU4s94nVrGbGOCqUpyWsg=="],
+
+    "@rollup/rollup-win32-arm64-msvc": ["@rollup/rollup-win32-arm64-msvc@4.62.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-5LOhoaesY3doG1c+ac/2JtgREpKoJr5bUHH8tKY0V8di7+uSV6BwLs2PlR0/yzefGOkR+wE7ZolZphHCsyG5Rw=="],
+
+    "@rollup/rollup-win32-ia32-msvc": ["@rollup/rollup-win32-ia32-msvc@4.62.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-yYkWHhmbhRTWTnWos5HC4GcPQfjlzzCNbM9e/+GXrLuaBXYA3qSDR9f0Vgufd5S8yX81U8jPKp7ZnAjZFMtRnw=="],
+
+    "@rollup/rollup-win32-x64-gnu": ["@rollup/rollup-win32-x64-gnu@4.62.0", "", { "os": "win32", "cpu": "x64" }, "sha512-SoTb6lPg25xZlA2ibwQ++ahCCnH+FP0qmEuafMJ4gznZKOlXioKEAeJLgCrqjM98ACziXM9V1amFjICVL4IFoA=="],
+
+    "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.62.0", "", { "os": "win32", "cpu": "x64" }, "sha512-5L+T1fMX4RIEBoZzT0+sQ0PhTS36NULFmMXtl1TZo44TMAROIMHbZufSOjVWt/Y622BtxgxtaNOokbTDvfsrZA=="],
+
+    "@types/babel__core": ["@types/babel__core@7.20.5", "", { "dependencies": { "@babel/parser": "^7.20.7", "@babel/types": "^7.20.7", "@types/babel__generator": "*", "@types/babel__template": "*", "@types/babel__traverse": "*" } }, "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA=="],
+
+    "@types/babel__generator": ["@types/babel__generator@7.27.0", "", { "dependencies": { "@babel/types": "^7.0.0" } }, "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg=="],
+
+    "@types/babel__template": ["@types/babel__template@7.4.4", "", { "dependencies": { "@babel/parser": "^7.1.0", "@babel/types": "^7.0.0" } }, "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A=="],
+
+    "@types/babel__traverse": ["@types/babel__traverse@7.28.0", "", { "dependencies": { "@babel/types": "^7.28.2" } }, "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q=="],
+
+    "@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
+
+    "@types/react": ["@types/react@19.2.17", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw=="],
+
+    "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
+
+    "@vitejs/plugin-react": ["@vitejs/plugin-react@4.7.0", "", { "dependencies": { "@babel/core": "^7.28.0", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-beta.27", "@types/babel__core": "^7.20.5", "react-refresh": "^0.17.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0" } }, "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA=="],
+
+    "baseline-browser-mapping": ["baseline-browser-mapping@2.10.37", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-girxaJ7WZssDOFhzCGZTDKoTa1gk6A1TbflaYTpykLJ4UU9Fz9kx1aREM8JCuoVHbL8X8T/mJg7w2oYSq72Oig=="],
+
+    "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
+
+    "browserslist": ["browserslist@4.28.2", "", { "dependencies": { "baseline-browser-mapping": "^2.10.12", "caniuse-lite": "^1.0.30001782", "electron-to-chromium": "^1.5.328", "node-releases": "^2.0.36", "update-browserslist-db": "^1.2.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg=="],
+
+    "caniuse-lite": ["caniuse-lite@1.0.30001799", "", {}, "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw=="],
+
+    "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
+
+    "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "electron-to-chromium": ["electron-to-chromium@1.5.372", "", {}, "sha512-M3yhbAlilnwqC8D21t28UCDGHyitShTmmLRU/H+b74P6Ski16Nb9HONYEaVpMj/pwC7BEo5B95FpjODLCWbtfA=="],
+
+    "esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
+
+    "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
+
+    "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
+
+    "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
+
+    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "gensync": ["gensync@1.0.0-beta.2", "", {}, "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="],
+
+    "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
+
+    "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
+
+    "jsesc": ["jsesc@3.1.0", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
+
+    "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
+
+    "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
+
+    "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "nanoid": ["nanoid@3.3.12", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ=="],
+
+    "node-releases": ["node-releases@2.0.47", "", {}, "sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og=="],
+
+    "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
+
+    "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
+
+    "postcss": ["postcss@8.5.15", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A=="],
+
+    "react": ["react@19.2.7", "", {}, "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ=="],
+
+    "react-dom": ["react-dom@19.2.7", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.7" } }, "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ=="],
+
+    "react-refresh": ["react-refresh@0.17.0", "", {}, "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ=="],
+
+    "rollup": ["rollup@4.62.0", "", { "dependencies": { "@types/estree": "1.0.9" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.62.0", "@rollup/rollup-android-arm64": "4.62.0", "@rollup/rollup-darwin-arm64": "4.62.0", "@rollup/rollup-darwin-x64": "4.62.0", "@rollup/rollup-freebsd-arm64": "4.62.0", "@rollup/rollup-freebsd-x64": "4.62.0", "@rollup/rollup-linux-arm-gnueabihf": "4.62.0", "@rollup/rollup-linux-arm-musleabihf": "4.62.0", "@rollup/rollup-linux-arm64-gnu": "4.62.0", "@rollup/rollup-linux-arm64-musl": "4.62.0", "@rollup/rollup-linux-loong64-gnu": "4.62.0", "@rollup/rollup-linux-loong64-musl": "4.62.0", "@rollup/rollup-linux-ppc64-gnu": "4.62.0", "@rollup/rollup-linux-ppc64-musl": "4.62.0", "@rollup/rollup-linux-riscv64-gnu": "4.62.0", "@rollup/rollup-linux-riscv64-musl": "4.62.0", "@rollup/rollup-linux-s390x-gnu": "4.62.0", "@rollup/rollup-linux-x64-gnu": "4.62.0", "@rollup/rollup-linux-x64-musl": "4.62.0", "@rollup/rollup-openbsd-x64": "4.62.0", "@rollup/rollup-openharmony-arm64": "4.62.0", "@rollup/rollup-win32-arm64-msvc": "4.62.0", "@rollup/rollup-win32-ia32-msvc": "4.62.0", "@rollup/rollup-win32-x64-gnu": "4.62.0", "@rollup/rollup-win32-x64-msvc": "4.62.0", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-nc72Wgq62I7rtDV4izT5/aaS0zxy3kttkinf9586ApknY3jZO9NYsmtc24fUckA0X7Q2v+ML4a15pdUlV5V/jA=="],
+
+    "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
+
+    "semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
+
+    "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "update-browserslist-db": ["update-browserslist-db@1.2.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w=="],
+
+    "vite": ["vite@6.4.3", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.4.4", "picomatch": "^4.0.2", "postcss": "^8.5.3", "rollup": "^4.34.9", "tinyglobby": "^0.2.13" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "jiti": ">=1.21.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A=="],
+
+    "vite-plugin-singlefile": ["vite-plugin-singlefile@2.3.3", "", { "dependencies": { "micromatch": "^4.0.8" }, "peerDependencies": { "rollup": "^4.59.0", "vite": "^5.4.21 || ^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["rollup"] }, "sha512-XVnGH0QzbOa8fxRSsHdCarVN1BSBXNi7uLMQYlrGRN5apdHkk62XQWRJhVever0lnfuyBkwn+kvVChdm/OoOUg=="],
+
+    "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
+
+    "micromatch/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
+  }
+}

--- a/templates/app-scaffold/index.html
+++ b/templates/app-scaffold/index.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <!--
+      Self-contained policy: WUPHF re-injects this same CSP when it renders the
+      app, but declaring it here keeps `bun run dev` honest about the runtime
+      sandbox (no network except the host bridge; inline JS/CSS only).
+    -->
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; img-src data: blob:; font-src data:; connect-src 'none'; base-uri 'none'"
+    />
+    <title>WUPHF App</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/templates/app-scaffold/package.json
+++ b/templates/app-scaffold/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "wuphf-app",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build"
+  },
+  "dependencies": {
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  },
+  "devDependencies": {
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "@vitejs/plugin-react": "^4.3.4",
+    "typescript": "^5.7.0",
+    "vite": "^6.0.0",
+    "vite-plugin-singlefile": "^2.1.0"
+  }
+}

--- a/templates/app-scaffold/src/App.tsx
+++ b/templates/app-scaffold/src/App.tsx
@@ -1,0 +1,53 @@
+import { useEffect, useState } from "react";
+
+import { getOfficeMembers, type OfficeMember } from "./wuphf-bridge";
+
+/**
+ * Starter App. Replace this with the actual internal tool. It demonstrates the
+ * one pattern that matters: read workspace data through the WUPHF bridge
+ * (callBroker / getOfficeMembers / getTasks), never fetch() the network.
+ */
+export function App() {
+  const [members, setMembers] = useState<OfficeMember[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    getOfficeMembers()
+      .then((res) => setMembers(res.members ?? []))
+      .catch((err: unknown) =>
+        setError(err instanceof Error ? err.message : "failed to load"),
+      );
+  }, []);
+
+  return (
+    <main className="app">
+      <header className="app__header">
+        <h1 className="app__title">Your new app</h1>
+        <p className="app__subtitle">
+          Edit <code>src/App.tsx</code>. Read workspace data with the bridge
+          (<code>callBroker</code>) — the sandbox blocks all other network.
+        </p>
+      </header>
+
+      <section className="app__panel">
+        <h2 className="app__panel-title">Office roster (bridge demo)</h2>
+        {error ? (
+          <p className="app__error">{error}</p>
+        ) : members === null ? (
+          <p className="app__muted">Loading…</p>
+        ) : members.length === 0 ? (
+          <p className="app__muted">No members.</p>
+        ) : (
+          <ul className="app__list">
+            {members.map((m) => (
+              <li key={m.slug} className="app__list-item">
+                <span className="app__list-name">{m.name}</span>
+                {m.role ? <span className="app__list-meta">{m.role}</span> : null}
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </main>
+  );
+}

--- a/templates/app-scaffold/src/main.tsx
+++ b/templates/app-scaffold/src/main.tsx
@@ -1,0 +1,14 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+
+import { App } from "./App";
+import "./styles.css";
+
+const root = document.getElementById("root");
+if (root) {
+  createRoot(root).render(
+    <StrictMode>
+      <App />
+    </StrictMode>,
+  );
+}

--- a/templates/app-scaffold/src/styles.css
+++ b/templates/app-scaffold/src/styles.css
@@ -1,0 +1,110 @@
+/*
+ * Self-contained styles only. No @import, no Google Fonts, no external assets —
+ * the sandbox blocks them. Use the system font stack. Keep it clean and legible;
+ * the app renders on a light surface inside WUPHF.
+ */
+
+:root {
+  --ink: #14181f;
+  --muted: #687083;
+  --line: rgba(20, 24, 31, 0.12);
+  --accent: #1342ff;
+  color-scheme: light;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family:
+    system-ui,
+    -apple-system,
+    "Segoe UI",
+    Roboto,
+    Helvetica,
+    Arial,
+    sans-serif;
+  color: var(--ink);
+  background: #fff;
+}
+
+.app {
+  max-width: 760px;
+  margin: 0 auto;
+  padding: 28px 24px 40px;
+}
+
+.app__title {
+  margin: 0 0 6px;
+  font-size: 24px;
+  font-weight: 650;
+}
+
+.app__subtitle {
+  margin: 0;
+  color: var(--muted);
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+.app__subtitle code,
+code {
+  font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  font-size: 0.9em;
+  background: rgba(20, 24, 31, 0.06);
+  padding: 1px 5px;
+  border-radius: 4px;
+}
+
+.app__panel {
+  margin-top: 24px;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 16px 18px;
+}
+
+.app__panel-title {
+  margin: 0 0 12px;
+  font-size: 13px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--muted);
+}
+
+.app__list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.app__list-item {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  padding: 8px 10px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+}
+
+.app__list-name {
+  font-weight: 550;
+}
+
+.app__list-meta {
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.app__muted {
+  color: var(--muted);
+}
+
+.app__error {
+  color: #d2453f;
+}

--- a/templates/app-scaffold/src/wuphf-bridge.ts
+++ b/templates/app-scaffold/src/wuphf-bridge.ts
@@ -1,0 +1,92 @@
+/**
+ * wuphf-bridge — the ONLY way a WUPHF App reaches workspace data.
+ *
+ * The app runs inside a hardened sandbox (opaque origin, CSP connect-src 'none'),
+ * so fetch/XHR/WebSocket are blocked. Data flows through window.parent via
+ * postMessage to the WUPHF host, which services a small READ-ONLY allowlist of
+ * broker GETs using the signed-in user's own session. Never call fetch() — it
+ * will be blocked. Use callBroker() instead.
+ *
+ * Wire contract (must match web/src/components/apps/CustomAppFrame.tsx):
+ *   app  -> host : { source: "wuphf-app",  type: "broker", id, method:"GET", path }
+ *   host -> app  : { source: "wuphf-host", id, ok, data? , error? }
+ */
+
+interface PendingResolver {
+  resolve: (value: unknown) => void;
+  reject: (error: Error) => void;
+}
+
+const pending = new Map<number, PendingResolver>();
+let nextId = 1;
+let listening = false;
+
+function ensureListener(): void {
+  if (listening) return;
+  listening = true;
+  window.addEventListener("message", (event: MessageEvent) => {
+    const data = event.data as
+      | { source?: string; id?: number; ok?: boolean; data?: unknown; error?: string }
+      | null;
+    if (!data || data.source !== "wuphf-host" || typeof data.id !== "number") {
+      return;
+    }
+    const resolver = pending.get(data.id);
+    if (!resolver) return;
+    pending.delete(data.id);
+    if (data.ok) {
+      resolver.resolve(data.data);
+    } else {
+      resolver.reject(new Error(data.error ?? "broker request failed"));
+    }
+  });
+}
+
+/**
+ * callBroker issues a read-only GET against the WUPHF broker through the host
+ * bridge. `path` must be one of the allowlisted prefixes (see the host):
+ *   /apps  /tasks  /office-members  /channels  /requests
+ *   /wiki/list  /wiki/catalog  /wiki/read  /wiki/tree
+ */
+export function callBroker<T = unknown>(path: string): Promise<T> {
+  ensureListener();
+  const id = nextId++;
+  return new Promise<T>((resolve, reject) => {
+    pending.set(id, { resolve: resolve as (v: unknown) => void, reject });
+    window.parent.postMessage(
+      { source: "wuphf-app", type: "broker", id, method: "GET", path },
+      "*",
+    );
+    // Fail loudly rather than hang forever if the host never replies.
+    window.setTimeout(() => {
+      if (pending.has(id)) {
+        pending.delete(id);
+        reject(new Error("broker request timed out"));
+      }
+    }, 15_000);
+  });
+}
+
+// ── Typed convenience wrappers for the common reads ─────────────────────────
+
+export interface OfficeMember {
+  slug: string;
+  name: string;
+  role?: string;
+}
+
+export interface OfficeTask {
+  id: string;
+  title: string;
+  owner?: string;
+  status?: string;
+  lifecycle_state?: string;
+}
+
+export function getOfficeMembers(): Promise<{ members: OfficeMember[] }> {
+  return callBroker<{ members: OfficeMember[] }>("/office-members");
+}
+
+export function getTasks(): Promise<{ tasks: OfficeTask[] }> {
+  return callBroker<{ tasks: OfficeTask[] }>("/tasks");
+}

--- a/templates/app-scaffold/tsconfig.json
+++ b/templates/app-scaffold/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src"]
+}

--- a/templates/app-scaffold/vite.config.ts
+++ b/templates/app-scaffold/vite.config.ts
@@ -1,0 +1,21 @@
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
+import { viteSingleFile } from "vite-plugin-singlefile";
+
+// Build a SINGLE self-contained index.html: all JS + CSS inlined, no external
+// requests. That one file is what register_app publishes; WUPHF renders it in a
+// sandboxed iframe with connect-src 'none', so nothing external would load
+// anyway. base: "./" keeps any residual asset refs relative.
+export default defineConfig({
+  base: "./",
+  plugins: [react(), viteSingleFile()],
+  build: {
+    target: "esnext",
+    cssCodeSplit: false,
+    assetsInlineLimit: 100_000_000,
+    chunkSizeWarningLimit: 4096,
+    rollupOptions: {
+      output: { inlineDynamicImports: true },
+    },
+  },
+});

--- a/templates/app-scaffold/vite.config.ts
+++ b/templates/app-scaffold/vite.config.ts
@@ -2,6 +2,13 @@ import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 import { viteSingleFile } from "vite-plugin-singlefile";
 
+// During a WUPHF live preview the broker runs `bun run dev` and fronts it with a
+// reverse proxy on a distinct 127.0.0.1 port (it injects the security CSP — do
+// not rely on serving headers here). WUPHF_HMR_CLIENT_PORT is that proxy port:
+// Vite's HMR client must connect back through it, not the raw Vite port (which
+// the proxy CSP blocks as cross-origin). Unset outside a preview (normal build).
+const hmrClientPort = Number(process.env.WUPHF_HMR_CLIENT_PORT) || undefined;
+
 // Build a SINGLE self-contained index.html: all JS + CSS inlined, no external
 // requests. That one file is what register_app publishes; WUPHF renders it in a
 // sandboxed iframe with connect-src 'none', so nothing external would load
@@ -9,6 +16,10 @@ import { viteSingleFile } from "vite-plugin-singlefile";
 export default defineConfig({
   base: "./",
   plugins: [react(), viteSingleFile()],
+  server: {
+    host: "127.0.0.1",
+    ...(hmrClientPort ? { hmr: { clientPort: hmrClientPort } } : {}),
+  },
   build: {
     target: "esnext",
     cssCodeSplit: false,

--- a/web/src/api/apps.ts
+++ b/web/src/api/apps.ts
@@ -62,6 +62,34 @@ export async function rollbackApp(
   return res.app;
 }
 
+/**
+ * Live dev-server preview status (GET /apps/{id}/dev). The broker runs a real
+ * Vite dev server per app behind a CSP-injecting proxy; `url` is the proxy
+ * origin to load in the iframe once `ready`. Until then `boot_log` streams the
+ * install/boot output. Mirrors the Go appDevStatus shape.
+ */
+export interface AppDevStatus {
+  ready: boolean;
+  url?: string;
+  boot_log?: string;
+  error?: string;
+}
+
+/** Ensure the app's live dev server is running and return its status. */
+export async function ensureAppDev(id: string): Promise<AppDevStatus> {
+  return get<AppDevStatus>(`/apps/${encodeURIComponent(id)}/dev`);
+}
+
+/** Poll the dev server's status without (re)starting it. */
+export async function getAppDevStatus(id: string): Promise<AppDevStatus> {
+  return get<AppDevStatus>(`/apps/${encodeURIComponent(id)}/dev/status`);
+}
+
+/** Tear down the app's live dev server. */
+export async function stopAppDev(id: string): Promise<void> {
+  await post(`/apps/${encodeURIComponent(id)}/dev/stop`, { actor: "human" });
+}
+
 export interface AppBuildRequest {
   name: string;
   description: string;

--- a/web/src/api/apps.ts
+++ b/web/src/api/apps.ts
@@ -1,0 +1,121 @@
+import { del, get, post } from "./client";
+import type { Task, TaskResponse } from "./tasks";
+
+/**
+ * CustomApp is the manifest for an agent-generated internal tool. Mirrors the
+ * Go CustomApp shape (internal/team/custom_app.go).
+ */
+export interface CustomApp {
+  id: string;
+  slug: string;
+  name: string;
+  icon: string;
+  summary?: string;
+  description?: string;
+  entry: string;
+  version: number;
+  createdBy: string;
+  updatedBy?: string;
+  createdAt: string;
+  updatedAt: string;
+  contentHash: string;
+}
+
+export interface CustomAppDetail {
+  app: CustomApp;
+  html: string;
+}
+
+export async function listApps(): Promise<CustomApp[]> {
+  const res = await get<{ apps: CustomApp[] }>("/apps");
+  return res.apps ?? [];
+}
+
+export async function getApp(id: string): Promise<CustomAppDetail> {
+  return get<CustomAppDetail>(`/apps/${encodeURIComponent(id)}`);
+}
+
+export async function deleteApp(id: string): Promise<void> {
+  await del(`/apps/${encodeURIComponent(id)}`);
+}
+
+export async function listAppVersions(id: string): Promise<number[]> {
+  const res = await get<{ versions: number[] }>(
+    `/apps/${encodeURIComponent(id)}/versions`,
+  );
+  return res.versions ?? [];
+}
+
+/**
+ * rollbackApp restores a prior version's bytes as a new forward version. History
+ * is append-only, so a rollback is itself reversible — this is the trust net that
+ * lets operators edit a depended-on tool without fear.
+ */
+export async function rollbackApp(
+  id: string,
+  version: number,
+): Promise<CustomApp> {
+  const res = await post<{ app: CustomApp }>(
+    `/apps/${encodeURIComponent(id)}/rollback`,
+    { version, actor: "human" },
+  );
+  return res.app;
+}
+
+export interface AppBuildRequest {
+  name: string;
+  description: string;
+  icon?: string;
+  summary?: string;
+  /** Set when improving an existing app rather than creating a new one. */
+  appId?: string;
+}
+
+/**
+ * requestAppBuild kicks off an App Builder task for an explicit, human-initiated
+ * build/improve (the /create-app, /update-app slash commands and the Edit button
+ * on an app screen). These paths skip the propose_app approval gate because the
+ * human already authorized the work. Implicit agent intent goes through
+ * propose_app -> a non-blocking approval instead.
+ *
+ * Returns the created Task so the caller can open its chat — an App Builder
+ * build is a normal task, and the human watches it happen in the task channel
+ * (with the live preview) rather than being left with a fire-and-forget toast.
+ */
+export async function requestAppBuild(req: AppBuildRequest): Promise<Task> {
+  const verb = req.appId ? "Improve" : "Build";
+  const title = `${verb} app: ${req.name}`;
+  const res = await post<TaskResponse>("/tasks", {
+    action: "create",
+    channel: "general",
+    title,
+    details: composeAppBrief(req),
+    owner: "app-builder",
+    created_by: "human",
+    task_type: "issue",
+  });
+  return res.task;
+}
+
+function composeAppBrief(req: AppBuildRequest): string {
+  const lines: string[] = [];
+  if (req.appId) {
+    lines.push(`Improve the existing app \`${req.appId}\` ("${req.name}").`);
+    lines.push(
+      "First call get_app to read its current source and manifest, then apply the change below.",
+    );
+  } else {
+    lines.push(`Build a new internal tool named "${req.name}".`);
+  }
+  if (req.summary?.trim()) {
+    lines.push("", `Summary: ${req.summary.trim()}`);
+  }
+  lines.push("", "What it should do:", req.description.trim());
+  lines.push(
+    "",
+    `When the build passes, register it with register_app${
+      req.appId ? ` (app_id=${req.appId})` : ""
+    } so it appears under Apps.`,
+  );
+  return lines.join("\n");
+}

--- a/web/src/components/apps/AppBuildPreview.test.tsx
+++ b/web/src/components/apps/AppBuildPreview.test.tsx
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+
+import type { CustomApp } from "../../api/apps";
+import {
+  parseAppNameFromTaskTitle,
+  resolveAppForTask,
+} from "./AppBuildPreview";
+
+function makeApp(overrides: Partial<CustomApp>): CustomApp {
+  return {
+    id: "app_0000000000000000",
+    slug: "app",
+    name: "App",
+    icon: "🧩",
+    entry: "index.html",
+    version: 1,
+    createdBy: "app-builder",
+    createdAt: "2026-06-15T00:00:00Z",
+    updatedAt: "2026-06-15T00:00:00Z",
+    contentHash: "abc",
+    ...overrides,
+  };
+}
+
+describe("parseAppNameFromTaskTitle", () => {
+  it("parses the App Builder task title verbs", () => {
+    expect(parseAppNameFromTaskTitle("Build app: Daily Agent Digest")).toBe(
+      "Daily Agent Digest",
+    );
+    expect(parseAppNameFromTaskTitle("Improve app: Lead Scorer")).toBe(
+      "Lead Scorer",
+    );
+    // Case-insensitive verb + trims surrounding whitespace.
+    expect(parseAppNameFromTaskTitle("  improve APP:  Lead Scorer  ")).toBe(
+      "Lead Scorer",
+    );
+  });
+
+  it("returns null for non-app task titles", () => {
+    expect(parseAppNameFromTaskTitle("Fix the login bug")).toBeNull();
+    expect(parseAppNameFromTaskTitle("appify the dashboard")).toBeNull();
+    expect(parseAppNameFromTaskTitle("")).toBeNull();
+  });
+});
+
+describe("resolveAppForTask", () => {
+  it("matches the app by name, case-insensitively", () => {
+    const apps = [
+      makeApp({ id: "app_a", name: "Lead Scorer" }),
+      makeApp({ id: "app_b", name: "Daily Agent Digest" }),
+    ];
+    expect(resolveAppForTask(apps, "daily agent digest")?.id).toBe("app_b");
+  });
+
+  it("prefers the most recently updated app when names collide", () => {
+    const apps = [
+      makeApp({
+        id: "app_old",
+        name: "Digest",
+        updatedAt: "2026-06-15T00:00:00Z",
+      }),
+      makeApp({
+        id: "app_new",
+        name: "Digest",
+        updatedAt: "2026-06-15T02:00:00Z",
+      }),
+    ];
+    expect(resolveAppForTask(apps, "Digest")?.id).toBe("app_new");
+  });
+
+  it("returns undefined when nothing matches or the name is null", () => {
+    const apps = [makeApp({ name: "Lead Scorer" })];
+    expect(resolveAppForTask(apps, "Daily Agent Digest")).toBeUndefined();
+    expect(resolveAppForTask(apps, null)).toBeUndefined();
+    expect(resolveAppForTask([], "Anything")).toBeUndefined();
+  });
+});

--- a/web/src/components/apps/AppBuildPreview.tsx
+++ b/web/src/components/apps/AppBuildPreview.tsx
@@ -4,7 +4,7 @@ import { OpenNewWindow } from "iconoir-react";
 
 import { type CustomApp, getApp, listApps } from "../../api/apps";
 import { router } from "../../lib/router";
-import { CustomAppFrame } from "./CustomAppFrame";
+import { AppLivePreview } from "./AppLivePreview";
 
 // Poll briefly while a build is in flight so a freshly-registered app (or a new
 // version) shows up in the preview within a few seconds, no reload needed.
@@ -93,7 +93,7 @@ export function AppBuildPreview({ taskTitle }: AppBuildPreviewProps) {
     );
   }
 
-  const { app: meta, html } = detail.data;
+  const { app: meta } = detail.data;
 
   return (
     <section className="app-build-preview" aria-label="App preview">
@@ -130,7 +130,7 @@ export function AppBuildPreview({ taskTitle }: AppBuildPreviewProps) {
         </button>
       </div>
       <div className="app-build-preview__frame">
-        <CustomAppFrame html={html} title={meta.name} />
+        <AppLivePreview appId={meta.id} title={meta.name} />
       </div>
     </section>
   );

--- a/web/src/components/apps/AppBuildPreview.tsx
+++ b/web/src/components/apps/AppBuildPreview.tsx
@@ -1,0 +1,137 @@
+import { useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { OpenNewWindow } from "iconoir-react";
+
+import { type CustomApp, getApp, listApps } from "../../api/apps";
+import { router } from "../../lib/router";
+import { CustomAppFrame } from "./CustomAppFrame";
+
+// Poll briefly while a build is in flight so a freshly-registered app (or a new
+// version) shows up in the preview within a few seconds, no reload needed.
+const PREVIEW_POLL_MS = 4000;
+
+/**
+ * Parse the app name out of an App Builder task title. Both the slash-command
+ * path (api/apps.ts) and the broker proposal path (broker_apps_proposal.go)
+ * format the title as "<verb> app: <name>", so this is a reliable correlation
+ * without a wire-shape change. Returns null when the title isn't an app task.
+ */
+export function parseAppNameFromTaskTitle(title: string): string | null {
+  const match = title.match(
+    /^\s*(?:build|improve|create|update)\s+app:\s*(.+?)\s*$/i,
+  );
+  return match ? match[1] : null;
+}
+
+/** Pick the app a build task is producing: exact name match, newest wins. */
+export function resolveAppForTask(
+  apps: CustomApp[],
+  appName: string | null,
+): CustomApp | undefined {
+  if (!appName) return undefined;
+  const wanted = appName.trim().toLowerCase();
+  const matches = apps.filter((a) => a.name.trim().toLowerCase() === wanted);
+  if (matches.length === 0) return undefined;
+  return matches.sort((a, b) =>
+    (b.updatedAt ?? "").localeCompare(a.updatedAt ?? ""),
+  )[0];
+}
+
+interface AppBuildPreviewProps {
+  /** The task title — the app name is parsed from it. */
+  taskTitle: string;
+}
+
+/**
+ * AppBuildPreview is the live preview pane shown beside the chat on an App
+ * Builder task. It resolves the app the task is building (by name) and renders
+ * it in the same hardened sandbox as the full app surface, refreshing as new
+ * versions are published. Until the first version lands it shows a building
+ * placeholder, so the 20–60s build is never dead air.
+ */
+export function AppBuildPreview({ taskTitle }: AppBuildPreviewProps) {
+  const appName = useMemo(
+    () => parseAppNameFromTaskTitle(taskTitle),
+    [taskTitle],
+  );
+
+  const appsQuery = useQuery({
+    queryKey: ["apps"],
+    queryFn: listApps,
+    refetchInterval: PREVIEW_POLL_MS,
+  });
+
+  const app = useMemo(
+    () => resolveAppForTask(appsQuery.data ?? [], appName),
+    [appsQuery.data, appName],
+  );
+
+  const detail = useQuery({
+    queryKey: ["app", app?.id],
+    queryFn: () => getApp(app?.id ?? ""),
+    enabled: Boolean(app?.id),
+    refetchInterval: PREVIEW_POLL_MS,
+  });
+
+  if (!(app && detail.data)) {
+    return (
+      <section className="app-build-preview" aria-label="App preview">
+        <div className="app-build-preview__header">
+          <span className="app-build-preview__title">Preview</span>
+        </div>
+        <div className="app-build-preview__state" role="status">
+          <span className="app-build-preview__spinner" aria-hidden="true" />
+          <p className="app-build-preview__state-title">
+            {appName ? `Building ${appName}…` : "Waiting for the App Builder…"}
+          </p>
+          <p className="app-build-preview__state-detail">
+            The live preview appears here the moment the App Builder publishes
+            its first version.
+          </p>
+        </div>
+      </section>
+    );
+  }
+
+  const { app: meta, html } = detail.data;
+
+  return (
+    <section className="app-build-preview" aria-label="App preview">
+      <div className="app-build-preview__header">
+        <span className="app-build-preview__icon" aria-hidden="true">
+          {meta.icon || "🧩"}
+        </span>
+        <span className="app-build-preview__title" title={meta.name}>
+          {meta.name}
+        </span>
+        <span className="app-build-preview__live">
+          <span className="app-build-preview__live-dot" aria-hidden="true" />
+          Live
+        </span>
+        <span
+          className="app-build-preview__version"
+          title={`Updated ${meta.updatedAt}`}
+        >
+          v{meta.version}
+        </span>
+        <button
+          type="button"
+          className="app-build-preview__open"
+          aria-label="Open app full screen"
+          title="Open full screen"
+          onClick={() =>
+            void router.navigate({
+              to: "/apps/$appId",
+              params: { appId: meta.id },
+            })
+          }
+        >
+          <OpenNewWindow width={14} height={14} />
+        </button>
+      </div>
+      <div className="app-build-preview__frame">
+        <CustomAppFrame html={html} title={meta.name} />
+      </div>
+    </section>
+  );
+}

--- a/web/src/components/apps/AppLivePreview.tsx
+++ b/web/src/components/apps/AppLivePreview.tsx
@@ -1,0 +1,107 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { ensureAppDev } from "../../api/apps";
+import { CustomAppFrame } from "./CustomAppFrame";
+
+const DEV_POLL_MS = 1500;
+
+/**
+ * The dev preview iframe loads `devUrl` directly with allow-same-origin, so the
+ * URL is security-critical: it must be a loopback http origin (the broker always
+ * returns one, but the iframe sandbox model can't depend on a server invariant).
+ * Reject anything else rather than frame a non-loopback origin.
+ */
+function isLoopbackDevUrl(url: string | undefined): url is string {
+  if (!url) return false;
+  try {
+    const u = new URL(url);
+    return (
+      u.protocol === "http:" &&
+      (u.hostname === "127.0.0.1" || u.hostname === "localhost")
+    );
+  } catch {
+    return false;
+  }
+}
+
+interface AppLivePreviewProps {
+  appId: string;
+  title: string;
+}
+
+/**
+ * AppLivePreview runs the app's live dev server (Vite + HMR behind the broker's
+ * CSP-injecting proxy) and renders it the instant it boots — edits hot-reload in
+ * the frame with no rebuild. While the server is installing/starting it streams
+ * the boot log instead of a frozen placeholder, so the wait is never dead air.
+ */
+export function AppLivePreview({ appId, title }: AppLivePreviewProps) {
+  const { data, isError, error } = useQuery({
+    queryKey: ["app-dev", appId],
+    queryFn: () => ensureAppDev(appId),
+    // Poll while booting; stop once the server is ready or has errored.
+    refetchInterval: (query) => {
+      const s = query.state.data;
+      return s?.ready || s?.error ? false : DEV_POLL_MS;
+    },
+  });
+
+  if (isError) {
+    return (
+      <div className="app-build-preview__state" role="alert">
+        <p className="app-build-preview__state-title">Preview unavailable</p>
+        <p className="app-build-preview__state-detail">
+          {error instanceof Error
+            ? error.message
+            : "Could not start the live preview."}
+        </p>
+      </div>
+    );
+  }
+
+  if (data?.error) {
+    return (
+      <div className="app-build-preview__bootlog" role="alert">
+        <p className="app-build-preview__state-title">
+          Preview failed to start
+        </p>
+        <pre className="app-build-preview__bootlog-text">
+          {data.boot_log || data.error}
+        </pre>
+      </div>
+    );
+  }
+
+  // Ready, but the broker handed back something that isn't a loopback origin —
+  // never frame it (defense-in-depth for the sandbox model).
+  if (data?.ready && !isLoopbackDevUrl(data.url)) {
+    return (
+      <div className="app-build-preview__state" role="alert">
+        <p className="app-build-preview__state-title">Preview blocked</p>
+        <p className="app-build-preview__state-detail">
+          The preview server returned an unexpected address, so it was not
+          loaded.
+        </p>
+      </div>
+    );
+  }
+
+  if (!(data?.ready && isLoopbackDevUrl(data.url))) {
+    return (
+      <div className="app-build-preview__state" role="status">
+        <span className="app-build-preview__spinner" aria-hidden="true" />
+        <p className="app-build-preview__state-title">Starting live preview…</p>
+        {data?.boot_log ? (
+          <pre className="app-build-preview__bootlog-text">{data.boot_log}</pre>
+        ) : (
+          <p className="app-build-preview__state-detail">
+            Installing dependencies and booting the dev server — this is a one
+            time warm-up.
+          </p>
+        )}
+      </div>
+    );
+  }
+
+  return <CustomAppFrame devUrl={data.url} title={title} />;
+}

--- a/web/src/components/apps/CreateAppDialog.tsx
+++ b/web/src/components/apps/CreateAppDialog.tsx
@@ -1,0 +1,219 @@
+import { type FormEvent, useEffect, useRef, useState } from "react";
+import { useMutation } from "@tanstack/react-query";
+
+import { type AppBuildRequest, requestAppBuild } from "../../api/apps";
+import { router } from "../../lib/router";
+import { useAppStore } from "../../stores/app";
+import { showNotice } from "../ui/Toast";
+
+const TITLE_ID = "app-builder-modal-title";
+
+/**
+ * CreateAppDialog is the human-initiated entry point for the App Builder, opened
+ * by /create-app, /update-app, and the Edit button on an app screen. Submitting
+ * kicks off an App Builder task directly — these paths are pre-authorized by the
+ * human, so they skip the propose_app approval gate.
+ *
+ * Mirrors the app's canonical modal frame (HelpModal / VersionModal): a
+ * .help-overlay + .help-modal card with a .help-header and Esc affordance,
+ * native .input / .btn controls. NOT the Radix/Tailwind dialog, which read as
+ * off-system next to every other modal.
+ */
+export function CreateAppDialog() {
+  const dialog = useAppStore((s) => s.appBuilderDialog);
+  const close = useAppStore((s) => s.closeAppBuilderDialog);
+  const noteAppBuilding = useAppStore((s) => s.noteAppBuilding);
+
+  const isUpdate = dialog?.mode === "update";
+  const open = dialog !== null;
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const nameRef = useRef<HTMLInputElement>(null);
+  const descRef = useRef<HTMLTextAreaElement>(null);
+
+  // Reset fields whenever a fresh dialog opens (name is prefilled + locked in
+  // update mode; the human types only the change).
+  useEffect(() => {
+    if (dialog) {
+      setName(dialog.name ?? "");
+      setDescription("");
+    }
+  }, [dialog]);
+
+  // Esc closes — claim it in the capture phase so we beat the global shortcut
+  // handler, same as VersionModal.
+  useEffect(() => {
+    if (!open) return;
+    function onKey(e: KeyboardEvent): void {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        e.stopImmediatePropagation();
+        close();
+      }
+    }
+    document.addEventListener("keydown", onKey, true);
+    return () => document.removeEventListener("keydown", onKey, true);
+  }, [open, close]);
+
+  // Focus the first field on open; restore prior focus on close.
+  useEffect(() => {
+    if (!open) return;
+    const prevFocus = document.activeElement as HTMLElement | null;
+    const id = window.requestAnimationFrame(() => {
+      (isUpdate ? descRef.current : nameRef.current)?.focus();
+    });
+    return () => {
+      window.cancelAnimationFrame(id);
+      if (prevFocus?.isConnected && typeof prevFocus.focus === "function") {
+        prevFocus.focus();
+      }
+    };
+  }, [open, isUpdate]);
+
+  const mutation = useMutation({
+    mutationFn: (req: AppBuildRequest) => requestAppBuild(req),
+    onSuccess: (task, req) => {
+      if (!req.appId) {
+        noteAppBuilding(req.name);
+      }
+      close();
+      // Open the task chat so the human lands with the App Builder agent and
+      // watches the build happen live (the task carries a live preview pane),
+      // rather than being left with a fire-and-forget toast.
+      if (task?.id) {
+        void router.navigate({
+          to: "/tasks/$taskId",
+          params: { taskId: task.id },
+        });
+      } else {
+        showNotice(
+          isUpdate
+            ? "App Builder is on it — your change will land shortly."
+            : "App Builder is building your app — it'll appear under Apps soon.",
+          "success",
+        );
+      }
+    },
+    onError: (err: unknown) => {
+      showNotice(
+        err instanceof Error ? err.message : "Could not start the App Builder.",
+        "error",
+      );
+    },
+  });
+
+  function onSubmit(event: FormEvent): void {
+    event.preventDefault();
+    const trimmedDescription = description.trim();
+    if (!trimmedDescription) return;
+    if (isUpdate) {
+      mutation.mutate({
+        name: name.trim() || "app",
+        description: trimmedDescription,
+        appId: dialog?.appId,
+      });
+      return;
+    }
+    const trimmedName = name.trim();
+    if (!trimmedName) return;
+    mutation.mutate({ name: trimmedName, description: trimmedDescription });
+  }
+
+  if (!open) return null;
+
+  const canSubmit =
+    description.trim().length > 0 && (isUpdate || name.trim().length > 0);
+
+  return (
+    // biome-ignore lint/a11y/useKeyWithClickEvents: backdrop click-to-dismiss matches HelpModal/VersionModal; the keyboard path is the document-level Escape handler above.
+    <div className="help-overlay">
+      <button
+        type="button"
+        className="help-backdrop"
+        onClick={() => close()}
+        tabIndex={-1}
+        aria-label="Close create app dialog"
+      />
+      <div
+        className="help-modal app-builder-modal card"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={TITLE_ID}
+      >
+        <header className="help-header">
+          <div>
+            <h2 id={TITLE_ID} className="help-title">
+              {isUpdate ? `Improve ${dialog?.name ?? "app"}` : "Create an app"}
+            </h2>
+            <p className="help-subtitle">
+              {isUpdate
+                ? "Describe the change. The App Builder updates this app in place."
+                : "Describe the internal tool you want. The App Builder designs, builds, and publishes it under Apps."}
+            </p>
+          </div>
+          <button
+            type="button"
+            className="help-close"
+            onClick={() => close()}
+            aria-label="Close"
+          >
+            Esc
+          </button>
+        </header>
+
+        <form className="help-body app-builder-modal__body" onSubmit={onSubmit}>
+          {!isUpdate && (
+            <label className="app-builder-modal__field">
+              <span className="app-builder-modal__label">Name</span>
+              <input
+                ref={nameRef}
+                className="input"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="e.g. Standup Digest"
+              />
+            </label>
+          )}
+          <label className="app-builder-modal__field">
+            <span className="app-builder-modal__label">
+              {isUpdate ? "What should change?" : "What should it do?"}
+            </span>
+            <textarea
+              ref={descRef}
+              className="app-builder-modal__textarea"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              rows={5}
+              placeholder={
+                isUpdate
+                  ? "e.g. add a CSV export button to the table"
+                  : "e.g. a daily digest listing each agent's open tasks grouped by status"
+              }
+            />
+          </label>
+
+          <div className="app-builder-modal__footer">
+            <button
+              type="button"
+              className="btn btn-ghost"
+              onClick={() => close()}
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              className="btn btn-primary"
+              disabled={!canSubmit || mutation.isPending}
+            >
+              {mutation.isPending
+                ? "Starting…"
+                : isUpdate
+                  ? "Request change"
+                  : "Build app"}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/apps/CustomAppFrame.test.ts
+++ b/web/src/components/apps/CustomAppFrame.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+
+import { isAllowedGetPath, withAppCsp } from "./CustomAppFrame";
+
+describe("isAllowedGetPath", () => {
+  it("allows whitelisted read-only office data paths", () => {
+    expect(isAllowedGetPath("/apps")).toBe(true);
+    expect(isAllowedGetPath("/tasks")).toBe(true);
+    expect(isAllowedGetPath("/tasks?status=open")).toBe(true);
+    expect(isAllowedGetPath("/office-members")).toBe(true);
+    expect(isAllowedGetPath("/wiki/list")).toBe(true);
+    expect(isAllowedGetPath("/apps/app_0123456789abcdef")).toBe(true);
+  });
+
+  it("rejects non-whitelisted, mutating, or off-broker paths", () => {
+    // Not on the allowlist.
+    expect(isAllowedGetPath("/config")).toBe(false);
+    expect(isAllowedGetPath("/web-token")).toBe(false);
+    expect(isAllowedGetPath("/memory")).toBe(false);
+    // Prefix-spoofing must not pass (/tasksomething is not /tasks/*).
+    expect(isAllowedGetPath("/tasks-secret")).toBe(false);
+    expect(isAllowedGetPath("/wiki/write")).toBe(false);
+    // Path traversal must be normalized away before the allowlist check, since
+    // the browser resolves it before sending (security review finding 1).
+    expect(isAllowedGetPath("/tasks/../config")).toBe(false);
+    expect(isAllowedGetPath("/tasks/../../memory")).toBe(false);
+    expect(isAllowedGetPath("/apps/../wiki/write")).toBe(false);
+    // Absolute / protocol-relative / non-rooted are rejected outright.
+    expect(isAllowedGetPath("https://evil.example/tasks")).toBe(false);
+    expect(isAllowedGetPath("//evil.example/tasks")).toBe(false);
+    expect(isAllowedGetPath("tasks")).toBe(false);
+    expect(isAllowedGetPath("")).toBe(false);
+  });
+});
+
+describe("withAppCsp", () => {
+  it("injects a connect-src 'none' CSP into the document head", () => {
+    const out = withAppCsp(
+      "<!doctype html><html><head><title>x</title></head><body>hi</body></html>",
+    );
+    expect(out).toContain("Content-Security-Policy");
+    expect(out).toContain("connect-src 'none'");
+    // CSP meta must land inside <head> so it parses before any inline script.
+    const headIdx = out.indexOf("<head>");
+    const cspIdx = out.indexOf("Content-Security-Policy");
+    expect(headIdx).toBeGreaterThanOrEqual(0);
+    expect(cspIdx).toBeGreaterThan(headIdx);
+  });
+
+  it("is not shadowed by a commented-out <head> (security review finding 2)", () => {
+    const out = withAppCsp(
+      "<!-- <head> decoy --><html><head><script>fetch('https://evil.example')</script></head><body>x</body></html>",
+    );
+    // The decoy comment is stripped, so the CSP lands in the REAL head.
+    expect(out).toContain("connect-src 'none'");
+    expect(out).not.toContain("<!--");
+    // CSP precedes the inline script in document order.
+    const cspIdx = out.indexOf("Content-Security-Policy");
+    const scriptIdx = out.indexOf("<script>");
+    expect(cspIdx).toBeGreaterThanOrEqual(0);
+    expect(cspIdx).toBeLessThan(scriptIdx);
+  });
+
+  it("wraps fragments lacking <head>/<html> in a full CSP-protected document", () => {
+    const out = withAppCsp("<div>just a fragment</div>");
+    expect(out).toContain("connect-src 'none'");
+    expect(out).toContain("just a fragment");
+    expect(out.startsWith("<!doctype html>")).toBe(true);
+  });
+});

--- a/web/src/components/apps/CustomAppFrame.tsx
+++ b/web/src/components/apps/CustomAppFrame.tsx
@@ -1,0 +1,181 @@
+import { useEffect, useMemo, useRef } from "react";
+
+import { get } from "../../api/client";
+
+/**
+ * CustomAppFrame renders an agent-generated internal tool inside a hardened
+ * sandbox and brokers its data access.
+ *
+ * Security model (the iframe is the real boundary, not the write-time HTML
+ * validator):
+ *   - sandbox="allow-scripts" ONLY — no allow-same-origin, so the app runs at an
+ *     opaque origin with no access to cookies, localStorage, or the parent DOM;
+ *     no allow-forms / allow-popups / allow-top-navigation.
+ *   - An injected CSP with connect-src 'none' blocks ALL network from inside the
+ *     frame (fetch/XHR/WebSocket), so a generated app cannot exfiltrate data,
+ *     even if its own bundle tried to. default-src 'none' + inline script/style
+ *     only — everything must be self-contained.
+ *   - The ONLY way out is window.parent.postMessage to this component, which
+ *     services a small READ-ONLY allowlist of broker GETs using the signed-in
+ *     user's own session (the app never holds a token). Writes are rejected.
+ */
+
+const APP_CSP = [
+  "default-src 'none'",
+  "script-src 'unsafe-inline'",
+  "style-src 'unsafe-inline'",
+  "img-src data: blob:",
+  "font-src data:",
+  "media-src data: blob:",
+  "connect-src 'none'",
+  "form-action 'none'",
+  "base-uri 'none'",
+  "frame-src 'none'",
+].join("; ");
+
+// Read-only broker paths an app may request through the bridge. Prefix match on
+// the path (query string ignored). Deliberately small: live office data an
+// internal tool would display. Mutations are NOT exposed in this version.
+const ALLOWED_GET_PREFIXES: readonly string[] = [
+  "/apps",
+  "/tasks",
+  "/office-members",
+  "/channels",
+  "/requests",
+  "/wiki/list",
+  "/wiki/catalog",
+  "/wiki/read",
+  "/wiki/tree",
+];
+
+const HOST_SOURCE = "wuphf-host";
+const APP_SOURCE = "wuphf-app";
+
+interface BrokerBridgeMessage {
+  source: typeof APP_SOURCE;
+  type: "broker";
+  id: string | number;
+  method?: string;
+  path?: string;
+}
+
+export function isAllowedGetPath(path: string): boolean {
+  if (!path.startsWith("/")) return false;
+  const [raw] = path.split("?");
+  // Normalize away ./ and ../ segments BEFORE the allowlist check. The browser
+  // resolves "/tasks/../config" to "/config" before the request leaves, so a
+  // prefix check on the raw string must not be fooled into allowing it. Also
+  // reject anything that changes the origin (e.g. "//evil/tasks" is a
+  // protocol-relative URL whose host would become "evil").
+  let clean: string;
+  try {
+    const url = new URL(raw, "http://localhost");
+    if (url.origin !== "http://localhost") return false;
+    clean = url.pathname;
+  } catch {
+    return false;
+  }
+  return ALLOWED_GET_PREFIXES.some(
+    (prefix) => clean === prefix || clean.startsWith(`${prefix}/`),
+  );
+}
+
+export function withAppCsp(html: string): string {
+  const meta = `<meta http-equiv="Content-Security-Policy" content="${APP_CSP}">`;
+  // Strip HTML comments before locating the injection point: a crafted
+  // `<!-- <head> -->` must not shadow the real <head> and leave the document
+  // with no CSP (which would re-enable network exfiltration). Comments are
+  // inert, so a genuine app renders identically. Inject the meta as the FIRST
+  // child of <head> so the CSP precedes any in-head or in-body script in
+  // document order.
+  const doc = html.replace(/<!--[\s\S]*?-->/g, "");
+  if (/<head[^>]*>/i.test(doc)) {
+    return doc.replace(/<head[^>]*>/i, (match) => `${match}${meta}`);
+  }
+  if (/<html[^>]*>/i.test(doc)) {
+    return doc.replace(
+      /<html[^>]*>/i,
+      (match) => `${match}<head>${meta}</head>`,
+    );
+  }
+  return `<!doctype html><html><head>${meta}</head><body>${doc}</body></html>`;
+}
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : "request failed";
+}
+
+interface CustomAppFrameProps {
+  html: string;
+  title: string;
+}
+
+export function CustomAppFrame({ html, title }: CustomAppFrameProps) {
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+  const srcDoc = useMemo(() => withAppCsp(html), [html]);
+
+  useEffect(() => {
+    function reply(
+      target: Window,
+      id: string | number,
+      payload: { ok: boolean; data?: unknown; error?: string },
+    ): void {
+      // The frame is an opaque origin (no allow-same-origin), so we cannot
+      // target a concrete origin; "*" is acceptable because the payload is the
+      // user's own office data and the sandbox forbids nested browsing contexts.
+      target.postMessage({ source: HOST_SOURCE, id, ...payload }, "*");
+    }
+
+    async function handle(
+      message: BrokerBridgeMessage,
+      target: Window,
+    ): Promise<void> {
+      const method = String(message.method ?? "GET").toUpperCase();
+      const path = String(message.path ?? "");
+      if (method !== "GET") {
+        reply(target, message.id, {
+          ok: false,
+          error: "Apps can only read data (GET) in this version.",
+        });
+        return;
+      }
+      if (!isAllowedGetPath(path)) {
+        reply(target, message.id, {
+          ok: false,
+          error: `Path not permitted for apps: ${path}`,
+        });
+        return;
+      }
+      try {
+        const data = await get(path);
+        reply(target, message.id, { ok: true, data });
+      } catch (err) {
+        reply(target, message.id, { ok: false, error: errorMessage(err) });
+      }
+    }
+
+    function onMessage(event: MessageEvent): void {
+      const frame = iframeRef.current;
+      // Identity by window reference, not origin: a sandboxed opaque-origin
+      // frame reports origin "null", so origin checks are useless here.
+      if (!frame || event.source !== frame.contentWindow) return;
+      const data = event.data as Partial<BrokerBridgeMessage> | null;
+      if (!data || data.source !== APP_SOURCE || data.type !== "broker") return;
+      if (data.id === undefined || event.source === null) return;
+      void handle(data as BrokerBridgeMessage, event.source as Window);
+    }
+
+    window.addEventListener("message", onMessage);
+    return () => window.removeEventListener("message", onMessage);
+  }, []);
+
+  return (
+    <iframe
+      ref={iframeRef}
+      className="custom-app-frame"
+      title={title}
+      sandbox="allow-scripts"
+      srcDoc={srcDoc}
+    />
+  );
+}

--- a/web/src/components/apps/CustomAppFrame.tsx
+++ b/web/src/components/apps/CustomAppFrame.tsx
@@ -106,24 +106,47 @@ function errorMessage(err: unknown): string {
 }
 
 interface CustomAppFrameProps {
-  html: string;
   title: string;
+  /** Sealed mode: the published single-file bundle, rendered via srcDoc. */
+  html?: string;
+  /**
+   * Dev (live) mode: the broker dev-server proxy origin. When set the frame
+   * loads it directly with HMR instead of the sealed bundle. The proxy injects
+   * the security CSP (a generated vite.config can't strip it) and serves a
+   * DISTINCT 127.0.0.1 origin, so allow-same-origin grants the app only its OWN
+   * origin — never the parent app's session. The postMessage bridge below works
+   * in both modes (identity is by window reference, not origin).
+   */
+  devUrl?: string;
 }
 
-export function CustomAppFrame({ html, title }: CustomAppFrameProps) {
+export function CustomAppFrame({ html, title, devUrl }: CustomAppFrameProps) {
   const iframeRef = useRef<HTMLIFrameElement>(null);
-  const srcDoc = useMemo(() => withAppCsp(html), [html]);
+  const srcDoc = useMemo(
+    () => (html !== undefined ? withAppCsp(html) : undefined),
+    [html],
+  );
 
   useEffect(() => {
+    // In DEV mode the frame is a real, known origin (the proxy), so pin replies
+    // to it — the office data must not reach a frame that navigated to a
+    // different origin. In SEALED mode the frame is an opaque origin ("null")
+    // and "*" is the only option (and is safe: no allow-same-origin, no nested
+    // browsing contexts).
+    let replyOrigin = "*";
+    if (devUrl) {
+      try {
+        replyOrigin = new URL(devUrl).origin;
+      } catch {
+        replyOrigin = "*";
+      }
+    }
     function reply(
       target: Window,
       id: string | number,
       payload: { ok: boolean; data?: unknown; error?: string },
     ): void {
-      // The frame is an opaque origin (no allow-same-origin), so we cannot
-      // target a concrete origin; "*" is acceptable because the payload is the
-      // user's own office data and the sandbox forbids nested browsing contexts.
-      target.postMessage({ source: HOST_SOURCE, id, ...payload }, "*");
+      target.postMessage({ source: HOST_SOURCE, id, ...payload }, replyOrigin);
     }
 
     async function handle(
@@ -167,7 +190,19 @@ export function CustomAppFrame({ html, title }: CustomAppFrameProps) {
 
     window.addEventListener("message", onMessage);
     return () => window.removeEventListener("message", onMessage);
-  }, []);
+  }, [devUrl]);
+
+  if (devUrl) {
+    return (
+      <iframe
+        ref={iframeRef}
+        className="custom-app-frame"
+        title={title}
+        sandbox="allow-scripts allow-same-origin"
+        src={devUrl}
+      />
+    );
+  }
 
   return (
     <iframe

--- a/web/src/components/apps/CustomAppView.tsx
+++ b/web/src/components/apps/CustomAppView.tsx
@@ -12,6 +12,7 @@ import { navigateToSidebarApp } from "../../lib/sidebarNav";
 import { useAppStore } from "../../stores/app";
 import { confirm } from "../ui/ConfirmDialog";
 import { showNotice } from "../ui/Toast";
+import { AppLivePreview } from "./AppLivePreview";
 import { CustomAppFrame } from "./CustomAppFrame";
 
 interface CustomAppViewProps {
@@ -29,6 +30,9 @@ export function CustomAppView({ appId }: CustomAppViewProps) {
   const queryClient = useQueryClient();
   const openUpdateAppDialog = useAppStore((s) => s.openUpdateAppDialog);
   const [menuOpen, setMenuOpen] = useState(false);
+  // Live = the running dev server (HMR); Sealed = the published single-file
+  // bundle. Default to Live so opening an app shows the real, current tool.
+  const [mode, setMode] = useState<"live" | "sealed">("live");
   const menuRef = useRef<HTMLDivElement>(null);
 
   const { data, isLoading, isError, error, refetch } = useQuery({
@@ -140,6 +144,24 @@ export function CustomAppView({ appId }: CustomAppViewProps) {
             <p className="custom-app-view__summary">{app.summary}</p>
           ) : null}
         </div>
+        <div className="custom-app-view__mode">
+          <button
+            type="button"
+            className="custom-app-view__mode-btn"
+            aria-pressed={mode === "live"}
+            onClick={() => setMode("live")}
+          >
+            Live
+          </button>
+          <button
+            type="button"
+            className="custom-app-view__mode-btn"
+            aria-pressed={mode === "sealed"}
+            onClick={() => setMode("sealed")}
+          >
+            Sealed
+          </button>
+        </div>
         <span
           className="custom-app-view__version"
           title={`Updated ${app.updatedAt}`}
@@ -207,7 +229,11 @@ export function CustomAppView({ appId }: CustomAppViewProps) {
         </div>
       </header>
       <div className="custom-app-view__body">
-        <CustomAppFrame html={html} title={app.name} />
+        {mode === "live" ? (
+          <AppLivePreview appId={appId} title={app.name} />
+        ) : (
+          <CustomAppFrame html={html} title={app.name} />
+        )}
       </div>
     </div>
   );

--- a/web/src/components/apps/CustomAppView.tsx
+++ b/web/src/components/apps/CustomAppView.tsx
@@ -1,0 +1,214 @@
+import { useEffect, useRef, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { EditPencil, MoreHoriz } from "iconoir-react";
+
+import {
+  deleteApp,
+  getApp,
+  listAppVersions,
+  rollbackApp,
+} from "../../api/apps";
+import { navigateToSidebarApp } from "../../lib/sidebarNav";
+import { useAppStore } from "../../stores/app";
+import { confirm } from "../ui/ConfirmDialog";
+import { showNotice } from "../ui/Toast";
+import { CustomAppFrame } from "./CustomAppFrame";
+
+interface CustomAppViewProps {
+  appId: string;
+}
+
+/**
+ * CustomAppView renders one agent-generated internal tool: a header (icon, name,
+ * version, Edit, an overflow menu) above the sandboxed CustomAppFrame. Edit is
+ * the primary action. The destructive Delete and the version rollback both live
+ * in the overflow menu so an operator can't lose or break a depended-on tool
+ * with a stray click — the trust net the modify wedge needs.
+ */
+export function CustomAppView({ appId }: CustomAppViewProps) {
+  const queryClient = useQueryClient();
+  const openUpdateAppDialog = useAppStore((s) => s.openUpdateAppDialog);
+  const [menuOpen, setMenuOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  const { data, isLoading, isError, error, refetch } = useQuery({
+    queryKey: ["app", appId],
+    queryFn: () => getApp(appId),
+    refetchInterval: 10_000,
+  });
+
+  const versions = useQuery({
+    queryKey: ["app-versions", appId],
+    queryFn: () => listAppVersions(appId),
+    enabled: menuOpen,
+  });
+
+  const rollback = useMutation({
+    mutationFn: (version: number) => rollbackApp(appId, version),
+    onSuccess: async (restored) => {
+      await queryClient.invalidateQueries({ queryKey: ["app", appId] });
+      await queryClient.invalidateQueries({
+        queryKey: ["app-versions", appId],
+      });
+      await queryClient.invalidateQueries({ queryKey: ["apps"] });
+      showNotice(`Restored — now on v${restored.version}.`, "success");
+    },
+    onError: (err: unknown) => {
+      showNotice(
+        err instanceof Error ? err.message : "Could not restore that version.",
+        "error",
+      );
+    },
+  });
+
+  // Close the overflow menu on outside click.
+  useEffect(() => {
+    if (!menuOpen) return;
+    function onDown(e: MouseEvent): void {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        setMenuOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", onDown);
+    return () => document.removeEventListener("mousedown", onDown);
+  }, [menuOpen]);
+
+  function onDelete(): void {
+    if (!data) return;
+    setMenuOpen(false);
+    confirm({
+      title: "Delete app",
+      message: `Delete "${data.app.name}"? This removes the tool for everyone in the office.`,
+      danger: true,
+      confirmLabel: "Delete",
+      onConfirm: async () => {
+        try {
+          await deleteApp(appId);
+          await queryClient.invalidateQueries({ queryKey: ["apps"] });
+          showNotice(`Deleted ${data.app.name}.`, "success");
+          navigateToSidebarApp("activity");
+        } catch (err) {
+          showNotice(
+            err instanceof Error ? err.message : "Could not delete the app.",
+            "error",
+          );
+        }
+      },
+    });
+  }
+
+  if (isLoading) {
+    return (
+      <div className="custom-app-view custom-app-view--state">
+        <p className="custom-app-view__loading">Loading app…</p>
+      </div>
+    );
+  }
+
+  if (isError || !data) {
+    return (
+      <div className="custom-app-view custom-app-view--state">
+        <div className="custom-app-view__error" role="alert">
+          <p>Could not load this app.</p>
+          <p className="custom-app-view__error-detail">
+            {error instanceof Error ? error.message : "Unknown error"}
+          </p>
+          <button
+            type="button"
+            className="custom-app-view__action"
+            onClick={() => void refetch()}
+          >
+            Retry
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  const { app, html } = data;
+  const priorVersions = (versions.data ?? []).filter((v) => v !== app.version);
+
+  return (
+    <div className="custom-app-view">
+      <header className="custom-app-view__header">
+        <span className="custom-app-view__icon" aria-hidden="true">
+          {app.icon || "🧩"}
+        </span>
+        <div className="custom-app-view__heading">
+          <h1 className="custom-app-view__name">{app.name}</h1>
+          {app.summary ? (
+            <p className="custom-app-view__summary">{app.summary}</p>
+          ) : null}
+        </div>
+        <span
+          className="custom-app-view__version"
+          title={`Updated ${app.updatedAt}`}
+        >
+          v{app.version}
+        </span>
+        <button
+          type="button"
+          className="custom-app-view__action"
+          onClick={() => openUpdateAppDialog(app.id, app.name)}
+        >
+          <EditPencil width={15} height={15} />
+          <span>Edit</span>
+        </button>
+        <div className="custom-app-view__menu-wrap" ref={menuRef}>
+          <button
+            type="button"
+            className="custom-app-view__icon-btn"
+            aria-label="More actions"
+            aria-haspopup="menu"
+            aria-expanded={menuOpen}
+            onClick={() => setMenuOpen((open) => !open)}
+          >
+            <MoreHoriz width={16} height={16} />
+          </button>
+          {menuOpen ? (
+            <div className="custom-app-view__menu" role="menu">
+              <div className="custom-app-view__menu-section">
+                Restore a previous version
+              </div>
+              {versions.isLoading ? (
+                <div className="custom-app-view__menu-empty">Loading…</div>
+              ) : priorVersions.length === 0 ? (
+                <div className="custom-app-view__menu-empty">
+                  No earlier versions yet.
+                </div>
+              ) : (
+                priorVersions.slice(0, 8).map((v) => (
+                  <button
+                    key={v}
+                    type="button"
+                    role="menuitem"
+                    className="custom-app-view__menu-item"
+                    disabled={rollback.isPending}
+                    onClick={() => {
+                      setMenuOpen(false);
+                      rollback.mutate(v);
+                    }}
+                  >
+                    Restore v{v}
+                  </button>
+                ))
+              )}
+              <div className="custom-app-view__menu-divider" />
+              <button
+                type="button"
+                role="menuitem"
+                className="custom-app-view__menu-item custom-app-view__menu-item--danger"
+                onClick={onDelete}
+              >
+                Delete app
+              </button>
+            </div>
+          ) : null}
+        </div>
+      </header>
+      <div className="custom-app-view__body">
+        <CustomAppFrame html={html} title={app.name} />
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/lifecycle/TaskDocument.tsx
+++ b/web/src/components/lifecycle/TaskDocument.tsx
@@ -25,8 +25,11 @@ import {
   type TaskVerificationResult,
   taskToLifecycleState,
 } from "../../api/tasks";
+import { APP_BUILDER_SLUG } from "../../lib/constants";
 import { formatTaskTitleForDisplay } from "../../lib/taskTitle";
 import type { LifecycleState } from "../../lib/types/lifecycle";
+import { AppBuildPreview } from "../apps/AppBuildPreview";
+import { ResizableSplit } from "../ui/ResizableSplit";
 import {
   isAwaitingStaffing,
   LifecycleStatePill,
@@ -596,6 +599,9 @@ export function TaskDocument({ taskId, initialDocument }: TaskDocumentProps) {
   const doc = query.data;
   const isDrafting = doc?.lifecycleState === "drafting";
   const awaitingStaffing = isAwaitingStaffing(doc);
+  // App Builder tasks get a live preview pane beside the chat: the human
+  // watches the app being built and resizes chat vs preview to taste.
+  const isAppBuilderTask = doc?.ownerSlug === APP_BUILDER_SLUG;
 
   if (query.isPending && !initialDocument) {
     return <TaskDocumentSkeleton />;
@@ -692,26 +698,43 @@ export function TaskDocument({ taskId, initialDocument }: TaskDocumentProps) {
         </div>
       </header>
 
-      {/* Body: chat-primary. The task's channel (the conversation where the
-       *  owner, CEO, and Librarian collaborate) owns the main column at full
-       *  scale; the secondary context — participants, description, activity,
-       *  sub-tasks — lives in the right rail a glance away. */}
-      <div className="issue-doc-body issue-doc-body--split">
-        <main className="issue-doc-chat" aria-label="Chat">
-          <div className="issue-doc-chat-header">Chat</div>
-          <TaskChannelChat channel={doc.channel} />
-        </main>
+      {/* Body. For an App Builder task the right side is a LIVE PREVIEW of the
+       *  app being built, with a draggable divider so the human can give chat
+       *  or preview as much room as they want. Every other task keeps the
+       *  chat-primary layout with the context rail (participants, description,
+       *  activity, sub-tasks) a glance away. */}
+      {isAppBuilderTask ? (
+        <div className="issue-doc-body issue-doc-body--app-build">
+          <ResizableSplit
+            storageKey="app-build-preview-ratio"
+            ariaLabel="Resize chat and app preview"
+            left={
+              <main className="issue-doc-chat" aria-label="Chat">
+                <div className="issue-doc-chat-header">Chat</div>
+                <TaskChannelChat channel={doc.channel} />
+              </main>
+            }
+            right={<AppBuildPreview taskTitle={doc.title} />}
+          />
+        </div>
+      ) : (
+        <div className="issue-doc-body issue-doc-body--split">
+          <main className="issue-doc-chat" aria-label="Chat">
+            <div className="issue-doc-chat-header">Chat</div>
+            <TaskChannelChat channel={doc.channel} />
+          </main>
 
-        <TaskContextRail
-          taskId={taskId}
-          channel={doc.channel}
-          description={doc.description}
-          isDrafting={isDrafting}
-          showSubTasks={!doc.parentTaskId}
-          verification={doc.verification}
-          definition={doc.definition}
-        />
-      </div>
+          <TaskContextRail
+            taskId={taskId}
+            channel={doc.channel}
+            description={doc.description}
+            isDrafting={isDrafting}
+            showSubTasks={!doc.parentTaskId}
+            verification={doc.verification}
+            definition={doc.definition}
+          />
+        </div>
+      )}
     </div>
   );
 }

--- a/web/src/components/sidebar/AppList.tsx
+++ b/web/src/components/sidebar/AppList.tsx
@@ -1,5 +1,5 @@
 // biome-ignore-all lint/a11y/useAriaPropsSupportedByRole: Passive metadata uses accessible labels queried by screen-reader tests; visual text remains unchanged.
-import { type ComponentType, useState } from "react";
+import { type ComponentType, Fragment, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import {
   BookStack,
@@ -25,6 +25,7 @@ import {
   WIKI_SURFACE_APP_IDS,
 } from "../../routes/routeRegistry";
 import { useCurrentApp } from "../../routes/useCurrentRoute";
+import { AppsSection } from "./AppsSection";
 import { SidebarItem } from "./SidebarItem";
 import { SidebarSection } from "./SidebarSection";
 import { TasksNavButton } from "./TasksNavButton";
@@ -136,15 +137,18 @@ export function AppList() {
   return (
     <div className="sidebar-scroll-wrap is-apps">
       {NAV_SECTIONS.map((section) => (
-        <SidebarSection
-          key={section.label}
-          label={section.label}
-          open={open[section.label] ?? true}
-          onToggle={() => toggle(section.label)}
-          data-testid={`sidebar-section-${section.label.toLowerCase()}`}
-        >
-          <div className="sidebar-apps">{section.items.map(renderItem)}</div>
-        </SidebarSection>
+        <Fragment key={section.label}>
+          {/* Apps is operator-facing, so it sits above Config, not at the bottom. */}
+          {section.label === "Config" ? <AppsSection /> : null}
+          <SidebarSection
+            label={section.label}
+            open={open[section.label] ?? true}
+            onToggle={() => toggle(section.label)}
+            data-testid={`sidebar-section-${section.label.toLowerCase()}`}
+          >
+            <div className="sidebar-apps">{section.items.map(renderItem)}</div>
+          </SidebarSection>
+        </Fragment>
       ))}
     </div>
   );

--- a/web/src/components/sidebar/AppsSection.tsx
+++ b/web/src/components/sidebar/AppsSection.tsx
@@ -1,0 +1,105 @@
+import { useEffect, useMemo, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { Plus, Tools } from "iconoir-react";
+
+import { listApps } from "../../api/apps";
+import { navigateToSidebarApp } from "../../lib/sidebarNav";
+import { useCurrentApp } from "../../routes/useCurrentRoute";
+import { useAppStore } from "../../stores/app";
+import { SidebarItem } from "./SidebarItem";
+import { SidebarSection } from "./SidebarSection";
+
+const BUILD_TTL_MS = 5 * 60_000;
+
+/**
+ * AppsSection lists the office's agent-generated internal tools (Apps), any
+ * in-flight builds, and the "Create app" affordance. Data-driven from GET /apps;
+ * the optimistic "building…" rows close the dead air between submitting a new app
+ * and it appearing (a build takes 20-60s).
+ */
+export function AppsSection() {
+  const currentApp = useCurrentApp();
+  const openCreateAppDialog = useAppStore((s) => s.openCreateAppDialog);
+  const appBuilds = useAppStore((s) => s.appBuilds);
+  const clearAppBuilding = useAppStore((s) => s.clearAppBuilding);
+  const [open, setOpen] = useState(true);
+
+  const { data: apps } = useQuery({
+    queryKey: ["apps"],
+    queryFn: listApps,
+    refetchInterval: 15_000,
+  });
+  const items = apps ?? [];
+
+  const realNames = useMemo(
+    () => new Set(items.map((a) => a.name.trim().toLowerCase())),
+    [items],
+  );
+
+  // A pending build resolves when its app appears in the list, or expires after
+  // the TTL (the build failed or the optimistic note outlived it).
+  const pending = useMemo(() => {
+    const now = Date.now();
+    return Object.entries(appBuilds)
+      .filter(
+        ([key, b]) => !realNames.has(key) && now - b.startedAt <= BUILD_TTL_MS,
+      )
+      .map(([, b]) => b.name);
+  }, [appBuilds, realNames]);
+
+  useEffect(() => {
+    const now = Date.now();
+    for (const [key, b] of Object.entries(appBuilds)) {
+      if (realNames.has(key) || now - b.startedAt > BUILD_TTL_MS) {
+        clearAppBuilding(b.name);
+      }
+    }
+  }, [appBuilds, realNames, clearAppBuilding]);
+
+  return (
+    <SidebarSection
+      label="Apps"
+      open={open}
+      onToggle={() => setOpen((prev) => !prev)}
+      data-testid="sidebar-section-apps"
+    >
+      <div className="sidebar-apps">
+        {items.map((app) => (
+          <SidebarItem
+            key={app.id}
+            icon={
+              app.icon ? (
+                <span className="sidebar-item-emoji">{app.icon}</span>
+              ) : (
+                <Tools className="sidebar-item-icon" />
+              )
+            }
+            label={app.name}
+            active={currentApp === app.id}
+            onClick={() => navigateToSidebarApp(app.id)}
+          />
+        ))}
+        {pending.map((name) => (
+          <div
+            key={`building-${name.toLowerCase()}`}
+            className="sidebar-app-building"
+            aria-live="polite"
+          >
+            <span
+              className="sidebar-app-building__spinner"
+              aria-hidden="true"
+            />
+            <span className="sidebar-app-building__label">{name}</span>
+            <span className="sidebar-app-building__meta">building…</span>
+          </div>
+        ))}
+        <SidebarItem
+          icon={<Plus className="sidebar-item-icon" />}
+          label="Create app"
+          active={false}
+          onClick={() => openCreateAppDialog()}
+        />
+      </div>
+    </SidebarSection>
+  );
+}

--- a/web/src/components/ui/ResizableSplit.tsx
+++ b/web/src/components/ui/ResizableSplit.tsx
@@ -1,0 +1,169 @@
+import {
+  type CSSProperties,
+  type ReactNode,
+  useCallback,
+  useRef,
+  useState,
+} from "react";
+
+interface ResizableSplitProps {
+  left: ReactNode;
+  right: ReactNode;
+  /** localStorage key the chosen ratio persists under. */
+  storageKey: string;
+  /** Left-pane fraction (0..1) used before the human drags. Default 0.55. */
+  initialRatio?: number;
+  /** Clamp bounds so neither pane can be dragged shut. Defaults 0.25 / 0.8. */
+  minRatio?: number;
+  maxRatio?: number;
+  /** Accessible label for the drag handle. */
+  ariaLabel?: string;
+  className?: string;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+function readStoredRatio(key: string, fallback: number): number {
+  if (typeof window === "undefined") return fallback;
+  const raw = window.localStorage.getItem(key);
+  if (!raw) return fallback;
+  const parsed = Number.parseFloat(raw);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+/**
+ * ResizableSplit is a two-pane horizontal split with a draggable divider. The
+ * left pane is sized by a ratio the human controls (drag the divider or use the
+ * arrow keys); the right pane takes the rest. The ratio persists per
+ * `storageKey` so the layout the operator picked survives reloads.
+ *
+ * The divider captures the pointer and the panes drop pointer-events mid-drag,
+ * so a drag that crosses a sandboxed iframe (the app preview) keeps tracking
+ * instead of being swallowed by the frame.
+ */
+export function ResizableSplit({
+  left,
+  right,
+  storageKey,
+  initialRatio = 0.55,
+  minRatio = 0.25,
+  maxRatio = 0.8,
+  ariaLabel = "Resize panes",
+  className,
+}: ResizableSplitProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [ratio, setRatioState] = useState(() =>
+    clamp(readStoredRatio(storageKey, initialRatio), minRatio, maxRatio),
+  );
+  const [dragging, setDragging] = useState(false);
+
+  const persist = useCallback(
+    (next: number) => {
+      if (typeof window !== "undefined") {
+        window.localStorage.setItem(storageKey, next.toFixed(4));
+      }
+    },
+    [storageKey],
+  );
+
+  const setRatio = useCallback(
+    (next: number, save = false) => {
+      const clamped = clamp(next, minRatio, maxRatio);
+      setRatioState(clamped);
+      if (save) persist(clamped);
+    },
+    [minRatio, maxRatio, persist],
+  );
+
+  const onPointerMove = useCallback(
+    (e: React.PointerEvent) => {
+      if (!dragging) return;
+      const el = containerRef.current;
+      if (!el) return;
+      const rect = el.getBoundingClientRect();
+      if (rect.width <= 0) return;
+      setRatio((e.clientX - rect.left) / rect.width);
+    },
+    [dragging, setRatio],
+  );
+
+  const endDrag = useCallback(
+    (e: React.PointerEvent) => {
+      if (!dragging) return;
+      setDragging(false);
+      persist(ratio);
+      try {
+        e.currentTarget.releasePointerCapture(e.pointerId);
+      } catch {
+        // Pointer capture may already be released; ignore.
+      }
+    },
+    [dragging, persist, ratio],
+  );
+
+  const onKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      const step = e.shiftKey ? 0.1 : 0.02;
+      if (e.key === "ArrowLeft") {
+        e.preventDefault();
+        setRatio(ratio - step, true);
+      } else if (e.key === "ArrowRight") {
+        e.preventDefault();
+        setRatio(ratio + step, true);
+      } else if (e.key === "Home") {
+        e.preventDefault();
+        setRatio(minRatio, true);
+      } else if (e.key === "End") {
+        e.preventDefault();
+        setRatio(maxRatio, true);
+      }
+    },
+    [ratio, setRatio, minRatio, maxRatio],
+  );
+
+  const pct = Math.round(ratio * 100);
+
+  return (
+    <div
+      ref={containerRef}
+      className={`resizable-split${dragging ? " resizable-split--dragging" : ""}${
+        className ? ` ${className}` : ""
+      }`}
+    >
+      <div
+        className="resizable-split__pane resizable-split__pane--left"
+        style={{ "--rs-left-basis": `${ratio * 100}%` } as CSSProperties}
+      >
+        {left}
+      </div>
+      {/* biome-ignore lint/a11y/useSemanticElements: this is the WAI-ARIA window-splitter pattern — a focusable, draggable handle with aria-valuenow/orientation. <hr> can't carry the drag + arrow-key resize affordance. */}
+      <div
+        role="separator"
+        aria-orientation="vertical"
+        aria-label={ariaLabel}
+        aria-valuemin={Math.round(minRatio * 100)}
+        aria-valuemax={Math.round(maxRatio * 100)}
+        aria-valuenow={pct}
+        tabIndex={0}
+        className="resizable-split__divider"
+        onPointerDown={(e) => {
+          e.preventDefault();
+          setDragging(true);
+          e.currentTarget.setPointerCapture(e.pointerId);
+        }}
+        onPointerMove={onPointerMove}
+        onPointerUp={endDrag}
+        onPointerCancel={endDrag}
+        onKeyDown={onKeyDown}
+        onDoubleClick={() => setRatio(initialRatio, true)}
+      >
+        <span className="resizable-split__grip" aria-hidden="true" />
+      </div>
+      <div className="resizable-split__pane resizable-split__pane--right">
+        {right}
+      </div>
+    </div>
+  );
+}

--- a/web/src/lib/constants.ts
+++ b/web/src/lib/constants.ts
@@ -18,6 +18,13 @@ export function appTitle(app: string): string {
   return app.replace(/-/g, " ").replace(/\b\w/g, (char) => char.toUpperCase());
 }
 
+/**
+ * Roster slug of the built-in App Builder agent (mirrors
+ * company.AppBuilderSlug / team's appBuilderSlug on the Go side). Tasks owned
+ * by this slug get the live app-build preview surface.
+ */
+export const APP_BUILDER_SLUG = "app-builder";
+
 export const ONBOARDING_COPY = {
   step1_headline: "AI employees with a shared brain",
   step1_subhead:

--- a/web/src/lib/slashCommands.ts
+++ b/web/src/lib/slashCommands.ts
@@ -68,6 +68,21 @@ export function handleSlashCommand(
     case "/help":
       store.setComposerHelpOpen(true);
       return true;
+    case "/create-app":
+      store.openCreateAppDialog();
+      return true;
+    case "/update-app": {
+      const appId = args.trim();
+      if (appId.startsWith("app_")) {
+        store.openUpdateAppDialog(appId);
+      } else {
+        showNotice(
+          "Usage: /update-app <app-id> — or open an app and click Edit.",
+          "info",
+        );
+      }
+      return true;
+    }
     case "/requests":
       navigateToApp("requests");
       return true;

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -28,6 +28,7 @@ import "./styles/onboarding-wizard.css";
 import "./styles/office-tour.css";
 import "./styles/office-tour-slides.css";
 import "./styles/operator.css";
+import "./styles/apps.css";
 
 // Attach the root route's component at startup. Defining the component
 // inside `lib/router.ts` would create a circular import: RootRoute reads

--- a/web/src/routes/RootRoute.tsx
+++ b/web/src/routes/RootRoute.tsx
@@ -22,6 +22,8 @@ import {
   getInjectedAnalyticsConfig,
   initApi,
 } from "../api/client";
+import { CreateAppDialog } from "../components/apps/CreateAppDialog";
+import { CustomAppView } from "../components/apps/CustomAppView";
 import { TelegramConnectHost } from "../components/integrations/TelegramConnectModal";
 import { Shell } from "../components/layout/Shell";
 import { UpgradeBanner } from "../components/layout/UpgradeBanner";
@@ -677,6 +679,11 @@ function MainContent() {
         return <FirstClassAppRedirect appId={route.appId} />;
       }
       if (!isAppPanelId(route.appId)) {
+        // Agent-generated Apps live at /apps/app_<hash>. Anything else under
+        // /apps that is neither a built-in panel nor a custom app id is unknown.
+        if (route.appId.startsWith("app_")) {
+          return <CustomAppView appId={route.appId} />;
+        }
         return <UnknownAppPanel appId={route.appId} />;
       }
       return <AppPanel appId={route.appId} />;
@@ -1178,6 +1185,7 @@ export default function RootRoute() {
       <ConfirmHost />
       <ProviderSwitcherHost />
       <TelegramConnectHost />
+      <CreateAppDialog />
     </ErrorBoundary>
   );
 }

--- a/web/src/stores/app.ts
+++ b/web/src/stores/app.ts
@@ -126,6 +126,14 @@ export function directChannelSlug(
  */
 export const HOME_COMPOSER_DRAFT_CHANNEL = "@home";
 
+export interface AppBuilderDialogState {
+  mode: "create" | "update";
+  /** Set in "update" mode — the app being improved. */
+  appId?: string;
+  /** App name, prefilled in "update" mode for display. */
+  name?: string;
+}
+
 export interface AppStore {
   // Connection
   brokerConnected: boolean;
@@ -224,6 +232,21 @@ export interface AppStore {
   telegramConnectMode: "provider" | "telegram";
   openConnectWizard: (mode: "provider" | "telegram") => void;
   setTelegramConnectOpen: (v: boolean) => void;
+
+  // App Builder dialog: /create-app, /update-app, and the Edit button on an
+  // app screen open this NL-description dialog, which kicks off an App Builder
+  // task. null when closed.
+  appBuilderDialog: AppBuilderDialogState | null;
+  openCreateAppDialog: () => void;
+  openUpdateAppDialog: (appId: string, name?: string) => void;
+  closeAppBuilderDialog: () => void;
+
+  // Optimistic "building…" rows for the Apps sidebar: a 20-60s App Builder
+  // build would otherwise be dead air between submit and the app appearing.
+  // Keyed by lowercased app name -> { display name, started-at epoch ms }.
+  appBuilds: Record<string, { name: string; startedAt: number }>;
+  noteAppBuilding: (name: string) => void;
+  clearAppBuilding: (name: string) => void;
 
   // Onboarding
   onboardingComplete: boolean;
@@ -401,6 +424,32 @@ export const useAppStore = create<AppStore>((set, get) => ({
   openConnectWizard: (mode) =>
     set({ telegramConnectOpen: true, telegramConnectMode: mode }),
   setTelegramConnectOpen: (v) => set({ telegramConnectOpen: v }),
+
+  appBuilderDialog: null,
+  openCreateAppDialog: () => set({ appBuilderDialog: { mode: "create" } }),
+  openUpdateAppDialog: (appId, name) =>
+    set({ appBuilderDialog: { mode: "update", appId, name } }),
+  closeAppBuilderDialog: () => set({ appBuilderDialog: null }),
+
+  appBuilds: {},
+  noteAppBuilding: (name) =>
+    set((state) => ({
+      appBuilds: {
+        ...state.appBuilds,
+        [name.trim().toLowerCase()]: {
+          name: name.trim(),
+          startedAt: Date.now(),
+        },
+      },
+    })),
+  clearAppBuilding: (name) =>
+    set((state) => {
+      const key = name.trim().toLowerCase();
+      if (!(key in state.appBuilds)) return {};
+      const next = { ...state.appBuilds };
+      delete next[key];
+      return { appBuilds: next };
+    }),
 
   agentActivitySnapshots: {},
   agentActivityHistory: {},

--- a/web/src/styles/apps.css
+++ b/web/src/styles/apps.css
@@ -566,6 +566,58 @@
   color: var(--text-secondary);
 }
 
+/* Streaming install/boot log while the live dev server warms up. */
+.app-build-preview__bootlog {
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-height: 0;
+  padding: 16px;
+  overflow: hidden;
+}
+
+.app-build-preview__bootlog-text {
+  margin: 0;
+  max-width: 100%;
+  max-height: 240px;
+  padding: 10px 12px;
+  overflow: auto;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm, 6px);
+  background: var(--bg-subtle);
+  color: var(--text-secondary);
+  font-family: var(--font-mono, monospace);
+  font-size: 11px;
+  line-height: 1.5;
+  text-align: left;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+/* Live/Sealed preview toggle on the standalone app screen. */
+.custom-app-view__mode {
+  display: inline-flex;
+  margin-right: 8px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm, 6px);
+  overflow: hidden;
+}
+
+.custom-app-view__mode-btn {
+  padding: 4px 10px;
+  border: 0;
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.custom-app-view__mode-btn[aria-pressed="true"] {
+  background: var(--accent);
+  color: var(--accent-contrast, #fff);
+}
+
 /* Narrow: stack chat over preview and retire the drag handle. */
 @media (max-width: 720px) {
   .issue-doc-body--app-build .resizable-split {

--- a/web/src/styles/apps.css
+++ b/web/src/styles/apps.css
@@ -1,0 +1,583 @@
+/* Apps — agent-generated internal tools. Token-driven so it tracks all themes. */
+
+.custom-app-view {
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
+  height: 100%;
+  min-height: 0;
+  background: var(--bg-card, #fff);
+  color: var(--text);
+}
+
+.custom-app-view--state {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 32px;
+}
+
+.custom-app-view__loading {
+  color: var(--text-secondary, #687083);
+  font-size: 14px;
+}
+
+.custom-app-view__error {
+  max-width: 480px;
+  text-align: center;
+  color: var(--text);
+}
+
+.custom-app-view__error-detail {
+  margin-top: 8px;
+  color: var(--text-secondary, #687083);
+  font-family: var(--font-mono, monospace);
+  font-size: 12px;
+  overflow-wrap: anywhere;
+}
+
+.custom-app-view__header {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  padding: 10px 16px;
+  border-bottom: 1px solid var(--border, rgba(20, 24, 31, 0.14));
+  background: var(--bg-card, #fff);
+}
+
+.custom-app-view__icon {
+  font-size: 20px;
+  line-height: 1;
+}
+
+.custom-app-view__heading {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.custom-app-view__name {
+  margin: 0;
+  font-size: 15px;
+  font-weight: 600;
+  line-height: 1.2;
+  color: var(--text);
+}
+
+.custom-app-view__summary {
+  margin: 0;
+  font-size: 12px;
+  color: var(--text-secondary, #687083);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.custom-app-view__version {
+  margin-left: auto;
+  padding: 2px 8px;
+  border: 1px solid var(--border, rgba(20, 24, 31, 0.14));
+  border-radius: var(--radius-sm, 6px);
+  color: var(--text-secondary, #687083);
+  font-family: var(--font-mono, monospace);
+  font-size: 11px;
+}
+
+.custom-app-view__action {
+  display: inline-flex;
+  gap: 6px;
+  align-items: center;
+  padding: 5px 10px;
+  border: 1px solid var(--border, rgba(20, 24, 31, 0.14));
+  border-radius: var(--radius-sm, 6px);
+  background: transparent;
+  color: var(--text);
+  font-size: 13px;
+  cursor: pointer;
+  transition:
+    background-color 120ms ease,
+    border-color 120ms ease;
+}
+
+.custom-app-view__action:hover {
+  background: var(--bg-subtle);
+}
+
+.custom-app-view__action--danger:hover {
+  border-color: var(--red);
+  color: var(--red);
+}
+
+.custom-app-view__icon-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm, 6px);
+  background: transparent;
+  color: var(--text);
+  cursor: pointer;
+  transition: background-color 120ms ease;
+}
+
+.custom-app-view__icon-btn:hover {
+  background: var(--bg-subtle);
+}
+
+.custom-app-view__menu-wrap {
+  position: relative;
+}
+
+.custom-app-view__menu {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  z-index: 40;
+  min-width: 210px;
+  padding: 6px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md, 8px);
+  background: var(--bg-card);
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.18);
+}
+
+.custom-app-view__menu-section {
+  padding: 6px 8px 4px;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-secondary);
+}
+
+.custom-app-view__menu-empty {
+  padding: 4px 8px 8px;
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+
+.custom-app-view__menu-item {
+  display: block;
+  width: 100%;
+  padding: 7px 8px;
+  border: 0;
+  border-radius: var(--radius-sm, 6px);
+  background: transparent;
+  color: var(--text);
+  font-size: 13px;
+  text-align: left;
+  cursor: pointer;
+}
+
+.custom-app-view__menu-item:hover {
+  background: var(--bg-subtle);
+}
+
+.custom-app-view__menu-item:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.custom-app-view__menu-item--danger {
+  color: var(--red);
+}
+
+.custom-app-view__menu-item--danger:hover {
+  background: var(--red-bg);
+}
+
+.custom-app-view__menu-divider {
+  height: 1px;
+  margin: 4px 0;
+  background: var(--border);
+}
+
+/* In-flight build row in the Apps sidebar (optimistic, until the app appears). */
+.sidebar-app-building {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 8px;
+  border-radius: var(--radius-sm, 6px);
+  font-size: 13px;
+}
+
+.sidebar-app-building__spinner {
+  flex: 0 0 auto;
+  width: 12px;
+  height: 12px;
+  border: 2px solid var(--border);
+  border-top-color: var(--accent);
+  border-radius: 50%;
+  animation: sidebar-app-spin 0.7s linear infinite;
+}
+
+.sidebar-app-building__label {
+  flex: 1 1 auto;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--text);
+}
+
+.sidebar-app-building__meta {
+  flex: 0 0 auto;
+  font-size: 11px;
+  color: var(--text-secondary);
+}
+
+@keyframes sidebar-app-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .sidebar-app-building__spinner {
+    animation: none;
+  }
+}
+
+.custom-app-view__body {
+  min-height: 0;
+  overflow: hidden;
+}
+
+.custom-app-frame {
+  display: block;
+  width: 100%;
+  height: 100%;
+  border: 0;
+  background: #fff;
+}
+
+/* App Builder dialog body — the Radix Dialog primitive handles the shell. */
+/*
+ * Create/Improve App modal. Rides the app's canonical modal frame (.help-overlay
+ * / .help-modal / .help-header / .help-body from search.css) and native .input /
+ * .btn controls, so it matches every other modal. Only the form-specific spacing
+ * and a token-styled textarea live here.
+ */
+.app-builder-modal {
+  width: min(92%, 520px);
+}
+
+.app-builder-modal__body {
+  /* Tighter than the default .help-body gap (22px) — these are stacked form
+     fields, not distinct sections. */
+  gap: 16px;
+}
+
+.app-builder-modal__field {
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+}
+
+.app-builder-modal__label {
+  font-size: var(--text-xs);
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--text-secondary);
+}
+
+/* Matches the native .input token surface, but sized + padded as a textarea
+   (the shared .input is a fixed 44px height with no vertical padding). */
+.app-builder-modal__textarea {
+  width: 100%;
+  min-height: 112px;
+  padding: 10px 12px;
+  border: 1px solid var(--input-border);
+  border-radius: var(--radius-md);
+  background: var(--input-bg);
+  color: var(--text);
+  font-size: var(--text-md, 14px);
+  font-family: var(--font-sans);
+  line-height: 1.5;
+  resize: vertical;
+  transition:
+    border-color var(--duration-slow),
+    box-shadow var(--duration-slow);
+}
+
+.app-builder-modal__textarea:hover:not(:focus-visible) {
+  border-color: var(--border-strong, var(--border));
+}
+
+.app-builder-modal__textarea:focus-visible {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-bg);
+}
+
+.app-builder-modal__footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+  margin-top: 2px;
+}
+
+/* ─── App Builder task: chat ↔ live preview split ───────────────────────── */
+/* Mirrors .issue-doc-body--split's flex/height model so the preview fills the
+   task surface; the inner ResizableSplit owns the column widths. */
+.issue-doc-body--app-build {
+  flex: 1 1 auto;
+  min-height: 0;
+  flex-direction: row;
+  gap: 0;
+  padding: 0;
+  align-items: stretch;
+}
+
+.resizable-split {
+  display: flex;
+  flex-direction: row;
+  width: 100%;
+  height: 100%;
+  min-height: 0;
+  align-items: stretch;
+}
+
+.resizable-split__pane {
+  display: flex;
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+}
+
+/* Left width is driven by the --rs-left-basis custom property the divider sets
+   inline (a var, not flex-basis directly, so the narrow-stack media query can
+   override it without !important). */
+.resizable-split__pane--left {
+  flex-grow: 0;
+  flex-shrink: 0;
+  flex-basis: var(--rs-left-basis, 55%);
+}
+
+.resizable-split__pane--right {
+  flex: 1 1 0;
+}
+
+.resizable-split__pane > * {
+  width: 100%;
+}
+
+.resizable-split__divider {
+  flex: 0 0 auto;
+  z-index: 2;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  /* 7px hit target that doesn't consume layout width (negative margins pull
+     the neighbouring panes back over the padding). */
+  width: 7px;
+  margin: 0 -3px;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  cursor: col-resize;
+  touch-action: none;
+}
+
+.resizable-split__grip {
+  width: 1px;
+  height: 100%;
+  background: var(--border);
+  transition:
+    background-color 120ms ease,
+    width 120ms ease;
+}
+
+.resizable-split__divider:hover .resizable-split__grip,
+.resizable-split__divider:focus-visible .resizable-split__grip,
+.resizable-split--dragging .resizable-split__grip {
+  width: 2px;
+  background: var(--accent);
+}
+
+.resizable-split__divider:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
+
+/* Mid-drag: stop the preview iframe (or any pane content) from swallowing
+   pointer moves, and suppress text selection so the drag stays smooth. */
+.resizable-split--dragging {
+  user-select: none;
+  cursor: col-resize;
+}
+
+.resizable-split--dragging .resizable-split__pane {
+  pointer-events: none;
+}
+
+/* ─── Live preview pane ─────────────────────────────────────────────────── */
+.app-build-preview {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  min-height: 0;
+  background: var(--bg-card);
+}
+
+.app-build-preview__header {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--border);
+}
+
+.app-build-preview__icon {
+  font-size: 15px;
+  line-height: 1;
+}
+
+.app-build-preview__title {
+  min-width: 0;
+  overflow: hidden;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.app-build-preview__live {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  margin-left: auto;
+  font-size: 11px;
+  color: var(--text-secondary);
+}
+
+.app-build-preview__live-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--green, #2ea043);
+  animation: app-build-live-pulse 1.8s ease-out infinite;
+}
+
+@keyframes app-build-live-pulse {
+  0% {
+    box-shadow: 0 0 0 0 rgba(46, 160, 67, 0.4);
+  }
+  70% {
+    box-shadow: 0 0 0 5px rgba(46, 160, 67, 0);
+  }
+  100% {
+    box-shadow: 0 0 0 0 rgba(46, 160, 67, 0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .app-build-preview__live-dot {
+    animation: none;
+  }
+}
+
+.app-build-preview__version {
+  padding: 1px 7px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm, 6px);
+  color: var(--text-secondary);
+  font-family: var(--font-mono, monospace);
+  font-size: 11px;
+}
+
+.app-build-preview__open {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm, 6px);
+  background: transparent;
+  color: var(--text);
+  cursor: pointer;
+  transition: background-color 120ms ease;
+}
+
+.app-build-preview__open:hover {
+  background: var(--bg-subtle);
+}
+
+.app-build-preview__frame {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.app-build-preview__frame .custom-app-frame {
+  width: 100%;
+  height: 100%;
+}
+
+/* Building / waiting placeholder — keeps the 20–60s build from being dead air. */
+.app-build-preview__state {
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  padding: 28px;
+  text-align: center;
+}
+
+.app-build-preview__spinner {
+  width: 22px;
+  height: 22px;
+  border: 2px solid var(--border);
+  border-top-color: var(--accent);
+  border-radius: 50%;
+  animation: sidebar-app-spin 0.7s linear infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .app-build-preview__spinner {
+    animation: none;
+  }
+}
+
+.app-build-preview__state-title {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.app-build-preview__state-detail {
+  margin: 0;
+  max-width: 320px;
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--text-secondary);
+}
+
+/* Narrow: stack chat over preview and retire the drag handle. */
+@media (max-width: 720px) {
+  .issue-doc-body--app-build .resizable-split {
+    flex-direction: column;
+  }
+  .issue-doc-body--app-build .resizable-split__pane--left,
+  .issue-doc-body--app-build .resizable-split__pane--right {
+    /* Overrides the base flex-basis var above (stylesheet vs stylesheet, later
+       rule wins) so each pane takes an equal share when stacked. */
+    flex: 1 1 auto;
+  }
+  .issue-doc-body--app-build .resizable-split__divider {
+    display: none;
+  }
+}


### PR DESCRIPTION
## Apps — agent-generated internal tools, built by an App Builder agent

Today WUPHF agents do work but leave no reusable software behind. When a workflow repeats (render a status digest, score a lead, build a dashboard), the agent redoes it from scratch each time. This PR adds a first-class **Apps** surface: any agent can turn a repeatable workflow into a small internal tool — proposed to the human, built by a dedicated built-in **App Builder** agent, listed in the sidebar, and re-runnable forever.

The validated wedge (via `/office-hours`): self-serve internal tools with **no engineering in the loop** — spin up many, modify in plain English, trustworthy. Differentiator vs Retool/v0/Lovable/dyad = the closed self-serve *create + modify* loop living inside the workspace.

### Approach — the dyad model, adapted

dyad runs generated apps as real local Vite/React/TS projects (it's a local app with Node). WUPHF is in dyad's position (local Go server + a real headless coding agent with native file tools), **not** bolt's (WebContainers — rejected: needs COOP/COEP + StackBlitz proxy + licensing). So the App Builder scaffolds a real **Vite + React 19 + TS** project from `templates/app-scaffold/`, and we render it two ways:

- **Live (dev) preview** — a real Vite dev server per app, reverse-proxied by the broker and framed with HMR. Edits hot-reload with no rebuild. This is what makes the build feel instant instead of multi-minute "Building…" dead air.
- **Sealed (ship) artifact** — `vite-plugin-singlefile` builds a single self-contained `index.html` that renders in the existing hardened sandboxed-iframe primitive. Zero new in-browser runtime, fully local/offline.

Apps reach workspace data only through a **whitelisted `postMessage` bridge** to the parent (read-only broker GETs under the user's own session) — never directly. This whitelisted bridge is the net-new secure design; dyad's direct-Supabase data layer does not transfer.

### What's in this PR

**Built-in App Builder agent** — seeded into every office at the manifest layer *and* back-filled at the broker load path (existing offices gain it on load, mirroring the Librarian). Roster member → the launcher spawns its session → it actually builds.

**Backend** (`internal/team/`)
- `custom_app.go` — versioned app store (snapshot per build, append-only `versions/`, source persistence, non-destructive rollback) under `<runtime-home>/.wuphf/apps/<id>/`.
- `custom_app_dev.go` — the live dev-server layer: `appDevManager` (idle-GC, StopAll), ephemeral 127.0.0.1 proxy per app, broker-owned `httputil.ReverseProxy` that injects an **agent-proof CSP** (`connect-src` = same-origin HMR socket only — no wildcard, no `'self'`), strips `X-Frame-Options`, and strips any CSP `<meta>` so the proxy header is the sole authority. DNS-rebind Host guard. HMR routes back through the proxy via `WUPHF_HMR_CLIENT_PORT`.
- `broker_apps.go` / `broker_apps_proposal.go` — `/apps` CRUD (writes gated to app-builder/human), `/apps/{id}/dev*`, `/apps/{id}/versions`, `/apps/{id}/rollback`; `propose_app` → non-blocking approval → app-builder task.
- `teammcp/app_tools.go` — `list_apps` + `propose_app` (all agents), `get_app` + `register_app` (App-Builder-gated).
- Shared sandbox validator extracted to `sandbox_html_policy.go` (rich-artifact + custom-app now thin configs).
- Slash `create-app` / `update-app`; prompt blocks (notice repetition → `list_apps` → `propose_app`; full build playbook + "narrate like a livestream").

**Frontend** (`web/src/`)
- `AppsSection` (data-driven `GET /apps`, above Config in the sidebar) + `CreateAppDialog` on the app's canonical modal frame.
- `CustomAppView` (Live/Sealed toggle, Edit primary, Delete/rollback in overflow menu).
- `CustomAppFrame` (sealed: `allow-scripts` only + injected CSP + read-only bridge; dev: `allow-scripts allow-same-origin` loading the distinct proxy origin, reply origin pinned to it).
- `AppLivePreview` (polls `ensureAppDev`, streams the boot log, loopback-URL guard before framing).
- `AppBuildPreview` + `ResizableSplit` — the App Builder task view is chat │ live-preview with a draggable, persisted divider.

**Scaffold** `templates/app-scaffold/` — Vite + React 19 + TS + singlefile, `wuphf-bridge.ts`, `AI_RULES.md`, committed `bun.lock` for deterministic/offline builds.

### Security

Reviewed by the `security-reviewer` subagent across both the sealed and dev surfaces (path-traversal, CSP-comment bypass, write authz on the sealed path; then 8 findings on the dev surface — 6 fixed, 1 can-only-break-the-preview documented, 1 doc note). The iframe sandbox is the real boundary, not the write-time validator. Dev-mode invariants are locked by tests: the proxy enforces the CSP over a hostile dev server, `connect-src` has no wildcard/`'self'`, the Vite-URL scrape is `Local:`-anchored against stdout decoys, foreign Host → 403.

### Verification

- Full Go suite (team / teammcp / company) green; web `tsc` 0; biome clean on changed files; web build OK.
- Live dev-server + HMR + bridge verified end-to-end via browser-harness on a real scaffold app: `bun install` warm 171ms → Vite ready ~1s → React mounts → bridge populates office data cross-origin → on-disk edit hot-reloads with no rebuild.

### Reviewed via gstack pipeline

`/office-hours` (wedge) → `/plan-eng-review` (ENG CLEARED, 3 findings folded) → `/plan-design-review` (8/10, 6 findings folded). Design doc + review report on file.

### Status

**Draft.** Live dev-server preview is built, browser-verified, and hardened. Remaining before "ready": 3-theme screenshots published to the PR, plus the stacked follow-up (instant preview for a brand-new build — see the PR stacked on this branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
