### PR TITLE
feat(apps): version timeline + non-destructive preview + restore

### DIFF
--- a/docs/specs/app-builder-live-preview.md
+++ b/docs/specs/app-builder-live-preview.md
@@ -1,9 +1,11 @@
 # App Builder — Live Dev-Server Preview (SOTA)
 
-Status: **Phase 1 SHIPPED (PR #1099) + instant-new-build (pre-scaffold)
-SHIPPED on the stacked branch.** Architecture approved by the founder
-(2026-06-15): live dev-server-per-app behind a broker proxy; the single-file
-build stays as the sealed "ship" artifact.
+Status: **Phase 1 SHIPPED (PR #1099) + instant-new-build (pre-scaffold,
+#1100) + structured build-activity feed (Phase 2, #1102) + version timeline /
+non-destructive preview (Phase 4) all SHIPPED on the stacked branch.**
+Architecture approved by the founder (2026-06-15): live dev-server-per-app
+behind a broker proxy; the single-file build stays as the sealed "ship"
+artifact.
 
 ## Shipped so far
 
@@ -169,9 +171,19 @@ repo rules).
 3. **Pre-commit `tsc --noEmit` + `vite build` gate + bounded ~2-round auto-fix**
    re-prompt with `file:line:col` (dyad `chat_stream_handlers.ts` auto-fix loop).
    Auto-loop build errors (ground truth); human-gate runtime errors. Effort M.
-4. **Git-commit-per-response version timeline** (we already commit to git):
-   non-destructive preview of a past version + forward-preserving "Restore".
-   Effort M.
+4. **Version timeline + non-destructive preview** — SHIPPED. Every published
+   build is already retained append-only under `apps/<id>/versions/v<N>/`
+   (snapshot dirs, NOT git — the store is deliberately decoupled from the wiki
+   git worker). This phase exposes that history: each snapshot now carries a
+   `meta.json` (who/when), `GET /apps/{id}/versions` returns structured,
+   current-flagged entries, and the new `GET /apps/{id}/versions/{n}` reads a
+   past build's bytes WITHOUT changing the current version. The app view gained a
+   **History** toggle → a timeline rail beside the preview; selecting an older
+   build previews it read-only (a banner offers "Restore this version" /
+   "Back to current"). Restore reuses the existing append-only `Rollback`
+   (re-publishes those bytes as a new forward version), so a restore is itself
+   reversible. Restore moved out of the overflow menu (which now holds only the
+   destructive Delete).
 5. **Select-to-edit** (`data-dyad-id="file:line:col"` JSX tagging + injected
    selector → source map) **+ iframe error capture** via postMessage — the magic
    moment; works under our sandbox. Effort S–M.

--- a/internal/team/broker_apps.go
+++ b/internal/team/broker_apps.go
@@ -17,6 +17,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -90,6 +91,12 @@ func (b *Broker) handleAppByID(w http.ResponseWriter, r *http.Request) {
 	case "versions":
 		if r.Method != http.MethodGet {
 			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		// /apps/{id}/versions/{n} reads one retained build for non-destructive
+		// preview; /apps/{id}/versions lists them.
+		if len(parts) > 2 {
+			b.handleAppVersion(w, r, id, parts[2])
 			return
 		}
 		versions, err := b.appStore().ListVersions(id)
@@ -196,6 +203,31 @@ func (b *Broker) handleAppRoot(w http.ResponseWriter, r *http.Request, id string
 	default:
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 	}
+}
+
+// handleAppVersion serves GET /apps/{id}/versions/{n}: one retained build's
+// bytes + metadata for non-destructive preview. It NEVER changes the current
+// version — restoring is the separate POST /apps/{id}/rollback. The bytes were
+// validated at write time and render in the same sandboxed frame as the sealed
+// current view, so this adds no new rendering surface.
+func (b *Broker) handleAppVersion(w http.ResponseWriter, r *http.Request, id, raw string) {
+	n, err := strconv.Atoi(raw)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid version"})
+		return
+	}
+	ver, htmlBody, err := b.appStore().GetVersion(id, n)
+	if err != nil {
+		writeAppError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"version":   ver.Version,
+		"updatedAt": ver.UpdatedAt,
+		"updatedBy": ver.UpdatedBy,
+		"current":   ver.Current,
+		"html":      htmlBody,
+	})
 }
 
 func (b *Broker) handleAppRollback(w http.ResponseWriter, r *http.Request, id string) {

--- a/internal/team/broker_apps_integration_test.go
+++ b/internal/team/broker_apps_integration_test.go
@@ -137,6 +137,127 @@ func TestRegisterAppRestrictedToAppBuilder(t *testing.T) {
 	}
 }
 
+// TestAppVersionEndpointsNonDestructive drives the version-timeline HTTP surface
+// end-to-end: listing retained builds (structured, newest-first, current-flagged)
+// and reading one past build's bytes for preview WITHOUT changing the current
+// version. This is the new serving surface behind Phase 4's history timeline.
+func TestAppVersionEndpointsNonDestructive(t *testing.T) {
+	// Isolate the app store under a temp runtime home so the test never touches
+	// a real ~/.wuphf/apps. Must be set before the first /apps call constructs
+	// the store (appStore() reads CustomAppsRootDir lazily, via sync.Once).
+	t.Setenv("WUPHF_RUNTIME_HOME", t.TempDir())
+
+	b := newTestBroker(t)
+	if err := b.StartOnPort(0); err != nil {
+		t.Fatalf("start broker: %v", err)
+	}
+	defer b.Stop()
+	base := fmt.Sprintf("http://%s", b.Addr())
+
+	htmlB := `<!doctype html><html><head></head><body><div id="root">B</div><script>var b=2;</script></body></html>`
+
+	// Register v1, then update to v2 (both as the App Builder).
+	v1Body, _ := json.Marshal(map[string]any{"name": "Lead Scorer", "html": validAppHTML})
+	created := postAppsAsAgent(t, base+"/apps", b.Token(), appBuilderSlug, v1Body)
+	app, _ := created["app"].(map[string]any)
+	id, _ := app["id"].(string)
+	if id == "" {
+		t.Fatalf("no app id in register response: %v", created)
+	}
+	v2Body, _ := json.Marshal(map[string]any{"id": id, "name": "Lead Scorer", "html": htmlB})
+	postAppsAsAgent(t, base+"/apps", b.Token(), appBuilderSlug, v2Body)
+
+	// List → two structured versions, newest first, v2 current.
+	status, list := getAppsJSON(t, base+"/apps/"+id+"/versions", b.Token())
+	if status != http.StatusOK {
+		t.Fatalf("list versions: %d", status)
+	}
+	versions, _ := list["versions"].([]any)
+	if len(versions) != 2 {
+		t.Fatalf("versions = %v, want 2", versions)
+	}
+	first, _ := versions[0].(map[string]any)
+	if v, _ := first["version"].(float64); int(v) != 2 {
+		t.Fatalf("newest version = %v, want 2", first["version"])
+	}
+	if cur, _ := first["current"].(bool); !cur {
+		t.Fatalf("newest version should be current: %v", first)
+	}
+	if by, _ := first["updatedBy"].(string); by != appBuilderSlug {
+		t.Fatalf("newest updatedBy = %q, want %q", by, appBuilderSlug)
+	}
+
+	// Read v1's bytes for preview — flat shape, exact v1 bytes, NOT current.
+	status, ver := getAppsJSON(t, base+"/apps/"+id+"/versions/1", b.Token())
+	if status != http.StatusOK {
+		t.Fatalf("get version 1: %d", status)
+	}
+	if html, _ := ver["html"].(string); html != validAppHTML {
+		t.Fatalf("v1 html mismatch: %q", ver["html"])
+	}
+	if cur, _ := ver["current"].(bool); cur {
+		t.Fatalf("v1 must not be flagged current: %v", ver)
+	}
+
+	// Non-destructive: the current build is still v2 after the preview read.
+	status, curResp := getAppsJSON(t, base+"/apps/"+id, b.Token())
+	if status != http.StatusOK {
+		t.Fatalf("get current: %d", status)
+	}
+	curApp, _ := curResp["app"].(map[string]any)
+	if v, _ := curApp["version"].(float64); int(v) != 2 {
+		t.Fatalf("preview read changed current version to %v", curApp["version"])
+	}
+	if html, _ := curResp["html"].(string); html != htmlB {
+		t.Fatalf("preview read changed the current bytes")
+	}
+
+	// Unknown version → 400-class caller error (consistent with rollback).
+	status, _ = getAppsJSON(t, base+"/apps/"+id+"/versions/99", b.Token())
+	if status != http.StatusBadRequest {
+		t.Fatalf("unknown version status = %d, want 400", status)
+	}
+}
+
+func getAppsJSON(t *testing.T, url, token string) (int, map[string]any) {
+	t.Helper()
+	req, _ := http.NewRequest(http.MethodGet, url, nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET %s: %v", url, err)
+	}
+	defer resp.Body.Close()
+	raw, _ := io.ReadAll(resp.Body)
+	var out map[string]any
+	if len(raw) > 0 {
+		_ = json.Unmarshal(raw, &out)
+	}
+	return resp.StatusCode, out
+}
+
+func postAppsAsAgent(t *testing.T, url, token, agentSlug string, body []byte) map[string]any {
+	t.Helper()
+	req, _ := http.NewRequest(http.MethodPost, url, bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-WUPHF-Agent", agentSlug)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST %s: %v", url, err)
+	}
+	defer resp.Body.Close()
+	raw, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("POST %s -> %d: %s", url, resp.StatusCode, raw)
+	}
+	var out map[string]any
+	if len(raw) > 0 {
+		_ = json.Unmarshal(raw, &out)
+	}
+	return out
+}
+
 func postAppsStatus(t *testing.T, url, token, agentSlug string, body []byte) int {
 	t.Helper()
 	req, _ := http.NewRequest(http.MethodPost, url, bytes.NewReader(body))

--- a/internal/team/custom_app.go
+++ b/internal/team/custom_app.go
@@ -49,6 +49,7 @@ const (
 	// back to a known-good build, and the App Builder can edit real source
 	// instead of regenerating from prose.
 	customAppVersionsDir        = "versions"
+	customAppVersionMetaFile    = "meta.json"
 	customAppSourceDir          = "src"
 	customAppMaxSourceFiles     = 300
 	customAppMaxSourceFileBytes = 512 * 1024
@@ -339,7 +340,7 @@ func (s *customAppStore) Save(req CustomAppWriteRequest, now time.Time) (CustomA
 	// Retain this version's built bytes (append-only history) so a later edit
 	// can roll back to a known-good build. Without this the version counter is
 	// a false affordance — it promises an undo that cannot happen.
-	if err := s.snapshotVersionLocked(dir, app.Version, htmlBody); err != nil {
+	if err := s.snapshotVersionLocked(dir, app, htmlBody); err != nil {
 		return CustomApp{}, err
 	}
 	// Persist the source project when provided so edits modify real files.
@@ -468,16 +469,27 @@ func writeScaffoldSourceLocked(srcRoot string) error {
 	})
 }
 
-func (s *customAppStore) snapshotVersionLocked(dir string, version int, htmlBody string) error {
-	if version < 1 {
+func (s *customAppStore) snapshotVersionLocked(dir string, app CustomApp, htmlBody string) error {
+	if app.Version < 1 {
 		return nil
 	}
-	vdir := filepath.Join(dir, customAppVersionsDir, fmt.Sprintf("v%d", version))
+	vdir := filepath.Join(dir, customAppVersionsDir, fmt.Sprintf("v%d", app.Version))
 	if err := os.MkdirAll(vdir, 0o700); err != nil {
 		return fmt.Errorf("app: mkdir version: %w", err)
 	}
 	if err := writeFileAtomic(filepath.Join(vdir, customAppEntry), []byte(htmlBody), 0o600); err != nil {
 		return fmt.Errorf("app: write version snapshot: %w", err)
+	}
+	// Capture who/when beside the bytes so the history timeline can label each
+	// build. Versions snapshotted before this file existed degrade gracefully to
+	// a bare version number (readVersionMetaLocked returns ok=false).
+	meta := customAppVersionMeta{Version: app.Version, UpdatedAt: app.UpdatedAt, UpdatedBy: app.UpdatedBy}
+	metaBytes, err := json.Marshal(meta)
+	if err != nil {
+		return fmt.Errorf("app: marshal version meta: %w", err)
+	}
+	if err := writeFileAtomic(filepath.Join(vdir, customAppVersionMetaFile), metaBytes, 0o600); err != nil {
+		return fmt.Errorf("app: write version meta: %w", err)
 	}
 	return nil
 }
@@ -605,22 +617,50 @@ func (s *customAppStore) Source(id string) (map[string]string, error) {
 	return out, nil
 }
 
-// ListVersions returns the retained version numbers, newest first.
-func (s *customAppStore) ListVersions(id string) ([]int, error) {
+// CustomAppVersion is one retained build in an app's append-only history,
+// surfaced by the version timeline. Metadata (who/when) is captured at snapshot
+// time; builds snapshotted before that existed degrade to just the version
+// number. Current marks the app's live build.
+type CustomAppVersion struct {
+	Version   int    `json:"version"`
+	UpdatedAt string `json:"updatedAt,omitempty"`
+	UpdatedBy string `json:"updatedBy,omitempty"`
+	Current   bool   `json:"current"`
+}
+
+// customAppVersionMeta is the on-disk metadata stored beside each retained build
+// (versions/v<N>/meta.json). Current is intentionally NOT persisted — it is
+// derived against the manifest at read time so it can never go stale.
+type customAppVersionMeta struct {
+	Version   int    `json:"version"`
+	UpdatedAt string `json:"updatedAt"`
+	UpdatedBy string `json:"updatedBy"`
+}
+
+// ListVersions returns the retained versions, newest first, each annotated with
+// its capture metadata and whether it is the current build.
+func (s *customAppStore) ListVersions(id string) ([]CustomAppVersion, error) {
 	if err := validateCustomAppID(id); err != nil {
 		return nil, err
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	// Best-effort current version: a missing manifest just means nothing is
+	// marked current (the versions dir read below still drives the list), so an
+	// unknown/corrupt app degrades to an empty list rather than an error.
+	var current int
+	if app, err := s.readManifestLocked(id); err == nil {
+		current = app.Version
+	}
 	dir := filepath.Join(s.appDir(id), customAppVersionsDir)
 	entries, err := os.ReadDir(dir)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return []int{}, nil
+			return []CustomAppVersion{}, nil
 		}
 		return nil, fmt.Errorf("app: read versions: %w", err)
 	}
-	out := []int{}
+	out := []CustomAppVersion{}
 	for _, e := range entries {
 		if !e.IsDir() || !strings.HasPrefix(e.Name(), "v") {
 			continue
@@ -629,10 +669,60 @@ func (s *customAppStore) ListVersions(id string) ([]int, error) {
 		if err != nil || n < 1 {
 			continue
 		}
-		out = append(out, n)
+		ver := CustomAppVersion{Version: n, Current: n == current}
+		if meta, ok := s.readVersionMetaLocked(dir, n); ok {
+			ver.UpdatedAt = meta.UpdatedAt
+			ver.UpdatedBy = meta.UpdatedBy
+		}
+		out = append(out, ver)
 	}
-	sort.Sort(sort.Reverse(sort.IntSlice(out)))
+	sort.Slice(out, func(i, j int) bool { return out[i].Version > out[j].Version })
 	return out, nil
+}
+
+// GetVersion returns a retained build's bytes plus its metadata WITHOUT changing
+// the current version — the non-destructive read behind the timeline's preview.
+// Restoring is the separate, explicit Rollback.
+func (s *customAppStore) GetVersion(id string, version int) (CustomAppVersion, string, error) {
+	if err := validateCustomAppID(id); err != nil {
+		return CustomAppVersion{}, "", err
+	}
+	if version < 1 {
+		return CustomAppVersion{}, "", newCustomAppCallerError("app: invalid version %d", version)
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	versionsDir := filepath.Join(s.appDir(id), customAppVersionsDir)
+	body, err := os.ReadFile(filepath.Join(versionsDir, fmt.Sprintf("v%d", version), customAppEntry))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return CustomAppVersion{}, "", newCustomAppCallerError("app: version v%d not found", version)
+		}
+		return CustomAppVersion{}, "", fmt.Errorf("app: read version: %w", err)
+	}
+	ver := CustomAppVersion{Version: version}
+	if app, err := s.readManifestLocked(id); err == nil {
+		ver.Current = version == app.Version
+	}
+	if meta, ok := s.readVersionMetaLocked(versionsDir, version); ok {
+		ver.UpdatedAt = meta.UpdatedAt
+		ver.UpdatedBy = meta.UpdatedBy
+	}
+	return ver, string(body), nil
+}
+
+// readVersionMetaLocked reads versions/v<N>/meta.json. ok=false (not an error)
+// when the file is absent or unparseable, so legacy snapshots degrade quietly.
+func (s *customAppStore) readVersionMetaLocked(versionsDir string, version int) (customAppVersionMeta, bool) {
+	raw, err := os.ReadFile(filepath.Join(versionsDir, fmt.Sprintf("v%d", version), customAppVersionMetaFile))
+	if err != nil {
+		return customAppVersionMeta{}, false
+	}
+	var meta customAppVersionMeta
+	if err := json.Unmarshal(raw, &meta); err != nil {
+		return customAppVersionMeta{}, false
+	}
+	return meta, true
 }
 
 // Rollback restores a prior version's built bytes as a NEW forward version.

--- a/internal/team/custom_app_test.go
+++ b/internal/team/custom_app_test.go
@@ -171,8 +171,17 @@ func TestCustomAppVersionRetentionAndRollback(t *testing.T) {
 	if err != nil {
 		t.Fatalf("versions: %v", err)
 	}
-	if len(vs) != 2 || vs[0] != 2 || vs[1] != 1 {
-		t.Fatalf("versions = %v, want [2 1]", vs)
+	if len(vs) != 2 || vs[0].Version != 2 || vs[1].Version != 1 {
+		t.Fatalf("versions = %v, want [v2 v1]", vs)
+	}
+	// The newest snapshot is the current build; the prior one is not.
+	if !vs[0].Current || vs[1].Current {
+		t.Fatalf("current flags = [%v %v], want [true false]", vs[0].Current, vs[1].Current)
+	}
+	// Capture metadata (who/when) rides along with each retained build so the
+	// timeline can label it.
+	if vs[1].UpdatedBy != "app-builder" || vs[1].UpdatedAt == "" {
+		t.Fatalf("v1 meta = %+v, want updatedBy app-builder + a timestamp", vs[1])
 	}
 
 	// Rollback to v1 restores htmlA's exact bytes as a NEW version (append-only).
@@ -189,6 +198,55 @@ func TestCustomAppVersionRetentionAndRollback(t *testing.T) {
 	}
 	if vs2, _ := store.ListVersions(id); len(vs2) != 3 {
 		t.Fatalf("versions after rollback = %v, want 3 entries", vs2)
+	}
+}
+
+// TestCustomAppGetVersionNonDestructive verifies the timeline's preview read:
+// fetching a past version returns its exact bytes + metadata and does NOT change
+// the current build.
+func TestCustomAppGetVersionNonDestructive(t *testing.T) {
+	store := newCustomAppStore(t.TempDir())
+	now := time.Unix(1_700_000_000, 0).UTC()
+	htmlA := validAppHTML
+	htmlB := `<!doctype html><html><head></head><body><div id="root">B</div><script>var b=2;</script></body></html>`
+
+	a, err := store.Save(CustomAppWriteRequest{Name: "Tool", HTML: htmlA, Actor: "app-builder"}, now)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	id := a.ID
+	if _, err := store.Save(CustomAppWriteRequest{ID: id, Name: "Tool", HTML: htmlB, Actor: "pam"}, now.Add(time.Minute)); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+
+	// Reading v1 returns htmlA's bytes, its capture metadata, and is NOT current.
+	ver, body, err := store.GetVersion(id, 1)
+	if err != nil {
+		t.Fatalf("get version 1: %v", err)
+	}
+	if body != htmlA {
+		t.Fatalf("v1 bytes are not htmlA")
+	}
+	if ver.Current {
+		t.Fatalf("v1 should not be current")
+	}
+	if ver.UpdatedBy != "app-builder" {
+		t.Fatalf("v1 updatedBy = %q, want app-builder", ver.UpdatedBy)
+	}
+
+	// v2 reads back as the current build.
+	if v2, _, err := store.GetVersion(id, 2); err != nil || !v2.Current {
+		t.Fatalf("v2 = %+v err=%v, want current", v2, err)
+	}
+
+	// The current build is untouched by the preview reads.
+	if _, cur, _ := store.Get(id); cur != htmlB {
+		t.Fatalf("preview read mutated the current build")
+	}
+
+	// Unknown version is a caller (400-class) error, not a 500.
+	if _, _, err := store.GetVersion(id, 99); !isCustomAppCallerError(err) {
+		t.Fatalf("get unknown version err = %v, want caller error", err)
 	}
 }
 

--- a/web/src/api/apps.ts
+++ b/web/src/api/apps.ts
@@ -44,11 +44,44 @@ export async function deleteApp(id: string): Promise<void> {
   await del(`/apps/${encodeURIComponent(id)}`);
 }
 
-export async function listAppVersions(id: string): Promise<number[]> {
-  const res = await get<{ versions: number[] }>(
+/**
+ * CustomAppVersion is one retained build in an app's append-only history.
+ * Metadata (updatedBy/updatedAt) is captured at snapshot time; builds from
+ * before that existed degrade to just the version number. Mirrors the Go
+ * CustomAppVersion shape (internal/team/custom_app.go).
+ */
+export interface CustomAppVersion {
+  version: number;
+  updatedBy?: string;
+  updatedAt?: string;
+  /** True for the app's live current build. */
+  current: boolean;
+}
+
+export async function listAppVersions(id: string): Promise<CustomAppVersion[]> {
+  const res = await get<{ versions: CustomAppVersion[] }>(
     `/apps/${encodeURIComponent(id)}/versions`,
   );
   return res.versions ?? [];
+}
+
+export interface AppVersionDetail extends CustomAppVersion {
+  html: string;
+}
+
+/**
+ * getAppVersion reads one retained build's bytes + metadata for non-destructive
+ * preview. It NEVER changes the current version — that is the separate
+ * {@link rollbackApp}. The bytes render in the same sandboxed frame as the
+ * sealed current view.
+ */
+export async function getAppVersion(
+  id: string,
+  version: number,
+): Promise<AppVersionDetail> {
+  return get<AppVersionDetail>(
+    `/apps/${encodeURIComponent(id)}/versions/${version}`,
+  );
 }
 
 /**

--- a/web/src/components/apps/AppVersionTimeline.test.tsx
+++ b/web/src/components/apps/AppVersionTimeline.test.tsx
@@ -1,0 +1,73 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import type { CustomAppVersion } from "../../api/apps";
+import { AppVersionTimeline } from "./AppVersionTimeline";
+
+function v(version: number, current: boolean, by?: string): CustomAppVersion {
+  return {
+    version,
+    current,
+    updatedBy: by,
+    updatedAt: by ? "2026-06-15T12:00:00Z" : undefined,
+  };
+}
+
+describe("AppVersionTimeline", () => {
+  it("lists versions newest-first with a Current pill and author meta", () => {
+    render(
+      <AppVersionTimeline
+        versions={[v(3, true, "pam"), v(2, false, "app-builder"), v(1, false)]}
+        isLoading={false}
+        selectedVersion={null}
+        currentVersion={3}
+        onSelect={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("v3")).toBeInTheDocument();
+    expect(screen.getByText("Current")).toBeInTheDocument();
+    expect(screen.getByText(/app-builder/)).toBeInTheDocument();
+  });
+
+  it("marks the current build active when nothing older is selected", () => {
+    render(
+      <AppVersionTimeline
+        versions={[v(2, true, "pam"), v(1, false, "pam")]}
+        isLoading={false}
+        selectedVersion={null}
+        currentVersion={2}
+        onSelect={vi.fn()}
+      />,
+    );
+    const active = document.querySelector(".app-version-timeline__row--active");
+    expect(active?.textContent).toContain("v2");
+  });
+
+  it("calls onSelect with the clicked version", () => {
+    const onSelect = vi.fn();
+    render(
+      <AppVersionTimeline
+        versions={[v(2, true, "pam"), v(1, false, "pam")]}
+        isLoading={false}
+        selectedVersion={null}
+        currentVersion={2}
+        onSelect={onSelect}
+      />,
+    );
+    fireEvent.click(screen.getByText("v1"));
+    expect(onSelect).toHaveBeenCalledWith(1);
+  });
+
+  it("shows an empty state when there are no versions", () => {
+    render(
+      <AppVersionTimeline
+        versions={[]}
+        isLoading={false}
+        selectedVersion={null}
+        currentVersion={0}
+        onSelect={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/No saved versions yet/i)).toBeInTheDocument();
+  });
+});

--- a/web/src/components/apps/AppVersionTimeline.tsx
+++ b/web/src/components/apps/AppVersionTimeline.tsx
@@ -1,0 +1,77 @@
+import type { CustomAppVersion } from "../../api/apps";
+import { formatRelativeTime } from "../../lib/format";
+
+interface AppVersionTimelineProps {
+  versions: CustomAppVersion[];
+  isLoading: boolean;
+  /** The version being previewed, or null when viewing the current build. */
+  selectedVersion: number | null;
+  currentVersion: number;
+  onSelect: (version: number) => void;
+}
+
+/**
+ * AppVersionTimeline is the read rail of an app's append-only history. Each row
+ * is one retained build (who/when), newest first. Selecting a row previews that
+ * build non-destructively in the frame beside it — restoring is a separate,
+ * explicit action on the preview banner. Presentational: the parent owns the
+ * data and the preview/restore state.
+ */
+export function AppVersionTimeline({
+  versions,
+  isLoading,
+  selectedVersion,
+  currentVersion,
+  onSelect,
+}: AppVersionTimelineProps) {
+  return (
+    <aside className="app-version-timeline" aria-label="Version history">
+      <div className="app-version-timeline__header">Version history</div>
+      {isLoading ? (
+        <div className="app-version-timeline__empty">Loading history…</div>
+      ) : versions.length === 0 ? (
+        <div className="app-version-timeline__empty">
+          No saved versions yet. Each published build is kept here.
+        </div>
+      ) : (
+        <ul className="app-version-timeline__list">
+          {versions.map((v) => {
+            // The "current build" row is active when nothing older is selected.
+            const isActive =
+              selectedVersion === v.version ||
+              (selectedVersion === null && v.version === currentVersion);
+            return (
+              <li key={v.version}>
+                <button
+                  type="button"
+                  className={`app-version-timeline__row${
+                    isActive ? " app-version-timeline__row--active" : ""
+                  }`}
+                  aria-current={isActive ? "true" : undefined}
+                  onClick={() => onSelect(v.version)}
+                >
+                  <span className="app-version-timeline__badge">
+                    v{v.version}
+                  </span>
+                  {v.current ? (
+                    <span className="app-version-timeline__current">
+                      Current
+                    </span>
+                  ) : null}
+                  <span className="app-version-timeline__meta">
+                    {[
+                      v.updatedBy,
+                      v.updatedAt && formatRelativeTime(v.updatedAt),
+                    ]
+                      .filter(Boolean)
+                      .join(" · ")}
+                  </span>
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </aside>
+  );
+}

--- a/web/src/components/apps/CustomAppView.test.tsx
+++ b/web/src/components/apps/CustomAppView.test.tsx
@@ -1,0 +1,164 @@
+import type { ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  deleteApp,
+  getApp,
+  getAppVersion,
+  listAppVersions,
+  rollbackApp,
+} from "../../api/apps";
+import { CustomAppView } from "./CustomAppView";
+
+vi.mock("../../api/apps", () => ({
+  getApp: vi.fn(),
+  listAppVersions: vi.fn(),
+  getAppVersion: vi.fn(),
+  rollbackApp: vi.fn(),
+  deleteApp: vi.fn(),
+}));
+
+vi.mock("../../stores/app", () => ({
+  useAppStore: (
+    selector: (s: { openUpdateAppDialog: () => void }) => unknown,
+  ) => selector({ openUpdateAppDialog: vi.fn() }),
+}));
+
+vi.mock("../ui/Toast", () => ({ showNotice: vi.fn() }));
+vi.mock("../ui/ConfirmDialog", () => ({ confirm: vi.fn() }));
+vi.mock("../../lib/sidebarNav", () => ({ navigateToSidebarApp: vi.fn() }));
+
+// The live preview boots a real dev server; stub it so the view renders inert.
+vi.mock("./AppLivePreview", () => ({
+  AppLivePreview: () => <div data-testid="live-preview" />,
+}));
+vi.mock("./CustomAppFrame", () => ({
+  CustomAppFrame: ({ html, title }: { html: string; title: string }) => (
+    <div data-testid="frame" data-title={title}>
+      {html}
+    </div>
+  ),
+}));
+
+const APP_ID = "app_0000000000000abc";
+
+function appDetail() {
+  return {
+    app: {
+      id: APP_ID,
+      slug: "lead-scorer",
+      name: "Lead Scorer",
+      icon: "🧩",
+      summary: "Scores inbound leads",
+      entry: "index.html",
+      version: 3,
+      createdBy: "app-builder",
+      createdAt: "2026-06-10T00:00:00Z",
+      updatedAt: "2026-06-15T12:00:00Z",
+      contentHash: "h",
+    },
+    html: "CURRENT_HTML",
+  };
+}
+
+function renderView() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    );
+  }
+  return render(<CustomAppView appId={APP_ID} />, { wrapper: Wrapper });
+}
+
+describe("CustomAppView version history", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getApp).mockResolvedValue(appDetail());
+    vi.mocked(listAppVersions).mockResolvedValue([
+      {
+        version: 3,
+        current: true,
+        updatedBy: "pam",
+        updatedAt: "2026-06-15T12:00:00Z",
+      },
+      {
+        version: 2,
+        current: false,
+        updatedBy: "app-builder",
+        updatedAt: "2026-06-14T12:00:00Z",
+      },
+      {
+        version: 1,
+        current: false,
+        updatedBy: "app-builder",
+        updatedAt: "2026-06-13T12:00:00Z",
+      },
+    ]);
+    vi.mocked(getAppVersion).mockResolvedValue({
+      version: 2,
+      current: false,
+      updatedBy: "app-builder",
+      updatedAt: "2026-06-14T12:00:00Z",
+      html: "V2_HTML",
+    });
+    vi.mocked(rollbackApp).mockResolvedValue({
+      ...appDetail().app,
+      version: 4,
+    });
+    vi.mocked(deleteApp).mockResolvedValue();
+  });
+
+  it("opens the timeline, previews an older version non-destructively, then restores", async () => {
+    renderView();
+    await screen.findByText("Lead Scorer");
+    // Default view is the live preview, not a past version.
+    expect(screen.getByTestId("live-preview")).toBeInTheDocument();
+
+    // Open history → the timeline lists prior builds.
+    fireEvent.click(screen.getByRole("button", { name: /history/i }));
+    await screen.findByText("Version history");
+    expect(await screen.findByText("v2")).toBeInTheDocument();
+
+    // Select v2 → non-destructive preview: getAppVersion is read, the current
+    // build is NOT mutated (no rollback yet), and the read-only banner appears.
+    fireEvent.click(screen.getByText("v2"));
+    await waitFor(() =>
+      expect(vi.mocked(getAppVersion)).toHaveBeenCalledWith(APP_ID, 2),
+    );
+    expect(await screen.findByText(/Viewing/)).toBeInTheDocument();
+    expect(screen.getByTestId("frame").getAttribute("data-title")).toContain(
+      "v2",
+    );
+    expect(vi.mocked(rollbackApp)).not.toHaveBeenCalled();
+
+    // Restore → the explicit, append-only rollback runs.
+    fireEvent.click(
+      screen.getByRole("button", { name: /restore this version/i }),
+    );
+    await waitFor(() =>
+      expect(vi.mocked(rollbackApp)).toHaveBeenCalledWith(APP_ID, 2),
+    );
+  });
+
+  it("returns to the current build from the preview banner without restoring", async () => {
+    renderView();
+    await screen.findByText("Lead Scorer");
+    fireEvent.click(screen.getByRole("button", { name: /history/i }));
+    fireEvent.click(await screen.findByText("v2"));
+    await screen.findByText(/Viewing/);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /back to current v3/i }),
+    );
+    await waitFor(() =>
+      expect(screen.queryByText(/Viewing/)).not.toBeInTheDocument(),
+    );
+    expect(vi.mocked(rollbackApp)).not.toHaveBeenCalled();
+    expect(screen.getByTestId("live-preview")).toBeInTheDocument();
+  });
+});

--- a/web/src/components/apps/CustomAppView.tsx
+++ b/web/src/components/apps/CustomAppView.tsx
@@ -1,18 +1,21 @@
 import { useEffect, useRef, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { EditPencil, MoreHoriz } from "iconoir-react";
+import { ClockRotateRight, EditPencil, MoreHoriz } from "iconoir-react";
 
 import {
   deleteApp,
   getApp,
+  getAppVersion,
   listAppVersions,
   rollbackApp,
 } from "../../api/apps";
+import { formatRelativeTime } from "../../lib/format";
 import { navigateToSidebarApp } from "../../lib/sidebarNav";
 import { useAppStore } from "../../stores/app";
 import { confirm } from "../ui/ConfirmDialog";
 import { showNotice } from "../ui/Toast";
 import { AppLivePreview } from "./AppLivePreview";
+import { AppVersionTimeline } from "./AppVersionTimeline";
 import { CustomAppFrame } from "./CustomAppFrame";
 
 interface CustomAppViewProps {
@@ -21,15 +24,23 @@ interface CustomAppViewProps {
 
 /**
  * CustomAppView renders one agent-generated internal tool: a header (icon, name,
- * version, Edit, an overflow menu) above the sandboxed CustomAppFrame. Edit is
- * the primary action. The destructive Delete and the version rollback both live
- * in the overflow menu so an operator can't lose or break a depended-on tool
- * with a stray click — the trust net the modify wedge needs.
+ * version, History, Edit, an overflow menu) above the sandboxed frame. Edit is
+ * the primary action; the destructive Delete lives in the overflow menu so a
+ * stray click can't remove a depended-on tool.
+ *
+ * History is the trust net behind the modify wedge: it opens an append-only
+ * version timeline beside the preview. Selecting an older build previews it
+ * NON-destructively (the current version is untouched); "Restore this version"
+ * then re-publishes those bytes as a new forward version, so a restore is itself
+ * reversible. An operator can look before they leap.
  */
 export function CustomAppView({ appId }: CustomAppViewProps) {
   const queryClient = useQueryClient();
   const openUpdateAppDialog = useAppStore((s) => s.openUpdateAppDialog);
   const [menuOpen, setMenuOpen] = useState(false);
+  const [historyOpen, setHistoryOpen] = useState(false);
+  // The older build being previewed, or null while viewing the current build.
+  const [previewVersion, setPreviewVersion] = useState<number | null>(null);
   // Live = the running dev server (HMR); Sealed = the published single-file
   // bundle. Default to Live so opening an app shows the real, current tool.
   const [mode, setMode] = useState<"live" | "sealed">("live");
@@ -44,12 +55,23 @@ export function CustomAppView({ appId }: CustomAppViewProps) {
   const versions = useQuery({
     queryKey: ["app-versions", appId],
     queryFn: () => listAppVersions(appId),
-    enabled: menuOpen,
+    enabled: historyOpen,
+  });
+
+  const currentVersion = data?.app.version ?? 0;
+  const isPreviewing =
+    previewVersion !== null && previewVersion !== currentVersion;
+
+  const versionPreview = useQuery({
+    queryKey: ["app-version", appId, previewVersion],
+    queryFn: () => getAppVersion(appId, previewVersion as number),
+    enabled: isPreviewing,
   });
 
   const rollback = useMutation({
     mutationFn: (version: number) => rollbackApp(appId, version),
     onSuccess: async (restored) => {
+      setPreviewVersion(null);
       await queryClient.invalidateQueries({ queryKey: ["app", appId] });
       await queryClient.invalidateQueries({
         queryKey: ["app-versions", appId],
@@ -76,6 +98,19 @@ export function CustomAppView({ appId }: CustomAppViewProps) {
     document.addEventListener("mousedown", onDown);
     return () => document.removeEventListener("mousedown", onDown);
   }, [menuOpen]);
+
+  function toggleHistory(): void {
+    setHistoryOpen((open) => {
+      // Leaving history drops any in-flight preview so the frame returns to live.
+      if (open) setPreviewVersion(null);
+      return !open;
+    });
+  }
+
+  function onSelectVersion(version: number): void {
+    // Selecting the current build is "back to live", not a preview.
+    setPreviewVersion(version === currentVersion ? null : version);
+  }
 
   function onDelete(): void {
     if (!data) return;
@@ -130,7 +165,6 @@ export function CustomAppView({ appId }: CustomAppViewProps) {
   }
 
   const { app, html } = data;
-  const priorVersions = (versions.data ?? []).filter((v) => v !== app.version);
 
   return (
     <div className="custom-app-view">
@@ -144,30 +178,43 @@ export function CustomAppView({ appId }: CustomAppViewProps) {
             <p className="custom-app-view__summary">{app.summary}</p>
           ) : null}
         </div>
-        <div className="custom-app-view__mode">
-          <button
-            type="button"
-            className="custom-app-view__mode-btn"
-            aria-pressed={mode === "live"}
-            onClick={() => setMode("live")}
-          >
-            Live
-          </button>
-          <button
-            type="button"
-            className="custom-app-view__mode-btn"
-            aria-pressed={mode === "sealed"}
-            onClick={() => setMode("sealed")}
-          >
-            Sealed
-          </button>
-        </div>
+        {/* The Live/Sealed toggle is meaningless while previewing an older,
+            already-sealed build, so it yields to the preview banner. */}
+        {isPreviewing ? null : (
+          <div className="custom-app-view__mode">
+            <button
+              type="button"
+              className="custom-app-view__mode-btn"
+              aria-pressed={mode === "live"}
+              onClick={() => setMode("live")}
+            >
+              Live
+            </button>
+            <button
+              type="button"
+              className="custom-app-view__mode-btn"
+              aria-pressed={mode === "sealed"}
+              onClick={() => setMode("sealed")}
+            >
+              Sealed
+            </button>
+          </div>
+        )}
         <span
           className="custom-app-view__version"
           title={`Updated ${app.updatedAt}`}
         >
           v{app.version}
         </span>
+        <button
+          type="button"
+          className="custom-app-view__action"
+          aria-pressed={historyOpen}
+          onClick={toggleHistory}
+        >
+          <ClockRotateRight width={15} height={15} />
+          <span>History</span>
+        </button>
         <button
           type="button"
           className="custom-app-view__action"
@@ -189,33 +236,6 @@ export function CustomAppView({ appId }: CustomAppViewProps) {
           </button>
           {menuOpen ? (
             <div className="custom-app-view__menu" role="menu">
-              <div className="custom-app-view__menu-section">
-                Restore a previous version
-              </div>
-              {versions.isLoading ? (
-                <div className="custom-app-view__menu-empty">Loading…</div>
-              ) : priorVersions.length === 0 ? (
-                <div className="custom-app-view__menu-empty">
-                  No earlier versions yet.
-                </div>
-              ) : (
-                priorVersions.slice(0, 8).map((v) => (
-                  <button
-                    key={v}
-                    type="button"
-                    role="menuitem"
-                    className="custom-app-view__menu-item"
-                    disabled={rollback.isPending}
-                    onClick={() => {
-                      setMenuOpen(false);
-                      rollback.mutate(v);
-                    }}
-                  >
-                    Restore v{v}
-                  </button>
-                ))
-              )}
-              <div className="custom-app-view__menu-divider" />
               <button
                 type="button"
                 role="menuitem"
@@ -228,12 +248,103 @@ export function CustomAppView({ appId }: CustomAppViewProps) {
           ) : null}
         </div>
       </header>
-      <div className="custom-app-view__body">
-        {mode === "live" ? (
-          <AppLivePreview appId={appId} title={app.name} />
-        ) : (
-          <CustomAppFrame html={html} title={app.name} />
-        )}
+      <div
+        className={`custom-app-view__body${
+          historyOpen ? " custom-app-view__body--history" : ""
+        }`}
+      >
+        {historyOpen ? (
+          <AppVersionTimeline
+            versions={versions.data ?? []}
+            isLoading={versions.isLoading}
+            selectedVersion={previewVersion}
+            currentVersion={app.version}
+            onSelect={onSelectVersion}
+          />
+        ) : null}
+        <div className="custom-app-view__stage">
+          {isPreviewing ? (
+            <PreviewBanner
+              version={previewVersion as number}
+              currentVersion={app.version}
+              updatedBy={versionPreview.data?.updatedBy}
+              updatedAt={versionPreview.data?.updatedAt}
+              restoring={rollback.isPending}
+              onRestore={() => rollback.mutate(previewVersion as number)}
+              onBack={() => setPreviewVersion(null)}
+            />
+          ) : null}
+          {isPreviewing ? (
+            versionPreview.isLoading || !versionPreview.data ? (
+              <div className="custom-app-view__preview-loading">
+                Loading v{previewVersion}…
+              </div>
+            ) : (
+              <CustomAppFrame
+                html={versionPreview.data.html}
+                title={`${app.name} (v${previewVersion})`}
+              />
+            )
+          ) : mode === "live" ? (
+            <AppLivePreview appId={appId} title={app.name} />
+          ) : (
+            <CustomAppFrame html={html} title={app.name} />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+interface PreviewBannerProps {
+  version: number;
+  currentVersion: number;
+  updatedBy?: string;
+  updatedAt?: string;
+  restoring: boolean;
+  onRestore: () => void;
+  onBack: () => void;
+}
+
+/**
+ * PreviewBanner sits atop a non-destructive version preview: it names what the
+ * operator is looking at and offers the two safe exits — restore these bytes as
+ * a new forward version, or step back to the current build.
+ */
+function PreviewBanner({
+  version,
+  currentVersion,
+  updatedBy,
+  updatedAt,
+  restoring,
+  onRestore,
+  onBack,
+}: PreviewBannerProps) {
+  const meta = [updatedBy, updatedAt && formatRelativeTime(updatedAt)]
+    .filter(Boolean)
+    .join(" · ");
+  return (
+    <div className="custom-app-view__banner" role="status">
+      <span className="custom-app-view__banner-text">
+        Viewing <strong>v{version}</strong> (read-only)
+        {meta ? ` · ${meta}` : ""}
+      </span>
+      <div className="custom-app-view__banner-actions">
+        <button
+          type="button"
+          className="custom-app-view__banner-btn custom-app-view__banner-btn--primary"
+          disabled={restoring}
+          onClick={onRestore}
+        >
+          {restoring ? "Restoring…" : "Restore this version"}
+        </button>
+        <button
+          type="button"
+          className="custom-app-view__banner-btn"
+          onClick={onBack}
+        >
+          Back to current v{currentVersion}
+        </button>
       </div>
     </div>
   );

--- a/web/src/styles/apps.css
+++ b/web/src/styles/apps.css
@@ -246,6 +246,38 @@
 .custom-app-view__body {
   min-height: 0;
   overflow: hidden;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+}
+
+/* History open: a version-timeline rail to the left of the live preview. */
+.custom-app-view__body--history {
+  grid-template-columns: 248px minmax(0, 1fr);
+}
+
+.custom-app-view__stage {
+  position: relative;
+  min-width: 0;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+/* The frame / live preview / loader fills the stage below any banner. */
+.custom-app-view__stage > * {
+  min-height: 0;
+}
+
+.custom-app-view__stage > *:last-child {
+  flex: 1 1 auto;
+}
+
+.custom-app-view__preview-loading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-secondary);
+  font-size: 13px;
 }
 
 .custom-app-frame {
@@ -254,6 +286,147 @@
   height: 100%;
   border: 0;
   background: #fff;
+}
+
+/* Read-only banner over a non-destructive version preview. */
+.custom-app-view__banner {
+  display: flex;
+  flex: none;
+  flex-wrap: wrap;
+  gap: 8px 12px;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 14px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-subtle);
+  color: var(--text);
+  font-size: 13px;
+}
+
+.custom-app-view__banner-text strong {
+  font-family: var(--font-mono, monospace);
+}
+
+.custom-app-view__banner-actions {
+  display: inline-flex;
+  gap: 8px;
+}
+
+.custom-app-view__banner-btn {
+  padding: 4px 10px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm, 6px);
+  background: transparent;
+  color: var(--text);
+  font-size: 12px;
+  cursor: pointer;
+  transition:
+    background-color 120ms ease,
+    border-color 120ms ease;
+}
+
+.custom-app-view__banner-btn:hover {
+  background: var(--bg-card);
+}
+
+.custom-app-view__banner-btn--primary {
+  border-color: var(--accent);
+  background: var(--accent);
+  color: var(--accent-contrast, #fff);
+}
+
+.custom-app-view__banner-btn--primary:hover {
+  background: var(--accent);
+  opacity: 0.9;
+}
+
+.custom-app-view__banner-btn:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+/* Version timeline rail. */
+.app-version-timeline {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  border-right: 1px solid var(--border);
+  background: var(--bg-card);
+  overflow-y: auto;
+}
+
+.app-version-timeline__header {
+  padding: 10px 14px 6px;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-secondary);
+}
+
+.app-version-timeline__empty {
+  padding: 4px 14px 12px;
+  font-size: 12px;
+  line-height: 1.4;
+  color: var(--text-secondary);
+}
+
+.app-version-timeline__list {
+  margin: 0;
+  padding: 0 6px 8px;
+  list-style: none;
+}
+
+.app-version-timeline__row {
+  display: grid;
+  grid-template-columns: auto auto;
+  align-items: center;
+  gap: 4px 8px;
+  width: 100%;
+  padding: 8px 10px;
+  border: 0;
+  border-radius: var(--radius-sm, 6px);
+  background: transparent;
+  color: var(--text);
+  text-align: left;
+  cursor: pointer;
+  transition: background-color 120ms ease;
+}
+
+.app-version-timeline__row:hover {
+  background: var(--bg-subtle);
+}
+
+.app-version-timeline__row--active {
+  background: var(--bg-subtle);
+  box-shadow: inset 2px 0 0 var(--accent);
+}
+
+.app-version-timeline__badge {
+  font-family: var(--font-mono, monospace);
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.app-version-timeline__current {
+  justify-self: start;
+  padding: 1px 6px;
+  border-radius: 999px;
+  background: var(--accent);
+  color: var(--accent-contrast, #fff);
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.app-version-timeline__meta {
+  grid-column: 1 / -1;
+  color: var(--text-secondary);
+  font-size: 11px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 /* App Builder dialog body — the Radix Dialog primitive handles the shell. */


### PR DESCRIPTION
## Version timeline + non-destructive preview — look before you leap

**Stacked on #1102** (live build-activity feed). Base branch: `feat/apps-activity-cards`.

Phase 4 of the App Builder dyad-SOTA work. Every published build was *already* retained append-only under `apps/<id>/versions/v<N>/` (snapshot dirs, deliberately decoupled from the wiki git worker — see `custom_app.go`). But the only affordance was a bare **"Restore vN"** list in the overflow menu: meaningless integers, and clicking one **restored immediately** with no way to see what you were committing to. That's the opposite of the trust net the modify wedge needs.

This exposes the history as a real timeline with a non-destructive preview — the operator can look at an old build before they leap.

### What's here

**Backend (`internal/team`)** — the data layer mostly existed; this surfaces it.
- `snapshotVersionLocked` now writes a `meta.json` (`version`/`updatedAt`/`updatedBy`) beside each retained build. Snapshots from before this existed degrade gracefully to a bare version number.
- `ListVersions` returns structured, current-flagged `CustomAppVersion` entries (was `[]int`). A missing/corrupt manifest degrades to an empty list, not an error.
- **New** `GetVersion` + `GET /apps/{id}/versions/{n}` read one past build's bytes + metadata **without changing the current version** — the non-destructive read. The bytes were validated at write time and render in the *same* sandboxed frame as the sealed current view, so there's no new rendering surface. Restore is still the separate, explicit, append-only `POST /apps/{id}/rollback`.

**Frontend (`web/src`)** — token-only CSS, verified against the token surface for all 3 themes.
- `listAppVersions` → `CustomAppVersion[]`; new `getAppVersion` helper.
- **New `AppVersionTimeline`** rail: one row per build (who · when), a "Current" pill, newest-first.
- `CustomAppView` gains a **History** toggle. The timeline opens beside the preview; selecting an older build previews it **read-only** with a banner offering **Restore this version** / **Back to current vN**. Restore reuses the existing append-only `Rollback`, so a restore is itself reversible.
- Restore **moved out of the overflow menu** (now holds only the destructive Delete) — the design-review trust-net finding (DR2).

### Tests

- **Go**: `GetVersion` non-destructive read + unknown-version caller error; `ListVersions` current/meta flags; a new **end-to-end HTTP test** for the versions endpoints (structured list, flat single-version read, current build untouched after a preview read, 400 on unknown version), isolated under a temp `WUPHF_RUNTIME_HOME`. Full Go `internal/team` suite green.
- **Web**: `AppVersionTimeline` unit (rows / current pill / `onSelect` / empty) + `CustomAppView` integration (History → non-destructive preview → restore; and back-to-current without restoring). Full web suite green (`bunx tsc --noEmit` clean, biome clean on changed files).

### Note

The 3 `golangci-lint` `noctx` findings in `custom_app_dev.go` are **pre-existing from #1099** (live dev preview) and out of scope here — this PR does not touch that file. My changed files are lint-clean.

### Status

**Draft.** Builds on #1102 → #1100 → #1099; merge those first. Next from the roadmap (`docs/specs/app-builder-live-preview.md`): Phase 3 (pre-publish `tsc`+`vite build` gate with bounded auto-fix) and Phase 5 (select-to-edit).

> Screenshot note: same browser-harness CDP reattach gap as #1102 — a fresh still of the timeline + read-only banner isn't attached yet. The behavior is covered by the unit + component + HTTP tests above. I'll add a still once the harness reconnects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
