### PR TITLE
ci(desktop): free disk before DMG packaging to fix hdiutil flake

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -54,6 +54,18 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # ratchet:actions/checkout@v4
 
+      - name: Free disk space for DMG packaging
+        # macos-14 runners ship near-full; `hdiutil create` for the universal .app
+        # has twice failed with "No space left on device" (v0.1.0, v0.227.0).
+        # Reclaim the simulator runtimes we never use (~10-20 GB) up front. This
+        # leaves the active Xcode/CLT intact, so codesign + notarytool still work.
+        run: |
+          df -h /
+          sudo rm -rf /Library/Developer/CoreSimulator/Profiles/Runtimes/* || true
+          sudo rm -rf ~/Library/Developer/Xcode/iOS\ DeviceSupport/* || true
+          sudo rm -rf ~/Library/Developer/CoreSimulator/Caches/* || true
+          df -h /
+
       - name: Resolve version
         id: ver
         env:


### PR DESCRIPTION
## Problem
The `macos-14` runner ships near-full. `hdiutil create` for the universal `.app` has failed **twice** with `No space left on device` — once on `desktop-v0.1.0` and again on `v0.227.0` — each time needing a manual job rerun, and each time leaving the website's `releases/latest/download/WUPHF-mac.dmg` 404ing until the rerun finished.

## Fix
Add a step at the top of the macOS job that reclaims the unused iOS/watchOS/tvOS **simulator runtimes** (~10-20 GB) plus stale CoreSimulator/DeviceSupport caches. The active Xcode / Command Line Tools are untouched, so `codesign` + `notarytool` still work.

## Why not just rerun
Reruns are a coin flip on a fresh runner's free space. This makes the macOS DMG packaging deterministic so every release reliably ships a signed dmg.

## Test plan
- [x] YAML validates
- [ ] Next release (or a manual `desktop-release` dispatch) packages the dmg without an out-of-disk failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved macOS build reliability by optimizing disk space usage during release builds. Added cleanup step to free up disk space before creating the universal macOS distribution, reducing build failure occurrences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->