### PR TITLE
fix(tasks): new Issues created inside a task chat get their own channel

### DIFF
--- a/internal/team/broker_tasks_lifecycle.go
+++ b/internal/team/broker_tasks_lifecycle.go
@@ -278,9 +278,9 @@ func (b *Broker) EnsureTask(channel, title, details, owner, createdBy, threadID 
 	// the per-task channel deterministically.
 	b.counter++
 	taskID := b.allocateIssueIDLocked()
-	// Mint a dedicated channel for new business-objective tasks that
-	// defaulted to "general".
-	if shouldMintPerTaskChannel(channel, &teamTask{
+	// Mint a dedicated channel for a task that defaulted to "general" or was
+	// created from inside another task's chat (so it never shares one).
+	if shouldMintPerTaskChannel(channel, b.channelOwnedByAnotherTaskLocked(channel), &teamTask{
 		Title:   title,
 		Details: strings.TrimSpace(details),
 		Owner:   strings.TrimSpace(owner),

--- a/internal/team/broker_tasks_mutation_service.go
+++ b/internal/team/broker_tasks_mutation_service.go
@@ -704,11 +704,13 @@ func (b *Broker) MutateTask(body TaskPostRequest) (TaskResponse, error) {
 		// name the per-task channel "task-<id>" deterministically.
 		b.counter++
 		taskID := b.allocateIssueIDLocked()
-		// For new business-objective tasks that defaulted to "general",
-		// mint a dedicated task-<id> channel so each goal runs in
-		// isolation.  Non-business / system / sub-issue / incident tasks
-		// stay in "general" (shouldMintPerTaskChannel guards all that).
-		if shouldMintPerTaskChannel(channel, &teamTask{
+		// Mint a dedicated task-<id> channel so each goal runs in isolation.
+		// This fires when the task defaulted to "general" AND when it was
+		// created from inside another task's chat (channelOwnedByAnotherTask) —
+		// otherwise a new Issue spun up from an existing Issue's chat would
+		// silently share that chat. System / incident tasks stay in "general"
+		// (shouldMintPerTaskChannel guards all that).
+		if shouldMintPerTaskChannel(channel, b.channelOwnedByAnotherTaskLocked(channel), &teamTask{
 			Title:         strings.TrimSpace(body.Title),
 			Details:       strings.TrimSpace(body.Details),
 			Owner:         strings.TrimSpace(body.Owner),

--- a/internal/team/broker_tasks_plan.go
+++ b/internal/team/broker_tasks_plan.go
@@ -141,9 +141,10 @@ func (b *Broker) handleTaskPlan(w http.ResponseWriter, r *http.Request) {
 		b.counter++
 		taskID := b.allocateIssueIDLocked()
 		titleToID[strings.TrimSpace(item.Title)] = taskID
-		// Mint a dedicated channel for new business-objective tasks
-		// that defaulted to "general".
-		if shouldMintPerTaskChannel(taskChannel, &teamTask{
+		// Mint a dedicated channel for each task that defaulted to "general"
+		// or was planned from inside another task's chat — so decomposing a
+		// goal never piles every resulting task into one shared timeline.
+		if shouldMintPerTaskChannel(taskChannel, b.channelOwnedByAnotherTaskLocked(taskChannel), &teamTask{
 			Title:         strings.TrimSpace(item.Title),
 			Details:       strings.TrimSpace(item.Details),
 			Owner:         strings.TrimSpace(item.Assignee),
@@ -412,9 +413,9 @@ func (b *Broker) EnsurePlannedTask(input plannedTaskInput) (teamTask, bool, erro
 	// the per-task channel deterministically.
 	b.counter++
 	taskID := b.allocateIssueIDLocked()
-	// Mint a dedicated channel for new business-objective tasks that
-	// defaulted to "general".
-	if shouldMintPerTaskChannel(channel, &teamTask{
+	// Mint a dedicated channel for a task that defaulted to "general" or was
+	// created from inside another task's chat (so it never shares one).
+	if shouldMintPerTaskChannel(channel, b.channelOwnedByAnotherTaskLocked(channel), &teamTask{
 		Title:         title,
 		Details:       strings.TrimSpace(input.Details),
 		Owner:         strings.TrimSpace(input.Owner),

--- a/internal/team/broker_tasks_test.go
+++ b/internal/team/broker_tasks_test.go
@@ -900,6 +900,84 @@ func TestBrokerSubtaskMintsOwnChannelSeparateFromParent(t *testing.T) {
 	}
 }
 
+// TestBrokerSecondTopLevelTaskFromTaskChannelMintsOwnChannel pins the fix for
+// the "every new Issue piles into the same chat" bug. A top-level Issue created
+// from inside ANOTHER Issue's per-task channel (the way the CEO creates a second
+// Issue while talking in the first Issue's chat) must mint its OWN channel, not
+// share the first Issue's. Reproduces the live OFFICE-22 / OFFICE-28 case where
+// a second issue (no parent_issue_id) landed in the first issue's task-<id>
+// channel. Exercised through the HTTP /tasks path, not the internal call.
+func TestBrokerSecondTopLevelTaskFromTaskChannelMintsOwnChannel(t *testing.T) {
+	b := newTestBroker(t)
+	if err := b.StartOnPort(0); err != nil {
+		t.Fatalf("failed to start broker: %v", err)
+	}
+	defer b.Stop()
+
+	base := fmt.Sprintf("http://%s", b.Addr())
+	post := func(payload map[string]any) teamTask {
+		body, _ := json.Marshal(payload)
+		req, _ := http.NewRequest(http.MethodPost, base+"/tasks", bytes.NewReader(body))
+		req.Header.Set("Authorization", "Bearer "+b.Token())
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("task post failed: %v", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			raw, _ := io.ReadAll(resp.Body)
+			t.Fatalf("unexpected status %d: %s", resp.StatusCode, raw)
+		}
+		var result struct {
+			Task teamTask `json:"task"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+			t.Fatalf("decode task response: %v", err)
+		}
+		return result.Task
+	}
+
+	// First top-level Issue from #general → mints its own task-<id> channel.
+	first := post(map[string]any{
+		"action":     "create",
+		"title":      "Daily Digest from email",
+		"details":    "Top-level issue one",
+		"created_by": "ceo",
+	})
+	if first.Channel == "general" || first.Channel == "" {
+		t.Fatalf("expected first issue to mint its own channel, got %q", first.Channel)
+	}
+
+	// Second top-level Issue (NO parent_issue_id) created from inside the first
+	// Issue's chat — it arrives carrying the first Issue's channel.
+	second := post(map[string]any{
+		"action":     "create",
+		"title":      "Outbound email reply agent",
+		"details":    "Top-level issue two",
+		"created_by": "ceo",
+		"channel":    first.Channel,
+	})
+	if strings.TrimSpace(second.ParentIssueID) != "" {
+		t.Fatalf("expected a top-level issue (no parent), got parent %q", second.ParentIssueID)
+	}
+	// The bug: the second issue shared the first's channel.
+	if second.Channel == first.Channel {
+		t.Fatalf("second top-level Issue must not share the first Issue's channel %q", first.Channel)
+	}
+	expectedSlug := normalizeChannelSlug("task-" + second.ID)
+	if second.Channel != expectedSlug {
+		t.Fatalf("expected second issue channel %q, got %q", expectedSlug, second.Channel)
+	}
+	// Each channel holds exactly its own task — no shared timeline.
+	if got := len(b.ChannelTasks(first.Channel)); got != 1 {
+		t.Fatalf("expected one task in first channel %q, got %d", first.Channel, got)
+	}
+	if got := len(b.ChannelTasks(second.Channel)); got != 1 {
+		t.Fatalf("expected one task in second channel %q, got %d", second.Channel, got)
+	}
+}
+
 func TestBrokerTaskPlanAssignsWorktreeForLocalWorktreeTask(t *testing.T) {
 	setPrepareTaskWorktreeForTest(t, func(taskID string) (string, string, error) {
 		return "/tmp/wuphf-task-" + taskID, "wuphf-" + taskID, nil
@@ -2570,36 +2648,39 @@ func TestPerTaskChannelMintedForBusinessObjective(t *testing.T) {
 	}
 }
 
-// TestShouldMintPerTaskChannelGuards pins the channel-minting gate after
-// the keyword heuristic was dropped (2026-06-03): every real top-level
-// task in "general" mints its own channel, and only the two internal
-// guards (system task / incident self-heal) withhold one. Sub-issues mint
-// their OWN channel separate from the parent — regardless of the incoming
-// channel, since the creating agent hands them the parent's channel — so a
-// child's chatter never lands in the parent's chat. For a top-level task an
-// explicit non-general channel request is left as-is.
+// TestShouldMintPerTaskChannelGuards pins the channel-minting gate. Every real
+// top-level task mints its own channel when it would otherwise default to
+// "general" OR when it was created from inside another task's per-task channel
+// (ownedByAnotherTask) — so a new Issue spun up from an existing Issue's chat
+// never piles into that chat. Only the two internal guards (system task /
+// incident self-heal) withhold a channel. Sub-issues always mint their OWN
+// channel, separate from the parent. A genuinely explicit, non-per-task shared
+// channel (e.g. a project/bridged channel) is left as-is.
 func TestShouldMintPerTaskChannelGuards(t *testing.T) {
 	cases := []struct {
-		name    string
-		channel string
-		task    teamTask
-		want    bool
+		name             string
+		channel          string
+		ownedByOtherTask bool
+		task             teamTask
+		want             bool
 	}{
-		{"plain keyword-less task mints", "general", teamTask{Title: "Tidy up the backlog"}, true},
-		{"business-objective task mints", "general", teamTask{Title: "Launch the sales campaign"}, true},
-		{"system task stays in general", "general", teamTask{Title: "Backup & Migration", System: true}, false},
-		{"incident self-heal stays in general", "general", teamTask{Title: "Recover", PipelineID: "incident"}, false},
-		{"sub-task mints its own channel", "general", teamTask{Title: "child", ParentIssueID: "task-1"}, true},
-		{"sub-task mints even when handed the parent's channel", "task-1", teamTask{Title: "child", ParentIssueID: "task-1"}, true},
-		{"sub-task incident self-heal still stays in general", "general", teamTask{Title: "child", ParentIssueID: "task-1", PipelineID: "incident"}, false},
-		{"explicit non-general channel kept", "youtube-factory", teamTask{Title: "Publish the launch video"}, false},
-		{"empty task in general still mints", "general", teamTask{}, true},
+		{"plain keyword-less task mints", "general", false, teamTask{Title: "Tidy up the backlog"}, true},
+		{"business-objective task mints", "general", false, teamTask{Title: "Launch the sales campaign"}, true},
+		{"system task stays in general", "general", false, teamTask{Title: "Backup & Migration", System: true}, false},
+		{"incident self-heal stays in general", "general", false, teamTask{Title: "Recover", PipelineID: "incident"}, false},
+		{"sub-task mints its own channel", "general", false, teamTask{Title: "child", ParentIssueID: "task-1"}, true},
+		{"sub-task mints even when handed the parent's channel", "task-1", true, teamTask{Title: "child", ParentIssueID: "task-1"}, true},
+		{"sub-task incident self-heal still stays in general", "general", false, teamTask{Title: "child", ParentIssueID: "task-1", PipelineID: "incident"}, false},
+		{"top-level task created in ANOTHER task's channel mints its own", "task-22", true, teamTask{Title: "Outbound email reply agent"}, true},
+		{"system task in another task's channel still does not mint", "task-22", true, teamTask{Title: "Backup", System: true}, false},
+		{"explicit non-per-task channel kept", "youtube-factory", false, teamTask{Title: "Publish the launch video"}, false},
+		{"empty task in general still mints", "general", false, teamTask{}, true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := shouldMintPerTaskChannel(tc.channel, &tc.task)
+			got := shouldMintPerTaskChannel(tc.channel, tc.ownedByOtherTask, &tc.task)
 			if got != tc.want {
-				t.Fatalf("shouldMintPerTaskChannel(%q, %+v) = %v, want %v", tc.channel, tc.task, got, tc.want)
+				t.Fatalf("shouldMintPerTaskChannel(%q, %v, %+v) = %v, want %v", tc.channel, tc.ownedByOtherTask, tc.task, got, tc.want)
 			}
 		})
 	}

--- a/internal/team/broker_tasks_worktrees.go
+++ b/internal/team/broker_tasks_worktrees.go
@@ -265,32 +265,32 @@ func (b *Broker) preferredTaskChannelLocked(requestedChannel, _, _, _, _ string)
 // shouldMintPerTaskChannel reports whether a newly created task
 // warrants a dedicated task-<id> channel.
 //
-// The product vision is "every task spins up its own channel", so the
-// default is to mint for any real task. We only withhold a channel for the
-// two internal-plumbing cases that genuinely belong in #general:
-//  1. It is not a system task (System==true is the Backup & Migration
-//     entry, which always owns "general").
-//  2. It is not an incident self-heal (PipelineID=="incident") — those are
-//     internal tooling, not user work.
+// The product vision is "every task spins up its own channel". Two
+// internal-plumbing cases are checked FIRST and always withhold a channel,
+// even for a sub-issue — they genuinely belong in #general:
+//  1. system tasks (System==true is the Backup & Migration entry, which
+//     always owns "general").
+//  2. incident self-heals (PipelineID=="incident") — internal tooling, not
+//     user work.
 //
-// Sub-issues (ParentIssueID!="") always mint their OWN task-<childID>
-// channel — separate from the parent. The channel handed to a sub-issue
-// create is the creating agent's current conversation, which is almost
-// always the parent task's channel, so we mint regardless of whether it
-// resolved to "general". Without this, every child posts its working
-// chatter into the parent's chat and the two tasks share one timeline.
-// A sub-issue gets its own chat, just like a top-level task; it stays tied
-// to the parent via ParentIssueID, which the Issue board nests under the
-// parent card.
+// A sub-issue (ParentIssueID!="") that clears those two guards mints its OWN
+// task-<childID> channel, separate from the parent. The channel handed to a
+// sub-issue create is the creating agent's current conversation — almost
+// always the parent task's channel — so we mint regardless of whether it
+// resolved to "general". Without this, every child posts its working chatter
+// into the parent's chat and the two tasks share one timeline. A sub-issue
+// gets its own chat, just like a top-level task; it stays tied to the parent
+// via ParentIssueID, which the Issue board nests under the parent card.
 //
-// Top-level tasks mint when the resolved channel is "general" OR when it is
-// another task's per-task channel (incomingChannelOwnedByAnotherTask). The
-// creating agent's conversation is usually inside some existing task's chat,
-// so a new top-level Issue created from there arrives carrying that task's
-// channel; without this it would silently share the other task's timeline
-// (every new Issue piling into the same chat). We leave the task in the
-// requested channel only when it is an explicit, non-per-task shared channel
-// the caller deliberately targeted (a project or bridged channel).
+// A top-level task that clears those guards mints when the resolved channel
+// is "general" OR is another task's per-task channel
+// (incomingChannelOwnedByAnotherTask). The creating agent's conversation is
+// usually inside some existing task's chat, so a new top-level Issue created
+// from there arrives carrying that task's channel; without this it would
+// silently share the other task's timeline (every new Issue piling into the
+// same chat). We leave the task in the requested channel only when it is an
+// explicit, non-per-task shared channel the caller deliberately targeted (a
+// project or bridged channel).
 //
 // Note: this used to additionally require taskLooksLikeLiveBusinessObjective
 // (a keyword heuristic). That under-delivered the vision — a real task whose

--- a/internal/team/broker_tasks_worktrees.go
+++ b/internal/team/broker_tasks_worktrees.go
@@ -278,21 +278,26 @@ func (b *Broker) preferredTaskChannelLocked(requestedChannel, _, _, _, _ string)
 // create is the creating agent's current conversation, which is almost
 // always the parent task's channel, so we mint regardless of whether it
 // resolved to "general". Without this, every child posts its working
-// chatter into the parent's chat and the two tasks share one timeline
-// (the bug this guard previously caused). A sub-issue gets its own chat,
-// just like a top-level task; it stays tied to the parent via
-// ParentIssueID, which the Issue board nests under the parent card.
+// chatter into the parent's chat and the two tasks share one timeline.
+// A sub-issue gets its own chat, just like a top-level task; it stays tied
+// to the parent via ParentIssueID, which the Issue board nests under the
+// parent card.
 //
-// Top-level tasks only mint when the resolved channel is "general" — an
-// explicit non-general channel request is already a real channel, so we
-// leave it alone.
+// Top-level tasks mint when the resolved channel is "general" OR when it is
+// another task's per-task channel (incomingChannelOwnedByAnotherTask). The
+// creating agent's conversation is usually inside some existing task's chat,
+// so a new top-level Issue created from there arrives carrying that task's
+// channel; without this it would silently share the other task's timeline
+// (every new Issue piling into the same chat). We leave the task in the
+// requested channel only when it is an explicit, non-per-task shared channel
+// the caller deliberately targeted (a project or bridged channel).
 //
 // Note: this used to additionally require taskLooksLikeLiveBusinessObjective
 // (a keyword heuristic). That under-delivered the vision — a real task whose
 // title lacked execution keywords ("Draft Q3 outbound sequence") stayed in
 // #general — so the heuristic was dropped (2026-06-03). The function is still
 // used elsewhere (notifications / pipeline), just not as a channel gate.
-func shouldMintPerTaskChannel(channel string, task *teamTask) bool {
+func shouldMintPerTaskChannel(channel string, incomingChannelOwnedByAnotherTask bool, task *teamTask) bool {
 	if task == nil {
 		return false
 	}
@@ -305,10 +310,25 @@ func shouldMintPerTaskChannel(channel string, task *teamTask) bool {
 	if strings.TrimSpace(task.ParentIssueID) != "" {
 		return true
 	}
-	if normalizeChannelSlug(channel) != "general" {
-		return false
+	if normalizeChannelSlug(channel) == "general" {
+		return true
 	}
-	return true
+	if incomingChannelOwnedByAnotherTask {
+		return true
+	}
+	return false
+}
+
+// channelOwnedByAnotherTaskLocked reports whether the given channel is some
+// other task's dedicated per-task channel (its slug is linked back to an
+// owning task via TaskID). Used by the create paths so a brand-new top-level
+// Issue minted from inside an existing task's chat spins up its own channel
+// instead of piling into that task's timeline. A brand-new task has no
+// channel of its own yet, so any per-task incoming channel is "another
+// task's". Caller MUST hold b.mu.
+func (b *Broker) channelOwnedByAnotherTaskLocked(channel string) bool {
+	ch := b.findChannelLocked(channel)
+	return ch != nil && strings.TrimSpace(ch.TaskID) != ""
 }
 
 // createPerTaskChannelLocked mints a dedicated channel for a task.


### PR DESCRIPTION
## Problem (recurrence)

Reported: "latest release is still creating tasks but those tasks still share the same chat." Confirmed against v0.227.0 (which includes the earlier sub-task fix) by inspecting the live workspace:

```
OFFICE-22  parent=-  channel=task-office-22   "Daily Digest from email"
OFFICE-28  parent=-  channel=task-office-22   "Outbound email reply agent"   ← shares OFFICE-22's chat
```

Both are **top-level Issues with no `parent_issue_id`**, so the previous sub-task fix never applied. `OFFICE-28` was created while the CEO was talking inside `OFFICE-22`'s chat, so it inherited `task-office-22`.

## Root cause

`shouldMintPerTaskChannel` only minted a dedicated channel when the incoming channel was `general`. A new top-level Issue created from inside another Issue's `task-<id>` channel hit the "non-general → don't mint" guard and silently shared that Issue's timeline.

## Fix

Mint a dedicated channel for a real top-level task when the incoming channel is `general` **OR** is another task's per-task channel — detected via the channel's linked `TaskID` (`channelOwnedByAnotherTaskLocked`), not a slug-prefix heuristic. Genuinely explicit, non-per-task shared channels (project / bridged) are still respected. Threaded through all four create paths (mutation, plan ×2, lifecycle).

## Tests

- **Live HTTP regression** `TestBrokerSecondTopLevelTaskFromTaskChannelMintsOwnChannel`: a second top-level Issue created from the first Issue's channel must mint its own `task-<id>`. Verified to **fail pre-fix** (shares the first's channel) and **pass post-fix**.
- `TestShouldMintPerTaskChannelGuards` extended for the new signature + cases ("top-level task created in another task's channel mints its own", "system task in another task's channel still doesn't mint").
- Full `internal/team` + `internal/teammcp` pass (the only failure locally is a pre-existing `TestOfficeEvals` TempDir-cleanup flake that also fails on clean `main` and is green in CI).

## Test plan

- [x] `go build ./...`, `go vet`, `gofmt`
- [x] new regression test fails pre-fix / passes post-fix
- [x] `go test ./internal/team ./internal/teammcp` (minus the pre-existing OfficeEvals teardown flake)
- [x] `-race` on the channel/task tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
- Fixed task-channel allocation so newly created top-level tasks initiated from within another task’s channel (and tasks that effectively resolve to the default “general” channel) now receive their own dedicated per-task channel instead of sharing the parent’s channel.

## Improvements
- Added stricter validation of per-task LLM runtime override settings at the boundary during task creation and planning for more consistent behavior.

## Tests
- Added an integration test reproducing the prior channel-sharing issue and expanded channel-minting contract coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->