### PR TITLE
fix(tasks): migrate existing Issues squatting in another task's channel

### DIFF
--- a/internal/team/broker_defaults.go
+++ b/internal/team/broker_defaults.go
@@ -339,7 +339,57 @@ func (b *Broker) normalizeLoadedStateLocked() {
 		_ = b.syncTaskWorktreeLocked(&b.tasks[i])
 	}
 	b.reconcileOrphanedBlockedTasksLocked()
+	b.reconcileSharedTaskChannelsLocked()
 	b.pendingInterview = firstBlockingRequest(b.requests)
+}
+
+// reconcileSharedTaskChannelsLocked re-homes tasks that are squatting in
+// another task's dedicated per-task channel. Before the channel-minting fix,
+// a top-level Issue created from inside an existing Issue's chat inherited that
+// chat's channel, so several tasks could share one task-<id> channel (e.g.
+// OFFICE-28 sitting in OFFICE-22's "task-office-22"). This one-shot migration
+// gives each squatter its own task-<childID> channel going forward.
+//
+// A channel "belongs" to the task whose ID equals its linked TaskID. A task
+// whose Channel is a per-task channel owned by a DIFFERENT task is re-homed;
+// the task that legitimately owns the channel, tasks in #general, and tasks in
+// non-per-task shared channels (no TaskID — project/bridged channels) are left
+// alone. System and incident tasks legitimately live in #general and are
+// skipped. Historical messages stay in the old channel — only the task→channel
+// link moves, so new activity lands in the task's own chat.
+//
+// Idempotent: after the first pass each re-homed task owns its new channel
+// (TaskID == its own ID), so a second pass finds nothing to move. Caller must
+// hold b.mu. Runs once per broker boot from normalizeLoadedStateLocked.
+func (b *Broker) reconcileSharedTaskChannelsLocked() {
+	for i := range b.tasks {
+		t := &b.tasks[i]
+		if t.System || strings.TrimSpace(t.PipelineID) == "incident" {
+			continue
+		}
+		ch := b.findChannelLocked(t.Channel)
+		if ch == nil {
+			continue
+		}
+		owner := strings.TrimSpace(ch.TaskID)
+		// Not a per-task channel (general / project / bridged), or this task
+		// already owns it — nothing to do.
+		if owner == "" || owner == strings.TrimSpace(t.ID) {
+			continue
+		}
+		// Squatting in another task's channel — mint its own and move the link.
+		newCh := b.createPerTaskChannelLocked(t.ID, t.Title, t.Owner, "system")
+		if newCh == nil {
+			// createPerTaskChannelLocked logs the failure; leave the task in the
+			// shared channel rather than dropping it somewhere worse.
+			continue
+		}
+		old := t.Channel
+		t.Channel = newCh.Slug
+		t.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
+		b.appendActionLocked("task_rehomed", "office", newCh.Slug, "system",
+			truncateSummary("Moved out of shared channel "+old+" into its own", 140), t.ID)
+	}
 }
 
 // reconcileOrphanedBlockedTasksLocked unblocks tasks whose dependencies

--- a/internal/team/broker_tasks_test.go
+++ b/internal/team/broker_tasks_test.go
@@ -131,6 +131,80 @@ func TestReconcileOrphanedBlockedTasksLocked_UnblocksCancelledParent(t *testing.
 	b.mu.Unlock()
 }
 
+// TestReconcileSharedTaskChannelsLocked_RehomesSquatters pins the one-shot
+// migration that splits already-shared per-task channels. Reproduces the live
+// OFFICE-22 / OFFICE-28 case: OFFICE-28 (created from inside OFFICE-22's chat)
+// shares OFFICE-22's "task-office-22" channel. After the migration OFFICE-28
+// owns its own "task-office-28"; OFFICE-22 is untouched; #general and
+// non-per-task channels are left alone; and a second pass is a no-op.
+func TestReconcileSharedTaskChannelsLocked_RehomesSquatters(t *testing.T) {
+	b := newTestBroker(t)
+	ensureTestMemberAccess(b, "general", "eng", "Eng")
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	// task-office-22 is OFFICE-22's dedicated per-task channel.
+	b.channels = append(b.channels, teamChannel{
+		Slug: "task-office-22", Name: "Daily Digest", TaskID: "OFFICE-22",
+		Members: []string{"eng"}, CreatedBy: "system",
+		CreatedAt: time.Now().UTC().Format(time.RFC3339),
+	})
+	// A genuinely shared, non-per-task channel (no TaskID) — must be left alone.
+	b.channels = append(b.channels, teamChannel{
+		Slug: "project-loop", Name: "project-loop",
+		Members: []string{"eng"}, CreatedBy: "system",
+		CreatedAt: time.Now().UTC().Format(time.RFC3339),
+	})
+	b.tasks = []teamTask{
+		{ID: "OFFICE-22", Title: "Daily Digest from email", Owner: "eng", status: "in_progress", Channel: "task-office-22"},
+		{ID: "OFFICE-28", Title: "Outbound email reply agent", Owner: "eng", status: "in_progress", Channel: "task-office-22"},
+		{ID: "OFFICE-30", Title: "Backup", Owner: "eng", status: "open", Channel: "general"},
+		{ID: "OFFICE-31", Title: "Shared project work", Owner: "eng", status: "open", Channel: "project-loop"},
+	}
+
+	b.reconcileSharedTaskChannelsLocked()
+
+	byID := map[string]*teamTask{}
+	for i := range b.tasks {
+		byID[b.tasks[i].ID] = &b.tasks[i]
+	}
+	// The owner keeps its channel.
+	if got := byID["OFFICE-22"].Channel; got != "task-office-22" {
+		t.Fatalf("OFFICE-22 (owner) channel must be unchanged, got %q", got)
+	}
+	// The squatter gets its own channel.
+	wantChild := normalizeChannelSlug("task-OFFICE-28")
+	if got := byID["OFFICE-28"].Channel; got != wantChild {
+		t.Fatalf("OFFICE-28 must be re-homed to %q, got %q", wantChild, got)
+	}
+	if got := byID["OFFICE-28"].Channel; got == byID["OFFICE-22"].Channel {
+		t.Fatalf("OFFICE-28 must not share OFFICE-22's channel %q", got)
+	}
+	// The minted channel exists and links back to the squatter.
+	newCh := b.findChannelLocked(wantChild)
+	if newCh == nil || newCh.TaskID != "OFFICE-28" {
+		t.Fatalf("expected channel %q linked to OFFICE-28, got %+v", wantChild, newCh)
+	}
+	// #general and non-per-task shared channels are untouched.
+	if got := byID["OFFICE-30"].Channel; got != "general" {
+		t.Fatalf("OFFICE-30 in #general must be untouched, got %q", got)
+	}
+	if got := byID["OFFICE-31"].Channel; got != "project-loop" {
+		t.Fatalf("OFFICE-31 in a non-per-task shared channel must be untouched, got %q", got)
+	}
+
+	// Idempotent: a second pass changes nothing.
+	before := map[string]string{}
+	for i := range b.tasks {
+		before[b.tasks[i].ID] = b.tasks[i].Channel + "|" + b.tasks[i].UpdatedAt
+	}
+	b.reconcileSharedTaskChannelsLocked()
+	for i := range b.tasks {
+		if got := b.tasks[i].Channel + "|" + b.tasks[i].UpdatedAt; got != before[b.tasks[i].ID] {
+			t.Errorf("task %s changed on second pass: %q -> %q", b.tasks[i].ID, before[b.tasks[i].ID], got)
+		}
+	}
+}
+
 // TestTaskReuseMatch_HasScopedIdentity pins the precondition for
 // scoped-identity dedupe in findReusableTaskLocked: a match counts as
 // scoped only when SourceSignalID or SourceDecisionID is non-empty.


### PR DESCRIPTION
## Why

#1107 stopped **new** Issues from being created into another Issue's chat, but Issues already persisted with a shared channel stay shared. Live example from the workspace:

```
OFFICE-22  channel=task-office-22   (owner of the channel)
OFFICE-28  channel=task-office-22   ← still squatting after #1107
```

## What

One-shot, idempotent boot migration `reconcileSharedTaskChannelsLocked`, run from `normalizeLoadedStateLocked` (same place as the other load-time reconcilers). For each task whose `Channel` is a per-task channel owned by a **different** task (`channel.TaskID != task.ID`), it mints the task's own `task-<id>` channel and moves the link.

**Left untouched:** the task that legitimately owns the channel, tasks in `#general`, tasks in non-per-task shared channels (no `TaskID` — project/bridged), and system/incident tasks. Only the task→channel link moves — historical messages stay in the old channel, so new activity lands in the task's own chat.

**Idempotent:** after the first pass each task owns its channel, so subsequent boots are no-ops.

## Test

`TestReconcileSharedTaskChannelsLocked_RehomesSquatters` reproduces the OFFICE-22/OFFICE-28 case: the squatter is re-homed to its own channel, the owner is untouched, `#general` and non-per-task channels are left alone, and a second pass changes nothing.

## Test plan

- [x] `go build ./...`, `go vet`, `gofmt`
- [x] `go test ./internal/team ./internal/teammcp` (exit 0)
- [x] migration unit test (re-home + idempotency + leave-alone cases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where some tasks were incorrectly assigned to shared channels. Affected tasks are now automatically relocated to their proper dedicated channels during system startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->