### PR TITLE
fix(website): stop the desktop download links 404ing

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -55,16 +55,40 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # ratchet:actions/checkout@v4
 
       - name: Free disk space for DMG packaging
-        # macos-14 runners ship near-full; `hdiutil create` for the universal .app
-        # has twice failed with "No space left on device" (v0.1.0, v0.227.0).
-        # Reclaim the simulator runtimes we never use (~10-20 GB) up front. This
-        # leaves the active Xcode/CLT intact, so codesign + notarytool still work.
+        # macos-14 runners ship near-full; `hdiutil create` for the universal
+        # .app has failed with "No space left on device" (v0.1.0, v0.227.0,
+        # v0.227.2). Reclaim the big tools this Go/Wails build never touches
+        # BEFORE building so packaging has headroom. The *active* Xcode is kept
+        # (codesign, hdiutil, notarytool, stapler all need it) — only the other
+        # installed Xcode versions and unused SDKs are removed.
         run: |
-          df -h /
+          set -uo pipefail
+          echo "Disk before cleanup:"; df -h /
+          # iOS simulator runtimes, caches, and device-support (~10-20 GB).
           sudo rm -rf /Library/Developer/CoreSimulator/Profiles/Runtimes/* || true
-          sudo rm -rf ~/Library/Developer/Xcode/iOS\ DeviceSupport/* || true
           sudo rm -rf ~/Library/Developer/CoreSimulator/Caches/* || true
-          df -h /
+          sudo rm -rf ~/Library/Developer/Xcode/iOS\ DeviceSupport/* || true
+          # Android SDK/NDK — never used by this build (~10+ GB).
+          sudo rm -rf "${ANDROID_SDK_ROOT:-}" "${ANDROID_HOME:-}" ~/Library/Android || true
+          # Extra Xcode installs — keep ONLY the one `xcode-select` points at.
+          # Guard on the active path actually being an /Applications/Xcode*.app so
+          # a CLT-only selection can never delete every Xcode out from under us.
+          active_xcode="$(xcode-select -p 2>/dev/null | sed 's#/Contents/Developer##')"
+          echo "Active Xcode: ${active_xcode:-<none>}"
+          case "$active_xcode" in
+            /Applications/Xcode*.app)
+              for x in /Applications/Xcode*.app; do
+                [ -e "$x" ] || continue
+                [ "$x" = "$active_xcode" ] && continue
+                echo "Removing unused $x"
+                sudo rm -rf "$x" || true
+              done
+              ;;
+            *)
+              echo "Active toolchain is not a removable Xcode.app; skipping Xcode pruning"
+              ;;
+          esac
+          echo "Disk after cleanup:"; df -h /
 
       - name: Resolve version
         id: ver
@@ -98,7 +122,22 @@ jobs:
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # ratchet:oven-sh/setup-bun@v2
 
       - name: Build embedded web bundle
-        run: cd web && bun install && bun run build
+        run: |
+          cd web
+          # Retry `bun install`: the xlsx dep pulls from the sheetjs CDN, which
+          # intermittently 502s and has failed desktop releases (v0.227.2).
+          # `bun run build` is a real build step, so only the network-bound
+          # install is retried.
+          for attempt in 1 2 3; do
+            if bun install; then break; fi
+            if [ "$attempt" = 3 ]; then
+              echo "::error::bun install failed after 3 attempts (transient registry/CDN error?)"
+              exit 1
+            fi
+            echo "::warning::bun install attempt $attempt failed; retrying in $((attempt * 10))s"
+            sleep $((attempt * 10))
+          done
+          bun run build
 
       - name: Install Wails CLI
         run: go install github.com/wailsapp/wails/v2/cmd/wails@${{ env.WAILS_VERSION }}
@@ -244,7 +283,22 @@ jobs:
 
       - name: Build embedded web bundle
         shell: bash
-        run: cd web && bun install && bun run build
+        run: |
+          cd web
+          # Retry `bun install`: the xlsx dep pulls from the sheetjs CDN, which
+          # intermittently 502s and failed the v0.227.2 Windows desktop build.
+          # `bun run build` is a real build step, so only the network-bound
+          # install is retried.
+          for attempt in 1 2 3; do
+            if bun install; then break; fi
+            if [ "$attempt" = 3 ]; then
+              echo "::error::bun install failed after 3 attempts (transient registry/CDN error?)"
+              exit 1
+            fi
+            echo "::warning::bun install attempt $attempt failed; retrying in $((attempt * 10))s"
+            sleep $((attempt * 10))
+          done
+          bun run build
 
       - name: Install Wails CLI
         shell: bash

--- a/.github/workflows/release-drift.yml
+++ b/.github/workflows/release-drift.yml
@@ -131,3 +131,44 @@ jobs:
             exit 1
           fi
           echo "All four surfaces agree at v$git_version. ✓"
+
+      - name: Verify desktop installer aliases are downloadable
+        # The /download.html page resolves its macOS/Windows buttons to the
+        # newest release that actually carries these version-less aliases.
+        # They're appended to each v* release by desktop-release.yml, whose
+        # build can fail on its own (runner disk space, a flaky CDN). When the
+        # LATEST release's desktop build fails, `releases/latest/download/<alias>`
+        # 404s — the original incident. The page now self-heals by falling back
+        # to an older release that still has the alias, so the only true outage
+        # is when NO recent release carries it at all: fail loud there. When
+        # merely the latest release is missing it, warn (don't fail) — the page
+        # still works, but a desktop build needs a re-run.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          aliases="WUPHF-mac.dmg WUPHF-windows-setup.exe"
+
+          # Asset names across recent published (non-draft) releases, and on the
+          # specific release users land on via releases/latest.
+          all_assets=$(gh api 'repos/${{ github.repository }}/releases?per_page=30' \
+            --jq '[.[] | select(.draft | not) | .assets[].name] | unique | .[]')
+          latest_assets=$(gh api repos/${{ github.repository }}/releases/latest \
+            --jq '.assets[].name')
+          latest_tag=$(gh api repos/${{ github.repository }}/releases/latest --jq .tag_name)
+
+          fail=0
+          for a in $aliases; do
+            if ! grep -qx "$a" <<<"$all_assets"; then
+              echo "::error::no published release carries '$a' — /download.html has nothing to link to"
+              echo "::error::check: gh run list --workflow=desktop-release.yml --limit=5"
+              fail=1
+            elif ! grep -qx "$a" <<<"$latest_assets"; then
+              echo "::warning::latest release ($latest_tag) is missing '$a' — its desktop build failed; /download.html falls back to an older release"
+              echo "::warning::re-run: gh workflow run desktop-release.yml --ref $latest_tag -f version=${latest_tag#v}"
+            fi
+          done
+          if [ "$fail" -ne 0 ]; then
+            exit 1
+          fi
+          echo "Desktop installer aliases are downloadable. ✓"

--- a/website/download.html
+++ b/website/download.html
@@ -119,7 +119,7 @@
   <section class="hero">
     <h1>WUPHF <span class="accent">Desktop</span></h1>
     <p class="lead">Your whole office of AI employees in a native window — no browser tab, no terminal. Same office as the CLI, just a real app.</p>
-    <a class="btn-primary" id="primaryDownload" href="https://github.com/nex-crm/wuphf/releases/latest" target="_blank" rel="noopener">Download</a>
+    <a class="btn-primary" id="primaryDownload" href="https://github.com/nex-crm/wuphf/releases" target="_blank" rel="noopener">Download</a>
     <span class="btn-sub" id="primarySub">Pick your platform below</span>
   </section>
 

--- a/website/download.html
+++ b/website/download.html
@@ -128,7 +128,7 @@
     <article class="card" id="card-mac">
       <h2>macOS <span class="badge-you" id="you-mac" hidden>YOU</span></h2>
       <p class="meta">Universal — Apple Silicon &amp; Intel · macOS 11+ · signed &amp; notarized by Apple</p>
-      <a class="btn-dl" href="https://github.com/nex-crm/wuphf/releases/latest/download/WUPHF-mac.dmg">Download .dmg</a>
+      <a class="btn-dl" id="dlMac" href="https://github.com/nex-crm/wuphf/releases">Download .dmg</a>
       <ol class="steps">
         <li>Open the downloaded <code>WUPHF-mac.dmg</code>.</li>
         <li>Drag <strong>WUPHF</strong> into your <strong>Applications</strong> folder.</li>
@@ -144,7 +144,7 @@
     <article class="card" id="card-win">
       <h2>Windows <span class="badge-you" id="you-win" hidden>YOU</span></h2>
       <p class="meta">Windows 10/11 · 64-bit · WebView2 (built in to Windows)</p>
-      <a class="btn-dl" href="https://github.com/nex-crm/wuphf/releases/latest/download/WUPHF-windows-setup.exe">Download installer</a>
+      <a class="btn-dl" id="dlWin" href="https://github.com/nex-crm/wuphf/releases">Download installer</a>
       <ol class="steps">
         <li>Run the downloaded <code>WUPHF-windows-setup.exe</code>.</li>
         <li>Follow the installer, then launch <strong>WUPHF</strong> from the Start menu.</li>
@@ -181,26 +181,84 @@
 
 <script>
   (function () {
-    // Detect OS and highlight the matching card + relabel the hero button.
+    var REPO = "nex-crm/wuphf";
+    var MAC_ASSET = "WUPHF-mac.dmg";
+    var WIN_ASSET = "WUPHF-windows-setup.exe";
+
+    // Detect OS to highlight the matching card + relabel the hero button.
     var ua = navigator.userAgent || "";
     var plat = (navigator.userAgentData && navigator.userAgentData.platform) || navigator.platform || "";
     var isMac = /Mac/i.test(plat) || /Mac OS X/i.test(ua);
     var isWin = /Win/i.test(plat) || /Windows/i.test(ua);
-    var MAC = "https://github.com/nex-crm/wuphf/releases/latest/download/WUPHF-mac.dmg";
-    var WIN = "https://github.com/nex-crm/wuphf/releases/latest/download/WUPHF-windows-setup.exe";
-    var btn = document.getElementById("primaryDownload");
-    var sub = document.getElementById("primarySub");
+
+    var primaryBtn = document.getElementById("primaryDownload");
+    var primarySub = document.getElementById("primarySub");
+    var macBtn = document.getElementById("dlMac");
+    var winBtn = document.getElementById("dlWin");
+
+    // Highlight the detected platform card immediately — this never depends on
+    // the asset URLs resolving, so it works even offline.
     if (isMac) {
-      btn.href = MAC; btn.textContent = "Download for macOS";
-      sub.textContent = "Universal .dmg · Apple Silicon & Intel";
       document.getElementById("card-mac").classList.add("detected");
       document.getElementById("you-mac").hidden = false;
     } else if (isWin) {
-      btn.href = WIN; btn.textContent = "Download for Windows";
-      sub.textContent = "Installer .exe · Windows 10/11 64-bit";
       document.getElementById("card-win").classList.add("detected");
       document.getElementById("you-win").hidden = false;
     }
+
+    // Resolve the newest release that ACTUALLY carries each installer.
+    //
+    // We deliberately avoid `releases/latest/download/<asset>`: GitHub's
+    // "latest" is the most recent release overall, which is a CLI/goreleaser
+    // tag. The desktop installers are appended to that release by a separate
+    // build job that can fail on its own (runner disk space, a flaky CDN) —
+    // when it does, the stable alias is missing from "latest" and the link
+    // 404s even though a perfectly good installer sits on the prior release.
+    // Scanning the releases list and picking the newest one that has the asset
+    // is self-healing: a single failed desktop build can't break this page.
+    function newestAssetUrl(releases, name) {
+      var sorted = releases
+        .filter(function (r) { return r && !r.draft; })
+        .sort(function (a, b) {
+          return new Date(b.published_at || b.created_at || 0) -
+                 new Date(a.published_at || a.created_at || 0);
+        });
+      for (var i = 0; i < sorted.length; i++) {
+        var assets = sorted[i].assets || [];
+        for (var j = 0; j < assets.length; j++) {
+          if (assets[j].name === name) return assets[j].browser_download_url;
+        }
+      }
+      return null;
+    }
+
+    function applyUrls(macUrl, winUrl) {
+      if (macUrl) macBtn.href = macUrl;
+      if (winUrl) winBtn.href = winUrl;
+      if (isMac && macUrl) {
+        primaryBtn.href = macUrl;
+        primaryBtn.textContent = "Download for macOS";
+        primarySub.textContent = "Universal .dmg · Apple Silicon & Intel";
+      } else if (isWin && winUrl) {
+        primaryBtn.href = winUrl;
+        primaryBtn.textContent = "Download for Windows";
+        primarySub.textContent = "Installer .exe · Windows 10/11 64-bit";
+      }
+    }
+
+    fetch("https://api.github.com/repos/" + REPO + "/releases?per_page=30", {
+      headers: { Accept: "application/vnd.github+json" }
+    })
+      .then(function (r) { return r.ok ? r.json() : Promise.reject(r.status); })
+      .then(function (releases) {
+        if (!Array.isArray(releases)) return;
+        applyUrls(newestAssetUrl(releases, MAC_ASSET), newestAssetUrl(releases, WIN_ASSET));
+      })
+      .catch(function () {
+        // Network/rate-limit failure: keep the evergreen /releases fallback
+        // hrefs already in the markup so the buttons still go somewhere real.
+      });
+
     // Copy buttons
     document.querySelectorAll("[data-copy]").forEach(function (b) {
       b.addEventListener("click", function () {

--- a/website/download.html
+++ b/website/download.html
@@ -160,6 +160,10 @@
     </article>
   </section>
 
+  <p style="text-align:center; margin-top:28px; font-size:13.5px;">
+    <a href="https://github.com/nex-crm/wuphf/releases" target="_blank" rel="noopener">View all releases &amp; previous versions on GitHub →</a>
+  </p>
+
   <section class="alt">
     <h3>Prefer the terminal? Or on Linux?</h3>
     <p class="muted">The desktop app and the CLI are the same office — use whichever you like. The CLI runs everywhere, including Linux:</p>


### PR DESCRIPTION
## Why

`wuphf.team/download.html` linked the macOS/Windows buttons to
`releases/latest/download/WUPHF-mac.dmg` and `…/WUPHF-windows-setup.exe`. Those
version-less aliases are appended to each `v*` release by `desktop-release.yml`
— **but only when that build succeeds**. `releases/latest` resolves to the most
recent release *overall* (a CLI/goreleaser tag), whose desktop build runs and
can fail independently.

The current `latest` (`v0.227.2`) had **both** desktop jobs fail:
- macOS: `hdiutil create` → `No space left on device`
- Windows: `bun install` → `GET https://cdn.sheetjs.com/...xlsx-0.20.3.tgz 502`

So `v0.227.2` carries only CLI tarballs → every download link **404'd**, even
though `v0.227.1` has working, publicly-downloadable installers. Nothing caught
it: the link-check only scans Markdown, never `website/*.html`.

(The release assets themselves are public — verified anonymous `200` — so this
was never a permissions issue, just the wrong release.)

## What

**`website/download.html`** — buttons no longer trust `/latest`. They resolve
each installer to the *newest release that actually contains it* via the public
GitHub releases API, with the evergreen `/releases` listing as the static
fallback if the API is unreachable. A single failed desktop build can no longer
break the page. Also adds a prominent "View all releases & previous versions on
GitHub" link so users can grab a specific/older version.

**`.github/workflows/release-drift.yml`** — extends the existing distribution
monitor to assert the installer aliases are downloadable: **fail** if no release
carries them, **warn** (page self-heals) when only `latest` is missing them —
printing the exact `gh workflow run desktop-release.yml` re-run command.

**`.github/workflows/desktop-release.yml`** — hardens the two failure modes:
- macOS frees the Android SDK + every non-active Xcode install before `hdiutil`
  (the active Xcode, needed by codesign/notarytool/stapler, is detected and
  kept; a CLT-only selection is guarded so it can't delete every Xcode).
- both jobs retry `bun install` 3× with backoff to ride out a transient CDN/
  registry 502. `bun run build` is left un-retried (a build failure is real).

## Test plan

- [x] `download.html`: extracted `<script>` passes `node --check`.
- [x] Resolver run against live release data → picks `v0.227.1`; both resolved
      URLs return `200` (skips the broken `v0.227.2`).
- [x] Static fallback hrefs (`/releases`, `/releases/latest`) return `200`.
- [x] `release-drift.yml` + `desktop-release.yml` parse as YAML.
- [x] Drift guard's `jq`/logic simulated against the live API → no failure,
      expected "v0.227.2 missing alias → falls back" warning.
- [x] New `desktop-release.yml` `run:` blocks are `shellcheck`-clean.
- [ ] Restore installers on current `latest`:
      `gh workflow run desktop-release.yml --ref v0.227.2 -f version=0.227.2`
      (release action — intentionally not run in this PR).

> Screenshots: change is in the static marketing site (`website/`), not the
> `web/` app, so the `web/e2e/screenshots` harness doesn't apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Download page now resolves the latest available platform installer assets via the GitHub releases API, updating the download buttons to point directly to current builds.
  * Added a centered link to view all releases and previous versions from the download page.

* **Bug Fixes**
  * Improved macOS and Windows desktop release build reliability by retrying `bun install` during the web-bundle build step to reduce failures from transient network issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->