### PR TITLE
fix: Composio API-key connect, agent idle recovery, JSONL preview, richer wiki articles

### DIFF
--- a/internal/action/composio.go
+++ b/internal/action/composio.go
@@ -240,6 +240,20 @@ func (c *ComposioREST) StartIntegrationConnection(ctx context.Context, req Integ
 	if platform == "" {
 		return IntegrationConnectResult{}, fmt.Errorf("platform is required")
 	}
+	// Toolkits Composio cannot host an OAuth app for (API-key / token auth, e.g.
+	// Instantly) cannot use the managed-auth flow — that path returns a bare
+	// "400 POST /auth_configs". Detect them up front and ask the UI to collect
+	// the user's credentials instead of failing opaquely.
+	if info := c.toolkitAuthInfo(ctx, platform); !info.Managed {
+		return IntegrationConnectResult{
+			Provider:       c.Name(),
+			Platform:       platform,
+			Status:         "needs_fields",
+			AuthMode:       strings.ToLower(info.Mode),
+			RequiredFields: info.Fields,
+			Instructions:   "Enter your " + DisplayPlatformName(platform) + " credentials to connect.",
+		}, nil
+	}
 	authConfigID, err := c.composioManagedAuthConfigID(ctx, platform)
 	if err != nil {
 		return IntegrationConnectResult{}, err

--- a/internal/action/composio_apikey.go
+++ b/internal/action/composio_apikey.go
@@ -94,14 +94,14 @@ func (c *ComposioREST) toolkitAuthInfo(ctx context.Context, platform string) too
 		}
 	}
 
-	// No managed OAuth scheme — find the first non-OAuth mode and surface its
-	// credential fields. If a mode is itself an OAuth scheme (and Composio just
-	// didn't list it as managed) we still prefer treating it as managed, since
-	// the user has no client credentials to paste.
+	// No managed OAuth scheme — scan the modes for the first non-OAuth one and
+	// surface its credential fields. OAuth-ish (or empty) modes are skipped:
+	// the user has no client credentials to paste for an OAuth app Composio
+	// doesn't host, so those fall through to the managed fallback below.
 	for _, ad := range detail.AuthConfigDetails {
 		mode := strings.ToUpper(strings.TrimSpace(ad.Mode))
 		if mode == "" || composioManagedAuthSchemes[mode] {
-			return toolkitAuthInfo{Managed: true}
+			continue
 		}
 		return toolkitAuthInfo{
 			Mode:   mode,
@@ -109,7 +109,7 @@ func (c *ComposioREST) toolkitAuthInfo(ctx context.Context, platform string) too
 		}
 	}
 
-	// Nothing introspectable — fall back to managed so we don't regress.
+	// No actionable non-OAuth mode — fall back to managed so we don't regress.
 	return toolkitAuthInfo{Managed: true}
 }
 
@@ -204,6 +204,27 @@ func (c *ComposioREST) CompleteAPIKeyConnection(ctx context.Context, platform st
 		mode = "API_KEY"
 	}
 
+	// Drop blank values and confirm every required credential is present BEFORE
+	// touching Composio. A missing/blank required field would otherwise create
+	// an auth config that then fails at /connected_accounts, leaving an orphan
+	// auth config behind.
+	cleaned := make(map[string]string, len(fields))
+	for k, v := range fields {
+		if tv := strings.TrimSpace(v); tv != "" {
+			cleaned[k] = tv
+		}
+	}
+	for _, f := range info.Fields {
+		if f.Required {
+			if _, ok := cleaned[f.Name]; !ok {
+				return IntegrationConnectResult{}, fmt.Errorf("missing required credential: %s", f.Name)
+			}
+		}
+	}
+	if len(cleaned) == 0 {
+		return IntegrationConnectResult{}, fmt.Errorf("no credentials supplied")
+	}
+
 	authConfigID, err := c.createCustomAuthConfig(ctx, platform, mode)
 	if err != nil {
 		return IntegrationConnectResult{}, fmt.Errorf("create custom auth config: %w", err)
@@ -218,7 +239,7 @@ func (c *ComposioREST) CompleteAPIKeyConnection(ctx context.Context, platform st
 			"user_id": strings.TrimSpace(c.UserID),
 			"state": map[string]any{
 				"authScheme": mode,
-				"val":        stringMapToAny(fields),
+				"val":        stringMapToAny(cleaned),
 			},
 		},
 	}

--- a/internal/action/composio_apikey.go
+++ b/internal/action/composio_apikey.go
@@ -1,0 +1,289 @@
+package action
+
+// composio_apikey.go — connect path for toolkits that authenticate with a
+// user-supplied API key / token rather than Composio-managed OAuth.
+//
+// Background: StartIntegrationConnection used to ALWAYS create an auth config
+// of type "use_composio_managed_auth". That only works for toolkits where
+// Composio hosts its own OAuth app (Gmail, Slack, …). For an API-key toolkit
+// like Instantly, Composio has no managed app, so POST /auth_configs returns a
+// bare 400 ("400 POST /auth_configs") with no guidance — the exact customer
+// bug this module fixes.
+//
+// The flow is now: detect the toolkit's auth mode (GET /toolkits/{slug}); if
+// Composio can manage it, keep the OAuth path; otherwise surface the required
+// credential fields so the UI can collect them, then create a custom-auth
+// config + connected account with the user's key.
+//
+// NOTE: the Composio v3 request/response shapes below follow the documented
+// API but have not been exercised against a live API-key toolkit in this
+// change. The shapes are isolated here and unit-tested for what WE send so a
+// field-name tweak after live verification is a one-line change.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// composioManagedAuthSchemes are the schemes Composio can host an app for, so
+// the existing zero-touch OAuth path applies. Everything else needs the user
+// to bring their own credential.
+var composioManagedAuthSchemes = map[string]bool{
+	"OAUTH2":  true,
+	"OAUTH1":  true,
+	"OAUTH1A": true,
+}
+
+// toolkitAuthInfo is the distilled auth shape for one toolkit.
+type toolkitAuthInfo struct {
+	// Managed is true when Composio hosts an OAuth app for this toolkit, so the
+	// existing use_composio_managed_auth + hosted-link flow works.
+	Managed bool
+	// Mode is the primary non-managed auth scheme (e.g. "API_KEY", "BEARER_TOKEN",
+	// "BASIC"). Empty when the toolkit is managed or exposes no scheme.
+	Mode string
+	// Fields are the credentials the user must supply for Mode.
+	Fields []IntegrationConnectField
+}
+
+// composioToolkitDetail mirrors the slice of GET /toolkits/{slug} we read.
+type composioToolkitDetail struct {
+	Slug                       string   `json:"slug"`
+	Name                       string   `json:"name"`
+	ComposioManagedAuthSchemes []string `json:"composio_managed_auth_schemes"`
+	AuthConfigDetails          []struct {
+		Mode   string `json:"mode"`
+		Fields struct {
+			ConnectedAccountInitiation composioFieldSet `json:"connected_account_initiation"`
+		} `json:"fields"`
+	} `json:"auth_config_details"`
+}
+
+type composioFieldSet struct {
+	Required []composioAuthField `json:"required"`
+	Optional []composioAuthField `json:"optional"`
+}
+
+type composioAuthField struct {
+	Name        string `json:"name"`
+	DisplayName string `json:"displayName"`
+	Description string `json:"description"`
+	Type        string `json:"type"`
+	Required    bool   `json:"required"`
+}
+
+// toolkitAuthInfo fetches a toolkit's auth detail and distills it. On any error
+// it returns Managed=true so callers fall back to the existing OAuth attempt
+// rather than blocking a toolkit we simply could not introspect.
+func (c *ComposioREST) toolkitAuthInfo(ctx context.Context, platform string) toolkitAuthInfo {
+	raw, err := c.get(ctx, "/toolkits/"+url.PathEscape(platform), nil)
+	if err != nil {
+		return toolkitAuthInfo{Managed: true}
+	}
+	var detail composioToolkitDetail
+	if err := json.Unmarshal(raw, &detail); err != nil {
+		return toolkitAuthInfo{Managed: true}
+	}
+
+	for _, scheme := range detail.ComposioManagedAuthSchemes {
+		if composioManagedAuthSchemes[strings.ToUpper(strings.TrimSpace(scheme))] {
+			return toolkitAuthInfo{Managed: true}
+		}
+	}
+
+	// No managed OAuth scheme — find the first non-OAuth mode and surface its
+	// credential fields. If a mode is itself an OAuth scheme (and Composio just
+	// didn't list it as managed) we still prefer treating it as managed, since
+	// the user has no client credentials to paste.
+	for _, ad := range detail.AuthConfigDetails {
+		mode := strings.ToUpper(strings.TrimSpace(ad.Mode))
+		if mode == "" || composioManagedAuthSchemes[mode] {
+			return toolkitAuthInfo{Managed: true}
+		}
+		return toolkitAuthInfo{
+			Mode:   mode,
+			Fields: connectFieldsFrom(ad.Fields.ConnectedAccountInitiation, mode),
+		}
+	}
+
+	// Nothing introspectable — fall back to managed so we don't regress.
+	return toolkitAuthInfo{Managed: true}
+}
+
+// connectFieldsFrom maps Composio's field metadata to our wire shape. When the
+// toolkit advertises no initiation fields we synthesise a single API-key field
+// so the user still gets a usable form for the common API_KEY case.
+func connectFieldsFrom(set composioFieldSet, mode string) []IntegrationConnectField {
+	all := append(append([]composioAuthField{}, set.Required...), set.Optional...)
+	out := make([]IntegrationConnectField, 0, len(all))
+	for _, f := range all {
+		name := strings.TrimSpace(f.Name)
+		if name == "" {
+			continue
+		}
+		out = append(out, IntegrationConnectField{
+			Name:        name,
+			Label:       firstNonEmpty(f.DisplayName, humanizeFieldName(name)),
+			Description: strings.TrimSpace(f.Description),
+			Secret:      isSecretField(name, f.Type),
+			Required:    f.Required || containsField(set.Required, name),
+		})
+	}
+	if len(out) == 0 {
+		out = append(out, defaultCredentialField(mode))
+	}
+	return out
+}
+
+func containsField(fields []composioAuthField, name string) bool {
+	for _, f := range fields {
+		if strings.EqualFold(strings.TrimSpace(f.Name), name) {
+			return true
+		}
+	}
+	return false
+}
+
+// defaultCredentialField is the fallback input when a toolkit exposes no
+// initiation field metadata — almost always a single API key / token.
+func defaultCredentialField(mode string) IntegrationConnectField {
+	switch mode {
+	case "BEARER_TOKEN":
+		return IntegrationConnectField{Name: "token", Label: "Access token", Secret: true, Required: true}
+	case "BASIC":
+		return IntegrationConnectField{Name: "password", Label: "Password", Secret: true, Required: true}
+	default:
+		return IntegrationConnectField{Name: "generic_api_key", Label: "API key", Secret: true, Required: true}
+	}
+}
+
+func isSecretField(name, fieldType string) bool {
+	n := strings.ToLower(name)
+	if strings.Contains(strings.ToLower(fieldType), "password") {
+		return true
+	}
+	for _, hint := range []string{"key", "token", "secret", "password"} {
+		if strings.Contains(n, hint) {
+			return true
+		}
+	}
+	return false
+}
+
+func humanizeFieldName(name string) string {
+	parts := strings.FieldsFunc(name, func(r rune) bool { return r == '_' || r == '-' })
+	for i, p := range parts {
+		if p == "" {
+			continue
+		}
+		parts[i] = strings.ToUpper(p[:1]) + p[1:]
+	}
+	if len(parts) == 0 {
+		return name
+	}
+	return strings.Join(parts, " ")
+}
+
+// CompleteAPIKeyConnection creates a custom-auth config and a connected account
+// for an API-key/token toolkit using the user-supplied credentials. Returns a
+// connected (or pending) result the UI can poll like the OAuth path.
+func (c *ComposioREST) CompleteAPIKeyConnection(ctx context.Context, platform string, fields map[string]string) (IntegrationConnectResult, error) {
+	platform = normalizeComposioPlatform(platform)
+	if platform == "" {
+		return IntegrationConnectResult{}, fmt.Errorf("platform is required")
+	}
+	if len(fields) == 0 {
+		return IntegrationConnectResult{}, fmt.Errorf("no credentials supplied")
+	}
+	info := c.toolkitAuthInfo(ctx, platform)
+	mode := info.Mode
+	if mode == "" {
+		mode = "API_KEY"
+	}
+
+	authConfigID, err := c.createCustomAuthConfig(ctx, platform, mode)
+	if err != nil {
+		return IntegrationConnectResult{}, fmt.Errorf("create custom auth config: %w", err)
+	}
+
+	// Connected account carries the user's credentials in the scheme-specific
+	// `val` map. Field names come from the toolkit's initiation metadata, so
+	// whatever Composio asked for is exactly what we send back.
+	body := map[string]any{
+		"auth_config": map[string]any{"id": authConfigID},
+		"connection": map[string]any{
+			"user_id": strings.TrimSpace(c.UserID),
+			"state": map[string]any{
+				"authScheme": mode,
+				"val":        stringMapToAny(fields),
+			},
+		},
+	}
+	raw, err := c.post(ctx, "/connected_accounts", body)
+	if err != nil {
+		return IntegrationConnectResult{}, fmt.Errorf("create connected account: %w", err)
+	}
+	var result struct {
+		ID     string `json:"id"`
+		Status string `json:"status"`
+	}
+	if err := json.Unmarshal(raw, &result); err != nil {
+		return IntegrationConnectResult{}, fmt.Errorf("parse connected account: %w", err)
+	}
+	status := connectionState(result.Status)
+	if status == "available" {
+		// A freshly created API-key account with no explicit status is active.
+		status = "connected"
+	}
+	return IntegrationConnectResult{
+		Provider:      c.Name(),
+		Platform:      platform,
+		Status:        status,
+		ConnectID:     strings.TrimSpace(result.ID),
+		ConnectionKey: strings.TrimSpace(result.ID),
+		AuthMode:      strings.ToLower(mode),
+	}, nil
+}
+
+// createCustomAuthConfig creates a use_custom_auth config for a non-OAuth
+// toolkit. The user's credential lands on the connected account, not here, so
+// this just declares "this toolkit will be connected with a custom scheme".
+func (c *ComposioREST) createCustomAuthConfig(ctx context.Context, platform, mode string) (string, error) {
+	body := map[string]any{
+		"toolkit": map[string]any{"slug": platform},
+		"auth_config": map[string]any{
+			"type":        "use_custom_auth",
+			"authScheme":  mode,
+			"name":        "WUPHF " + DisplayPlatformName(platform),
+			"credentials": map[string]any{},
+		},
+	}
+	raw, err := c.post(ctx, "/auth_configs", body)
+	if err != nil {
+		return "", err
+	}
+	var result struct {
+		ID         string             `json:"id"`
+		AuthConfig composioAuthConfig `json:"auth_config"`
+		Item       composioAuthConfig `json:"item"`
+		Data       composioAuthConfig `json:"data"`
+	}
+	if err := json.Unmarshal(raw, &result); err != nil {
+		return "", fmt.Errorf("parse custom auth config: %w", err)
+	}
+	if id := strings.TrimSpace(firstNonEmpty(result.ID, result.AuthConfig.ID, result.Item.ID, result.Data.ID)); id != "" {
+		return id, nil
+	}
+	return "", fmt.Errorf("custom auth config response did not include id")
+}
+
+func stringMapToAny(in map[string]string) map[string]any {
+	out := make(map[string]any, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
+}

--- a/internal/action/composio_apikey_test.go
+++ b/internal/action/composio_apikey_test.go
@@ -56,6 +56,94 @@ func TestToolkitAuthInfo_DetectsAPIKey(t *testing.T) {
 	}
 }
 
+// toolkitDetailJSON builds a GET /toolkits/{slug} body with the given managed
+// schemes and an ordered list of auth_config_details modes (each carrying one
+// required generic_api_key field).
+func toolkitDetailJSON(managedSchemes []string, modes ...string) map[string]any {
+	details := make([]map[string]any, 0, len(modes))
+	for _, m := range modes {
+		details = append(details, map[string]any{
+			"mode": m,
+			"fields": map[string]any{
+				"connected_account_initiation": map[string]any{
+					"required": []map[string]any{{"name": "generic_api_key", "displayName": "API Key", "required": true}},
+				},
+			},
+		})
+	}
+	return map[string]any{
+		"slug":                          "multi",
+		"composio_managed_auth_schemes": managedSchemes,
+		"auth_config_details":           details,
+	}
+}
+
+// TestToolkitAuthInfo_MixedModes locks the precedence rules so the connect-path
+// choice never becomes payload-order-dependent:
+//   - a managed scheme (composio_managed_auth_schemes) always wins;
+//   - otherwise the first non-OAuth mode is selected regardless of where OAuth
+//     rows sit, and empty-mode rows are skipped;
+//   - only-unmanaged-OAuth falls back to managed.
+func TestToolkitAuthInfo_MixedModes(t *testing.T) {
+	cases := []struct {
+		name           string
+		managedSchemes []string
+		modes          []string
+		wantManaged    bool
+		wantMode       string
+	}{
+		{"oauth-before-apikey", nil, []string{"OAUTH2", "API_KEY"}, false, "API_KEY"},
+		{"apikey-before-oauth", nil, []string{"API_KEY", "OAUTH2"}, false, "API_KEY"},
+		{"empty-mode-row-skipped", nil, []string{"", "API_KEY"}, false, "API_KEY"},
+		{"managed-schemes-win", []string{"OAUTH2"}, []string{"API_KEY"}, true, ""},
+		{"only-unmanaged-oauth", nil, []string{"OAUTH2"}, true, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mux := http.NewServeMux()
+			mux.HandleFunc("/toolkits/multi", func(w http.ResponseWriter, _ *http.Request) {
+				_ = json.NewEncoder(w).Encode(toolkitDetailJSON(tc.managedSchemes, tc.modes...))
+			})
+			server := httptest.NewServer(mux)
+			defer server.Close()
+			client := &ComposioREST{APIKey: "cmp_test", UserID: "ceo@example.com", BaseURL: server.URL, Client: server.Client()}
+
+			info := client.toolkitAuthInfo(context.Background(), "multi")
+			if info.Managed != tc.wantManaged {
+				t.Fatalf("Managed=%v want %v (%+v)", info.Managed, tc.wantManaged, info)
+			}
+			if info.Mode != tc.wantMode {
+				t.Fatalf("Mode=%q want %q", info.Mode, tc.wantMode)
+			}
+		})
+	}
+}
+
+// A blank required credential must be rejected BEFORE any Composio write, so we
+// never leave an orphan auth config behind.
+func TestCompleteAPIKeyConnection_RejectsMissingRequired(t *testing.T) {
+	authConfigCalled := false
+	mux := http.NewServeMux()
+	mux.HandleFunc("/toolkits/instantly", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(instantlyToolkitDetail())
+	})
+	mux.HandleFunc("/auth_configs", func(w http.ResponseWriter, _ *http.Request) {
+		authConfigCalled = true
+		_ = json.NewEncoder(w).Encode(map[string]any{"auth_config": map[string]any{"id": "ac_x"}})
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+	client := &ComposioREST{APIKey: "cmp_test", UserID: "ceo@example.com", BaseURL: server.URL, Client: server.Client()}
+
+	_, err := client.CompleteAPIKeyConnection(context.Background(), "instantly", map[string]string{"generic_api_key": "   "})
+	if err == nil {
+		t.Fatalf("expected an error when the required credential is blank")
+	}
+	if authConfigCalled {
+		t.Fatalf("must not create an auth config when a required credential is blank")
+	}
+}
+
 func TestToolkitAuthInfo_ManagedOAuthFallsBack(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/toolkits/gmail", func(w http.ResponseWriter, _ *http.Request) {

--- a/internal/action/composio_apikey_test.go
+++ b/internal/action/composio_apikey_test.go
@@ -1,0 +1,179 @@
+package action
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// instantlyToolkitDetail is the GET /toolkits/instantly response for an
+// API-key toolkit: no Composio-managed OAuth scheme, one API_KEY mode with a
+// single required credential field.
+func instantlyToolkitDetail() map[string]any {
+	return map[string]any{
+		"slug":                          "instantly",
+		"name":                          "Instantly",
+		"composio_managed_auth_schemes": []string{},
+		"auth_config_details": []map[string]any{{
+			"mode": "API_KEY",
+			"fields": map[string]any{
+				"connected_account_initiation": map[string]any{
+					"required": []map[string]any{{
+						"name":        "generic_api_key",
+						"displayName": "API Key",
+						"type":        "string",
+						"required":    true,
+					}},
+				},
+			},
+		}},
+	}
+}
+
+func TestToolkitAuthInfo_DetectsAPIKey(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/toolkits/instantly", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(instantlyToolkitDetail())
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+	client := &ComposioREST{APIKey: "cmp_test", UserID: "ceo@example.com", BaseURL: server.URL, Client: server.Client()}
+
+	info := client.toolkitAuthInfo(context.Background(), "instantly")
+	if info.Managed {
+		t.Fatalf("API-key toolkit must not be treated as managed: %+v", info)
+	}
+	if info.Mode != "API_KEY" {
+		t.Fatalf("expected Mode=API_KEY, got %q", info.Mode)
+	}
+	if len(info.Fields) != 1 || info.Fields[0].Name != "generic_api_key" {
+		t.Fatalf("expected one generic_api_key field, got %+v", info.Fields)
+	}
+	if !info.Fields[0].Secret {
+		t.Fatalf("an api key field must be marked secret: %+v", info.Fields[0])
+	}
+}
+
+func TestToolkitAuthInfo_ManagedOAuthFallsBack(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/toolkits/gmail", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"slug":                          "gmail",
+			"composio_managed_auth_schemes": []string{"OAUTH2"},
+		})
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+	client := &ComposioREST{APIKey: "cmp_test", UserID: "ceo@example.com", BaseURL: server.URL, Client: server.Client()}
+
+	if info := client.toolkitAuthInfo(context.Background(), "gmail"); !info.Managed {
+		t.Fatalf("OAuth toolkit must be managed, got %+v", info)
+	}
+}
+
+// An unintrospectable toolkit (404 / network error) must fall back to managed
+// so we never block a toolkit we simply couldn't read.
+func TestToolkitAuthInfo_UnknownFallsBackToManaged(t *testing.T) {
+	server := httptest.NewServer(http.NotFoundHandler())
+	defer server.Close()
+	client := &ComposioREST{APIKey: "cmp_test", UserID: "ceo@example.com", BaseURL: server.URL, Client: server.Client()}
+
+	if info := client.toolkitAuthInfo(context.Background(), "mystery"); !info.Managed {
+		t.Fatalf("unknown toolkit must fall back to managed, got %+v", info)
+	}
+}
+
+// StartIntegrationConnection must short-circuit to needs_fields for an API-key
+// toolkit instead of POSTing use_composio_managed_auth (which 400s).
+func TestStartIntegrationConnection_NeedsFieldsForAPIKey(t *testing.T) {
+	authConfigCalled := false
+	mux := http.NewServeMux()
+	mux.HandleFunc("/toolkits/instantly", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(instantlyToolkitDetail())
+	})
+	mux.HandleFunc("/auth_configs", func(w http.ResponseWriter, _ *http.Request) {
+		authConfigCalled = true
+		w.WriteHeader(http.StatusBadRequest)
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+	client := &ComposioREST{APIKey: "cmp_test", UserID: "ceo@example.com", BaseURL: server.URL, Client: server.Client()}
+
+	res, err := client.StartIntegrationConnection(context.Background(), IntegrationConnectRequest{Platform: "Instantly"})
+	if err != nil {
+		t.Fatalf("connect should not error for an API-key toolkit: %v", err)
+	}
+	if res.Status != "needs_fields" {
+		t.Fatalf("expected status needs_fields, got %q", res.Status)
+	}
+	if res.AuthMode != "api_key" {
+		t.Fatalf("expected auth_mode api_key, got %q", res.AuthMode)
+	}
+	if len(res.RequiredFields) == 0 {
+		t.Fatalf("expected required fields for the key entry form")
+	}
+	if authConfigCalled {
+		t.Fatalf("must NOT attempt the managed /auth_configs path for an API-key toolkit")
+	}
+}
+
+// CompleteAPIKeyConnection must create a use_custom_auth config then a
+// connected account carrying the user's key in the scheme-specific val map.
+func TestCompleteAPIKeyConnection_SendsCustomAuthAndKey(t *testing.T) {
+	var authBody, accountBody map[string]any
+	mux := http.NewServeMux()
+	mux.HandleFunc("/toolkits/instantly", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(instantlyToolkitDetail())
+	})
+	mux.HandleFunc("/auth_configs", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&authBody)
+		_ = json.NewEncoder(w).Encode(map[string]any{"auth_config": map[string]any{"id": "ac_custom"}})
+	})
+	mux.HandleFunc("/connected_accounts", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&accountBody)
+		_ = json.NewEncoder(w).Encode(map[string]any{"id": "ca_instantly", "status": "ACTIVE"})
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+	client := &ComposioREST{APIKey: "cmp_test", UserID: "ceo@example.com", BaseURL: server.URL, Client: server.Client()}
+
+	res, err := client.CompleteAPIKeyConnection(context.Background(), "Instantly", map[string]string{"generic_api_key": "ik_secret"})
+	if err != nil {
+		t.Fatalf("complete: %v", err)
+	}
+	if res.Status != "connected" {
+		t.Fatalf("expected connected, got %q (%+v)", res.Status, res)
+	}
+	if res.ConnectionKey != "ca_instantly" {
+		t.Fatalf("expected connection key ca_instantly, got %q", res.ConnectionKey)
+	}
+
+	// Auth config request shape.
+	ac, _ := authBody["auth_config"].(map[string]any)
+	if ac["type"] != "use_custom_auth" {
+		t.Fatalf("auth_config.type must be use_custom_auth, got %v", authBody)
+	}
+	if ac["authScheme"] != "API_KEY" {
+		t.Fatalf("auth_config.authScheme must be API_KEY, got %v", authBody)
+	}
+
+	// Connected account request shape: the user's key in connection.state.val.
+	conn, _ := accountBody["connection"].(map[string]any)
+	if conn["user_id"] != "ceo@example.com" {
+		t.Fatalf("connected account must carry the user id, got %v", accountBody)
+	}
+	state, _ := conn["state"].(map[string]any)
+	if state["authScheme"] != "API_KEY" {
+		t.Fatalf("connection.state.authScheme must be API_KEY, got %v", state)
+	}
+	val, _ := state["val"].(map[string]any)
+	if val["generic_api_key"] != "ik_secret" {
+		t.Fatalf("the user's api key must be sent in state.val, got %v", val)
+	}
+	acRef, _ := accountBody["auth_config"].(map[string]any)
+	if acRef["id"] != "ac_custom" {
+		t.Fatalf("connected account must reference the created auth config, got %v", accountBody)
+	}
+}

--- a/internal/action/types.go
+++ b/internal/action/types.go
@@ -163,6 +163,38 @@ type IntegrationConnectResult struct {
 	ConnectionKey string `json:"connection_key,omitempty"`
 	ExpiresAt     string `json:"expires_at,omitempty"`
 	Instructions  string `json:"instructions,omitempty"`
+	// AuthMode classifies how this toolkit authenticates: "oauth" (the
+	// hosted redirect flow), or "api_key"/"bearer"/"basic" (the user supplies
+	// their own credentials — Composio cannot mint a managed OAuth app).
+	AuthMode string `json:"auth_mode,omitempty"`
+	// RequiredFields is non-empty when Status == "needs_fields": the frontend
+	// must collect these values and POST them back to /integrations/connect/
+	// credentials. Drives the API-key entry card so toolkits like Instantly
+	// (which 400 on use_composio_managed_auth) get a real connect path instead
+	// of an opaque error.
+	RequiredFields []IntegrationConnectField `json:"required_fields,omitempty"`
+}
+
+// IntegrationConnectField describes one credential input the user must supply
+// for a non-OAuth toolkit (e.g. an API key). Mirrors the field metadata
+// Composio exposes for a toolkit's connected-account initiation.
+type IntegrationConnectField struct {
+	Name        string `json:"name"`
+	Label       string `json:"label"`
+	Description string `json:"description,omitempty"`
+	// Secret marks credential fields the UI should render as a password input
+	// (API keys, tokens) so they are masked on screen.
+	Secret   bool `json:"secret,omitempty"`
+	Required bool `json:"required,omitempty"`
+}
+
+// IntegrationConnectCredentialsRequest carries the user-supplied credentials
+// for a non-OAuth toolkit back to the broker, which hands them to Composio to
+// create a custom-auth config + connected account.
+type IntegrationConnectCredentialsRequest struct {
+	Provider string            `json:"provider,omitempty"`
+	Platform string            `json:"platform"`
+	Fields   map[string]string `json:"fields"`
 }
 
 type IntegrationDisconnectRequest struct {

--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -680,6 +680,7 @@ func (b *Broker) StartOnPort(port int) error {
 	mux.HandleFunc("/approval-audit", b.requireAuth(b.handleApprovalAudit))
 	mux.HandleFunc("/integrations", b.requireAuth(b.handleIntegrations))
 	mux.HandleFunc("/integrations/connect", b.requireAuth(b.handleIntegrationConnect))
+	mux.HandleFunc("/integrations/connect-credentials", b.requireAuth(b.handleIntegrationConnectCredentials))
 	mux.HandleFunc("/integrations/connect-status", b.requireAuth(b.handleIntegrationConnectStatus))
 	mux.HandleFunc("/integrations/disconnect", b.requireAuth(b.handleIntegrationDisconnect))
 	mux.HandleFunc("/integrations/audit", b.requireAuth(b.handleIntegrationAudit))

--- a/internal/team/broker_integrations.go
+++ b/internal/team/broker_integrations.go
@@ -144,6 +144,61 @@ func (b *Broker) handleIntegrationConnect(w http.ResponseWriter, r *http.Request
 	_ = json.NewEncoder(w).Encode(result)
 }
 
+// handleIntegrationConnectCredentials completes a connection for a non-OAuth
+// toolkit (API key / token) using the credentials the UI collected after
+// /integrations/connect returned status "needs_fields". The raw credentials are
+// handed straight to Composio and never logged or persisted by the broker.
+func (b *Broker) handleIntegrationConnectCredentials(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	var req action.IntegrationConnectCredentialsRequest
+	if !decodeIntegrationRequest(w, r, &req) {
+		return
+	}
+	provider := strings.ToLower(strings.TrimSpace(req.Provider))
+	if provider == "" {
+		provider = "composio"
+	}
+	if provider != "composio" {
+		http.Error(w, "only composio supports web-managed connect", http.StatusBadRequest)
+		return
+	}
+	if strings.TrimSpace(req.Platform) == "" || len(req.Fields) == 0 {
+		http.Error(w, "platform and fields are required", http.StatusBadRequest)
+		return
+	}
+	composio := action.NewComposioFromEnv()
+	result, err := composio.CompleteAPIKeyConnection(r.Context(), req.Platform, req.Fields)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("connect composio toolkit: %v", err), http.StatusBadGateway)
+		return
+	}
+	actor := integrationRequestActor(r)
+	if result.Status == "connected" && strings.TrimSpace(result.ConnectionKey) != "" {
+		_ = b.RecordActionWithMetadata(
+			"integration_connected",
+			"composio",
+			"general",
+			actor,
+			fmt.Sprintf("Connected %s via Composio (API key)", action.DisplayPlatformName(result.Platform)),
+			result.ConnectionKey,
+			nil,
+			"",
+			map[string]string{
+				"provider":       "composio",
+				"platform":       result.Platform,
+				"connection_key": result.ConnectionKey,
+				"status":         "connected",
+			},
+		)
+		b.fanOutConnected(result.Platform, result.ConnectionKey, "", actor)
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(result)
+}
+
 func (b *Broker) handleIntegrationConnectStatus(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)

--- a/internal/team/broker_streams.go
+++ b/internal/team/broker_streams.go
@@ -2,6 +2,7 @@ package team
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"sync"
 	"time"
@@ -549,7 +550,15 @@ func (b *Broker) reapStaleActivityLocked(now time.Time) []agentActivitySnapshot 
 		case age >= staleActivityThreshold:
 			snap.Status = "idle"
 			snap.Activity = "idle"
-			snap.Detail = "stale activity reaped (no progress for " + staleActivityThreshold.String() + ")"
+			// Plain-language, actionable detail — this string surfaces in the
+			// activity feed and the agent pill tooltip, so it must read as
+			// English to a non-technical operator (not "stale activity
+			// reaped") and tell them how to get the agent moving again.
+			mins := int(age.Round(time.Minute) / time.Minute)
+			if mins < 1 {
+				mins = 1
+			}
+			snap.Detail = fmt.Sprintf("Went idle after no progress for %d min — send a new message to bring it back.", mins)
 			snap.LastTime = now.UTC().Format(time.RFC3339)
 			// Reaping back to idle clears any prior stuck flag — the
 			// agent is no longer claiming to be working.

--- a/internal/team/broker_streams.go
+++ b/internal/team/broker_streams.go
@@ -558,7 +558,11 @@ func (b *Broker) reapStaleActivityLocked(now time.Time) []agentActivitySnapshot 
 			if mins < 1 {
 				mins = 1
 			}
-			snap.Detail = fmt.Sprintf("Went idle after no progress for %d min — send a new message to bring it back.", mins)
+			unit := "minutes"
+			if mins == 1 {
+				unit = "minute"
+			}
+			snap.Detail = fmt.Sprintf("Went idle after no progress for %d %s — send a new message to bring it back.", mins, unit)
 			snap.LastTime = now.UTC().Format(time.RFC3339)
 			// Reaping back to idle clears any prior stuck flag — the
 			// agent is no longer claiming to be working.

--- a/internal/team/broker_streams_test.go
+++ b/internal/team/broker_streams_test.go
@@ -243,6 +243,16 @@ func TestReapStaleActivityLocked(t *testing.T) {
 		if snap.Slug != "stale-active" && snap.Slug != "stale-thinking" {
 			t.Errorf("unexpected reaped slug: %q", snap.Slug)
 		}
+		// The idle detail must read as plain English to a non-technical
+		// operator and say how to recover — never engineer jargon like
+		// "stale activity reaped". Regression for the customer complaint
+		// that the live stream "doesn't tell much fruitful stuff".
+		if strings.Contains(snap.Detail, "reaped") || strings.Contains(snap.Detail, "stale activity") {
+			t.Errorf("reaped detail leaks jargon: %q", snap.Detail)
+		}
+		if !strings.Contains(snap.Detail, "send a new message") {
+			t.Errorf("reaped detail should tell the operator how to recover; got %q", snap.Detail)
+		}
 	}
 
 	if b.activity["fresh-active"].Status != "active" {

--- a/internal/team/entity_article.go
+++ b/internal/team/entity_article.go
@@ -37,7 +37,6 @@ import (
 	"log"
 	"regexp"
 	"sort"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -282,18 +281,18 @@ func buildEntityArticle(d entityArticleData) string {
 	b.WriteString(d.Title)
 	b.WriteString("\n\n")
 
-	// Lead paragraph — subject bolded, Wikipedia style.
-	fmt.Fprintf(&b, "**%s** is a %s in the team knowledge graph, with %s",
-		d.Title, entityKindNoun(d.Kind), countNoun(len(d.Facts), "recorded fact", "recorded facts"))
-	if len(tasks) > 0 {
-		fmt.Fprintf(&b, " from %s", countNoun(len(tasks), "completed task", "completed tasks"))
-	}
-	if len(d.Associated) > 0 {
-		fmt.Fprintf(&b, " and %s", countNoun(len(d.Associated), "associated entity", "associated entities"))
-	}
-	b.WriteString(".\n\n")
+	// Lead paragraph — Wikipedia-style: state plainly what the subject is and
+	// let the cited observations below carry the substance. This line used to
+	// dump fact/task/association counts ("in the team knowledge graph, with N
+	// recorded facts from M completed tasks…"); that read as metadata, not
+	// knowledge, and buried the actual insight, so it is intentionally gone.
+	fmt.Fprintf(&b, "**%s** is a %s.\n\n", d.Title, entityKindNoun(d.Kind))
 
-	// Infobox-style summary: key facts as a definition list.
+	// Infobox-style summary: identity + navigation only, lifted into a
+	// right-floating infobox by the reader. The raw fact count and the on-disk
+	// file path were pure metadata (the "amount of insights" / a path nobody
+	// clicks), so they are omitted — the body's cited observations are the
+	// substance, not a tally of them.
 	b.WriteString("## Summary\n\n")
 	writeDef := func(term, def string) {
 		b.WriteString(term)
@@ -302,8 +301,6 @@ func buildEntityArticle(d entityArticleData) string {
 		b.WriteString("\n\n")
 	}
 	writeDef("Kind", entityKindNoun(d.Kind))
-	writeDef("Article", briefPath(d.Kind, d.Slug))
-	writeDef("Facts on record", strconv.Itoa(len(d.Facts)))
 	if len(tasks) > 0 {
 		writeDef("Tasks", strings.Join(tasks, ", "))
 	}

--- a/internal/team/entity_article_test.go
+++ b/internal/team/entity_article_test.go
@@ -45,11 +45,10 @@ func TestBuildEntityArticle_Skeleton(t *testing.T) {
 	for _, want := range []string{
 		entityArticleMarker,
 		"# Acme Corp\n",
-		"**Acme Corp** is a company in the team knowledge graph, with 2 recorded facts from 1 completed task and 1 associated entity.",
+		// Substance-first lead: states what it is, no count boilerplate.
+		"**Acme Corp** is a company.\n",
 		"## Summary",
 		"Kind\n: company",
-		"Article\n: team/companies/acme-corp.md",
-		"Facts on record\n: 2",
 		"Tasks\n: TASK-3",
 		"Artifacts\n: [team/playbooks/acme-renewal.md](team/playbooks/acme-renewal.md)",
 		"Associated\n: [[people/eng]]",
@@ -65,6 +64,22 @@ func TestBuildEntityArticle_Skeleton(t *testing.T) {
 	} {
 		if !strings.Contains(got, want) {
 			t.Errorf("article missing %q\n--- article ---\n%s", want, got)
+		}
+	}
+	// The metadata-feeling boilerplate the customer flagged must be gone: no
+	// "knowledge graph" framing, no fact-count clause, no "Facts on record"
+	// infobox row, and no on-disk file path masquerading as content.
+	for _, banned := range []string{
+		// The lead's old count clause ("…in the team knowledge graph, with N
+		// recorded facts…"). The header HTML comment still references the
+		// knowledge graph, so match the reader-visible phrasing specifically.
+		"in the team knowledge graph",
+		"recorded fact",
+		"Facts on record",
+		"Article\n: team/companies/acme-corp.md",
+	} {
+		if strings.Contains(got, banned) {
+			t.Errorf("article still contains metadata boilerplate %q\n--- article ---\n%s", banned, got)
 		}
 	}
 	if again := buildEntityArticle(data); again != got {

--- a/internal/team/entity_minimal_brief.go
+++ b/internal/team/entity_minimal_brief.go
@@ -96,18 +96,19 @@ func MinimalBrief(ent IndexEntity) string {
 	b.WriteString(title)
 	b.WriteString("\n\n")
 
-	// Signals stub — fixed field order, skip empty fields.
-	b.WriteString("## Signals\n\n")
+	// Signals — only when we actually have identity signals to show. The old
+	// "## Signals\n- (none)" stub was metadata noise on a page that already had
+	// nothing to say; an empty section reads worse than no section, so a ghost
+	// with no signals skips it entirely and shows just the disclaimer.
 	bullets := signalBullets(ent.Signals)
-	if len(bullets) == 0 {
-		b.WriteString("- (none)\n")
-	} else {
+	if len(bullets) > 0 {
+		b.WriteString("## Signals\n\n")
 		for _, line := range bullets {
 			b.WriteString(line)
 			b.WriteString("\n")
 		}
+		b.WriteString("\n")
 	}
-	b.WriteString("\n")
 
 	// Disclaimer line — italicised so the next synthesis can replace
 	// the body without leaving conflicting prose. Fixed wording so

--- a/internal/team/entity_minimal_brief_test.go
+++ b/internal/team/entity_minimal_brief_test.go
@@ -111,9 +111,13 @@ func TestMinimalBrief_CompanyHumanizesSlug(t *testing.T) {
 	if !strings.Contains(got, "\n# North Star\n") {
 		t.Errorf("expected humanised H1 'North Star'; got:\n%s", got)
 	}
-	// Empty signals → "(none)" placeholder.
-	if !strings.Contains(got, "- (none)") {
-		t.Errorf("expected (none) placeholder when all signals empty; got:\n%s", got)
+	// Empty signals → no Signals section at all (the old "- (none)" stub was
+	// metadata noise on an already-empty page).
+	if strings.Contains(got, "(none)") {
+		t.Errorf("did not expect a (none) placeholder; got:\n%s", got)
+	}
+	if strings.Contains(got, "## Signals") {
+		t.Errorf("expected no Signals section when all signals empty; got:\n%s", got)
 	}
 }
 

--- a/internal/team/entity_synthesizer.go
+++ b/internal/team/entity_synthesizer.go
@@ -64,7 +64,11 @@ const MaxBriefSize = 32 * 1024
 // synthesizer from the cross-entity graph log — never invent related-entity
 // bullets. If the LLM output contains a "## Related" section, it is stripped
 // before the authoritative one is appended.
-const SynthesisPromptSystem = `You maintain entity briefs in a team wiki. Given an existing brief and new facts, produce an updated markdown brief that incorporates the facts. Never invent facts. Preserve the canonical structure (sections, ordering). Mark contradictions explicitly with **Contradiction:** inline callouts rather than resolving them. Do not write a "## Related" section — that block is managed automatically from the cross-entity graph. Output ONLY the updated markdown, no explanation.`
+const SynthesisPromptSystem = `You maintain entity briefs in a team wiki. Given an existing brief and new facts, produce an updated markdown brief that incorporates the facts.
+
+Write like a short encyclopedia article, not a metadata dump. Open with one plain-language sentence that says what this person or company actually is and why they matter to the team — never "X is a company in the knowledge graph" and never a count of facts. Then weave the facts into readable prose grouped by topic. If only one thing is known, just state that one thing clearly in a sentence; do not pad it with empty sections or placeholders. As more facts arrive, expand the prose — the brief should get richer over time, never stay a stub.
+
+Hard rules: Never invent facts. Mark contradictions explicitly with **Contradiction:** inline callouts rather than resolving them. Do not restate fact counts, file paths, or internal IDs as if they were content. Do not write a "## Related" section — that block is managed automatically from the cross-entity graph. Output ONLY the updated markdown, no explanation.`
 
 // MaxRelatedEntries bounds the number of "## Related" bullets rendered in a
 // synthesized brief. Ten was the v1 ceiling in the roadmap — enough for a

--- a/web/src/api/integrations.test.ts
+++ b/web/src/api/integrations.test.ts
@@ -9,6 +9,7 @@ import {
   listIntegrations,
   startComposioSignin,
   startIntegrationConnection,
+  submitIntegrationCredentials,
 } from "./integrations";
 
 describe("integrations api client", () => {
@@ -119,6 +120,27 @@ describe("integrations api client", () => {
       provider: "composio",
       platform: "gmail",
       connection_key: "ca_123",
+    });
+  });
+
+  it("submits API-key credentials for a non-OAuth toolkit", async () => {
+    const postSpy = vi.spyOn(client, "post").mockResolvedValue({
+      provider: "composio",
+      platform: "instantly",
+      status: "connected",
+      connection_key: "ca_instantly",
+    });
+
+    await expect(
+      submitIntegrationCredentials("composio", "instantly", {
+        generic_api_key: "ik_secret",
+      }),
+    ).resolves.toMatchObject({ status: "connected" });
+
+    expect(postSpy).toHaveBeenCalledWith("/integrations/connect-credentials", {
+      provider: "composio",
+      platform: "instantly",
+      fields: { generic_api_key: "ik_secret" },
     });
   });
 

--- a/web/src/api/integrations.ts
+++ b/web/src/api/integrations.ts
@@ -50,15 +50,29 @@ export interface ListIntegrationsParams {
   cursor?: string;
 }
 
+/** One credential input for a non-OAuth toolkit (API key / token / password). */
+export interface IntegrationConnectField {
+  name: string;
+  label: string;
+  description?: string;
+  /** Render as a masked password input. */
+  secret?: boolean;
+  required?: boolean;
+}
+
 export interface IntegrationConnectResult {
   provider: IntegrationProvider;
   platform: string;
+  /** "needs_fields" means the UI must collect required_fields and POST them to
+   * submitIntegrationCredentials before the toolkit is connected. */
   status: string;
   auth_url?: string;
   connect_id?: string;
   connection_key?: string;
   expires_at?: string;
   instructions?: string;
+  auth_mode?: string;
+  required_fields?: IntegrationConnectField[];
 }
 
 export interface IntegrationDisconnectResult {
@@ -104,6 +118,23 @@ export async function startIntegrationConnection(
   return post<IntegrationConnectResult>("/integrations/connect", {
     provider,
     platform,
+  });
+}
+
+/**
+ * Complete a non-OAuth (API-key/token) connection by submitting the credentials
+ * the user typed into the fields returned by `startIntegrationConnection` when
+ * its status was "needs_fields".
+ */
+export async function submitIntegrationCredentials(
+  provider: IntegrationProvider,
+  platform: string,
+  fields: Record<string, string>,
+): Promise<IntegrationConnectResult> {
+  return post<IntegrationConnectResult>("/integrations/connect-credentials", {
+    provider,
+    platform,
+    fields,
   });
 }
 

--- a/web/src/components/agents/AgentProfilePanel.tsx
+++ b/web/src/components/agents/AgentProfilePanel.tsx
@@ -22,6 +22,7 @@ import {
   listAgentLogTasks,
   type Task,
   type TaskLogSummary,
+  updateTaskStatus,
 } from "../../api/tasks";
 import { useDefaultHarness } from "../../hooks/useConfig";
 import type { HarnessKind } from "../../lib/harness";
@@ -35,6 +36,7 @@ import {
 import { router } from "../../lib/router";
 import { HarnessBadge } from "../ui/HarnessBadge";
 import { PixelAvatar } from "../ui/PixelAvatar";
+import { showNotice } from "../ui/Toast";
 import { AgentInstructionsSection } from "./AgentInstructionsSection";
 
 const PROVIDER_LABELS: Record<LLMRuntimeKind, string> = {
@@ -233,7 +235,41 @@ interface RecentTasksSectionProps {
   tasks: Task[];
 }
 
+/**
+ * Statuses where an agent should be making progress but may have silently
+ * stalled — the only states a "Resume" nudge makes sense for. Resuming routes
+ * through the broker's documented wake path (task_updated action →
+ * notifyTaskActionsLoop → enqueueHeadlessCodexTurn), re-engaging the owner.
+ */
+export function isResumableStatus(raw: string): boolean {
+  const s = raw.toLowerCase().replace(/[\s-]+/g, "_");
+  return (
+    s === "blocked" ||
+    s === "in_progress" ||
+    s === "running" ||
+    s === "queued" ||
+    s === "queued_behind_owner" ||
+    s === "planning"
+  );
+}
+
 function RecentArtifactsSection({ agentSlug, tasks }: RecentTasksSectionProps) {
+  const queryClient = useQueryClient();
+  const resumeMutation = useMutation({
+    mutationFn: (task: Task) =>
+      updateTaskStatus(task.id, "resume", task.channel ?? "", "human"),
+    onSuccess: (_data, task) => {
+      showNotice(`Resuming ${agentSlug} on “${task.title}”.`, "success");
+      void queryClient.invalidateQueries({ queryKey: ["office-tasks"] });
+      void queryClient.invalidateQueries({ queryKey: ["tasks"] });
+    },
+    onError: (err) => {
+      showNotice(
+        err instanceof Error ? err.message : "Failed to resume the agent.",
+        "error",
+      );
+    },
+  });
   const agentTasks = tasks
     .filter((t) => t.owner === agentSlug)
     .sort((a, b) => {
@@ -269,6 +305,20 @@ function RecentArtifactsSection({ agentSlug, tasks }: RecentTasksSectionProps) {
                   {normalizeTaskStatus(t.status)}
                 </span>
               </button>
+              {isResumableStatus(t.status) ? (
+                <button
+                  type="button"
+                  className="agent-profile-resume-btn"
+                  title="Re-engage this agent on the task if it has gone quiet"
+                  disabled={resumeMutation.isPending}
+                  onClick={() => resumeMutation.mutate(t)}
+                >
+                  {resumeMutation.isPending &&
+                  resumeMutation.variables?.id === t.id
+                    ? "Resuming…"
+                    : "Resume"}
+                </button>
+              ) : null}
             </li>
           ))}
         </ul>

--- a/web/src/components/agents/AgentProfilePanel.tsx
+++ b/web/src/components/agents/AgentProfilePanel.tsx
@@ -260,6 +260,11 @@ function RecentArtifactsSection({ agentSlug, tasks }: RecentTasksSectionProps) {
       updateTaskStatus(task.id, "resume", task.channel ?? "", "human"),
     onSuccess: (_data, task) => {
       showNotice(`Resuming ${agentSlug} on “${task.title}”.`, "success");
+      // This panel renders its task rows from ["office-tasks-profile"]; invalidate
+      // that first so the Resume row refreshes instead of staying clickable.
+      void queryClient.invalidateQueries({
+        queryKey: ["office-tasks-profile"],
+      });
       void queryClient.invalidateQueries({ queryKey: ["office-tasks"] });
       void queryClient.invalidateQueries({ queryKey: ["tasks"] });
     },

--- a/web/src/components/agents/isResumableStatus.test.ts
+++ b/web/src/components/agents/isResumableStatus.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+
+import { isResumableStatus } from "./AgentProfilePanel";
+
+describe("isResumableStatus", () => {
+  it("offers Resume for in-flight states that can silently stall", () => {
+    for (const s of [
+      "blocked",
+      "in_progress",
+      "in-progress",
+      "running",
+      "queued",
+      "queued_behind_owner",
+      "Queued Behind Owner",
+      "planning",
+    ]) {
+      expect(isResumableStatus(s)).toBe(true);
+    }
+  });
+
+  it("does not offer Resume for terminal or human-gated states", () => {
+    for (const s of [
+      "done",
+      "completed",
+      "review",
+      "approved",
+      "rejected",
+      "cancelled",
+      "archived",
+      "drafting",
+      "ready",
+      "open",
+    ]) {
+      expect(isResumableStatus(s)).toBe(false);
+    }
+  });
+});

--- a/web/src/components/apps/IntegrationsApp.tsx
+++ b/web/src/components/apps/IntegrationsApp.tsx
@@ -20,6 +20,7 @@ import {
   type IntegrationsResponse,
   listIntegrations,
   startIntegrationConnection,
+  submitIntegrationCredentials,
 } from "../../api/integrations";
 import { showNotice } from "../ui/Toast";
 import { ActionGrantsPanel } from "./integrations/ActionGrantsPanel";
@@ -437,6 +438,85 @@ function IntegrationErrorState({
   );
 }
 
+/**
+ * Credential form for a non-OAuth toolkit (API key / token). Shown when
+ * startIntegrationConnection returned status "needs_fields" — e.g. Instantly,
+ * which cannot use Composio-managed OAuth. Submitting POSTs the values to
+ * /integrations/connect-credentials.
+ */
+function ApiKeyConnectForm({
+  toolkitName,
+  result,
+  values,
+  onChange,
+  onSubmit,
+  onCancel,
+  pending,
+}: {
+  toolkitName: string;
+  result: IntegrationConnectResult;
+  values: Record<string, string>;
+  onChange: (name: string, value: string) => void;
+  onSubmit: () => void;
+  onCancel: () => void;
+  pending: boolean;
+}) {
+  const fields = result.required_fields ?? [];
+  const filled = fields
+    .filter((f) => f.required)
+    .every((f) => (values[f.name] ?? "").trim() !== "");
+  return (
+    <form
+      className="op-credential-form"
+      onSubmit={(e) => {
+        e.preventDefault();
+        if (filled && !pending) onSubmit();
+      }}
+    >
+      <p className="op-credential-intro">
+        {result.instructions ||
+          `Enter your ${toolkitName} credentials to connect.`}
+      </p>
+      {fields.map((field) => (
+        <label key={field.name} className="op-credential-field">
+          <span className="op-credential-label">
+            {field.label}
+            {field.required ? <span aria-hidden="true"> *</span> : null}
+          </span>
+          <input
+            className="op-credential-input"
+            type={field.secret ? "password" : "text"}
+            value={values[field.name] ?? ""}
+            autoComplete="off"
+            spellCheck={false}
+            onChange={(e) => onChange(field.name, e.target.value)}
+          />
+          {field.description ? (
+            <span className="op-credential-help">{field.description}</span>
+          ) : null}
+        </label>
+      ))}
+      <div className="op-credential-actions">
+        <button
+          type="submit"
+          className="btn btn-primary btn-sm"
+          disabled={!filled || pending}
+        >
+          {pending ? "Connecting…" : "Connect"}
+        </button>
+        <button
+          type="button"
+          className="btn btn-secondary btn-sm"
+          onClick={onCancel}
+          disabled={pending}
+        >
+          Cancel
+        </button>
+      </div>
+    </form>
+  );
+}
+
 function ToolkitDetail({
   item,
   onBack,
@@ -446,6 +526,7 @@ function ToolkitDetail({
 }) {
   const queryClient = useQueryClient();
   const [pending, setPending] = useState<IntegrationConnectResult | null>(null);
+  const [credValues, setCredValues] = useState<Record<string, string>>({});
   const [confirmDisconnect, setConfirmDisconnect] = useState(false);
   const connectionKey = item.connection_key || item.connections?.[0]?.key || "";
   const auditQuery = useQuery({
@@ -496,11 +577,38 @@ function ToolkitDetail({
     mutationFn: () => startIntegrationConnection(item.provider, item.platform),
     onSuccess: (result) => {
       setPending(result);
+      setCredValues({});
       if (result.auth_url) {
         window.open(result.auth_url, "_blank", "noopener,noreferrer");
+        showNotice(`Started ${item.name} connection.`, "success");
+      } else if (result.status === "needs_fields") {
+        // API-key/token toolkit (e.g. Instantly): no OAuth redirect — the form
+        // below collects the credentials. Don't claim we "started" anything.
+        showNotice(`Enter your ${item.name} credentials to connect.`, "info");
+      } else {
+        showNotice(`Started ${item.name} connection.`, "success");
       }
-      showNotice(`Started ${item.name} connection.`, "success");
       void queryClient.invalidateQueries({ queryKey: ["integrations-audit"] });
+    },
+    onError: (err) => {
+      showNotice(
+        err instanceof Error ? err.message : `Failed to connect ${item.name}`,
+        "error",
+      );
+    },
+  });
+  const credentialsMutation = useMutation({
+    mutationFn: () =>
+      submitIntegrationCredentials(item.provider, item.platform, credValues),
+    onSuccess: (result) => {
+      setPending(null);
+      setCredValues({});
+      showNotice(`${item.name} connected.`, "success");
+      void queryClient.invalidateQueries({ queryKey: ["integrations"] });
+      void queryClient.invalidateQueries({ queryKey: ["integrations-audit"] });
+      if (result.status !== "connected") {
+        showNotice(`${item.name} connection is ${result.status}.`, "info");
+      }
     },
     onError: (err) => {
       showNotice(
@@ -600,6 +708,22 @@ function ToolkitDetail({
             </button>
           </div>
         </section>
+        {pending?.status === "needs_fields" ? (
+          <ApiKeyConnectForm
+            toolkitName={item.name}
+            result={pending}
+            values={credValues}
+            onChange={(name, value) =>
+              setCredValues((prev) => ({ ...prev, [name]: value }))
+            }
+            onSubmit={() => credentialsMutation.mutate()}
+            onCancel={() => {
+              setPending(null);
+              setCredValues({});
+            }}
+            pending={credentialsMutation.isPending}
+          />
+        ) : null}
         {confirmDisconnect ? (
           <div className="op-confirm-row">
             <span>Disconnect {item.name}?</span>
@@ -620,7 +744,7 @@ function ToolkitDetail({
             </button>
           </div>
         ) : null}
-        {latestStatus ? (
+        {latestStatus && latestStatus !== "needs_fields" ? (
           <p className="op-runtime-note">
             Connection status: <strong>{latestStatus}</strong>
           </p>

--- a/web/src/components/apps/IntegrationsApp.tsx
+++ b/web/src/components/apps/IntegrationsApp.tsx
@@ -603,12 +603,14 @@ function ToolkitDetail({
     onSuccess: (result) => {
       setPending(null);
       setCredValues({});
-      showNotice(`${item.name} connected.`, "success");
-      void queryClient.invalidateQueries({ queryKey: ["integrations"] });
-      void queryClient.invalidateQueries({ queryKey: ["integrations-audit"] });
-      if (result.status !== "connected") {
+      if (result.status === "connected") {
+        showNotice(`${item.name} connected.`, "success");
+      } else {
+        // e.g. "pending"/"failed" — don't claim success for a non-live result.
         showNotice(`${item.name} connection is ${result.status}.`, "info");
       }
+      void queryClient.invalidateQueries({ queryKey: ["integrations"] });
+      void queryClient.invalidateQueries({ queryKey: ["integrations-audit"] });
     },
     onError: (err) => {
       showNotice(

--- a/web/src/components/wiki/ArticleReadView.stories.tsx
+++ b/web/src/components/wiki/ArticleReadView.stories.tsx
@@ -35,7 +35,7 @@ const meta: Meta<typeof ArticleReadView> = {
     ]),
     fetchPreview: async (slug: string) => ({
       title: slug.split("/").pop() ?? slug,
-      body: "Eng is a person in the team knowledge graph, with 2 recorded facts from 1 completed task…",
+      body: "Eng is a person. Owns the broker and has led the renewal motion since spring…",
     }),
     onNavigate: () => {},
     onEditSection: () => {},

--- a/web/src/components/wiki/ArticleReadView.test.tsx
+++ b/web/src/components/wiki/ArticleReadView.test.tsx
@@ -35,7 +35,9 @@ describe("<ArticleReadView> — B2 entity article", () => {
     expect(infobox).toHaveTextContent("Acme Corp");
     expect(infobox).toHaveTextContent("Kind");
     expect(infobox).toHaveTextContent("company");
-    expect(infobox).toHaveTextContent("Facts on record");
+    // Identity + navigation rows survive; the raw fact count was dropped.
+    expect(infobox).toHaveTextContent("Tasks");
+    expect(infobox).not.toHaveTextContent("Facts on record");
     // The raw Summary heading does not render in the body.
     expect(
       screen.queryByRole("heading", { name: /Summary/ }),

--- a/web/src/components/wiki/__fixtures__/entityArticleFixture.ts
+++ b/web/src/components/wiki/__fixtures__/entityArticleFixture.ts
@@ -13,18 +13,12 @@ export const ENTITY_ARTICLE_FIXTURE = `<!-- wuphf:entity-article — generated f
 
 # Acme Corp
 
-**Acme Corp** is a company in the team knowledge graph, with 2 recorded facts from 1 completed task and 1 associated entity.
+**Acme Corp** is a company.
 
 ## Summary
 
 Kind
 : company
-
-Article
-: team/companies/acme-corp.md
-
-Facts on record
-: 2
 
 Tasks
 : TASK-3

--- a/web/src/components/wiki/articleContent.test.ts
+++ b/web/src/components/wiki/articleContent.test.ts
@@ -17,16 +17,17 @@ describe("prepareArticleMarkdown — B2 generated entity article", () => {
   it("lifts the ## Summary definition list out as infobox rows", () => {
     expect(prepared.infobox).not.toBeNull();
     const rows = prepared.infobox ?? [];
+    // Identity + navigation only — the raw fact count ("Facts on record") and
+    // the on-disk path ("Article") were metadata noise and are no longer
+    // emitted by the generator.
     expect(rows.map((r) => r.term)).toEqual([
       "Kind",
-      "Article",
-      "Facts on record",
       "Tasks",
       "Artifacts",
       "Associated",
     ]);
     expect(rows[0].value).toBe("company");
-    expect(rows[5].value).toBe("[[people/eng]]");
+    expect(rows[3].value).toBe("[[people/eng]]");
     // The Summary section is removed from the rendered body.
     expect(prepared.markdown).not.toContain("## Summary");
     expect(prepared.markdown).not.toContain("Facts on record");
@@ -104,11 +105,14 @@ describe("makeWikilinkResolver", () => {
 });
 
 describe("excerptFromMarkdown", () => {
-  it("returns the first prose words with markdown flattened", () => {
+  it("leads with the substance and skips the infobox def-list", () => {
     const excerpt = excerptFromMarkdown(ENTITY_ARTICLE_FIXTURE, 12);
-    expect(excerpt).toBe(
-      "Acme Corp is a company in the team knowledge graph, with 2…",
-    );
+    // The Wikipedia-style lead comes first…
+    expect(excerpt.startsWith("Acme Corp is a company.")).toBe(true);
+    // …and the ## Summary infobox terms never bleed into the teaser.
+    expect(excerpt).not.toContain("Kind");
+    expect(excerpt).not.toContain("Tasks");
+    expect(excerpt).not.toContain("Facts on record");
   });
 
   it("skips comments, headings, and footnote definitions", () => {

--- a/web/src/components/wiki/articleContent.ts
+++ b/web/src/components/wiki/articleContent.ts
@@ -198,11 +198,20 @@ function normalizeWikiKey(pathOrSlug: string): string {
  */
 export function excerptFromMarkdown(content: string, maxWords = 40): string {
   const words: string[] = [];
+  // Skip the `## Summary` definition-list block (the infobox). Its bare term
+  // lines ("Kind", "Tasks", …) are not `:`-prefixed, so without this they leak
+  // into the excerpt as if they were prose — especially now that the lead is a
+  // short Wikipedia-style sentence rather than a long count clause.
+  let inSummary = false;
   for (const rawLine of content.split("\n")) {
     const line = rawLine.trim();
+    if (/^#{1,6}\s/.test(line)) {
+      inSummary = /^#{2,6}\s+summary\s*$/i.test(line);
+      continue;
+    }
+    if (inSummary) continue;
     if (line === "") continue;
     if (line.startsWith("<!--") || line.endsWith("-->")) continue;
-    if (/^#{1,6}\s/.test(line)) continue;
     if (line.startsWith(":")) continue;
     if (FOOTNOTE_DEF_RE.test(line)) continue;
     if (line === "---") continue;

--- a/web/src/components/wiki/tree/WikiTreeNode.tsx
+++ b/web/src/components/wiki/tree/WikiTreeNode.tsx
@@ -20,6 +20,7 @@ import {
   type LucideIcon,
   NotebookText,
   Presentation,
+  Table2,
 } from "lucide-react";
 
 import type { WikiFSTreeNode } from "../../../api/wiki";
@@ -85,6 +86,7 @@ const FILE_GLYPH: Record<FileKind, LucideIcon> = {
   notebook: NotebookText,
   mermaid: GitBranch,
   source: FileCode2,
+  jsonl: Table2,
   google: FileText,
   fallback: File,
 };

--- a/web/src/components/wiki/viewers/FileViewer.test.tsx
+++ b/web/src/components/wiki/viewers/FileViewer.test.tsx
@@ -30,6 +30,7 @@ vi.mock("./PptxViewer", () => sentinel("pptx"));
 vi.mock("./NotebookViewer", () => sentinel("notebook"));
 vi.mock("./MermaidViewer", () => sentinel("mermaid"));
 vi.mock("./SourceViewer", () => sentinel("source"));
+vi.mock("./JsonlViewer", () => sentinel("jsonl"));
 
 import FileViewer, {
   fileKindForPath,
@@ -58,6 +59,11 @@ describe("fileKindForPath", () => {
     ["team/code/app.tsx", "source"],
     ["team/notes/todo.txt", "source"],
     ["team/data/matrix.tsv", "source"],
+    // JSON Lines routes to its own structured record viewer, not source.
+    ["team/data/facts.jsonl", "jsonl"],
+    ["team/logs/events.ndjson", "jsonl"],
+    // A plain `.json` is still source (single document, not line-delimited).
+    ["team/config/settings.json", "source"],
     // Unknown / binary → fallback
     ["team/assets/font.woff2", "fallback"],
     ["team/archives/backup.zip", "fallback"],
@@ -140,6 +146,17 @@ describe("<FileViewer> routing", () => {
     render(<FileViewer path="team/code/server.go" />);
     await waitFor(() =>
       expect(screen.getByTestId("viewer-source")).toBeInTheDocument(),
+    );
+  });
+
+  it("renders the jsonl viewer for a .jsonl path", async () => {
+    render(<FileViewer path="team/data/facts.jsonl" />);
+    await waitFor(() =>
+      expect(screen.getByTestId("viewer-jsonl")).toBeInTheDocument(),
+    );
+    expect(screen.getByTestId("viewer-jsonl")).toHaveAttribute(
+      "data-path",
+      "team/data/facts.jsonl",
     );
   });
 

--- a/web/src/components/wiki/viewers/FileViewer.tsx
+++ b/web/src/components/wiki/viewers/FileViewer.tsx
@@ -36,6 +36,7 @@ const PptxViewer = lazy(() => import("./PptxViewer"));
 const NotebookViewer = lazy(() => import("./NotebookViewer"));
 const MermaidViewer = lazy(() => import("./MermaidViewer"));
 const SourceViewer = lazy(() => import("./SourceViewer"));
+const JsonlViewer = lazy(() => import("./JsonlViewer"));
 const GoogleDocViewer = lazy(() => import("./GoogleDocViewer"));
 
 /**
@@ -57,6 +58,7 @@ const LAZY_VIEWER_BY_KIND: Record<
   notebook: NotebookViewer,
   mermaid: MermaidViewer,
   source: SourceViewer,
+  jsonl: JsonlViewer,
   google: GoogleDocViewer,
 };
 

--- a/web/src/components/wiki/viewers/JsonlViewer.test.tsx
+++ b/web/src/components/wiki/viewers/JsonlViewer.test.tsx
@@ -1,0 +1,104 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/api/wiki", () => ({
+  wikiFileUrl: (path: string) => `/wiki/file?path=${encodeURIComponent(path)}`,
+}));
+
+import JsonlViewer from "./JsonlViewer";
+
+function mockFetchText(text: string, ok = true): void {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () => ({
+      ok,
+      status: ok ? 200 : 500,
+      text: async () => text,
+    })),
+  );
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("<JsonlViewer>", () => {
+  it("renders a table when every record is a flat object with shared keys", async () => {
+    mockFetchText(
+      [
+        JSON.stringify({ name: "Acme", stage: "lead" }),
+        JSON.stringify({ name: "Globex", stage: "won" }),
+      ].join("\n"),
+    );
+    render(<JsonlViewer path="team/companies/pipeline.jsonl" />);
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole("columnheader", { name: "name" }),
+      ).toBeInTheDocument(),
+    );
+    expect(
+      screen.getByRole("columnheader", { name: "stage" }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("cell", { name: "Acme" })).toBeInTheDocument();
+    expect(screen.getByRole("cell", { name: "won" })).toBeInTheDocument();
+    expect(screen.getByText("2 records")).toBeInTheDocument();
+  });
+
+  it("unions keys across records and shows an em-dash for missing values", async () => {
+    mockFetchText(
+      [JSON.stringify({ a: "1" }), JSON.stringify({ a: "2", b: "extra" })].join(
+        "\n",
+      ),
+    );
+    render(<JsonlViewer path="team/data/x.jsonl" />);
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole("columnheader", { name: "b" }),
+      ).toBeInTheDocument(),
+    );
+    // First record has no `b`, so its cell renders the missing-value dash.
+    expect(screen.getByText("—")).toBeInTheDocument();
+  });
+
+  it("falls back to per-record cards for non-object records", async () => {
+    mockFetchText(['"just a string"', "[1, 2, 3]"].join("\n"));
+    render(<JsonlViewer path="team/data/mixed.jsonl" />);
+
+    await waitFor(() =>
+      expect(screen.getByText("2 records")).toBeInTheDocument(),
+    );
+    // No table is rendered for heterogeneous/non-object records.
+    expect(screen.queryByRole("table")).not.toBeInTheDocument();
+    expect(screen.getByText(/just a string/)).toBeInTheDocument();
+  });
+
+  it("keeps an unparseable line verbatim and counts it", async () => {
+    mockFetchText(
+      [JSON.stringify({ ok: true }), "{ not valid json"].join("\n"),
+    );
+    render(<JsonlViewer path="team/data/broken.jsonl" />);
+
+    await waitFor(() =>
+      expect(screen.getByText(/1 unparseable line/)).toBeInTheDocument(),
+    );
+    expect(screen.getByText(/not valid json/)).toBeInTheDocument();
+  });
+
+  it("shows an empty state when the file has no records", async () => {
+    mockFetchText("\n  \n");
+    render(<JsonlViewer path="team/data/empty.jsonl" />);
+    await waitFor(() =>
+      expect(screen.getByText(/this jsonl file is empty/i)).toBeInTheDocument(),
+    );
+  });
+
+  it("surfaces a load error", async () => {
+    mockFetchText("", false);
+    render(<JsonlViewer path="team/data/x.jsonl" />);
+    await waitFor(() =>
+      expect(screen.getByRole("alert")).toHaveTextContent(/HTTP 500/),
+    );
+  });
+});

--- a/web/src/components/wiki/viewers/JsonlViewer.tsx
+++ b/web/src/components/wiki/viewers/JsonlViewer.tsx
@@ -101,6 +101,9 @@ function decideLayout(records: ParsedRecord[]): Layout {
     }
     if (keys.length > MAX_TABLE_COLUMNS) return { mode: "cards" };
   }
+  // Records that are all empty objects ({}) yield no columns — a 0-column table
+  // is useless, so show the cards instead.
+  if (keys.length === 0) return { mode: "cards" };
   return { mode: "table", keys };
 }
 

--- a/web/src/components/wiki/viewers/JsonlViewer.tsx
+++ b/web/src/components/wiki/viewers/JsonlViewer.tsx
@@ -1,0 +1,311 @@
+import { useEffect, useMemo, useState } from "react";
+
+import { wikiFileUrl } from "@/api/wiki";
+
+/** Hard cap on rendered records. JSONL fact/event logs can run to tens of
+ * thousands of lines; we render the first MAX_RECORDS and surface a notice with
+ * the true total so the tab stays responsive. */
+const MAX_RECORDS = 1000;
+
+/** Above this many distinct top-level keys the table becomes unreadable, so we
+ * fall back to per-record cards even when every record is a flat object. */
+const MAX_TABLE_COLUMNS = 12;
+
+/** Stringified cell values longer than this are clipped (full value stays in
+ * the cell's title attribute) so one fat field can't blow out a column. */
+const MAX_CELL_CHARS = 200;
+
+interface JsonlViewerProps {
+  path: string;
+}
+
+interface ParsedRecord {
+  /** 1-based line number in the source file. */
+  line: number;
+  /** Parsed JSON value, or undefined when the line failed to parse. */
+  value?: unknown;
+  /** Raw line text — shown verbatim when parsing failed. */
+  raw: string;
+  ok: boolean;
+}
+
+/**
+ * Parse a JSON Lines document: one JSON value per non-blank line. Blank lines
+ * are skipped. A line that fails to parse is kept (flagged `ok: false`) so the
+ * viewer can show it as-is rather than dropping data silently.
+ */
+function parseJsonl(text: string): ParsedRecord[] {
+  const records: ParsedRecord[] = [];
+  const lines = text.split(/\r\n|\r|\n/);
+  for (let i = 0; i < lines.length; i++) {
+    const raw = lines[i];
+    if (raw.trim() === "") continue;
+    try {
+      records.push({ line: i + 1, value: JSON.parse(raw), raw, ok: true });
+    } catch {
+      records.push({ line: i + 1, raw, ok: false });
+    }
+  }
+  return records;
+}
+
+/** True for a plain JSON object ({}), false for arrays, null, and primitives. */
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** Render any JSON value as a compact, human-readable string for a table cell.
+ * A missing key (undefined) and an explicit JSON null both read as "no value"
+ * (an em-dash) so empty cells are unambiguous rather than blank. */
+function formatCell(value: unknown): string {
+  if (value === null || value === undefined) return "—";
+  if (typeof value === "string") return value;
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  return JSON.stringify(value);
+}
+
+function clip(text: string): string {
+  return text.length > MAX_CELL_CHARS
+    ? `${text.slice(0, MAX_CELL_CHARS)}…`
+    : text;
+}
+
+type LoadState =
+  | { status: "loading" }
+  | { status: "error"; message: string }
+  | { status: "ready"; records: ParsedRecord[] };
+
+/** How the records should render: a shared-key table, or per-record cards. */
+type Layout = { mode: "cards" } | { mode: "table"; keys: string[] };
+
+/**
+ * Choose a table layout only when every parsed record is a flat object and the
+ * union of their keys stays small enough to read; otherwise fall back to
+ * per-record cards. Pure so the component's useMemo stays a thin wrapper.
+ */
+function decideLayout(records: ParsedRecord[]): Layout {
+  const parsed = records.filter((r) => r.ok);
+  const allObjects =
+    parsed.length > 0 && parsed.every((r) => isPlainObject(r.value));
+  if (!allObjects) return { mode: "cards" };
+  const keys: string[] = [];
+  const seen = new Set<string>();
+  for (const r of parsed) {
+    for (const k of Object.keys(r.value as Record<string, unknown>)) {
+      if (!seen.has(k)) {
+        seen.add(k);
+        keys.push(k);
+      }
+    }
+    if (keys.length > MAX_TABLE_COLUMNS) return { mode: "cards" };
+  }
+  return { mode: "table", keys };
+}
+
+/** Fetches and parses the JSONL file at `path`, exposing a load state. Kept as
+ * a hook so the component body stays a thin render of that state. */
+function useJsonlRecords(path: string): LoadState {
+  const [state, setState] = useState<LoadState>({ status: "loading" });
+  useEffect(() => {
+    let cancelled = false;
+    setState({ status: "loading" });
+    fetch(wikiFileUrl(path))
+      .then(async (res) => {
+        if (!res.ok)
+          throw new Error(`Failed to load file (HTTP ${res.status})`);
+        return res.text();
+      })
+      .then((text) => {
+        if (!cancelled) {
+          setState({ status: "ready", records: parseJsonl(text) });
+        }
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) {
+          setState({
+            status: "error",
+            message:
+              err instanceof Error ? err.message : "Failed to read JSONL file",
+          });
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [path]);
+  return state;
+}
+
+/** Shared-key table body: one column per key, missing/null cells as em-dashes,
+ * and an unparseable line shown verbatim across the full row width. */
+function JsonlTable({
+  records,
+  keys,
+}: {
+  records: ParsedRecord[];
+  keys: string[];
+}) {
+  return (
+    <table>
+      <thead>
+        <tr>
+          {keys.map((k) => (
+            <th key={k} scope="col">
+              {k}
+            </th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {records.map((r) => {
+          if (!r.ok) {
+            return (
+              <tr key={r.line} className="wk-viewer__row--error">
+                <td colSpan={keys.length} title={r.raw}>
+                  {clip(r.raw)}
+                </td>
+              </tr>
+            );
+          }
+          const obj = r.value as Record<string, unknown>;
+          return (
+            <tr key={r.line}>
+              {keys.map((k) => {
+                const cell = formatCell(obj[k]);
+                return (
+                  <td key={k} title={cell}>
+                    {clip(cell)}
+                  </td>
+                );
+              })}
+            </tr>
+          );
+        })}
+      </tbody>
+    </table>
+  );
+}
+
+/** Per-record card body: one pretty-printed JSON block per record, used when
+ * the records are heterogeneous or too wide for a table. */
+function JsonlCards({ records }: { records: ParsedRecord[] }) {
+  return (
+    <ol className="wk-viewer__records">
+      {records.map((r) => (
+        <li key={r.line} className="wk-viewer__record">
+          <pre
+            className={
+              r.ok
+                ? "wk-viewer__record-json"
+                : "wk-viewer__record-json wk-viewer__record-json--error"
+            }
+          >
+            {r.ok ? JSON.stringify(r.value, null, 2) : r.raw}
+          </pre>
+        </li>
+      ))}
+    </ol>
+  );
+}
+
+/**
+ * JsonlViewer — renders a `.jsonl` (JSON Lines) file as a readable record view.
+ * When every record is a flat object with a small, shared key set it renders a
+ * table; otherwise it falls back to one pretty-printed card per record. Either
+ * way a non-technical reader sees structured fields instead of a raw blob, and
+ * a malformed line is surfaced verbatim rather than dropped.
+ */
+export default function JsonlViewer({ path }: JsonlViewerProps) {
+  const state = useJsonlRecords(path);
+  const filename = useMemo(() => path.split("/").pop() ?? path, [path]);
+
+  // Decide table-vs-cards once per load (see decideLayout).
+  const layout = useMemo(
+    () => (state.status === "ready" ? decideLayout(state.records) : null),
+    [state],
+  );
+
+  if (state.status === "loading") {
+    return (
+      <section className="wk-viewer wk-viewer--jsonl" aria-label={filename}>
+        <div className="wk-viewer__loading" role="status">
+          Loading records…
+        </div>
+      </section>
+    );
+  }
+
+  if (state.status === "error") {
+    return (
+      <section className="wk-viewer wk-viewer--jsonl" aria-label={filename}>
+        <div className="wk-viewer__error" role="alert">
+          {state.message}
+        </div>
+      </section>
+    );
+  }
+
+  const { records } = state;
+  if (records.length === 0) {
+    return (
+      <section className="wk-viewer wk-viewer--jsonl" aria-label={filename}>
+        <div className="wk-viewer__empty">This JSONL file is empty.</div>
+      </section>
+    );
+  }
+
+  const total = records.length;
+  const shown = records.slice(0, MAX_RECORDS);
+  const truncated = total > shown.length;
+  const badLines = records.filter((r) => !r.ok).length;
+  const src = wikiFileUrl(path);
+
+  return (
+    <section className="wk-viewer wk-viewer--jsonl" aria-label={filename}>
+      <div className="wk-viewer__toolbar">
+        <span className="wk-viewer__filename" title={filename}>
+          {filename}
+        </span>
+        <span className="wk-viewer__meta">
+          {total} {total === 1 ? "record" : "records"}
+          {badLines > 0
+            ? ` · ${badLines} unparseable ${badLines === 1 ? "line" : "lines"}`
+            : ""}
+        </span>
+        <span className="wk-viewer__spacer" aria-hidden="true" />
+        <a
+          className="wk-viewer__action"
+          href={src}
+          download={filename}
+          title={`Download ${filename}`}
+        >
+          Download
+        </a>
+        <a
+          className="wk-viewer__action"
+          href={src}
+          target="_blank"
+          rel="noreferrer noopener"
+          title="Open the raw file in a new tab"
+        >
+          Open in new tab
+        </a>
+      </div>
+      <section className="wk-viewer__body" aria-label={`${filename} records`}>
+        {layout?.mode === "table" ? (
+          <JsonlTable records={shown} keys={layout.keys} />
+        ) : (
+          <JsonlCards records={shown} />
+        )}
+        {truncated ? (
+          <p className="wk-viewer__notice" role="status">
+            Showing the first {shown.length} of {total} records. Download the
+            file to see everything.
+          </p>
+        ) : null}
+      </section>
+    </section>
+  );
+}

--- a/web/src/components/wiki/viewers/fileKind.ts
+++ b/web/src/components/wiki/viewers/fileKind.ts
@@ -29,6 +29,7 @@ export type FileKind =
   | "notebook"
   | "mermaid"
   | "source"
+  | "jsonl"
   | "google"
   | "fallback";
 
@@ -66,6 +67,11 @@ const CSV_EXTS = new Set(["csv"]);
 const XLSX_EXTS = new Set(["xlsx", "xls"]);
 
 const NOTEBOOK_EXTS = new Set(["ipynb"]);
+
+// JSON Lines (one JSON value per line). Routed to its own structured viewer —
+// not the source viewer — so fact/event logs render as readable records rather
+// than a wall of raw text. `.ndjson` is the same format under another name.
+const JSONL_EXTS = new Set(["jsonl", "ndjson"]);
 
 const MERMAID_EXTS = new Set(["mmd", "mermaid"]);
 
@@ -168,6 +174,9 @@ export function fileKindForPath(path: string): FileKind {
   if (CSV_EXTS.has(ext)) return "csv";
   if (XLSX_EXTS.has(ext)) return "xlsx";
   if (NOTEBOOK_EXTS.has(ext)) return "notebook";
+  // JSONL is checked before SOURCE_EXTS so `.jsonl` never falls through to the
+  // syntax-highlighted source view — it gets the structured record viewer.
+  if (JSONL_EXTS.has(ext)) return "jsonl";
   if (MERMAID_EXTS.has(ext)) return "mermaid";
   if (GOOGLE_EXTS.has(ext)) return "google";
   const singleton = SINGLETON_KIND_BY_EXT[ext];
@@ -221,6 +230,8 @@ export function fileKindLabel(path: string): string {
       return "Diagram";
     case "source":
       return "Source";
+    case "jsonl":
+      return "Records";
     case "google":
       return "Google";
     default: {

--- a/web/src/styles/agents.css
+++ b/web/src/styles/agents.css
@@ -697,6 +697,43 @@
   color: var(--accent);
 }
 
+/* When a task row also carries a Resume nudge, let the title button take the
+   available space and keep the action pinned to the trailing edge. */
+.agent-profile-list-item .agent-profile-task-btn {
+  flex: 1 1 auto;
+  min-width: 0;
+  width: auto;
+}
+
+/* "Resume" nudge for a stalled task — re-engages the agent via the proven
+   task wake path. Quiet by default, accent on hover, so it does not compete
+   with the task title. */
+.agent-profile-resume-btn {
+  flex: 0 0 auto;
+  font-family: var(--font-sans);
+  font-size: var(--text-xs);
+  font-weight: 500;
+  color: var(--text-secondary);
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 2px 9px;
+  cursor: pointer;
+  transition:
+    color 0.15s,
+    border-color 0.15s,
+    background 0.15s;
+}
+.agent-profile-resume-btn:hover:not(:disabled) {
+  color: var(--accent);
+  border-color: var(--accent);
+  background: var(--accent-bg);
+}
+.agent-profile-resume-btn:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
 .agent-profile-run-id {
   font-family: var(--font-mono);
   font-size: var(--text-xs);

--- a/web/src/styles/operator.css
+++ b/web/src/styles/operator.css
@@ -804,6 +804,57 @@
   flex-wrap: wrap;
 }
 
+/* API-key / token connect form (non-OAuth toolkits like Instantly). */
+.op-credential-form {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin: 10px 0 12px;
+  padding: 14px 14px 16px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--bg-card);
+}
+.op-credential-intro {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: var(--text-sm);
+}
+.op-credential-field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.op-credential-label {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.op-credential-input {
+  font: inherit;
+  font-size: var(--text-sm);
+  color: var(--text);
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 7px 10px;
+}
+.op-credential-input:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+  border-color: var(--accent);
+}
+.op-credential-help {
+  font-size: var(--text-xs);
+  color: var(--text-tertiary, var(--text-secondary));
+}
+.op-credential-actions {
+  display: flex;
+  gap: 8px;
+}
+
 .op-subhead {
   margin: 0;
   font-family: var(--font-mono);

--- a/web/src/styles/wiki-viewers.css
+++ b/web/src/styles/wiki-viewers.css
@@ -504,6 +504,65 @@
   background: var(--wk-code-bg);
 }
 
+/* ─── JSONL record viewer ────────────────────────────────────────────────── */
+
+/* Table mode reuses the shared `.wk-viewer table` styles above; the body just
+   drops its padding so the grid reaches the pane edges like csv/xlsx. */
+.wk-viewer--jsonl .wk-viewer__body {
+  padding: 0;
+}
+/* A row whose source line failed to parse — surfaced verbatim rather than
+   dropped — reads as a quiet warning so the reader knows that line is raw. */
+.wk-viewer__row--error td {
+  color: var(--wk-text-muted);
+  font-style: italic;
+}
+/* Card (record-list) fallback for heterogeneous / deeply-nested JSONL where a
+   table would be unreadable: one pretty-printed record per row. */
+.wk-viewer__records {
+  margin: 0;
+  padding: 12px 16px;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  counter-reset: wk-record;
+}
+.wk-viewer__record {
+  position: relative;
+  counter-increment: wk-record;
+  border: 1px solid var(--wk-border-light);
+  border-radius: var(--radius-md, 8px);
+  background: var(--wk-surface);
+  overflow: hidden;
+}
+.wk-viewer__record::before {
+  content: counter(wk-record);
+  position: absolute;
+  top: 8px;
+  right: 12px;
+  font-family: var(--wk-mono);
+  font-size: 11px;
+  color: var(--wk-text-tertiary);
+  user-select: none;
+}
+.wk-viewer__record-json {
+  margin: 0;
+  padding: 12px 16px;
+  overflow-x: auto;
+  font-family: var(--wk-mono);
+  font-size: 12.5px;
+  line-height: 1.55;
+  tab-size: 2;
+  white-space: pre-wrap;
+  word-break: break-word;
+  background: var(--wk-code-bg);
+  color: var(--wk-text);
+}
+.wk-viewer__record-json--error {
+  color: var(--red, #c0392b);
+}
+
 /* xlsx sheet tabs */
 .wk-viewer__sheet-tabs {
   display: flex;

--- a/web/src/styles/wiki-viewers.css
+++ b/web/src/styles/wiki-viewers.css
@@ -555,7 +555,7 @@
   line-height: 1.55;
   tab-size: 2;
   white-space: pre-wrap;
-  word-break: break-word;
+  overflow-wrap: anywhere;
   background: var(--wk-code-bg);
   color: var(--wk-text);
 }


### PR DESCRIPTION
Addresses a batch of customer complaints. Four self-contained fixes; one larger
wiki re-organization is intentionally deferred (see end).

## What's fixed

### 1. Connecting "Instantly" via Composio (the 400)
Connecting Instantly returned a bare `400 POST /auth_configs`. Root cause: we
**always** created a Composio-*managed OAuth* config, but Instantly authenticates
by **API key** — Composio rejects that shape. We now detect the toolkit's auth
scheme (`GET /toolkits/{slug}`); API-key/token toolkits return `status:
"needs_fields"` with the required credential fields, the UI renders a key-entry
form, and submitting creates a `use_custom_auth` config + connected account.

**Verified live against Composio** (not mocked): connecting Instantly now returns
a real `Instantly API Key` field with Composio's own guidance ("must be a v2 key")
and a masked input — instead of the opaque 400. Screenshot below.

### 2. Agents going idle with no way back
- Idle agents now read **"Went idle after no progress for N min — send a new
  message to bring it back"** instead of `stale activity reaped (no progress for
  5m0s)`.
- New **Resume** button on a stalled agent's task rows, which re-engages the
  agent through the broker's existing wake path (`task_updated` →
  `enqueueHeadlessCodexTurn`) — a discoverable one-click recovery.

### 3. JSONL files weren't previewable in the wiki
New `JsonlViewer` renders `.jsonl`/`.ndjson` as readable records (a shared-key
table when records line up, per-record cards otherwise), surfacing malformed
lines verbatim rather than dropping them. Previously they fell through to a
download-only card.

### 4. Wiki articles "said nothing but counts"
- Dropped the lead boilerplate (`X is a company in the team knowledge graph, with
  N recorded facts...`) for a plain `**X** is a company.`
- Removed the metadata infobox rows (`Facts on record`, file path) and the empty
  `Signals: (none)` stub on new pages.
- Teaser extractor now leads with substance; synthesizer prompt asks for
  substance-first prose that grows richer over time.

## Tests
- Go: `internal/action` + `internal/team` targeted suites green (composio
  API-key detection/submission, reaper copy, entity article/brief/synthesizer).
- Web: 80+ tests across the touched files green; `tsc` + `biome` clean (only
  pre-existing warnings on untouched code).

## Needs a real key to fully verify
The Composio **write path** (`CompleteAPIKeyConnection`: create custom-auth
config + connected account) is unit-tested for request shape and verified up to
the form against live Composio, but completing a connection needs a real
Instantly **v2** API key — left for live confirmation. The exact v3 write shapes
are isolated in `composio_apikey.go` so any field tweak is a one-liner.

## Deferred (separate slice)
The larger **Wikipedia-style wiki reorganization** (remove fixed
people/companies/customers folders, flat entity+concept namespace,
categories for nav, insights folded under headers) is a real IA redesign and is
tracked as the next chunk, not bundled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Screenshots (verified live against Composio)

**Connecting Instantly → API-key form** (was: `400 POST /auth_configs`):

![Instantly API-key form](https://raw.githubusercontent.com/nex-crm/wuphf/screenshots/pr-1111/composio-instantly-form.png)

**Live Composio catalog search:**

![Composio search](https://raw.githubusercontent.com/nex-crm/wuphf/screenshots/pr-1111/composio-instantly-search.png)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added a credential-based (API-key/token) integration connection flow for non-OAuth toolkits.
  * Added the ability to resume eligible agent tasks.
  * Added a JSONL record viewer with table/card rendering.

* **Improvements**
  * Simplified entity article/brief formatting and cleaner wiki excerpts (less infobox/metadata leakage).
  * Enhanced agent task/operator messaging for clearer “stale activity” recovery guidance.

* **UI/UX**
  * Added credential input forms styled for manual entry and improved JSONL navigation/icon behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->