### PR TITLE
feat(wiki): add the Wikipedia-style category layer (phases 0–3b) [release]

### DIFF
--- a/docs/specs/WIKI-SCHEMA.md
+++ b/docs/specs/WIKI-SCHEMA.md
@@ -50,7 +50,10 @@ Layer 1 — Raw sources (immutable)
   These files are the factual record. The LLM reads them but NEVER modifies them.
 
 Layer 2 — The wiki (LLM-owned markdown)
-  team/{kind}/{slug}.md                  # entity briefs (person, company, project)
+  team/{kind}/{slug}.md                  # entity briefs (person, company, customer)
+  team/concepts/{slug}.md                # concept articles (topics/ideas, not a
+                                         # specific person/company) — same article
+                                         # shape as a brief, type: concept
   wiki/facts/{kind}/{slug}.jsonl         # append-only fact log per entity
   wiki/insights/entity/{slug}.jsonl      # append-only typed insight log per entity
   wiki/insights/knowledge/{slug}.md      # workspace-wide facts/decisions/preferences
@@ -84,7 +87,14 @@ YAML frontmatter fields used across wiki files. Every field has a default; legac
 ---
 canonical_slug: sarah-jones          # authoritative slug. If this is a redirect,
                                       # the value is the real slug this file points to
-kind: person                          # person | company | project | team | workspace
+type: entity                          # entity | concept  (default entity). A concept
+                                      # article (team/concepts/{slug}.md) is type: concept.
+kind: person                          # person | company | customer | concept
+categories:                           # many-to-many nav categories (Wikipedia-style).
+  - Sales                             # OPTIONAL, default []. Drives the category nav;
+  - RevOps                            # derived-indexed but markdown is authoritative.
+redirect_to:                          # OPTIONAL. Set on a re-filed stub to the survivor
+                                      # path (see §7.2). Absent on a normal article.
 aliases:                              # other names this entity is known by
   - Sarah J.
   - sjones
@@ -101,6 +111,21 @@ created_at: 2026-01-16T09:14:00Z
 created_by: nazz                      # the human who caused this entity to exist
 ---
 ```
+
+**New fields (Wikipedia-IA layer):**
+- `type` — `entity` (default) or `concept`. Concept articles live at
+  `team/concepts/{slug}.md` and describe a topic/idea rather than a specific
+  person/company. Everything else (the article shape, sentinels, synthesis
+  bookkeeping) is identical to an entity brief.
+- `categories` — a many-to-many list that drives the **category navigation**
+  (Wikipedia-style: an article can sit under several categories, and the
+  sidebar tree is built on demand from these, not from the folder it lives in).
+  Optional, default `[]`. The category index is **derived** (rebuilt from this
+  frontmatter on `rm -rf index/` + restart) — markdown stays authoritative
+  (§7.4). Category slugs never collide with article slugs (they are surfaced
+  through `_category/<slug>` pseudo-paths, not `[[wikilinks]]`).
+- `redirect_to` — present only on a **re-filed stub** (§7.2). Its value is the
+  survivor path the stub redirects to.
 
 ### 4.2 Fact — line in `wiki/facts/{kind}/{slug}.jsonl`
 
@@ -296,6 +321,24 @@ Algorithm:
 5. Update graph edges.
 
 Merging is a human-confirmed operation, surfaced through lint → `ResolveContradictionModal`.
+
+**Re-filing a mis-placed article** (e.g. a concept article that was written into
+`team/companies/` because the extractor only had entity folders) uses the SAME
+redirect mechanism — never a rename (§11.4):
+
+1. Write the article at its correct survivor path (e.g. `team/concepts/{slug}.md`)
+   with `type: concept` + `categories:`, carrying the old body and git history.
+2. REPLACE the old path with a redirect stub: frontmatter `canonical_slug: <survivor>`
+   + `redirect_to: <survivor-path>`, body `This page redirects to [[concepts/{slug}]].
+   Prior content preserved in git history.` Existing `[[companies/{slug}]]` links keep
+   resolving via the stub.
+3. Append the mapping to `wiki/redirects.md` — the human-readable redirect index. This
+   file is a **written mirror** of the redirect set, regenerated from stub frontmatter
+   by the broker's redirect writer under the `archivist` identity. It is NOT a second
+   source of truth: redirects are derived from `canonical_slug`/`redirect_to` frontmatter
+   during reconcile, so `rm -rf index/` + restart reproduces them.
+
+Re-filing is human/librarian-confirmed, exactly like a slug merge.
 
 ### 7.3 Fact ID determinism
 
@@ -514,6 +557,7 @@ and a full DLQ entry is written to `permanent-failures.jsonl`.
 | Date | Change | Rationale |
 |---|---|---|
 | 2026-04-22 | Initial draft | Karpathy schema layer for Slice 1 of wiki-intelligence port. Covers three-layer architecture, frontmatter vocabulary, canonical slug rules, decay formula, lint rules, prompt guidance, anti-patterns. |
+| 2026-06-18 | Wikipedia-IA layer | Added `type: entity\|concept`, many-to-many `categories:` (derived-indexed, markdown-authoritative) as the category-nav layer, the `team/concepts/{slug}.md` concept-article location, `redirect_to:` on re-filed stubs, and the `wiki/redirects.md` written-mirror writer (§7.2). On-disk folder layout unchanged — folders become an implementation detail; categories drive nav. |
 
 Update this log on every substantive revision. Small wording tweaks don't require a log entry; new fields, new file locations, and changed algorithms do.
 

--- a/docs/specs/wiki-wikipedia-ia.md
+++ b/docs/specs/wiki-wikipedia-ia.md
@@ -1,0 +1,154 @@
+# Wikipedia-style wiki IA — design spec
+
+> Status: design approved (2026-06-18). Phase 0 (WIKI-SCHEMA contract amendment) landed.
+> This is the authoritative spec for the wiki reorg; `WIKI-SCHEMA.md` is the machine contract,
+> this doc is the design rationale + the Wikipedia-fidelity standard the implementation follows.
+> Detailed phased plan: `~/.claude/plans/wobbly-sleeping-kitten.md` (+ `-agent-…` file:line version).
+
+## 1. Context & goal
+
+Today the wiki organizes articles by **fixed top-level folders** under `team/`
+(people / companies / customers / playbooks / …) and an article's "category" in the UI is just
+its first path segment. This causes the customer-reported problems: insight/concept articles get
+filed into entity folders (`team/companies/hubspot-mql.md`, `linear-ci.md` are insights, not
+companies), the nav is rigid, there's no home for non-entity **concept** articles, and agents
+dump standalone "insight" pages instead of folding knowledge into the right article.
+
+**Goal: make the wiki behave like Wikipedia** across four dimensions — **navigation/IA**,
+**article writing**, **associations**, and the **agent read/write/query** paths — because the
+wiki is the agents' compounding knowledge substrate, not only a human reading surface.
+
+## 2. Approach: a category LAYER, not a physical flatten
+
+Keep the on-disk folder layout (preserves the load-bearing invariants below); add a
+**category + concept layer** on top. Folders become an invisible implementation detail;
+**categories drive navigation**. This is exactly the MediaWiki model (flat main namespace +
+Category namespace), achieved without breaking the substrate.
+
+**Load-bearing invariants the design must not break** (from `WIKI-SCHEMA.md`):
+- **Substrate/rebuild:** `rm -rf index/` + restart rebuilds identically from markdown; every new
+  index layer is derived + added to `ReconcileFromMarkdown` + `CanonicalHashAll`.
+- **Single-writer:** all writes via `WikiWorker.Enqueue*` under a git identity. No direct writes.
+- **Slug immutability + redirects:** never rename in place; re-file uses redirect stubs (§7.2).
+- **`[[kind/slug]]` wikilink grammar + Obsidian vault compatibility** stay intact.
+
+## 3. The Wikipedia IA model (what we are mirroring)
+
+Grounded in **WP:LAYOUT** (Manual of Style/Layout) and **Help:Category** (MediaWiki category model).
+
+### 3.1 Namespaces / IA
+- **Flat article namespace** (Main): entities AND concepts live in one flat-feeling namespace;
+  there is no folder hierarchy for articles.
+- **Category namespace**: categories are **first-class pages** (`Category:X`) with a description
+  and **parent categories**, forming a **subcategory tree (DAG)**. A category page auto-lists its
+  **subcategories + member articles alphabetically**.
+- **Redirects**: alternate titles → canonical (we already have the mechanism; add the on-disk
+  `redirects.md` mirror). **Disambiguation pages** for ambiguous titles.
+
+### 3.2 Article-writing standard (WP:LAYOUT order, top → bottom)
+Every generated/synthesized article emits, in this order:
+1. **Hatnote(s)** — e.g. "Redirected from X", disambiguation pointers.
+2. **Infobox** — structured key facts (our `## Summary` definition list).
+3. **Lead section** — no heading; the **first sentence bolds the title and defines it**
+   ("**X** is a {kind}…"); summary-style; **encyclopedic, neutral, third person**; stands alone.
+4. **Body sections** — `##` / `###` headings, no skipped levels, single blank line between.
+5. **Appendices, in this exact order:** `## See also` (bulleted **blue** links to related articles
+   only — no red links, no disambig, no external) → `## References`/Notes (footnote citations) →
+   Further reading → External links.
+6. **Foot:** navbox(es) (grouped related-article navigation) → **categories rendered at the very
+   bottom**.
+
+### 3.3 Categories (Help:Category)
+- `categories:` frontmatter ≈ `[[Category:X]]`: **many-to-many**, assigned by **defining
+  characteristics** (not subjective traits); **every article in ≥1 category**.
+- Categories are **pages** with `parent_categories:` → the nav tree is real (built on demand from
+  category→parent edges), not folder containment.
+
+### 3.4 Associations (the full Wikipedia set)
+- **Wikilinks** `[[kind/slug]]` / `[[concepts/slug]]` — the primary association; wikilink every
+  entity AND concept **on first mention**.
+- **Categories** — classification association.
+- **Backlinks / "What links here"** — reverse links (we have the bidirectional entity graph;
+  surface it as a backlinks view agents and humans can query).
+- **`## See also`** — curated related-article links.
+- **Navboxes** — grouped related-article nav at the foot (generated from the graph / category
+  co-membership).
+- **Redirects** + **disambiguation** pages.
+
+## 4. WUPHF ↔ Wikipedia mapping
+
+| Wikipedia | WUPHF implementation |
+|---|---|
+| Main (article) namespace, flat | `team/**/*.md` (folders invisible; nav by category) |
+| Entity vs concept article | `type: entity` (people/companies/customers) vs `type: concept` (`team/concepts/{slug}.md`) |
+| `[[Category:X]]`, many-to-many | `categories:` frontmatter (derived index) |
+| Category page + subcategories | category page model + `parent_categories:`; `_category/<slug>` pseudo-path nav |
+| Lead ("X is a Y") | deterministic article lead (entity_article.go / concept_article.go) |
+| Infobox | `## Summary` definition list (lifted to a right-rail infobox by the reader) |
+| See also | `## See also` (curated; reshaped from today's `## Associated`) |
+| References/footnotes | `## References` + `[^n]` citations to tasks/artifacts |
+| Navbox / What links here | EntityGraph in/out-edges → navbox + backlinks view |
+| Redirect | redirect stub (`canonical_slug`/`redirect_to`) + `redirects.md` mirror |
+| `[[wikilinks]]` | `[[kind/slug]]` wikilink grammar (concepts = `[[concepts/slug]]`) |
+
+## 5. Agent-facing model (write · find · associate)
+
+The wiki is the agents' substrate; the Wikipedia model governs their paths:
+
+**WRITE (Wikipedia-faithful authoring).**
+- Extraction (`prompts/extract_entities_lite.tmpl`, `ValidEntityKinds()` entity_facts.go:52):
+  recognize **concepts** as a kind so mentions link to `[[concepts/slug]]` and emit
+  entity↔concept relationships (today only person/company/customer).
+- Synthesis prompt (`SynthesisPromptSystem`) + librarian prompt (`librarian.go`): write the lead,
+  assign `categories:` by **defining characteristics**, put related links in `## See also`,
+  wikilink every entity/concept on first mention, and **fold insights under a header** in the most
+  relevant article — never a standalone page.
+- **`WIKI-SCHEMA.md §10`** (the opening directive every wiki prompt references) gains the Wikipedia
+  authoring rules — highest-leverage single edit; all prompts inherit it.
+
+**FIND (retrieval via the graph, not folders).**
+- `context_assembler.go` + `prompt_builder.go`: assemble an agent's turn context from
+  **categories** (same-category articles) + **wikilinks** + **backlinks (What links here)** +
+  **concept articles**, not just the entity's own brief.
+- Index `categories` + concept articles in bleve/sqlite; add **category-scoped retrieval**.
+- Expose a **"What links here"** backlinks query (EntityGraph in-edges).
+
+**ASSOCIATE (entities AND concepts).**
+- `entity_graph.go`: add **concept nodes** + entity↔concept / concept↔concept edges (`Coalesce`/
+  `Query` are already kind-generic; the gate is `ValidEntityKinds` + extraction emitting refs).
+- Associations rendered as `## See also` + navbox + foot categories from the graph + category index.
+
+**Net effect:** agents file encyclopedic entity/concept articles, categorize by defining trait,
+wikilink+backlink associations, fold new insights under the right header, and retrieve by
+category/link/backlink — so knowledge compounds and stays findable, like Wikipedia.
+
+## 6. Phased delivery (each = one shippable PR)
+
+0. **Schema amendment** (✅ done) — `type`, `categories`, `team/concepts/`, `redirect_to`,
+   redirects.md writer, §7.2 re-file, §12 changelog. Follow-up: add `parent_categories`, the
+   WP:LAYOUT order, the Category-page model, disambiguation, and the §10 agent-authoring rules.
+1. **Category derived index** — `article_categories` (+ category→parent edges) on both stores,
+   reconcile hook in `reconcileEntityBrief`, fold into `CanonicalHashAll`, populate the dead
+   `meta.Categories`; `rm -rf index` rebuild-equality test.
+2. **Category API** — `GET /wiki/categories[/{slug}]` mirroring `/wiki/sections` (cache + SSE).
+3. **Flip nav to categories** (the visible win) — re-point `WikiCategoryPage`/`CategoriesFooter`/
+   `Wiki.tsx` from folder `group` to real categories; render the **subcategory tree**; backfill so
+   nav is never empty.
+4. **Concept articles + agent authoring** — `EntityKindConcepts`; `concept_article.go` mirroring
+   `entity_article.go` in **WP:LAYOUT order**; extraction recognizes concepts; librarian/synthesis
+   prompts + §10 updated; `## Associated` → `## See also`; categories at foot.
+5. **Insights fold under headers** — `wiki_section_merge.go` (`mergeUnderHeader`, fence-safe,
+   outside sentinel regions); agent names target; no target → notebook for librarian promotion.
+6. **Re-file via redirects** (riskiest, last) — `wiki_redirect.go` (`redirects.md` writer +
+   `Refile` = survivor + stub, never rename) + `DetectMisplaced`; "Redirected from" hatnote;
+   human/librarian-confirmed.
+
+Cross-cutting **agent retrieval + backlinks ("What links here") + navbox** work rides Phases 3–4.
+
+## 7. Verification (per phase)
+- Go: `bash scripts/test-go.sh ./internal/team`; `gofmt`, `go vet`, **`golangci-lint run`**
+  (catches staticcheck — not just vet). Web: `bash scripts/test-web.sh`, `bunx tsc --noEmit`,
+  `bunx biome check`. Substrate test: `rm -rf index` rebuild ⇒ `CanonicalHashAll` stable.
+- Live (browser-harness): category nav renders the subcategory tree; a concept article opens in
+  WP:LAYOUT order; an insight folds under a header; a re-filed article shows the hatnote.
+  **Run the test broker on isolated `--web-port` AND `--broker-port` (7900+) — never 7890/7891 (prod).**

--- a/docs/specs/wiki-wikipedia-ia.md
+++ b/docs/specs/wiki-wikipedia-ia.md
@@ -127,13 +127,18 @@ category/link/backlink — so knowledge compounds and stays findable, like Wikip
 0. **Schema amendment** (✅ done) — `type`, `categories`, `team/concepts/`, `redirect_to`,
    redirects.md writer, §7.2 re-file, §12 changelog. Follow-up: add `parent_categories`, the
    WP:LAYOUT order, the Category-page model, disambiguation, and the §10 agent-authoring rules.
-1. **Category derived index** — `article_categories` (+ category→parent edges) on both stores,
-   reconcile hook in `reconcileEntityBrief`, fold into `CanonicalHashAll`, populate the dead
-   `meta.Categories`; `rm -rf index` rebuild-equality test.
+1. **Category derived index** (✅ done) — `article_categories` on both stores (sqlite +
+   in-memory), reconcile hook in `reconcileEntityBrief`, folded into `CanonicalHashAll`
+   (backend-agnostic), `meta.Categories` populated from frontmatter; `rm -rf index`
+   rebuild-equality + backend-parity tests. **Re-sequence:** the category→parent (subcategory
+   tree) edges moved to Phase 3 — their only data source is category pages, which Phase 3
+   authors; an always-empty parent table here would be speculative plumbing, and
+   `CREATE TABLE IF NOT EXISTS` keeps the Phase 3 addition non-breaking.
 2. **Category API** — `GET /wiki/categories[/{slug}]` mirroring `/wiki/sections` (cache + SSE).
 3. **Flip nav to categories** (the visible win) — re-point `WikiCategoryPage`/`CategoriesFooter`/
-   `Wiki.tsx` from folder `group` to real categories; render the **subcategory tree**; backfill so
-   nav is never empty.
+   `Wiki.tsx` from folder `group` to real categories; introduce **category pages** (with
+   `parent_categories:`) + the category→parent derived edges and render the **subcategory tree**;
+   backfill so nav is never empty.
 4. **Concept articles + agent authoring** — `EntityKindConcepts`; `concept_article.go` mirroring
    `entity_article.go` in **WP:LAYOUT order**; extraction recognizes concepts; librarian/synthesis
    prompts + §10 updated; `## Associated` → `## See also`; categories at foot.

--- a/docs/specs/wiki-wikipedia-ia.md
+++ b/docs/specs/wiki-wikipedia-ia.md
@@ -134,7 +134,10 @@ category/link/backlink — so knowledge compounds and stays findable, like Wikip
    tree) edges moved to Phase 3 — their only data source is category pages, which Phase 3
    authors; an always-empty parent table here would be speculative plumbing, and
    `CREATE TABLE IF NOT EXISTS` keeps the Phase 3 addition non-breaking.
-2. **Category API** — `GET /wiki/categories[/{slug}]` mirroring `/wiki/sections` (cache + SSE).
+2. **Category API** (✅ done) — `GET /wiki/categories` (cached list, slug+title+count) and
+   `GET /wiki/categories/{slug}` (live member articles) mirroring `/wiki/sections`: debounced
+   in-memory cache fed by wiki:write, `wiki:categories_updated` SSE, reads the derived index.
+   Frontend stubs (`fetchCategories`/`fetchCategory`/`subscribeCategoriesUpdated`) in `web/src/api/wiki.ts`.
 3. **Flip nav to categories** (the visible win) — re-point `WikiCategoryPage`/`CategoriesFooter`/
    `Wiki.tsx` from folder `group` to real categories; introduce **category pages** (with
    `parent_categories:`) + the category→parent derived edges and render the **subcategory tree**;

--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -148,46 +148,48 @@ type Broker struct {
 	slackSpawns       map[string]slackSpawnRecord    // slug → pending agent spawn awaiting /slack/agents/spawn/complete (persisted)
 	// slackSpawnAuthTest is the auth.test seam for the spawn-complete flow;
 	// nil means the real Slack Web API. Tests inject a fake.
-	slackSpawnAuthTest      slackSpawnAuthTestFunc
-	messageSubscribers      map[int]chan channelMessage
-	actionSubscribers       map[int]chan officeActionLog
-	activity                map[string]agentActivitySnapshot
-	activitySubscribers     map[int]chan agentActivitySnapshot
-	officeSubscribers       map[int]chan officeChangeEvent
-	wikiSubscribers         map[int]chan wikiWriteEvent
-	notebookSubscribers     map[int]chan notebookWriteEvent
-	reviewSubscribers       map[int]chan ReviewStateChangeEvent
-	entitySubscribers       map[int]chan EntityBriefSynthesizedEvent
-	factSubscribers         map[int]chan EntityFactRecordedEvent
-	wikiSectionsSubscribers map[int]chan WikiSectionsUpdatedEvent
-	wikiWorker              *WikiWorker
-	wikiInitMu              sync.Mutex
-	wikiInitErr             error
-	autoNotebookWriter      *AutoNotebookWriter
-	humanWikiWriter         *HumanWikiIntentWriter
-	obsidianWatcher         *ObsidianWatcher
-	demandIndex             *NotebookDemandIndex
-	channelIntentDispatcher *ChannelIntentDispatcher
-	promotionSweep          *PromotionSweep
-	wikiIndex               *WikiIndex
-	wikiExtractor           *Extractor
-	wikiDLQ                 *DLQ
-	wikiSectionsCache       *wikiSectionsCache
-	reviewLog               *ReviewLog
-	reviewResolver          ReviewerResolver
-	inboxCursorMu           sync.RWMutex
-	userInboxCursors        map[string]InboxCursor
-	factLog                 *FactLog
-	readLog                 *ReadLog
-	entityGraph             *EntityGraph
-	entitySynthesizer       *EntitySynthesizer
-	wikiCompressor          *WikiCompressor
-	teamLearningLog         *LearningLog
-	playbookSynthesizer     *PlaybookSynthesizer
-	pamDispatcher           *PamDispatcher
-	scanTracker             *scanStatusTracker
-	nextSubscriberID        int
-	agentStreams            map[string]*agentStreamBuffer
+	slackSpawnAuthTest        slackSpawnAuthTestFunc
+	messageSubscribers        map[int]chan channelMessage
+	actionSubscribers         map[int]chan officeActionLog
+	activity                  map[string]agentActivitySnapshot
+	activitySubscribers       map[int]chan agentActivitySnapshot
+	officeSubscribers         map[int]chan officeChangeEvent
+	wikiSubscribers           map[int]chan wikiWriteEvent
+	notebookSubscribers       map[int]chan notebookWriteEvent
+	reviewSubscribers         map[int]chan ReviewStateChangeEvent
+	entitySubscribers         map[int]chan EntityBriefSynthesizedEvent
+	factSubscribers           map[int]chan EntityFactRecordedEvent
+	wikiSectionsSubscribers   map[int]chan WikiSectionsUpdatedEvent
+	wikiCategoriesSubscribers map[int]chan WikiCategoriesUpdatedEvent
+	wikiWorker                *WikiWorker
+	wikiInitMu                sync.Mutex
+	wikiInitErr               error
+	autoNotebookWriter        *AutoNotebookWriter
+	humanWikiWriter           *HumanWikiIntentWriter
+	obsidianWatcher           *ObsidianWatcher
+	demandIndex               *NotebookDemandIndex
+	channelIntentDispatcher   *ChannelIntentDispatcher
+	promotionSweep            *PromotionSweep
+	wikiIndex                 *WikiIndex
+	wikiExtractor             *Extractor
+	wikiDLQ                   *DLQ
+	wikiSectionsCache         *wikiSectionsCache
+	wikiCategoriesCache       *wikiCategoriesCache
+	reviewLog                 *ReviewLog
+	reviewResolver            ReviewerResolver
+	inboxCursorMu             sync.RWMutex
+	userInboxCursors          map[string]InboxCursor
+	factLog                   *FactLog
+	readLog                   *ReadLog
+	entityGraph               *EntityGraph
+	entitySynthesizer         *EntitySynthesizer
+	wikiCompressor            *WikiCompressor
+	teamLearningLog           *LearningLog
+	playbookSynthesizer       *PlaybookSynthesizer
+	pamDispatcher             *PamDispatcher
+	scanTracker               *scanStatusTracker
+	nextSubscriberID          int
+	agentStreams              map[string]*agentStreamBuffer
 	// mu is the broker's single big lock. contendedMutex == sync.Mutex
 	// semantics plus sampled slow-wait logging (broker_mutex.go) so a
 	// long holder wedging every endpoint is visible in the log.
@@ -497,6 +499,7 @@ func (b *Broker) Start() error {
 	b.mu.Unlock()
 
 	b.ensureWikiSectionsCache()
+	b.ensureWikiCategoriesCache()
 	b.ensureReviewLog()
 	b.ensureEntitySynthesizer()
 	b.ensureWikiCompressor()
@@ -614,6 +617,8 @@ func (b *Broker) StartOnPort(port int) error {
 	mux.HandleFunc("/wiki/visual", b.requireAuth(b.handleWikiVisualArtifact))
 	mux.HandleFunc("/wiki/archive/sweep", b.requireAuth(b.handleWikiArchiveSweep))
 	mux.HandleFunc("/wiki/sections", b.requireAuth(b.handleWikiSections))
+	mux.HandleFunc("/wiki/categories", b.requireAuth(b.handleWikiCategories))
+	mux.HandleFunc("/wiki/categories/", b.requireAuth(b.handleWikiCategory))
 	mux.HandleFunc("/wiki/lint/run", b.requireAuth(b.handleLintRun))
 	mux.HandleFunc("/wiki/lint/resolve", b.requireAuth(b.handleLintResolve))
 	mux.HandleFunc("/wiki/maintenance/suggest", b.requireAuth(b.handleWikiMaintenanceSuggest))

--- a/internal/team/broker_auth.go
+++ b/internal/team/broker_auth.go
@@ -127,6 +127,7 @@ func humanRouteAllowed(r *http.Request) bool {
 			path == "/wiki/audit",
 			path == "/wiki/visual",
 			path == "/wiki/sections",
+			path == "/wiki/categories",
 			path == "/wiki/diff",
 			path == "/agent-files/read",
 			path == "/notebook/visual-artifacts",
@@ -148,6 +149,10 @@ func humanRouteAllowed(r *http.Request) bool {
 			// Slice 5: per-article version history is a human-readable view on
 			// the same footing as /wiki/audit and /wiki/article. The article
 			// path is the suffix; the handler validates it under team/.
+			return true
+		case strings.HasPrefix(path, "/wiki/categories/"):
+			// Category detail (GET /wiki/categories/{slug}); the category slug
+			// is the suffix. Same read-only footing as /wiki/categories.
 			return true
 		case isTaskDetailPath(path):
 			// Lane E: human sessions hit /tasks/{id} for the Decision

--- a/internal/team/broker_sse.go
+++ b/internal/team/broker_sse.go
@@ -55,6 +55,8 @@ func (b *Broker) handleEvents(w http.ResponseWriter, r *http.Request) {
 	defer unsubscribeFacts()
 	sectionsEvents, unsubscribeSections := b.SubscribeWikiSectionsUpdated(16)
 	defer unsubscribeSections()
+	categoriesEvents, unsubscribeCategories := b.SubscribeWikiCategoriesUpdated(16)
+	defer unsubscribeCategories()
 	playbookEvents, unsubscribePlaybook := b.SubscribePlaybookExecutionEvents(64)
 	defer unsubscribePlaybook()
 	playbookSynthEvents, unsubscribePlaybookSynth := b.SubscribePlaybookSynthesizedEvents(64)
@@ -136,6 +138,10 @@ func (b *Broker) handleEvents(w http.ResponseWriter, r *http.Request) {
 			}
 		case evt, ok := <-sectionsEvents:
 			if !ok || writeEvent(wikiSectionsEventName, evt) != nil {
+				return
+			}
+		case evt, ok := <-categoriesEvents:
+			if !ok || writeEvent(wikiCategoriesEventName, evt) != nil {
 				return
 			}
 		case evt, ok := <-playbookEvents:

--- a/internal/team/wiki_article.go
+++ b/internal/team/wiki_article.go
@@ -103,6 +103,11 @@ type CatalogEntry struct {
 	AuthorSlug   string `json:"author_slug"`
 	LastEditedTs string `json:"last_edited_ts"`
 	Group        string `json:"group"`
+	// Categories are the article's many-to-many category slugs from its
+	// `categories:` frontmatter (markdown-authoritative). Always present
+	// (possibly empty) so the UI can rely on the field. The folder `Group`
+	// stays as a fallback nav key during the category migration.
+	Categories []string `json:"categories"`
 	// Read tracking — always present; zero when no reads have been recorded.
 	LastRead       *time.Time `json:"last_read,omitempty"`
 	HumanReadCount int        `json:"human_read_count"`
@@ -224,12 +229,17 @@ func (r *Repo) BuildCatalog(ctx context.Context, sortBy string, readLog *ReadLog
 	var entries []CatalogEntry
 
 	walkErr := r.walkCatalogArticles(includeArchived, func(rel string, content []byte, isArchived bool) {
+		cats := parseCategoriesFrontmatter(string(content))
+		if cats == nil {
+			cats = []string{}
+		}
 		entry := CatalogEntry{
-			Path:      rel,
-			Archived:  isArchived,
-			Title:     extractTitle(content, rel),
-			Group:     groupFromPath(rel),
-			WordCount: countWords(content),
+			Path:       rel,
+			Archived:   isArchived,
+			Title:      extractTitle(content, rel),
+			Group:      groupFromPath(rel),
+			Categories: cats,
+			WordCount:  countWords(content),
 		}
 		entries = append(entries, entry)
 	})

--- a/internal/team/wiki_article.go
+++ b/internal/team/wiki_article.go
@@ -384,6 +384,13 @@ func (r *Repo) BuildArticle(ctx context.Context, relPath, reader string, readLog
 		Ghost:             parseGhostFrontmatter(string(content)),
 		AttachedArtifacts: []RichArtifact{},
 	}
+	// Categories are markdown-authoritative (the article's own `categories:`
+	// frontmatter); the index is a derived mirror. Parse them straight from the
+	// content so the article view is self-contained. Keep the [] default when
+	// the article declares none.
+	if cats := parseCategoriesFrontmatter(string(content)); len(cats) > 0 {
+		meta.Categories = cats
+	}
 
 	// Revision history and last-edit info (via git log).
 	if refs, err := r.Log(ctx, relPath); err == nil && len(refs) > 0 {

--- a/internal/team/wiki_article.go
+++ b/internal/team/wiki_article.go
@@ -167,7 +167,9 @@ func (r *Repo) walkCatalogArticles(includeArchived bool, fn func(rel string, con
 			rel, relErr := filepath.Rel(r.Root(), path)
 			if relErr == nil {
 				slash := filepath.ToSlash(rel)
-				if slash == "team/inbox" || slash == "team/skills" {
+				// team/.categories/ holds category-definition pages (the
+				// subcategory tree), not articles — keep them out of the catalog.
+				if slash == "team/inbox" || slash == "team/skills" || slash == "team/.categories" {
 					return filepath.SkipDir
 				}
 			}

--- a/internal/team/wiki_categories.go
+++ b/internal/team/wiki_categories.go
@@ -1,0 +1,84 @@
+package team
+
+// wiki_categories.go — the article→category derived index (Phase 1 of the
+// Wikipedia-style wiki IA reorg; see docs/specs/wiki-wikipedia-ia.md and
+// WIKI-SCHEMA.md §4.1).
+//
+// Categories are a many-to-many classification layer authored in each article's
+// `categories:` frontmatter. Markdown is the source of truth; the
+// article_categories rows the FactStore holds are a rebuildable cache. Like
+// every other index layer (facts/entities/edges/redirects) this folds into
+// CanonicalHashAll and is reproduced identically by a full
+// ReconcileFromMarkdown after `rm -rf index/` (the §7.4 substrate guarantee).
+//
+// Scope note: this slice indexes article→category memberships only. The
+// category→parent (subcategory tree) edges land with the category pages that
+// are their sole data source (a later phase); an empty parent table now would
+// be speculative plumbing, and CREATE TABLE IF NOT EXISTS keeps that addition
+// non-breaking.
+
+import "sort"
+
+// ArticleCategory is one (article, category) membership row in the derived
+// article_categories index. ArticlePath is the wiki-root-relative markdown path
+// (e.g. "team/companies/acme.md"); Category is a normalized category slug.
+type ArticleCategory struct {
+	ArticlePath string `json:"article_path"`
+	Category    string `json:"category"`
+}
+
+// CategoryCount is a category slug with the number of articles filed under it.
+// Returned by ListAllCategories; backs the category nav/API (Phase 2+).
+type CategoryCount struct {
+	Slug  string `json:"slug"`
+	Count int    `json:"count"`
+}
+
+// parseCategoriesFrontmatter extracts the `categories:` list from an article's
+// YAML frontmatter and normalizes it to stable, deduped, sorted category slugs.
+// Returns nil when the article has no frontmatter or no categories. Callers
+// treat nil as "clear this article's category rows" so removing a category from
+// frontmatter is reflected on the next reconcile.
+func parseCategoriesFrontmatter(body string) []string {
+	return categoriesFromFrontmatter(extractFrontmatter(body))
+}
+
+// categoriesFromFrontmatter is the same as parseCategoriesFrontmatter but takes
+// an already-extracted frontmatter block, so the reconcile path that already
+// parsed the frontmatter for entity fields does not re-scan the body.
+func categoriesFromFrontmatter(fm string) []string {
+	if fm == "" {
+		return nil
+	}
+	return normalizeCategories(frontmatterList(fm, "categories"))
+}
+
+// normalizeCategories slugifies each raw category value, drops blanks, dedupes,
+// and sorts ascending so the derived index is deterministic regardless of
+// authoring order or casing ("Revenue Operations" and "revenue-operations"
+// collapse to one slug). Returns nil for an empty input.
+func normalizeCategories(raw []string) []string {
+	if len(raw) == 0 {
+		return nil
+	}
+	seen := make(map[string]bool, len(raw))
+	out := make([]string, 0, len(raw))
+	for _, c := range raw {
+		slug := categorySlug(c)
+		if slug == "" || seen[slug] {
+			continue
+		}
+		seen[slug] = true
+		out = append(out, slug)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// categorySlug normalizes a single category label to a slug. It reuses the
+// package's shared slugify rules (lowercase, unicode letters/digits kept, runs
+// of separators collapsed to one dash) so a category slug is a valid
+// `_category/<slug>` nav path segment and matches entity/concept slug grammar.
+func categorySlug(s string) string {
+	return slugify(s)
+}

--- a/internal/team/wiki_categories.go
+++ b/internal/team/wiki_categories.go
@@ -17,7 +17,11 @@ package team
 // be speculative plumbing, and CREATE TABLE IF NOT EXISTS keeps that addition
 // non-breaking.
 
-import "sort"
+import (
+	"regexp"
+	"sort"
+	"strings"
+)
 
 // ArticleCategory is one (article, category) membership row in the derived
 // article_categories index. ArticlePath is the wiki-root-relative markdown path
@@ -32,6 +36,43 @@ type ArticleCategory struct {
 type CategoryCount struct {
 	Slug  string `json:"slug"`
 	Count int    `json:"count"`
+}
+
+// CategoryParent is one (category → parent) edge in the derived
+// category_parents index — the subcategory tree (DAG). Both are normalized
+// category slugs. Source of truth is a category page's `parent_categories:`
+// frontmatter at team/.categories/{slug}.md.
+type CategoryParent struct {
+	Category string `json:"category"`
+	Parent   string `json:"parent"`
+}
+
+// categoryPagePathRe matches a category page: team/.categories/{slug}.md, a
+// dot-prefixed directory so the pages stay out of the normal article tree.
+var categoryPagePathRe = regexp.MustCompile(`^team/\.categories/[^/]+\.md$`)
+
+// isCategoryPagePath reports whether relPath is a category-definition page.
+func isCategoryPagePath(relPath string) bool {
+	return categoryPagePathRe.MatchString(strings.TrimPrefix(relPath, "./"))
+}
+
+// categoryPageSlug extracts the normalized category slug from a category-page
+// path (team/.categories/sales.md → "sales").
+func categoryPageSlug(relPath string) string {
+	rel := strings.TrimPrefix(relPath, "./")
+	rel = strings.TrimPrefix(rel, "team/.categories/")
+	return categorySlug(strings.TrimSuffix(rel, ".md"))
+}
+
+// parseParentCategoriesFrontmatter extracts a category page's `parent_categories:`
+// list, normalized to stable, deduped, sorted slugs. Returns nil when absent —
+// callers treat nil as "this category has no parents" (a root).
+func parseParentCategoriesFrontmatter(body string) []string {
+	fm := extractFrontmatter(body)
+	if fm == "" {
+		return nil
+	}
+	return normalizeCategories(frontmatterList(fm, "parent_categories"))
 }
 
 // parseCategoriesFrontmatter extracts the `categories:` list from an article's

--- a/internal/team/wiki_categories_api.go
+++ b/internal/team/wiki_categories_api.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -38,11 +39,13 @@ const CategoryRefreshTimeout = 10 * time.Second
 const wikiCategoriesEventName = "wiki:categories_updated"
 
 // DiscoveredCategory is one category in the nav list: a slug, a display title
-// derived from it, and how many articles are filed under it.
+// derived from it, how many articles are filed under it, and its parent
+// categories (the subcategory tree). Parents is always present (possibly empty).
 type DiscoveredCategory struct {
-	Slug         string `json:"slug"`
-	Title        string `json:"title"`
-	ArticleCount int    `json:"article_count"`
+	Slug         string   `json:"slug"`
+	Title        string   `json:"title"`
+	ArticleCount int      `json:"article_count"`
+	Parents      []string `json:"parents"`
 }
 
 // CategoryArticle is one member of a category: its wiki-root-relative path plus
@@ -205,12 +208,44 @@ func (c *wikiCategoriesCache) refresh(ctx context.Context) {
 		log.Printf("wiki categories: list failed: %v", err)
 		return
 	}
-	cats := make([]DiscoveredCategory, 0, len(counts))
+	edges, err := idx.ListAllCategoryParents(callCtx)
+	if err != nil {
+		log.Printf("wiki categories: parents failed: %v", err)
+		return
+	}
+
+	// The category universe is every slug that has articles OR participates in a
+	// parent edge — so parent categories appear in the tree even before any
+	// article is filed under them.
+	countBySlug := make(map[string]int, len(counts))
+	universe := make(map[string]struct{}, len(counts))
 	for _, cc := range counts {
+		countBySlug[cc.Slug] = cc.Count
+		universe[cc.Slug] = struct{}{}
+	}
+	parentsBySlug := make(map[string][]string)
+	for _, e := range edges {
+		parentsBySlug[e.Category] = append(parentsBySlug[e.Category], e.Parent)
+		universe[e.Category] = struct{}{}
+		universe[e.Parent] = struct{}{}
+	}
+	slugs := make([]string, 0, len(universe))
+	for slug := range universe {
+		slugs = append(slugs, slug)
+	}
+	sort.Strings(slugs)
+
+	cats := make([]DiscoveredCategory, 0, len(slugs))
+	for _, slug := range slugs {
+		parents := parentsBySlug[slug] // already parent-sorted (edges come sorted)
+		if parents == nil {
+			parents = []string{}
+		}
 		cats = append(cats, DiscoveredCategory{
-			Slug:         cc.Slug,
-			Title:        categoryTitleFromSlug(cc.Slug),
-			ArticleCount: cc.Count,
+			Slug:         slug,
+			Title:        categoryTitleFromSlug(slug),
+			ArticleCount: countBySlug[slug],
+			Parents:      parents,
 		})
 	}
 
@@ -241,7 +276,7 @@ func (c *wikiCategoriesCache) resolveIndex() *WikiIndex {
 func categoriesSignature(cats []DiscoveredCategory) string {
 	parts := make([]string, 0, len(cats))
 	for _, c := range cats {
-		parts = append(parts, fmt.Sprintf("%s:%d", c.Slug, c.ArticleCount))
+		parts = append(parts, fmt.Sprintf("%s:%d:%s", c.Slug, c.ArticleCount, strings.Join(c.Parents, ",")))
 	}
 	return strings.Join(parts, "|")
 }

--- a/internal/team/wiki_categories_api.go
+++ b/internal/team/wiki_categories_api.go
@@ -1,0 +1,397 @@
+package team
+
+// wiki_categories_api.go — the read API + live cache for the Wikipedia-style
+// category layer (Phase 2; see docs/specs/wiki-wikipedia-ia.md).
+//
+// Categories are a many-to-many classification authored in each article's
+// `categories:` frontmatter and held in the derived article_categories index
+// (Phase 1). This file surfaces that index over HTTP, mirroring the
+// /wiki/sections cache + SSE shape:
+//
+//   - GET /wiki/categories        → the cached category list (slug, title, count)
+//   - GET /wiki/categories/{slug} → that category's member articles (live query)
+//
+// The list is served from a debounced in-memory cache fed by wiki:write events,
+// and a wiki:categories_updated SSE event fires whenever the set changes — the
+// same machinery as wikiSectionsCache, so the frontend nav can hot-swap.
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+// CategoriesRefreshDebounce bounds how often the category list recomputes under
+// a burst of wiki:write events. Matches the sections debounce so the two
+// background loops keep the same cadence.
+const CategoriesRefreshDebounce = 500 * time.Millisecond
+
+// CategoryRefreshTimeout bounds one category-list recompute (an index query).
+const CategoryRefreshTimeout = 10 * time.Second
+
+// wikiCategoriesEventName is the SSE event emitted when the cached category set
+// changes shape. Narrower than wiki:write so the nav can subscribe directly.
+const wikiCategoriesEventName = "wiki:categories_updated"
+
+// DiscoveredCategory is one category in the nav list: a slug, a display title
+// derived from it, and how many articles are filed under it.
+type DiscoveredCategory struct {
+	Slug         string `json:"slug"`
+	Title        string `json:"title"`
+	ArticleCount int    `json:"article_count"`
+}
+
+// CategoryArticle is one member of a category: its wiki-root-relative path plus
+// its display title (first H1, falling back to the filename).
+type CategoryArticle struct {
+	Path  string `json:"path"`
+	Title string `json:"title"`
+}
+
+// CategoryDetail is the GET /wiki/categories/{slug} response: the category and
+// its member articles, sorted by path.
+type CategoryDetail struct {
+	Slug     string            `json:"slug"`
+	Title    string            `json:"title"`
+	Articles []CategoryArticle `json:"articles"`
+}
+
+// WikiCategoriesUpdatedEvent is the SSE payload broadcast when the cached
+// category list changes. The full list ships so the UI can hot-swap without a
+// follow-up request.
+type WikiCategoriesUpdatedEvent struct {
+	Categories []DiscoveredCategory `json:"categories"`
+	Timestamp  string               `json:"timestamp"`
+}
+
+// categoryTitleFromSlug renders a human title for a category slug, reusing the
+// same slug→Title casing as wiki sections ("revenue-operations" → "Revenue
+// Operations").
+func categoryTitleFromSlug(slug string) string {
+	return sectionTitleFromSlug(slug)
+}
+
+// wikiCategoriesCache is the debounced in-memory cache + SSE fan-out behind
+// GET /wiki/categories. One per broker; lives as long as the broker. It reads
+// the derived article_categories index (markdown-authoritative) rather than
+// walking the filesystem.
+type wikiCategoriesCache struct {
+	index     func() *WikiIndex
+	publisher wikiCategoriesPublisher
+
+	mu         sync.RWMutex
+	categories []DiscoveredCategory
+	lastSig    string
+
+	stopCh    chan struct{}
+	runMu     sync.Mutex
+	refreshCh chan struct{}
+	stopped   bool
+}
+
+// wikiCategoriesPublisher is the subset of Broker the cache needs, kept as an
+// interface so the cache is testable without an HTTP server.
+type wikiCategoriesPublisher interface {
+	PublishWikiCategoriesUpdated(evt WikiCategoriesUpdatedEvent)
+}
+
+// newWikiCategoriesCache wires a cache against an index resolver (a closure so
+// it picks up the index lazily — the index may be built after the cache).
+func newWikiCategoriesCache(index func() *WikiIndex, publisher wikiCategoriesPublisher) *wikiCategoriesCache {
+	return &wikiCategoriesCache{
+		index:     index,
+		publisher: publisher,
+		refreshCh: make(chan struct{}, 1),
+	}
+}
+
+// Start kicks off the debounce loop after one immediate compute so the cache is
+// warm before the first request.
+func (c *wikiCategoriesCache) Start(ctx context.Context) {
+	c.runMu.Lock()
+	if c.stopCh != nil {
+		c.runMu.Unlock()
+		return
+	}
+	c.stopCh = make(chan struct{})
+	c.runMu.Unlock()
+
+	c.refresh(ctx)
+	go c.loop(ctx)
+}
+
+// Stop signals the debounce loop to exit. Idempotent.
+func (c *wikiCategoriesCache) Stop() {
+	c.runMu.Lock()
+	defer c.runMu.Unlock()
+	if c.stopped || c.stopCh == nil {
+		return
+	}
+	c.stopped = true
+	close(c.stopCh)
+}
+
+// Enqueue is the non-blocking signal poked on every wiki:write. A pending token
+// coalesces multiple writes into one refresh.
+func (c *wikiCategoriesCache) Enqueue() {
+	select {
+	case c.refreshCh <- struct{}{}:
+	default:
+	}
+}
+
+// Categories returns a copy of the current cached list.
+func (c *wikiCategoriesCache) Categories() []DiscoveredCategory {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if len(c.categories) == 0 {
+		return []DiscoveredCategory{}
+	}
+	out := make([]DiscoveredCategory, len(c.categories))
+	copy(out, c.categories)
+	return out
+}
+
+// loop is the debounce drain — same shape as wikiSectionsCache.loop.
+func (c *wikiCategoriesCache) loop(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-c.stopCh:
+			return
+		case <-c.refreshCh:
+			timer := time.NewTimer(CategoriesRefreshDebounce)
+		waitLoop:
+			for {
+				select {
+				case <-ctx.Done():
+					timer.Stop()
+					return
+				case <-c.stopCh:
+					timer.Stop()
+					return
+				case <-c.refreshCh:
+					if !timer.Stop() {
+						<-timer.C
+					}
+					timer.Reset(CategoriesRefreshDebounce)
+				case <-timer.C:
+					break waitLoop
+				}
+			}
+			c.refresh(ctx)
+		}
+	}
+}
+
+// refresh recomputes the category list from the index and publishes a SSE event
+// when the set changed. A nil index (markdown backend off) or query error
+// leaves the last-known cache intact.
+func (c *wikiCategoriesCache) refresh(ctx context.Context) {
+	idx := c.resolveIndex()
+	if idx == nil {
+		return
+	}
+	callCtx, cancel := context.WithTimeout(ctx, CategoryRefreshTimeout)
+	defer cancel()
+
+	counts, err := idx.ListAllCategories(callCtx)
+	if err != nil {
+		log.Printf("wiki categories: list failed: %v", err)
+		return
+	}
+	cats := make([]DiscoveredCategory, 0, len(counts))
+	for _, cc := range counts {
+		cats = append(cats, DiscoveredCategory{
+			Slug:         cc.Slug,
+			Title:        categoryTitleFromSlug(cc.Slug),
+			ArticleCount: cc.Count,
+		})
+	}
+
+	sig := categoriesSignature(cats)
+	c.mu.Lock()
+	changed := sig != c.lastSig
+	c.categories = cats
+	c.lastSig = sig
+	c.mu.Unlock()
+
+	if changed && c.publisher != nil {
+		c.publisher.PublishWikiCategoriesUpdated(WikiCategoriesUpdatedEvent{
+			Categories: cats,
+			Timestamp:  time.Now().UTC().Format(time.RFC3339),
+		})
+	}
+}
+
+func (c *wikiCategoriesCache) resolveIndex() *WikiIndex {
+	if c.index == nil {
+		return nil
+	}
+	return c.index()
+}
+
+// categoriesSignature is a compact fingerprint of the category set (slug+count),
+// so a write that doesn't change membership doesn't spam the SSE channel.
+func categoriesSignature(cats []DiscoveredCategory) string {
+	parts := make([]string, 0, len(cats))
+	for _, c := range cats {
+		parts = append(parts, fmt.Sprintf("%s:%d", c.Slug, c.ArticleCount))
+	}
+	return strings.Join(parts, "|")
+}
+
+// ── Broker wiring ────────────────────────────────────────────────────
+
+// SubscribeWikiCategoriesUpdated returns a channel of category-updated events
+// plus an unsubscribe func. Mirror of SubscribeWikiSectionsUpdated.
+func (b *Broker) SubscribeWikiCategoriesUpdated(buffer int) (<-chan WikiCategoriesUpdatedEvent, func()) {
+	if buffer <= 0 {
+		buffer = 16
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.wikiCategoriesSubscribers == nil {
+		b.wikiCategoriesSubscribers = make(map[int]chan WikiCategoriesUpdatedEvent)
+	}
+	id := b.nextSubscriberID
+	b.nextSubscriberID++
+	ch := make(chan WikiCategoriesUpdatedEvent, buffer)
+	b.wikiCategoriesSubscribers[id] = ch
+	return ch, func() {
+		b.mu.Lock()
+		if existing, ok := b.wikiCategoriesSubscribers[id]; ok {
+			delete(b.wikiCategoriesSubscribers, id)
+			close(existing)
+		}
+		b.mu.Unlock()
+	}
+}
+
+// PublishWikiCategoriesUpdated fans a category-updated event out to every
+// current SSE subscriber. Non-blocking per subscriber.
+func (b *Broker) PublishWikiCategoriesUpdated(evt WikiCategoriesUpdatedEvent) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	for _, ch := range b.wikiCategoriesSubscribers {
+		select {
+		case ch <- evt:
+		default:
+		}
+	}
+}
+
+// EnqueueCategoriesRefresh pokes the category cache after a wiki write. No-op
+// when the cache is not attached (tests, non-markdown backend).
+func (b *Broker) EnqueueCategoriesRefresh() {
+	b.mu.Lock()
+	cache := b.wikiCategoriesCache
+	b.mu.Unlock()
+	if cache == nil {
+		return
+	}
+	cache.Enqueue()
+}
+
+// WikiCategoriesCache returns the attached cache, or nil when the markdown
+// backend is not active. Primarily used by tests.
+func (b *Broker) WikiCategoriesCache() *wikiCategoriesCache {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.wikiCategoriesCache
+}
+
+// ensureWikiCategoriesCache wires the cache against the broker's wiki index.
+// Idempotent. Called alongside ensureWikiSectionsCache.
+func (b *Broker) ensureWikiCategoriesCache() {
+	b.mu.Lock()
+	if b.wikiCategoriesCache != nil {
+		b.mu.Unlock()
+		return
+	}
+	worker := b.wikiWorker
+	b.mu.Unlock()
+	if worker == nil {
+		return
+	}
+	cache := newWikiCategoriesCache(b.WikiIndex, b)
+	cache.Start(context.Background())
+
+	b.mu.Lock()
+	b.wikiCategoriesCache = cache
+	b.mu.Unlock()
+}
+
+// handleWikiCategories is GET /wiki/categories.
+//
+//	Response: { "categories": DiscoveredCategory[] }
+//
+// Served from the in-memory cache. 503 when the wiki backend is not active.
+func (b *Broker) handleWikiCategories(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	cache := b.WikiCategoriesCache()
+	if cache == nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "wiki backend is not active"})
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"categories": cache.Categories()})
+}
+
+// handleWikiCategory is GET /wiki/categories/{slug}.
+//
+//	Response: CategoryDetail
+//
+// Member articles are queried live from the index and enriched with titles.
+// 503 when the wiki backend is not active, 400 for an empty slug.
+func (b *Broker) handleWikiCategory(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	slug := strings.Trim(strings.TrimPrefix(r.URL.Path, "/wiki/categories/"), "/")
+	if slug == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "category slug is required"})
+		return
+	}
+	idx := b.WikiIndex()
+	worker := b.WikiWorker()
+	if idx == nil || worker == nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "wiki backend is not active"})
+		return
+	}
+	paths, err := idx.ListArticlesInCategory(r.Context(), slug)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	writeJSON(w, http.StatusOK, CategoryDetail{
+		Slug:     slug,
+		Title:    categoryTitleFromSlug(slug),
+		Articles: categoryArticles(worker.Repo(), paths),
+	})
+}
+
+// categoryArticles enriches member paths with their display titles. A missing
+// or unreadable article falls back to a filename-derived title rather than
+// dropping the row, so a mid-flight delete doesn't blank the listing.
+func categoryArticles(repo *Repo, paths []string) []CategoryArticle {
+	out := make([]CategoryArticle, 0, len(paths))
+	for _, p := range paths {
+		title := ""
+		if content, err := readArticle(repo, p); err == nil {
+			title = extractTitle(content, p)
+		} else {
+			title = extractTitle(nil, p)
+		}
+		out = append(out, CategoryArticle{Path: p, Title: title})
+	}
+	return out
+}

--- a/internal/team/wiki_categories_api_test.go
+++ b/internal/team/wiki_categories_api_test.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"sync"
 	"testing"
 )
@@ -66,16 +67,11 @@ func TestWikiCategoriesCacheRefresh(t *testing.T) {
 
 	got := cache.Categories()
 	want := []DiscoveredCategory{
-		{Slug: "ai-agents", Title: "Ai Agents", ArticleCount: 2},
-		{Slug: "revenue-operations", Title: "Revenue Operations", ArticleCount: 1},
+		{Slug: "ai-agents", Title: "Ai Agents", ArticleCount: 2, Parents: []string{}},
+		{Slug: "revenue-operations", Title: "Revenue Operations", ArticleCount: 1, Parents: []string{}},
 	}
-	if len(got) != len(want) {
+	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("Categories() = %+v, want %+v", got, want)
-	}
-	for i := range want {
-		if got[i] != want[i] {
-			t.Errorf("Categories()[%d] = %+v, want %+v", i, got[i], want[i])
-		}
 	}
 
 	// The empty→non-empty transition must have emitted exactly one event.
@@ -83,6 +79,35 @@ func TestWikiCategoriesCacheRefresh(t *testing.T) {
 		t.Error("expected a categories_updated event on first populate, got none")
 	} else if len(evts[len(evts)-1].Categories) != 2 {
 		t.Errorf("last event carried %d categories, want 2", len(evts[len(evts)-1].Categories))
+	}
+}
+
+func TestWikiCategoriesCacheTree(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	writeBrief(t, root, "team/.categories/sales.md",
+		"---\nparent_categories: [revenue]\n---\n# Sales\n")
+	writeBrief(t, root, "team/companies/acme.md",
+		"---\nkind: company\ncategories: [sales]\n---\n# Acme\n")
+
+	idx := NewWikiIndex(root)
+	defer idx.Close()
+	if err := idx.ReconcileFromMarkdown(ctx); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	cache := newWikiCategoriesCache(func() *WikiIndex { return idx }, nil)
+	cache.Start(ctx)
+	defer cache.Stop()
+
+	got := cache.Categories()
+	// "revenue" is parent-only (no articles) but appears in the tree universe;
+	// "sales" has one article and lists revenue as a parent.
+	want := []DiscoveredCategory{
+		{Slug: "revenue", Title: "Revenue", ArticleCount: 0, Parents: []string{}},
+		{Slug: "sales", Title: "Sales", ArticleCount: 1, Parents: []string{"revenue"}},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Categories() = %+v, want %+v", got, want)
 	}
 }
 

--- a/internal/team/wiki_categories_api_test.go
+++ b/internal/team/wiki_categories_api_test.go
@@ -1,0 +1,189 @@
+package team
+
+// wiki_categories_api_test.go — Phase 2 coverage for the category read API:
+// the debounced cache (list + SSE emit), the signature fingerprint, and the
+// two HTTP handlers (list + detail) including their 503/400 edges.
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+)
+
+func TestCategoriesSignature(t *testing.T) {
+	a := []DiscoveredCategory{{Slug: "ai-agents", ArticleCount: 2}, {Slug: "sales", ArticleCount: 1}}
+	b := []DiscoveredCategory{{Slug: "ai-agents", ArticleCount: 2}, {Slug: "sales", ArticleCount: 1}}
+	if categoriesSignature(a) != categoriesSignature(b) {
+		t.Error("identical category sets produced different signatures")
+	}
+	// A count change must move the signature (drives the SSE emit).
+	c := []DiscoveredCategory{{Slug: "ai-agents", ArticleCount: 3}, {Slug: "sales", ArticleCount: 1}}
+	if categoriesSignature(a) == categoriesSignature(c) {
+		t.Error("count change did not move the signature")
+	}
+}
+
+type recordingCategoriesPublisher struct {
+	mu     sync.Mutex
+	events []WikiCategoriesUpdatedEvent
+}
+
+func (r *recordingCategoriesPublisher) PublishWikiCategoriesUpdated(evt WikiCategoriesUpdatedEvent) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.events = append(r.events, evt)
+}
+
+func (r *recordingCategoriesPublisher) snapshot() []WikiCategoriesUpdatedEvent {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]WikiCategoriesUpdatedEvent, len(r.events))
+	copy(out, r.events)
+	return out
+}
+
+func TestWikiCategoriesCacheRefresh(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	writeBrief(t, root, "team/companies/acme.md",
+		"---\nkind: company\ncategories: [revenue-operations, ai-agents]\n---\n# Acme\n")
+	writeBrief(t, root, "team/concepts/mql.md",
+		"---\ntype: concept\ncategories: [ai-agents]\n---\n# MQL\n")
+
+	idx := NewWikiIndex(root)
+	defer idx.Close()
+	if err := idx.ReconcileFromMarkdown(ctx); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	recorder := &recordingCategoriesPublisher{}
+	cache := newWikiCategoriesCache(func() *WikiIndex { return idx }, recorder)
+	cache.Start(ctx) // synchronous initial compute
+	defer cache.Stop()
+
+	got := cache.Categories()
+	want := []DiscoveredCategory{
+		{Slug: "ai-agents", Title: "Ai Agents", ArticleCount: 2},
+		{Slug: "revenue-operations", Title: "Revenue Operations", ArticleCount: 1},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("Categories() = %+v, want %+v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("Categories()[%d] = %+v, want %+v", i, got[i], want[i])
+		}
+	}
+
+	// The empty→non-empty transition must have emitted exactly one event.
+	if evts := recorder.snapshot(); len(evts) == 0 {
+		t.Error("expected a categories_updated event on first populate, got none")
+	} else if len(evts[len(evts)-1].Categories) != 2 {
+		t.Errorf("last event carried %d categories, want 2", len(evts[len(evts)-1].Categories))
+	}
+}
+
+// brokerWithCategories builds a minimal in-package Broker wired with a populated
+// category cache + index + worker, enough to exercise the handlers directly.
+func brokerWithCategories(t *testing.T) (*Broker, *WikiIndex) {
+	t.Helper()
+	ctx := context.Background()
+	root := t.TempDir()
+	writeBrief(t, root, "team/companies/acme.md",
+		"---\nkind: company\ncategories: [ai-agents]\n---\n# Acme Corp\n\nBody.\n")
+	writeBrief(t, root, "team/concepts/mql.md",
+		"---\ntype: concept\ncategories: [ai-agents]\n---\n# Marketing Qualified Lead\n")
+
+	idx := NewWikiIndex(root)
+	t.Cleanup(func() { _ = idx.Close() })
+	if err := idx.ReconcileFromMarkdown(ctx); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	b := &Broker{}
+	b.wikiIndex = idx
+	b.wikiWorker = NewWikiWorker(NewRepoAt(root, t.TempDir()), noopPublisher{})
+	cache := newWikiCategoriesCache(func() *WikiIndex { return idx }, nil)
+	cache.Start(ctx)
+	t.Cleanup(cache.Stop)
+	b.wikiCategoriesCache = cache
+	return b, idx
+}
+
+func TestHandleWikiCategories(t *testing.T) {
+	b, _ := brokerWithCategories(t)
+
+	rr := httptest.NewRecorder()
+	b.handleWikiCategories(rr, httptest.NewRequest(http.MethodGet, "/wiki/categories", nil))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rr.Code, rr.Body.String())
+	}
+	var resp struct {
+		Categories []DiscoveredCategory `json:"categories"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Categories) != 1 || resp.Categories[0].Slug != "ai-agents" || resp.Categories[0].ArticleCount != 2 {
+		t.Fatalf("categories = %+v, want one ai-agents(count 2)", resp.Categories)
+	}
+
+	// No cache attached → 503.
+	empty := &Broker{}
+	rr2 := httptest.NewRecorder()
+	empty.handleWikiCategories(rr2, httptest.NewRequest(http.MethodGet, "/wiki/categories", nil))
+	if rr2.Code != http.StatusServiceUnavailable {
+		t.Errorf("nil-cache status = %d, want 503", rr2.Code)
+	}
+}
+
+func TestHandleWikiCategory(t *testing.T) {
+	b, _ := brokerWithCategories(t)
+
+	rr := httptest.NewRecorder()
+	b.handleWikiCategory(rr, httptest.NewRequest(http.MethodGet, "/wiki/categories/ai-agents", nil))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rr.Code, rr.Body.String())
+	}
+	var detail CategoryDetail
+	if err := json.Unmarshal(rr.Body.Bytes(), &detail); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if detail.Slug != "ai-agents" || detail.Title != "Ai Agents" {
+		t.Errorf("detail slug/title = %q/%q", detail.Slug, detail.Title)
+	}
+	if len(detail.Articles) != 2 {
+		t.Fatalf("articles = %+v, want 2", detail.Articles)
+	}
+	// Titles come from each article's H1, sorted by path (companies before concepts).
+	if detail.Articles[0].Path != "team/companies/acme.md" || detail.Articles[0].Title != "Acme Corp" {
+		t.Errorf("article[0] = %+v, want acme/Acme Corp", detail.Articles[0])
+	}
+	if detail.Articles[1].Path != "team/concepts/mql.md" || detail.Articles[1].Title != "Marketing Qualified Lead" {
+		t.Errorf("article[1] = %+v, want mql/Marketing Qualified Lead", detail.Articles[1])
+	}
+
+	// Empty slug → 400.
+	rr2 := httptest.NewRecorder()
+	b.handleWikiCategory(rr2, httptest.NewRequest(http.MethodGet, "/wiki/categories/", nil))
+	if rr2.Code != http.StatusBadRequest {
+		t.Errorf("empty-slug status = %d, want 400", rr2.Code)
+	}
+
+	// Unknown category → 200 with an empty article list (not an error).
+	rr3 := httptest.NewRecorder()
+	b.handleWikiCategory(rr3, httptest.NewRequest(http.MethodGet, "/wiki/categories/nope", nil))
+	if rr3.Code != http.StatusOK {
+		t.Fatalf("unknown-category status = %d, want 200", rr3.Code)
+	}
+	var empty CategoryDetail
+	if err := json.Unmarshal(rr3.Body.Bytes(), &empty); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(empty.Articles) != 0 {
+		t.Errorf("unknown category articles = %+v, want empty", empty.Articles)
+	}
+}

--- a/internal/team/wiki_categories_store.go
+++ b/internal/team/wiki_categories_store.go
@@ -1,0 +1,156 @@
+package team
+
+// wiki_categories_store.go — the in-memory FactStore implementation of the
+// category derived indexes (article→category memberships + category→parent
+// tree edges) plus the WikiIndex passthroughs that expose them. Split out of
+// wiki_index.go to keep that file within the file-size budget; the SQLite
+// implementation of the same methods lives in wiki_index_sqlite.go.
+
+import (
+	"context"
+	"sort"
+)
+
+// --- WikiIndex passthroughs --------------------------------------------------
+
+// ListAllCategories returns every category slug with its article count, sorted
+// by slug. Passthrough to the FactStore; backs GET /wiki/categories.
+func (w *WikiIndex) ListAllCategories(ctx context.Context) ([]CategoryCount, error) {
+	return w.store.ListAllCategories(ctx)
+}
+
+// ListArticlesInCategory returns the wiki-root-relative paths of every article
+// filed under a category slug, sorted. Passthrough to the FactStore; backs
+// GET /wiki/categories/{slug}.
+func (w *WikiIndex) ListArticlesInCategory(ctx context.Context, category string) ([]string, error) {
+	return w.store.ListArticlesInCategory(ctx, category)
+}
+
+// ListAllCategoryParents returns every category→parent edge (the subcategory
+// tree). Passthrough to the FactStore; backs GET /wiki/categories tree.
+func (w *WikiIndex) ListAllCategoryParents(ctx context.Context) ([]CategoryParent, error) {
+	return w.store.ListAllCategoryParents(ctx)
+}
+
+// ListCategoryParents returns a single category's parents. Passthrough.
+func (w *WikiIndex) ListCategoryParents(ctx context.Context, category string) ([]string, error) {
+	return w.store.ListCategoryParents(ctx, category)
+}
+
+// --- inMemoryFactStore: article_categories + category_parents ---------------
+
+func (s *inMemoryFactStore) UpsertArticleCategories(_ context.Context, articlePath string, categories []string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(categories) == 0 {
+		delete(s.articleCats, articlePath)
+		return nil
+	}
+	set := make(map[string]bool, len(categories))
+	for _, c := range categories {
+		if c != "" {
+			set[c] = true
+		}
+	}
+	if len(set) == 0 {
+		delete(s.articleCats, articlePath)
+		return nil
+	}
+	s.articleCats[articlePath] = set
+	return nil
+}
+
+func (s *inMemoryFactStore) ListArticlesInCategory(_ context.Context, category string) ([]string, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	var out []string
+	for path, set := range s.articleCats {
+		if set[category] {
+			out = append(out, path)
+		}
+	}
+	sort.Strings(out)
+	return out, nil
+}
+
+func (s *inMemoryFactStore) ListCategoriesForArticle(_ context.Context, articlePath string) ([]string, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	set := s.articleCats[articlePath]
+	if len(set) == 0 {
+		return nil, nil
+	}
+	out := make([]string, 0, len(set))
+	for c := range set {
+		out = append(out, c)
+	}
+	sort.Strings(out)
+	return out, nil
+}
+
+func (s *inMemoryFactStore) ListAllCategories(_ context.Context) ([]CategoryCount, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	counts := map[string]int{}
+	for _, set := range s.articleCats {
+		for c := range set {
+			counts[c]++
+		}
+	}
+	out := make([]CategoryCount, 0, len(counts))
+	for slug, n := range counts {
+		out = append(out, CategoryCount{Slug: slug, Count: n})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Slug < out[j].Slug })
+	return out, nil
+}
+
+func (s *inMemoryFactStore) UpsertCategoryParents(_ context.Context, category string, parents []string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	set := make(map[string]bool, len(parents))
+	for _, p := range parents {
+		if p != "" {
+			set[p] = true
+		}
+	}
+	if len(set) == 0 {
+		delete(s.categoryParents, category)
+		return nil
+	}
+	s.categoryParents[category] = set
+	return nil
+}
+
+func (s *inMemoryFactStore) ListCategoryParents(_ context.Context, category string) ([]string, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	set := s.categoryParents[category]
+	if len(set) == 0 {
+		return nil, nil
+	}
+	out := make([]string, 0, len(set))
+	for p := range set {
+		out = append(out, p)
+	}
+	sort.Strings(out)
+	return out, nil
+}
+
+func (s *inMemoryFactStore) ListAllCategoryParents(_ context.Context) ([]CategoryParent, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	var out []CategoryParent
+	for cat, set := range s.categoryParents {
+		for p := range set {
+			out = append(out, CategoryParent{Category: cat, Parent: p})
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Category != out[j].Category {
+			return out[i].Category < out[j].Category
+		}
+		return out[i].Parent < out[j].Parent
+	})
+	return out, nil
+}

--- a/internal/team/wiki_categories_test.go
+++ b/internal/team/wiki_categories_test.go
@@ -270,6 +270,51 @@ func TestBuildArticle_Categories(t *testing.T) {
 	}
 }
 
+func TestBuildCatalog_Categories(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	root := t.TempDir()
+	repo := NewRepoAt(root, filepath.Join(t.TempDir(), "bak"))
+	ctx := context.Background()
+	if err := repo.Init(ctx); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+
+	// A playbook filed into People via categories — folder is playbooks but the
+	// catalog entry must carry the real category so cross-folder nav works.
+	withCats := "---\ncategories: [people, revenue-operations]\n---\n# Hiring Loop\n"
+	if _, _, err := repo.Commit(ctx, "ceo", "team/playbooks/hiring-loop.md", withCats, "create", "add"); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+	bare := "# Bare\n\nNo frontmatter.\n"
+	if _, _, err := repo.Commit(ctx, "ceo", "team/people/zoe.md", bare, "create", "add"); err != nil {
+		t.Fatalf("commit bare: %v", err)
+	}
+
+	entries, err := repo.BuildCatalog(ctx, "", nil, false)
+	if err != nil {
+		t.Fatalf("BuildCatalog: %v", err)
+	}
+	byPath := map[string]CatalogEntry{}
+	for _, e := range entries {
+		byPath[e.Path] = e
+	}
+
+	hiring, ok := byPath["team/playbooks/hiring-loop.md"]
+	if !ok {
+		t.Fatalf("hiring-loop not in catalog: %+v", entries)
+	}
+	if !reflect.DeepEqual(hiring.Categories, []string{"people", "revenue-operations"}) {
+		t.Errorf("hiring Categories = %v, want [people revenue-operations]", hiring.Categories)
+	}
+	// An article without categories carries a non-nil empty slice (stable JSON).
+	zoe := byPath["team/people/zoe.md"]
+	if zoe.Categories == nil || len(zoe.Categories) != 0 {
+		t.Errorf("zoe Categories = %v, want non-nil empty slice", zoe.Categories)
+	}
+}
+
 // --- helpers --------------------------------------------------------------
 
 func writeBrief(t *testing.T, root, rel, content string) {

--- a/internal/team/wiki_categories_test.go
+++ b/internal/team/wiki_categories_test.go
@@ -1,0 +1,312 @@
+package team
+
+// wiki_categories_test.go — Phase 1 coverage for the article→category derived
+// index: frontmatter parsing, store round-trips on BOTH backends, the §7.4
+// rm-rf rebuild-equality contract with categories present, backend hash
+// parity, and BuildArticle surfacing categories from frontmatter.
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestParseCategoriesFrontmatter(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want []string
+	}{
+		{"none", "# Title\n\nNo frontmatter.\n", nil},
+		{"empty list", "---\ncategories: []\n---\n# T\n", nil},
+		{
+			"inline bracket",
+			"---\ncategories: [revenue-operations, ai-agents]\n---\n# T\n",
+			[]string{"ai-agents", "revenue-operations"}, // sorted
+		},
+		{
+			"block list",
+			"---\ncategories:\n  - Revenue Operations\n  - AI Agents\n---\n# T\n",
+			[]string{"ai-agents", "revenue-operations"},
+		},
+		{
+			"bare scalar",
+			"---\ncategories: Sales\n---\n# T\n",
+			[]string{"sales"},
+		},
+		{
+			"dedup + casing collapse",
+			"---\ncategories: [Sales, sales, SALES]\n---\n# T\n",
+			[]string{"sales"},
+		},
+		{
+			"other frontmatter keys ignored",
+			"---\nkind: company\ncategories: [b2b]\naliases:\n  - x\n---\n# T\n",
+			[]string{"b2b"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseCategoriesFrontmatter(tc.body)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("parseCategoriesFrontmatter() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// storeFactory builds a fresh FactStore for the backend-parameterized tests.
+type storeFactory struct {
+	name string
+	make func(t *testing.T) FactStore
+}
+
+func categoryStoreFactories() []storeFactory {
+	return []storeFactory{
+		{"inmemory", func(*testing.T) FactStore { return newInMemoryFactStore() }},
+		{"sqlite", func(t *testing.T) FactStore {
+			s, err := NewSQLiteFactStore(filepath.Join(t.TempDir(), "cat.sqlite"))
+			if err != nil {
+				t.Fatalf("NewSQLiteFactStore: %v", err)
+			}
+			t.Cleanup(func() { _ = s.Close() })
+			return s
+		}},
+	}
+}
+
+func TestArticleCategories_StoreRoundtrip(t *testing.T) {
+	ctx := context.Background()
+	for _, sf := range categoryStoreFactories() {
+		t.Run(sf.name, func(t *testing.T) {
+			s := sf.make(t)
+
+			// Two articles share "ai-agents"; one also has "revenue-operations".
+			if err := s.UpsertArticleCategories(ctx, "team/companies/acme.md", []string{"ai-agents", "revenue-operations"}); err != nil {
+				t.Fatalf("upsert acme: %v", err)
+			}
+			if err := s.UpsertArticleCategories(ctx, "team/concepts/mql.md", []string{"ai-agents"}); err != nil {
+				t.Fatalf("upsert mql: %v", err)
+			}
+
+			assertSlice(t, "articles in ai-agents", listArticles(t, ctx, s, "ai-agents"),
+				[]string{"team/companies/acme.md", "team/concepts/mql.md"})
+			assertSlice(t, "articles in revenue-operations", listArticles(t, ctx, s, "revenue-operations"),
+				[]string{"team/companies/acme.md"})
+			assertSlice(t, "categories for acme", listCats(t, ctx, s, "team/companies/acme.md"),
+				[]string{"ai-agents", "revenue-operations"})
+
+			all, err := s.ListAllCategories(ctx)
+			if err != nil {
+				t.Fatalf("ListAllCategories: %v", err)
+			}
+			want := []CategoryCount{{Slug: "ai-agents", Count: 2}, {Slug: "revenue-operations", Count: 1}}
+			if !reflect.DeepEqual(all, want) {
+				t.Errorf("ListAllCategories = %v, want %v", all, want)
+			}
+
+			// Set-replace: re-upsert acme with a different set; old rows drop.
+			if err := s.UpsertArticleCategories(ctx, "team/companies/acme.md", []string{"b2b"}); err != nil {
+				t.Fatalf("re-upsert acme: %v", err)
+			}
+			assertSlice(t, "acme after replace", listCats(t, ctx, s, "team/companies/acme.md"), []string{"b2b"})
+			assertSlice(t, "revenue-operations now empty", listArticles(t, ctx, s, "revenue-operations"), nil)
+
+			// Clear: empty set removes all rows for the article.
+			if err := s.UpsertArticleCategories(ctx, "team/companies/acme.md", nil); err != nil {
+				t.Fatalf("clear acme: %v", err)
+			}
+			assertSlice(t, "acme cleared", listCats(t, ctx, s, "team/companies/acme.md"), nil)
+			assertSlice(t, "b2b empty after clear", listArticles(t, ctx, s, "b2b"), nil)
+		})
+	}
+}
+
+// TestWikiIndex_CategoriesReconcileAndRebuild proves the reconcile hook
+// populates article_categories from frontmatter, the §7.4 hash is stable across
+// a full rm-rf rebuild WITH categories present, and a frontmatter mutation moves
+// the hash (the category layer participates in drift detection).
+func TestWikiIndex_CategoriesReconcileAndRebuild(t *testing.T) {
+	ctx := context.Background()
+	for _, sf := range categoryStoreFactories() {
+		t.Run(sf.name, func(t *testing.T) {
+			root := t.TempDir()
+			writeBrief(t, root, "team/companies/acme.md",
+				"---\nkind: company\ncategories: [revenue-operations, ai-agents]\n---\n# Acme\n")
+			writeBrief(t, root, "team/concepts/mql.md",
+				"---\ntype: concept\ncategories:\n  - AI Agents\n---\n# MQL\n")
+
+			store1 := sf.make(t)
+			idx1 := NewWikiIndex(root, WithFactStore(store1))
+			if err := idx1.ReconcileFromMarkdown(ctx); err != nil {
+				t.Fatalf("reconcile 1: %v", err)
+			}
+
+			// Memberships landed, keyed by wiki-root-relative path.
+			assertSlice(t, "ai-agents members", listArticles(t, ctx, store1, "ai-agents"),
+				[]string{"team/companies/acme.md", "team/concepts/mql.md"})
+			assertSlice(t, "revenue-operations members", listArticles(t, ctx, store1, "revenue-operations"),
+				[]string{"team/companies/acme.md"})
+
+			h1, err := idx1.CanonicalHashAll(ctx)
+			if err != nil {
+				t.Fatalf("hash 1: %v", err)
+			}
+
+			// rm -rf index: rebuild from the same markdown into a fresh store.
+			store2 := sf.make(t)
+			idx2 := NewWikiIndex(root, WithFactStore(store2))
+			if err := idx2.ReconcileFromMarkdown(ctx); err != nil {
+				t.Fatalf("reconcile 2: %v", err)
+			}
+			h2, err := idx2.CanonicalHashAll(ctx)
+			if err != nil {
+				t.Fatalf("hash 2: %v", err)
+			}
+			if h1 != h2 {
+				t.Errorf("CanonicalHashAll drift after rebuild with categories: %s -> %s", h1, h2)
+			}
+
+			// Mutate acme's categories on disk; the hash must move (category
+			// layer is covered, not silently dropped).
+			writeBrief(t, root, "team/companies/acme.md",
+				"---\nkind: company\ncategories: [revenue-operations]\n---\n# Acme\n")
+			store3 := sf.make(t)
+			idx3 := NewWikiIndex(root, WithFactStore(store3))
+			if err := idx3.ReconcileFromMarkdown(ctx); err != nil {
+				t.Fatalf("reconcile 3: %v", err)
+			}
+			h3, err := idx3.CanonicalHashAll(ctx)
+			if err != nil {
+				t.Fatalf("hash 3: %v", err)
+			}
+			if h1 == h3 {
+				t.Error("CanonicalHashAll unchanged after category mutation (layer not covered)")
+			}
+			// acme no longer carries ai-agents; mql still does.
+			assertSlice(t, "ai-agents after mutation", listArticles(t, ctx, store3, "ai-agents"),
+				[]string{"team/concepts/mql.md"})
+		})
+	}
+}
+
+// TestWikiIndex_CategoriesHashBackendParity locks the §7.4 promise that the
+// canonical hash is backend-agnostic: the same markdown corpus yields the same
+// CanonicalHashAll on the in-memory and SQLite stores once categories exist.
+func TestWikiIndex_CategoriesHashBackendParity(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	writeBrief(t, root, "team/companies/acme.md",
+		"---\ncanonical_slug: acme\nkind: company\ncategories: [revenue-operations, ai-agents]\n---\n# Acme\n")
+	writeBrief(t, root, "team/concepts/mql.md",
+		"---\ntype: concept\ncategories: [ai-agents]\n---\n# MQL\n")
+
+	mem := newInMemoryFactStore()
+	idxMem := NewWikiIndex(root, WithFactStore(mem))
+	if err := idxMem.ReconcileFromMarkdown(ctx); err != nil {
+		t.Fatalf("reconcile in-memory: %v", err)
+	}
+	hMem, err := idxMem.CanonicalHashAll(ctx)
+	if err != nil {
+		t.Fatalf("hash in-memory: %v", err)
+	}
+
+	sq, err := NewSQLiteFactStore(filepath.Join(t.TempDir(), "parity.sqlite"))
+	if err != nil {
+		t.Fatalf("NewSQLiteFactStore: %v", err)
+	}
+	defer func() { _ = sq.Close() }()
+	idxSq := NewWikiIndex(root, WithFactStore(sq))
+	if err := idxSq.ReconcileFromMarkdown(ctx); err != nil {
+		t.Fatalf("reconcile sqlite: %v", err)
+	}
+	hSq, err := idxSq.CanonicalHashAll(ctx)
+	if err != nil {
+		t.Fatalf("hash sqlite: %v", err)
+	}
+
+	if hMem != hSq {
+		t.Errorf("CanonicalHashAll backend mismatch: in-memory %s != sqlite %s", hMem, hSq)
+	}
+}
+
+func TestBuildArticle_Categories(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	root := t.TempDir()
+	repo := NewRepoAt(root, filepath.Join(t.TempDir(), "bak"))
+	ctx := context.Background()
+	if err := repo.Init(ctx); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+
+	withCats := "---\ncategories: [Revenue Operations, ai-agents]\n---\n# Acme\n\nBody.\n"
+	if _, _, err := repo.Commit(ctx, "archivist", "team/companies/acme.md", withCats, "create", "add acme"); err != nil {
+		t.Fatalf("commit acme: %v", err)
+	}
+	noCats := "# Bare\n\nNo frontmatter here.\n"
+	if _, _, err := repo.Commit(ctx, "archivist", "team/companies/bare.md", noCats, "create", "add bare"); err != nil {
+		t.Fatalf("commit bare: %v", err)
+	}
+
+	meta, err := repo.BuildArticle(ctx, "team/companies/acme.md", "", nil)
+	if err != nil {
+		t.Fatalf("BuildArticle acme: %v", err)
+	}
+	if !reflect.DeepEqual(meta.Categories, []string{"ai-agents", "revenue-operations"}) {
+		t.Errorf("acme Categories = %v, want [ai-agents revenue-operations]", meta.Categories)
+	}
+
+	bare, err := repo.BuildArticle(ctx, "team/companies/bare.md", "", nil)
+	if err != nil {
+		t.Fatalf("BuildArticle bare: %v", err)
+	}
+	// No categories declared → empty, non-nil slice (stable JSON shape).
+	if bare.Categories == nil || len(bare.Categories) != 0 {
+		t.Errorf("bare Categories = %v, want non-nil empty slice", bare.Categories)
+	}
+}
+
+// --- helpers --------------------------------------------------------------
+
+func writeBrief(t *testing.T, root, rel, content string) {
+	t.Helper()
+	abs := filepath.Join(root, filepath.FromSlash(rel))
+	if err := os.MkdirAll(filepath.Dir(abs), 0o755); err != nil {
+		t.Fatalf("mkdir for %s: %v", rel, err)
+	}
+	if err := os.WriteFile(abs, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", rel, err)
+	}
+}
+
+func listArticles(t *testing.T, ctx context.Context, s FactStore, cat string) []string {
+	t.Helper()
+	got, err := s.ListArticlesInCategory(ctx, cat)
+	if err != nil {
+		t.Fatalf("ListArticlesInCategory(%q): %v", cat, err)
+	}
+	return got
+}
+
+func listCats(t *testing.T, ctx context.Context, s FactStore, path string) []string {
+	t.Helper()
+	got, err := s.ListCategoriesForArticle(ctx, path)
+	if err != nil {
+		t.Fatalf("ListCategoriesForArticle(%q): %v", path, err)
+	}
+	return got
+}
+
+func assertSlice(t *testing.T, label string, got, want []string) {
+	t.Helper()
+	if len(got) == 0 && len(want) == 0 {
+		return
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("%s = %v, want %v", label, got, want)
+	}
+}

--- a/internal/team/wiki_category_tree_test.go
+++ b/internal/team/wiki_category_tree_test.go
@@ -1,0 +1,246 @@
+package team
+
+// wiki_category_tree_test.go — Phase 3b coverage for the category_parents
+// derived index (the subcategory tree): frontmatter parsing, path detection,
+// store round-trips on both backends, the rm-rf rebuild + backend-parity
+// contract, and the guarantee that a category page is NOT indexed as an entity
+// or article.
+
+import (
+	"context"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestParseParentCategoriesFrontmatter(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want []string
+	}{
+		{"none", "# Sales\n\nA category.\n", nil},
+		{"inline", "---\nparent_categories: [revenue, gtm]\n---\n# T\n", []string{"gtm", "revenue"}},
+		{"block + casing", "---\nparent_categories:\n  - Revenue\n  - GTM\n---\n# T\n", []string{"gtm", "revenue"}},
+		{"dedup", "---\nparent_categories: [revenue, Revenue]\n---\n# T\n", []string{"revenue"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := parseParentCategoriesFrontmatter(tc.body); !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("parseParentCategoriesFrontmatter() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsCategoryPagePath(t *testing.T) {
+	cases := []struct {
+		path string
+		ok   bool
+		slug string
+	}{
+		{"team/.categories/sales.md", true, "sales"},
+		{"team/.categories/revenue-operations.md", true, "revenue-operations"},
+		{"team/companies/acme.md", false, ""},
+		{"team/.categories/sub/nested.md", false, ""}, // only direct children
+		{"team/people/bob.md", false, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.path, func(t *testing.T) {
+			if got := isCategoryPagePath(tc.path); got != tc.ok {
+				t.Errorf("isCategoryPagePath(%q) = %v, want %v", tc.path, got, tc.ok)
+			}
+			if tc.ok {
+				if got := categoryPageSlug(tc.path); got != tc.slug {
+					t.Errorf("categoryPageSlug(%q) = %q, want %q", tc.path, got, tc.slug)
+				}
+			}
+		})
+	}
+}
+
+func TestCategoryParents_StoreRoundtrip(t *testing.T) {
+	ctx := context.Background()
+	for _, sf := range categoryStoreFactories() {
+		t.Run(sf.name, func(t *testing.T) {
+			s := sf.make(t)
+			if err := s.UpsertCategoryParents(ctx, "sales", []string{"revenue", "gtm"}); err != nil {
+				t.Fatalf("upsert sales: %v", err)
+			}
+			if err := s.UpsertCategoryParents(ctx, "marketing", []string{"gtm"}); err != nil {
+				t.Fatalf("upsert marketing: %v", err)
+			}
+
+			parents, err := s.ListCategoryParents(ctx, "sales")
+			if err != nil {
+				t.Fatalf("list parents: %v", err)
+			}
+			if !reflect.DeepEqual(parents, []string{"gtm", "revenue"}) {
+				t.Errorf("sales parents = %v, want [gtm revenue]", parents)
+			}
+
+			all, err := s.ListAllCategoryParents(ctx)
+			if err != nil {
+				t.Fatalf("list all: %v", err)
+			}
+			want := []CategoryParent{
+				{Category: "marketing", Parent: "gtm"},
+				{Category: "sales", Parent: "gtm"},
+				{Category: "sales", Parent: "revenue"},
+			}
+			if !reflect.DeepEqual(all, want) {
+				t.Errorf("all parents = %v, want %v", all, want)
+			}
+
+			// Set-replace, then clear.
+			if err := s.UpsertCategoryParents(ctx, "sales", []string{"revenue"}); err != nil {
+				t.Fatalf("replace: %v", err)
+			}
+			if p, _ := s.ListCategoryParents(ctx, "sales"); !reflect.DeepEqual(p, []string{"revenue"}) {
+				t.Errorf("after replace = %v, want [revenue]", p)
+			}
+			if err := s.UpsertCategoryParents(ctx, "sales", nil); err != nil {
+				t.Fatalf("clear: %v", err)
+			}
+			if p, _ := s.ListCategoryParents(ctx, "sales"); len(p) != 0 {
+				t.Errorf("after clear = %v, want empty", p)
+			}
+		})
+	}
+}
+
+// TestWikiIndex_CategoryTreeReconcileAndRebuild proves a category page's
+// parent_categories reconcile into category_parents, the page is NOT indexed as
+// an entity or article, the §7.4 hash is stable across rebuild + backend, and a
+// frontmatter edit moves the hash.
+func TestWikiIndex_CategoryTreeReconcileAndRebuild(t *testing.T) {
+	ctx := context.Background()
+	build := func(t *testing.T, store FactStore, root string) (*WikiIndex, string) {
+		idx := NewWikiIndex(root, WithFactStore(store))
+		if err := idx.ReconcileFromMarkdown(ctx); err != nil {
+			t.Fatalf("reconcile: %v", err)
+		}
+		h, err := idx.CanonicalHashAll(ctx)
+		if err != nil {
+			t.Fatalf("hash: %v", err)
+		}
+		return idx, h
+	}
+
+	for _, sf := range categoryStoreFactories() {
+		t.Run(sf.name, func(t *testing.T) {
+			root := t.TempDir()
+			// A category page with parents + an ordinary article filed into it.
+			writeBrief(t, root, "team/.categories/sales.md",
+				"---\nparent_categories: [revenue, gtm]\n---\n# Sales\n\nDeals.\n")
+			writeBrief(t, root, "team/companies/acme.md",
+				"---\nkind: company\ncategories: [sales]\n---\n# Acme\n")
+
+			store1 := sf.make(t)
+			idx1, h1 := build(t, store1, root)
+
+			edges, err := idx1.ListAllCategoryParents(ctx)
+			if err != nil {
+				t.Fatalf("edges: %v", err)
+			}
+			want := []CategoryParent{{Category: "sales", Parent: "gtm"}, {Category: "sales", Parent: "revenue"}}
+			if !reflect.DeepEqual(edges, want) {
+				t.Errorf("edges = %v, want %v", edges, want)
+			}
+
+			// The category page is NOT an article (no article_categories rows)…
+			if cats, _ := store1.ListCategoriesForArticle(ctx, "team/.categories/sales.md"); len(cats) != 0 {
+				t.Errorf("category page got article_categories rows: %v", cats)
+			}
+			// …and NOT an entity.
+			entityCount := 0
+			_ = store1.IterateEntities(ctx, func(e IndexEntity) error {
+				if e.Slug == "sales" {
+					t.Errorf("category page was indexed as entity %+v", e)
+				}
+				entityCount++
+				return nil
+			})
+			// acme is the only entity; the category page must not have added one.
+			if entityCount != 1 {
+				t.Errorf("entity count = %d, want 1 (acme only)", entityCount)
+			}
+
+			// rm -rf index: rebuild from the same markdown → identical hash.
+			store2 := sf.make(t)
+			_, h2 := build(t, store2, root)
+			if h1 != h2 {
+				t.Errorf("CanonicalHashAll drift after rebuild with category tree: %s -> %s", h1, h2)
+			}
+
+			// Mutate the parents → hash moves.
+			writeBrief(t, root, "team/.categories/sales.md",
+				"---\nparent_categories: [revenue]\n---\n# Sales\n")
+			store3 := sf.make(t)
+			_, h3 := build(t, store3, root)
+			if h1 == h3 {
+				t.Error("CanonicalHashAll unchanged after parent mutation (category_parents not covered)")
+			}
+		})
+	}
+}
+
+func TestWikiIndex_CategoryTreeHashBackendParity(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	writeBrief(t, root, "team/.categories/sales.md",
+		"---\nparent_categories: [revenue, gtm]\n---\n# Sales\n")
+	writeBrief(t, root, "team/companies/acme.md",
+		"---\nkind: company\ncategories: [sales]\n---\n# Acme\n")
+
+	mem := newInMemoryFactStore()
+	idxMem := NewWikiIndex(root, WithFactStore(mem))
+	if err := idxMem.ReconcileFromMarkdown(ctx); err != nil {
+		t.Fatalf("reconcile mem: %v", err)
+	}
+	hMem, _ := idxMem.CanonicalHashAll(ctx)
+
+	sq, err := NewSQLiteFactStore(filepath.Join(t.TempDir(), "tree.sqlite"))
+	if err != nil {
+		t.Fatalf("sqlite: %v", err)
+	}
+	defer func() { _ = sq.Close() }()
+	idxSq := NewWikiIndex(root, WithFactStore(sq))
+	if err := idxSq.ReconcileFromMarkdown(ctx); err != nil {
+		t.Fatalf("reconcile sqlite: %v", err)
+	}
+	hSq, _ := idxSq.CanonicalHashAll(ctx)
+
+	if hMem != hSq {
+		t.Errorf("CanonicalHashAll backend mismatch: mem %s != sqlite %s", hMem, hSq)
+	}
+}
+
+func TestCatalogExcludesCategoryPages(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	root := t.TempDir()
+	repo := NewRepoAt(root, filepath.Join(t.TempDir(), "bak"))
+	ctx := context.Background()
+	if err := repo.Init(ctx); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	if _, _, err := repo.Commit(ctx, "ceo", "team/.categories/sales.md",
+		"---\nparent_categories: [revenue]\n---\n# Sales\n", "create", "add cat"); err != nil {
+		t.Fatalf("commit cat page: %v", err)
+	}
+	if _, _, err := repo.Commit(ctx, "ceo", "team/companies/acme.md", "# Acme\n", "create", "add acme"); err != nil {
+		t.Fatalf("commit acme: %v", err)
+	}
+
+	entries, err := repo.BuildCatalog(ctx, "", nil, false)
+	if err != nil {
+		t.Fatalf("BuildCatalog: %v", err)
+	}
+	for _, e := range entries {
+		if e.Path == "team/.categories/sales.md" {
+			t.Fatalf("category page leaked into catalog: %+v", entries)
+		}
+	}
+}

--- a/internal/team/wiki_index.go
+++ b/internal/team/wiki_index.go
@@ -181,6 +181,16 @@ type FactStore interface {
 	// sorted by slug ascending. Backs the category nav/API.
 	ListAllCategories(ctx context.Context) ([]CategoryCount, error)
 
+	// UpsertCategoryParents REPLACES the parent edges of a category with
+	// `parents` (normalized slugs). An empty/nil slice clears them (the category
+	// becomes a tree root). Source is a category page's `parent_categories:`.
+	UpsertCategoryParents(ctx context.Context, category string, parents []string) error
+	// ListCategoryParents returns a category's parent slugs, sorted ascending.
+	ListCategoryParents(ctx context.Context, category string) ([]string, error)
+	// ListAllCategoryParents returns every category→parent edge, sorted by
+	// (category, parent). Backs the subcategory tree + CanonicalHashAll.
+	ListAllCategoryParents(ctx context.Context) ([]CategoryParent, error)
+
 	// ListFactsByPredicateObject returns every fact whose triplet matches
 	// (predicate, object) exactly. Used by the typed-predicate graph walk
 	// for multi_hop queries (Slice 2 Thread A).
@@ -489,6 +499,17 @@ func (w *WikiIndex) ListArticlesInCategory(ctx context.Context, category string)
 	return w.store.ListArticlesInCategory(ctx, category)
 }
 
+// ListAllCategoryParents returns every category→parent edge (the subcategory
+// tree). Passthrough to the FactStore; backs GET /wiki/categories tree.
+func (w *WikiIndex) ListAllCategoryParents(ctx context.Context) ([]CategoryParent, error) {
+	return w.store.ListAllCategoryParents(ctx)
+}
+
+// ListCategoryParents returns a single category's parents. Passthrough.
+func (w *WikiIndex) ListCategoryParents(ctx context.Context, category string) ([]string, error) {
+	return w.store.ListCategoryParents(ctx, category)
+}
+
 // ListEdgesForEntity returns graph.log edges incident on an entity.
 func (w *WikiIndex) ListEdgesForEntity(ctx context.Context, slug string) ([]IndexEdge, error) {
 	resolved, redirected, err := w.store.ResolveRedirect(ctx, slug)
@@ -516,6 +537,10 @@ func (w *WikiIndex) ReconcilePath(ctx context.Context, relPath string) error {
 	switch {
 	case isFactLogPath(relPath):
 		return w.reconcileFactLog(ctx, abs, relPath)
+	case isCategoryPagePath(relPath):
+		// Checked before the entity-brief case: the brief regex would also
+		// match team/.categories/{slug}.md, but a category page is not an entity.
+		return w.reconcileCategoryPage(ctx, abs, relPath)
 	case isEntityBriefPath(relPath):
 		return w.reconcileEntityBrief(ctx, abs, relPath)
 	case isLintReportPath(relPath):
@@ -665,6 +690,12 @@ func (w *WikiIndex) reconcileFactLog(ctx context.Context, abs, relPath string) e
 }
 
 func (w *WikiIndex) reconcileEntityBrief(ctx context.Context, abs, relPath string) error {
+	// Defense in depth: category pages are routed to reconcileCategoryPage by
+	// the callers, but the brief regex would also match them — never index one
+	// as an entity.
+	if isCategoryPagePath(filepath.ToSlash(relPath)) {
+		return nil
+	}
 	data, err := os.ReadFile(abs)
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
@@ -724,6 +755,38 @@ func (w *WikiIndex) reconcileEntityBrief(ctx context.Context, abs, relPath strin
 		}
 	}
 	return w.store.UpsertEntity(ctx, entity)
+}
+
+// reconcileCategoryPage indexes a category-definition page at
+// team/.categories/{slug}.md: its `parent_categories:` frontmatter becomes the
+// category→parent edges of the subcategory tree. A nil/empty parent list clears
+// the category's edges (it becomes a root). The page is NOT indexed as an
+// entity or an article.
+func (w *WikiIndex) reconcileCategoryPage(ctx context.Context, abs, relPath string) error {
+	data, err := os.ReadFile(abs)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+	slug := categoryPageSlug(relPath)
+	if slug == "" {
+		return nil
+	}
+	parents := parseParentCategoriesFrontmatter(string(data))
+	// A category is never its own parent (guards against a self-referential
+	// frontmatter typo creating a 1-cycle in the tree).
+	filtered := parents[:0]
+	for _, p := range parents {
+		if p != slug {
+			filtered = append(filtered, p)
+		}
+	}
+	if err := w.store.UpsertCategoryParents(ctx, slug, filtered); err != nil {
+		return fmt.Errorf("upsert category parents %s: %w", slug, err)
+	}
+	return nil
 }
 
 func (w *WikiIndex) reconcileGraphLog(ctx context.Context, abs string) error {
@@ -854,7 +917,13 @@ func walkEntityBriefs(ctx context.Context, dir string, w *WikiIndex) error {
 		if relErr != nil {
 			return relErr
 		}
-		return w.reconcileEntityBrief(ctx, path, filepath.ToSlash(rel))
+		slash := filepath.ToSlash(rel)
+		// Category pages live under team/.categories/ and would otherwise be
+		// mis-parsed as entities by the brief regex; route them explicitly.
+		if isCategoryPagePath(slash) {
+			return w.reconcileCategoryPage(ctx, path, slash)
+		}
+		return w.reconcileEntityBrief(ctx, path, slash)
 	})
 }
 
@@ -969,15 +1038,19 @@ type inMemoryFactStore struct {
 	// normalized category slugs. Empty sets are pruned (the key is deleted) so
 	// the canonical hash never sees a phantom empty membership.
 	articleCats map[string]map[string]bool
+	// categoryParents maps a category slug to its set of parent slugs (the
+	// subcategory tree). Empty sets are pruned, like articleCats.
+	categoryParents map[string]map[string]bool
 }
 
 func newInMemoryFactStore() *inMemoryFactStore {
 	return &inMemoryFactStore{
-		facts:       map[string]TypedFact{},
-		entities:    map[string]IndexEntity{},
-		edgesBy:     map[string][]IndexEdge{},
-		redirects:   map[string]Redirect{},
-		articleCats: map[string]map[string]bool{},
+		facts:           map[string]TypedFact{},
+		entities:        map[string]IndexEntity{},
+		edgesBy:         map[string][]IndexEdge{},
+		redirects:       map[string]Redirect{},
+		articleCats:     map[string]map[string]bool{},
+		categoryParents: map[string]map[string]bool{},
 	}
 }
 
@@ -1264,6 +1337,56 @@ func (s *inMemoryFactStore) ListAllCategories(_ context.Context) ([]CategoryCoun
 	return out, nil
 }
 
+func (s *inMemoryFactStore) UpsertCategoryParents(_ context.Context, category string, parents []string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	set := make(map[string]bool, len(parents))
+	for _, p := range parents {
+		if p != "" {
+			set[p] = true
+		}
+	}
+	if len(set) == 0 {
+		delete(s.categoryParents, category)
+		return nil
+	}
+	s.categoryParents[category] = set
+	return nil
+}
+
+func (s *inMemoryFactStore) ListCategoryParents(_ context.Context, category string) ([]string, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	set := s.categoryParents[category]
+	if len(set) == 0 {
+		return nil, nil
+	}
+	out := make([]string, 0, len(set))
+	for p := range set {
+		out = append(out, p)
+	}
+	sort.Strings(out)
+	return out, nil
+}
+
+func (s *inMemoryFactStore) ListAllCategoryParents(_ context.Context) ([]CategoryParent, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	var out []CategoryParent
+	for cat, set := range s.categoryParents {
+		for p := range set {
+			out = append(out, CategoryParent{Category: cat, Parent: p})
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Category != out[j].Category {
+			return out[i].Category < out[j].Category
+		}
+		return out[i].Parent < out[j].Parent
+	})
+	return out, nil
+}
+
 func (s *inMemoryFactStore) CanonicalHashFacts(_ context.Context) (string, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -1387,6 +1510,29 @@ func (s *inMemoryFactStore) CanonicalHashAll(_ context.Context) (string, error) 
 	})
 	for _, ac := range cats {
 		b, err := json.Marshal(ac)
+		if err != nil {
+			return "", err
+		}
+		h.Write(b)
+		h.Write([]byte{'\n'})
+	}
+
+	// Category parents (sorted by category, then parent). Same CategoryParent
+	// serialisation as the SQLite backend.
+	var parents []CategoryParent
+	for cat, set := range s.categoryParents {
+		for p := range set {
+			parents = append(parents, CategoryParent{Category: cat, Parent: p})
+		}
+	}
+	sort.Slice(parents, func(i, j int) bool {
+		if parents[i].Category != parents[j].Category {
+			return parents[i].Category < parents[j].Category
+		}
+		return parents[i].Parent < parents[j].Parent
+	})
+	for _, cp := range parents {
+		b, err := json.Marshal(cp)
 		if err != nil {
 			return "", err
 		}

--- a/internal/team/wiki_index.go
+++ b/internal/team/wiki_index.go
@@ -486,29 +486,8 @@ func (w *WikiIndex) ListFactsByTriplet(ctx context.Context, subject, predicate, 
 	return w.store.ListFactsByTriplet(ctx, subject, predicate, objectPrefix)
 }
 
-// ListAllCategories returns every category slug with its article count, sorted
-// by slug. Passthrough to the FactStore; backs GET /wiki/categories.
-func (w *WikiIndex) ListAllCategories(ctx context.Context) ([]CategoryCount, error) {
-	return w.store.ListAllCategories(ctx)
-}
-
-// ListArticlesInCategory returns the wiki-root-relative paths of every article
-// filed under a category slug, sorted. Passthrough to the FactStore; backs
-// GET /wiki/categories/{slug}.
-func (w *WikiIndex) ListArticlesInCategory(ctx context.Context, category string) ([]string, error) {
-	return w.store.ListArticlesInCategory(ctx, category)
-}
-
-// ListAllCategoryParents returns every category→parent edge (the subcategory
-// tree). Passthrough to the FactStore; backs GET /wiki/categories tree.
-func (w *WikiIndex) ListAllCategoryParents(ctx context.Context) ([]CategoryParent, error) {
-	return w.store.ListAllCategoryParents(ctx)
-}
-
-// ListCategoryParents returns a single category's parents. Passthrough.
-func (w *WikiIndex) ListCategoryParents(ctx context.Context, category string) ([]string, error) {
-	return w.store.ListCategoryParents(ctx, category)
-}
+// Category passthroughs (ListAllCategories / ListArticlesInCategory /
+// ListAllCategoryParents / ListCategoryParents) live in wiki_categories_store.go.
 
 // ListEdgesForEntity returns graph.log edges incident on an entity.
 func (w *WikiIndex) ListEdgesForEntity(ctx context.Context, slug string) ([]IndexEdge, error) {
@@ -1271,121 +1250,8 @@ func (s *inMemoryFactStore) ResolveRedirect(_ context.Context, slug string) (str
 	return slug, false, nil
 }
 
-func (s *inMemoryFactStore) UpsertArticleCategories(_ context.Context, articlePath string, categories []string) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	if len(categories) == 0 {
-		delete(s.articleCats, articlePath)
-		return nil
-	}
-	set := make(map[string]bool, len(categories))
-	for _, c := range categories {
-		if c != "" {
-			set[c] = true
-		}
-	}
-	if len(set) == 0 {
-		delete(s.articleCats, articlePath)
-		return nil
-	}
-	s.articleCats[articlePath] = set
-	return nil
-}
-
-func (s *inMemoryFactStore) ListArticlesInCategory(_ context.Context, category string) ([]string, error) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	var out []string
-	for path, set := range s.articleCats {
-		if set[category] {
-			out = append(out, path)
-		}
-	}
-	sort.Strings(out)
-	return out, nil
-}
-
-func (s *inMemoryFactStore) ListCategoriesForArticle(_ context.Context, articlePath string) ([]string, error) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	set := s.articleCats[articlePath]
-	if len(set) == 0 {
-		return nil, nil
-	}
-	out := make([]string, 0, len(set))
-	for c := range set {
-		out = append(out, c)
-	}
-	sort.Strings(out)
-	return out, nil
-}
-
-func (s *inMemoryFactStore) ListAllCategories(_ context.Context) ([]CategoryCount, error) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	counts := map[string]int{}
-	for _, set := range s.articleCats {
-		for c := range set {
-			counts[c]++
-		}
-	}
-	out := make([]CategoryCount, 0, len(counts))
-	for slug, n := range counts {
-		out = append(out, CategoryCount{Slug: slug, Count: n})
-	}
-	sort.Slice(out, func(i, j int) bool { return out[i].Slug < out[j].Slug })
-	return out, nil
-}
-
-func (s *inMemoryFactStore) UpsertCategoryParents(_ context.Context, category string, parents []string) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	set := make(map[string]bool, len(parents))
-	for _, p := range parents {
-		if p != "" {
-			set[p] = true
-		}
-	}
-	if len(set) == 0 {
-		delete(s.categoryParents, category)
-		return nil
-	}
-	s.categoryParents[category] = set
-	return nil
-}
-
-func (s *inMemoryFactStore) ListCategoryParents(_ context.Context, category string) ([]string, error) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	set := s.categoryParents[category]
-	if len(set) == 0 {
-		return nil, nil
-	}
-	out := make([]string, 0, len(set))
-	for p := range set {
-		out = append(out, p)
-	}
-	sort.Strings(out)
-	return out, nil
-}
-
-func (s *inMemoryFactStore) ListAllCategoryParents(_ context.Context) ([]CategoryParent, error) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	var out []CategoryParent
-	for cat, set := range s.categoryParents {
-		for p := range set {
-			out = append(out, CategoryParent{Category: cat, Parent: p})
-		}
-	}
-	sort.Slice(out, func(i, j int) bool {
-		if out[i].Category != out[j].Category {
-			return out[i].Category < out[j].Category
-		}
-		return out[i].Parent < out[j].Parent
-	})
-	return out, nil
-}
+// inMemoryFactStore's article_categories + category_parents methods live in
+// wiki_categories_store.go.
 
 func (s *inMemoryFactStore) CanonicalHashFacts(_ context.Context) (string, error) {
 	s.mu.RLock()

--- a/internal/team/wiki_index.go
+++ b/internal/team/wiki_index.go
@@ -161,6 +161,26 @@ type FactStore interface {
 	CountFacts(ctx context.Context) (int, error)
 	ResolveRedirect(ctx context.Context, slug string) (string, bool, error)
 
+	// --- article_categories (Wikipedia-style category layer) ----------------
+	//
+	// Markdown is authoritative (an article's `categories:` frontmatter); these
+	// rows are a rebuildable derived cache that folds into CanonicalHashAll.
+
+	// UpsertArticleCategories REPLACES the full set of category memberships for
+	// articlePath with `categories` (normalized slugs). An empty/nil slice
+	// clears the article's rows. This set-replace semantic keeps the derived
+	// index in lockstep with the article's frontmatter on every reconcile.
+	UpsertArticleCategories(ctx context.Context, articlePath string, categories []string) error
+	// ListArticlesInCategory returns the wiki-root-relative paths of every
+	// article filed under the given category slug, sorted ascending.
+	ListArticlesInCategory(ctx context.Context, category string) ([]string, error)
+	// ListCategoriesForArticle returns the category slugs an article belongs to,
+	// sorted ascending.
+	ListCategoriesForArticle(ctx context.Context, articlePath string) ([]string, error)
+	// ListAllCategories returns every category slug with its article count,
+	// sorted by slug ascending. Backs the category nav/API.
+	ListAllCategories(ctx context.Context) ([]CategoryCount, error)
+
 	// ListFactsByPredicateObject returns every fact whose triplet matches
 	// (predicate, object) exactly. Used by the typed-predicate graph walk
 	// for multi_hop queries (Slice 2 Thread A).
@@ -652,7 +672,8 @@ func (w *WikiIndex) reconcileEntityBrief(ctx context.Context, abs, relPath strin
 		CanonicalSlug: slug,
 		Kind:          kind,
 	}
-	if fm := extractFrontmatter(string(data)); fm != "" {
+	fm := extractFrontmatter(string(data))
+	if fm != "" {
 		if v := frontmatterValue(fm, "canonical_slug"); v != "" {
 			entity.CanonicalSlug = v
 		}
@@ -673,6 +694,13 @@ func (w *WikiIndex) reconcileEntityBrief(ctx context.Context, abs, relPath strin
 		if aliases := frontmatterList(fm, "aliases"); len(aliases) > 0 {
 			entity.Aliases = aliases
 		}
+	}
+	// Derived article→category memberships. Authoritative source is the
+	// article's `categories:` frontmatter; nil clears stale rows so removing a
+	// category is reflected on reconcile. Runs for every team/X/Y.md article
+	// (entity briefs, playbooks, decisions, concepts), not just entities.
+	if err := w.store.UpsertArticleCategories(ctx, rel, categoriesFromFrontmatter(fm)); err != nil {
+		return fmt.Errorf("upsert categories %s: %w", rel, err)
 	}
 	if entity.CanonicalSlug != entity.Slug {
 		if err := w.store.UpsertRedirect(ctx, Redirect{
@@ -924,14 +952,19 @@ type inMemoryFactStore struct {
 	entities  map[string]IndexEntity
 	edgesBy   map[string][]IndexEdge // keyed by subject slug AND object slug
 	redirects map[string]Redirect
+	// articleCats maps an article's wiki-root-relative path to its set of
+	// normalized category slugs. Empty sets are pruned (the key is deleted) so
+	// the canonical hash never sees a phantom empty membership.
+	articleCats map[string]map[string]bool
 }
 
 func newInMemoryFactStore() *inMemoryFactStore {
 	return &inMemoryFactStore{
-		facts:     map[string]TypedFact{},
-		entities:  map[string]IndexEntity{},
-		edgesBy:   map[string][]IndexEdge{},
-		redirects: map[string]Redirect{},
+		facts:       map[string]TypedFact{},
+		entities:    map[string]IndexEntity{},
+		edgesBy:     map[string][]IndexEdge{},
+		redirects:   map[string]Redirect{},
+		articleCats: map[string]map[string]bool{},
 	}
 }
 
@@ -1152,6 +1185,72 @@ func (s *inMemoryFactStore) ResolveRedirect(_ context.Context, slug string) (str
 	return slug, false, nil
 }
 
+func (s *inMemoryFactStore) UpsertArticleCategories(_ context.Context, articlePath string, categories []string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(categories) == 0 {
+		delete(s.articleCats, articlePath)
+		return nil
+	}
+	set := make(map[string]bool, len(categories))
+	for _, c := range categories {
+		if c != "" {
+			set[c] = true
+		}
+	}
+	if len(set) == 0 {
+		delete(s.articleCats, articlePath)
+		return nil
+	}
+	s.articleCats[articlePath] = set
+	return nil
+}
+
+func (s *inMemoryFactStore) ListArticlesInCategory(_ context.Context, category string) ([]string, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	var out []string
+	for path, set := range s.articleCats {
+		if set[category] {
+			out = append(out, path)
+		}
+	}
+	sort.Strings(out)
+	return out, nil
+}
+
+func (s *inMemoryFactStore) ListCategoriesForArticle(_ context.Context, articlePath string) ([]string, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	set := s.articleCats[articlePath]
+	if len(set) == 0 {
+		return nil, nil
+	}
+	out := make([]string, 0, len(set))
+	for c := range set {
+		out = append(out, c)
+	}
+	sort.Strings(out)
+	return out, nil
+}
+
+func (s *inMemoryFactStore) ListAllCategories(_ context.Context) ([]CategoryCount, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	counts := map[string]int{}
+	for _, set := range s.articleCats {
+		for c := range set {
+			counts[c]++
+		}
+	}
+	out := make([]CategoryCount, 0, len(counts))
+	for slug, n := range counts {
+		out = append(out, CategoryCount{Slug: slug, Count: n})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Slug < out[j].Slug })
+	return out, nil
+}
+
 func (s *inMemoryFactStore) CanonicalHashFacts(_ context.Context) (string, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -1252,6 +1351,29 @@ func (s *inMemoryFactStore) CanonicalHashAll(_ context.Context) (string, error) 
 	sort.Strings(redirectFroms)
 	for _, from := range redirectFroms {
 		b, err := json.Marshal(s.redirects[from])
+		if err != nil {
+			return "", err
+		}
+		h.Write(b)
+		h.Write([]byte{'\n'})
+	}
+
+	// Article categories (sorted by article_path, then category). Serialised as
+	// ArticleCategory rows so the bytes match the SQLite backend exactly.
+	var cats []ArticleCategory
+	for path, set := range s.articleCats {
+		for c := range set {
+			cats = append(cats, ArticleCategory{ArticlePath: path, Category: c})
+		}
+	}
+	sort.Slice(cats, func(i, j int) bool {
+		if cats[i].ArticlePath != cats[j].ArticlePath {
+			return cats[i].ArticlePath < cats[j].ArticlePath
+		}
+		return cats[i].Category < cats[j].Category
+	})
+	for _, ac := range cats {
+		b, err := json.Marshal(ac)
 		if err != nil {
 			return "", err
 		}

--- a/internal/team/wiki_index.go
+++ b/internal/team/wiki_index.go
@@ -476,6 +476,19 @@ func (w *WikiIndex) ListFactsByTriplet(ctx context.Context, subject, predicate, 
 	return w.store.ListFactsByTriplet(ctx, subject, predicate, objectPrefix)
 }
 
+// ListAllCategories returns every category slug with its article count, sorted
+// by slug. Passthrough to the FactStore; backs GET /wiki/categories.
+func (w *WikiIndex) ListAllCategories(ctx context.Context) ([]CategoryCount, error) {
+	return w.store.ListAllCategories(ctx)
+}
+
+// ListArticlesInCategory returns the wiki-root-relative paths of every article
+// filed under a category slug, sorted. Passthrough to the FactStore; backs
+// GET /wiki/categories/{slug}.
+func (w *WikiIndex) ListArticlesInCategory(ctx context.Context, category string) ([]string, error) {
+	return w.store.ListArticlesInCategory(ctx, category)
+}
+
 // ListEdgesForEntity returns graph.log edges incident on an entity.
 func (w *WikiIndex) ListEdgesForEntity(ctx context.Context, slug string) ([]IndexEdge, error) {
 	resolved, redirected, err := w.store.ResolveRedirect(ctx, slug)

--- a/internal/team/wiki_index_sqlite.go
+++ b/internal/team/wiki_index_sqlite.go
@@ -120,6 +120,17 @@ CREATE TABLE IF NOT EXISTS redirects (
   merged_by   TEXT,
   commit_sha  TEXT
 );
+
+-- article_categories: derived many-to-many article-to-category memberships.
+-- Source of truth is each article's categories frontmatter; this table is a
+-- rebuildable cache (folds into CanonicalHashAll). CREATE TABLE IF NOT EXISTS
+-- is additive so existing DBs gain it on next open.
+CREATE TABLE IF NOT EXISTS article_categories (
+  article_path  TEXT NOT NULL,
+  category_slug TEXT NOT NULL,
+  PRIMARY KEY (article_path, category_slug)
+);
+CREATE INDEX IF NOT EXISTS idx_article_categories_cat ON article_categories(category_slug);
 `
 
 func (s *SQLiteFactStore) applySchema(ctx context.Context) error {
@@ -516,6 +527,95 @@ func (s *SQLiteFactStore) ResolveRedirect(ctx context.Context, slug string) (str
 	return to, true, nil
 }
 
+// UpsertArticleCategories replaces the full membership set for articlePath in a
+// single transaction (delete-then-insert), so the derived rows track the
+// article's frontmatter exactly. An empty/nil slice clears the article's rows.
+func (s *SQLiteFactStore) UpsertArticleCategories(ctx context.Context, articlePath string, categories []string) error {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("sqlite: begin article_categories tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }() // no-op after a successful Commit
+
+	if _, err := tx.ExecContext(ctx,
+		`DELETE FROM article_categories WHERE article_path = ?`, articlePath); err != nil {
+		return fmt.Errorf("sqlite: clear categories for %s: %w", articlePath, err)
+	}
+	seen := make(map[string]bool, len(categories))
+	for _, c := range categories {
+		if c == "" || seen[c] {
+			continue
+		}
+		seen[c] = true
+		if _, err := tx.ExecContext(ctx,
+			`INSERT OR IGNORE INTO article_categories (article_path, category_slug) VALUES (?, ?)`,
+			articlePath, c); err != nil {
+			return fmt.Errorf("sqlite: insert category %s for %s: %w", c, articlePath, err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("sqlite: commit article_categories for %s: %w", articlePath, err)
+	}
+	return nil
+}
+
+func (s *SQLiteFactStore) ListArticlesInCategory(ctx context.Context, category string) ([]string, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT article_path FROM article_categories
+		 WHERE category_slug = ? ORDER BY article_path ASC`, category)
+	if err != nil {
+		return nil, fmt.Errorf("sqlite: list articles in category %s: %w", category, err)
+	}
+	defer func() { _ = rows.Close() }()
+	var out []string
+	for rows.Next() {
+		var p string
+		if err := rows.Scan(&p); err != nil {
+			return nil, err
+		}
+		out = append(out, p)
+	}
+	return out, rows.Err()
+}
+
+func (s *SQLiteFactStore) ListCategoriesForArticle(ctx context.Context, articlePath string) ([]string, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT category_slug FROM article_categories
+		 WHERE article_path = ? ORDER BY category_slug ASC`, articlePath)
+	if err != nil {
+		return nil, fmt.Errorf("sqlite: list categories for %s: %w", articlePath, err)
+	}
+	defer func() { _ = rows.Close() }()
+	var out []string
+	for rows.Next() {
+		var c string
+		if err := rows.Scan(&c); err != nil {
+			return nil, err
+		}
+		out = append(out, c)
+	}
+	return out, rows.Err()
+}
+
+func (s *SQLiteFactStore) ListAllCategories(ctx context.Context) ([]CategoryCount, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT category_slug, COUNT(*) FROM article_categories
+		 GROUP BY category_slug ORDER BY category_slug ASC`)
+	if err != nil {
+		return nil, fmt.Errorf("sqlite: list all categories: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	var out []CategoryCount
+	for rows.Next() {
+		var cc CategoryCount
+		if err := rows.Scan(&cc.Slug, &cc.Count); err != nil {
+			return nil, err
+		}
+		out = append(out, cc)
+	}
+	return out, rows.Err()
+}
+
 // CanonicalHashFacts implements §7.4: sha256 over all fact rows sorted by ID.
 // Serialisation is identical to inMemoryFactStore so the contract test passes
 // against both backends from the same markdown corpus. ReinforcedAt is
@@ -719,6 +819,32 @@ func (s *SQLiteFactStore) CanonicalHashAll(ctx context.Context) (string, error) 
 		h.Write([]byte{'\n'})
 	}
 	if err := redRows.Err(); err != nil {
+		return "", err
+	}
+
+	// --- article categories (sorted by article_path, category_slug) ---
+	// Serialised as ArticleCategory rows so the bytes match the in-memory
+	// backend exactly, keeping the §7.4 hash backend-agnostic.
+	catRows, err := s.db.QueryContext(ctx,
+		`SELECT article_path, category_slug FROM article_categories
+		 ORDER BY article_path ASC, category_slug ASC`)
+	if err != nil {
+		return "", fmt.Errorf("CanonicalHashAll article_categories: %w", err)
+	}
+	defer func() { _ = catRows.Close() }()
+	for catRows.Next() {
+		var ac ArticleCategory
+		if err := catRows.Scan(&ac.ArticlePath, &ac.Category); err != nil {
+			return "", err
+		}
+		b, err := json.Marshal(ac)
+		if err != nil {
+			return "", err
+		}
+		h.Write(b)
+		h.Write([]byte{'\n'})
+	}
+	if err := catRows.Err(); err != nil {
 		return "", err
 	}
 

--- a/internal/team/wiki_index_sqlite.go
+++ b/internal/team/wiki_index_sqlite.go
@@ -131,6 +131,16 @@ CREATE TABLE IF NOT EXISTS article_categories (
   PRIMARY KEY (article_path, category_slug)
 );
 CREATE INDEX IF NOT EXISTS idx_article_categories_cat ON article_categories(category_slug);
+
+-- category_parents: derived category-to-parent edges (the subcategory tree).
+-- Source of truth is a category page's parent_categories frontmatter at
+-- team/.categories/{slug}.md. Rebuildable cache; folds into CanonicalHashAll.
+CREATE TABLE IF NOT EXISTS category_parents (
+  category_slug TEXT NOT NULL,
+  parent_slug   TEXT NOT NULL,
+  PRIMARY KEY (category_slug, parent_slug)
+);
+CREATE INDEX IF NOT EXISTS idx_category_parents_parent ON category_parents(parent_slug);
 `
 
 func (s *SQLiteFactStore) applySchema(ctx context.Context) error {
@@ -616,6 +626,75 @@ func (s *SQLiteFactStore) ListAllCategories(ctx context.Context) ([]CategoryCoun
 	return out, rows.Err()
 }
 
+// UpsertCategoryParents replaces a category's parent edges in one transaction
+// (delete-then-insert). An empty/nil slice clears them.
+func (s *SQLiteFactStore) UpsertCategoryParents(ctx context.Context, category string, parents []string) error {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("sqlite: begin category_parents tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }() // no-op after a successful Commit
+
+	if _, err := tx.ExecContext(ctx,
+		`DELETE FROM category_parents WHERE category_slug = ?`, category); err != nil {
+		return fmt.Errorf("sqlite: clear parents for %s: %w", category, err)
+	}
+	seen := make(map[string]bool, len(parents))
+	for _, p := range parents {
+		if p == "" || seen[p] {
+			continue
+		}
+		seen[p] = true
+		if _, err := tx.ExecContext(ctx,
+			`INSERT OR IGNORE INTO category_parents (category_slug, parent_slug) VALUES (?, ?)`,
+			category, p); err != nil {
+			return fmt.Errorf("sqlite: insert parent %s for %s: %w", p, category, err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("sqlite: commit category_parents for %s: %w", category, err)
+	}
+	return nil
+}
+
+func (s *SQLiteFactStore) ListCategoryParents(ctx context.Context, category string) ([]string, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT parent_slug FROM category_parents
+		 WHERE category_slug = ? ORDER BY parent_slug ASC`, category)
+	if err != nil {
+		return nil, fmt.Errorf("sqlite: list parents for %s: %w", category, err)
+	}
+	defer func() { _ = rows.Close() }()
+	var out []string
+	for rows.Next() {
+		var p string
+		if err := rows.Scan(&p); err != nil {
+			return nil, err
+		}
+		out = append(out, p)
+	}
+	return out, rows.Err()
+}
+
+func (s *SQLiteFactStore) ListAllCategoryParents(ctx context.Context) ([]CategoryParent, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT category_slug, parent_slug FROM category_parents
+		 ORDER BY category_slug ASC, parent_slug ASC`)
+	if err != nil {
+		return nil, fmt.Errorf("sqlite: list all category parents: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	var out []CategoryParent
+	for rows.Next() {
+		var cp CategoryParent
+		if err := rows.Scan(&cp.Category, &cp.Parent); err != nil {
+			return nil, err
+		}
+		out = append(out, cp)
+	}
+	return out, rows.Err()
+}
+
 // CanonicalHashFacts implements §7.4: sha256 over all fact rows sorted by ID.
 // Serialisation is identical to inMemoryFactStore so the contract test passes
 // against both backends from the same markdown corpus. ReinforcedAt is
@@ -845,6 +924,31 @@ func (s *SQLiteFactStore) CanonicalHashAll(ctx context.Context) (string, error) 
 		h.Write([]byte{'\n'})
 	}
 	if err := catRows.Err(); err != nil {
+		return "", err
+	}
+
+	// --- category parents (sorted by category_slug, parent_slug) ---
+	// Same CategoryParent serialisation as the in-memory backend.
+	cpRows, err := s.db.QueryContext(ctx,
+		`SELECT category_slug, parent_slug FROM category_parents
+		 ORDER BY category_slug ASC, parent_slug ASC`)
+	if err != nil {
+		return "", fmt.Errorf("CanonicalHashAll category_parents: %w", err)
+	}
+	defer func() { _ = cpRows.Close() }()
+	for cpRows.Next() {
+		var cp CategoryParent
+		if err := cpRows.Scan(&cp.Category, &cp.Parent); err != nil {
+			return "", err
+		}
+		b, err := json.Marshal(cp)
+		if err != nil {
+			return "", err
+		}
+		h.Write(b)
+		h.Write([]byte{'\n'})
+	}
+	if err := cpRows.Err(); err != nil {
 		return "", err
 	}
 

--- a/internal/team/wiki_sections.go
+++ b/internal/team/wiki_sections.go
@@ -580,16 +580,17 @@ func (b *Broker) PublishWikiSectionsUpdated(evt WikiSectionsUpdatedEvent) {
 
 // EnqueueSectionsRefresh is the broker-level adapter the wiki worker
 // calls after a successful team wiki write. Implements
-// wikiSectionsNotifier. No-op when the cache is not attached (tests,
-// non-markdown backend).
+// wikiSectionsNotifier. It fans out to every derived nav cache (sections
+// and categories) since any wiki write can change either. No-op for a
+// cache that is not attached (tests, non-markdown backend).
 func (b *Broker) EnqueueSectionsRefresh() {
 	b.mu.Lock()
 	cache := b.wikiSectionsCache
 	b.mu.Unlock()
-	if cache == nil {
-		return
+	if cache != nil {
+		cache.Enqueue()
 	}
-	cache.Enqueue()
+	b.EnqueueCategoriesRefresh()
 }
 
 // WikiSectionsCache returns the attached cache, or nil when the markdown

--- a/web/e2e/screenshots/wiki-category-page.mjs
+++ b/web/e2e/screenshots/wiki-category-page.mjs
@@ -4,8 +4,9 @@
 //
 //   1. An article (a hiring-loop playbook) showing its real category line —
 //      it is filed in People + Revenue Operations, not its own folder.
-//   2. Category: People — folder members PLUS that cross-folder playbook,
-//      reached by clicking the category line (real in-app navigation).
+//   2. Category: People — the subcategory tree ("Part of: Org",
+//      "Subcategories: Engineering") plus folder members AND that cross-folder
+//      playbook, reached by clicking the category line (real in-app navigation).
 //
 // Navigation is via clicking the in-app category link rather than setting
 // location.hash directly: the router round-trips the `_category/<slug>`
@@ -58,6 +59,25 @@ const CATALOG = [
   ]),
 ];
 
+// The subcategory tree (Phase 3b): People is a child of Org and the parent of
+// Engineering. Drives the "Part of:" + "Subcategories" sections on the page.
+const CATEGORIES = [
+  { slug: "org", title: "Org", article_count: 0, parents: [] },
+  { slug: "people", title: "People", article_count: 5, parents: ["org"] },
+  {
+    slug: "engineering",
+    title: "Engineering",
+    article_count: 0,
+    parents: ["people"],
+  },
+  {
+    slug: "revenue-operations",
+    title: "Revenue Operations",
+    article_count: 1,
+    parents: [],
+  },
+];
+
 const ARTICLE = {
   path: "team/playbooks/hiring-loop.md",
   title: "Hiring Loop",
@@ -87,7 +107,7 @@ async function mockWiki(ctx) {
   await ctx.route("**/api/wiki/catalog*", json({ articles: CATALOG }));
   await ctx.route("**/api/wiki/tree*", json({ nodes: [] }));
   await ctx.route("**/api/wiki/sections*", json({ sections: [] }));
-  await ctx.route("**/api/wiki/categories*", json({ categories: [] }));
+  await ctx.route("**/api/wiki/categories*", json({ categories: CATEGORIES }));
   await ctx.route("**/api/wiki/article*", json(ARTICLE));
   await ctx.route("**/api/wiki/history*", json({ commits: [] }));
   await ctx.route("**/api/wiki/visual-artifact*", (r) =>
@@ -133,11 +153,13 @@ await page.waitForSelector('[data-testid="wk-category-page"]', {
 await page.waitForFunction(() =>
   document.body.textContent?.includes("Hiring Loop"),
 );
+// Wait for the subcategory tree (Phase 3b) to render too.
+await page.waitForSelector('[aria-label="Subcategories"]', { timeout: 4_000 });
 await shotElement(
   page,
   '[data-testid="wk-category-page"]',
   OUT,
-  "02-category-people-cross-folder",
+  "02-category-people-tree-and-cross-folder",
 );
 
 console.log(`captured 2 screenshots to ${OUT}`);

--- a/web/e2e/screenshots/wiki-category-page.mjs
+++ b/web/e2e/screenshots/wiki-category-page.mjs
@@ -1,0 +1,147 @@
+// Capture the Wikipedia-style category page after the Phase 3 nav flip:
+// membership is now an article's many-to-many `categories:` frontmatter
+// (catalog `categories`), with the folder `group` kept as a fallback.
+//
+//   1. An article (a hiring-loop playbook) showing its real category line —
+//      it is filed in People + Revenue Operations, not its own folder.
+//   2. Category: People — folder members PLUS that cross-folder playbook,
+//      reached by clicking the category line (real in-app navigation).
+//
+// Navigation is via clicking the in-app category link rather than setting
+// location.hash directly: the router round-trips the `_category/<slug>`
+// pseudo-path, whereas a raw hash set percent-encodes the slash.
+//
+// Run via the wrapper:
+//   web/e2e/screenshots/publish.sh wiki-category-page <pr-number>
+
+import {
+  DEFAULT_BASE,
+  flipStore,
+  installCommonMocks,
+  launchBrowser,
+  shotElement,
+  shotPage,
+} from "./lib.mjs";
+import process from "node:process";
+
+const OUT = process.env.WUPHF_SCREENSHOTS_OUT;
+if (!OUT) {
+  console.error("WUPHF_SCREENSHOTS_OUT is not set; run via publish.sh");
+  process.exit(2);
+}
+
+const e = (path, title, group, categories) => ({
+  path,
+  title,
+  author_slug: "ceo",
+  last_edited_ts: "2026-06-12T12:00:00Z",
+  group,
+  categories,
+});
+
+// People live in team/people/ (folder fallback). The hiring loop lives in
+// team/playbooks/ but is filed into People via categories — it must show on
+// the People category page. The MQL note is filed into a real category
+// ("revenue-operations") that has no matching folder.
+const CATALOG = [
+  e("team/people/ana-ruiz.md", "Ana Ruiz", "people", []),
+  e("team/people/dana-cole.md", "Dana Cole", "people", []),
+  e("team/people/eng-watanabe.md", "Eng Watanabe", "people", []),
+  e("team/people/zoe-park.md", "Zoe Park", "people", []),
+  e("team/companies/acme-corp.md", "Acme Corp", "companies", ["companies"]),
+  e("team/playbooks/hiring-loop.md", "Hiring Loop", "playbooks", [
+    "people",
+    "revenue-operations",
+  ]),
+  e("team/playbooks/mql-definition.md", "MQL Definition", "playbooks", [
+    "revenue-operations",
+  ]),
+];
+
+const ARTICLE = {
+  path: "team/playbooks/hiring-loop.md",
+  title: "Hiring Loop",
+  content: [
+    "# Hiring Loop",
+    "",
+    "**Hiring Loop** is the playbook the team runs to take an open role from",
+    "intake to signed offer. It is filed under the People and Revenue",
+    "Operations categories rather than its Playbooks folder.",
+    "",
+    "## Stages",
+    "",
+    "Intake → sourcing → structured loop → debrief → offer.",
+  ].join("\n"),
+  last_edited_by: "ceo",
+  last_edited_ts: "2026-06-12T12:00:00Z",
+  revisions: 4,
+  contributors: ["ceo", "pm"],
+  backlinks: [],
+  word_count: 64,
+  categories: ["people", "revenue-operations"],
+};
+
+async function mockWiki(ctx) {
+  const json = (body) => (r) =>
+    r.fulfill({ contentType: "application/json", body: JSON.stringify(body) });
+  await ctx.route("**/api/wiki/catalog*", json({ articles: CATALOG }));
+  await ctx.route("**/api/wiki/tree*", json({ nodes: [] }));
+  await ctx.route("**/api/wiki/sections*", json({ sections: [] }));
+  await ctx.route("**/api/wiki/categories*", json({ categories: [] }));
+  await ctx.route("**/api/wiki/article*", json(ARTICLE));
+  await ctx.route("**/api/wiki/history*", json({ commits: [] }));
+  await ctx.route("**/api/wiki/visual-artifact*", (r) =>
+    r.fulfill({ status: 404, body: "" }),
+  );
+  await ctx.route("**/api/humans*", json([]));
+}
+
+const { browser, context, page, errors } = await launchBrowser({
+  viewport: { width: 1480, height: 940 },
+});
+
+await installCommonMocks(context, { extra: mockWiki });
+
+// Navigate via a full goto so the router initialises on the article route.
+// (A raw `location.hash` set after boot desyncs the router and would mis-route
+// the in-app category link to a search param.)
+await page.goto(`${DEFAULT_BASE}/#/wiki/team/playbooks/hiring-loop.md`, {
+  waitUntil: "load",
+});
+await page.waitForSelector(".status-bar", { timeout: 15_000 });
+await flipStore(page, {});
+
+// ─── The article, showing its real (cross-folder) category line ──
+await page.waitForSelector('[data-testid="wk-article-body"]', {
+  timeout: 8_000,
+});
+// The Categories line links to People + Revenue Operations (real categories).
+await page
+  .locator('[aria-label="Categories"]')
+  .getByRole("link", { name: "People" })
+  .waitFor({ timeout: 4_000 });
+await shotPage(page, OUT, "01-article-categories");
+
+// ─── Click the People category link → the category page (real nav) ──
+await page
+  .locator('[aria-label="Categories"]')
+  .getByRole("link", { name: "People" })
+  .click();
+await page.waitForSelector('[data-testid="wk-category-page"]', {
+  timeout: 8_000,
+});
+await page.waitForFunction(() =>
+  document.body.textContent?.includes("Hiring Loop"),
+);
+await shotElement(
+  page,
+  '[data-testid="wk-category-page"]',
+  OUT,
+  "02-category-people-cross-folder",
+);
+
+console.log(`captured 2 screenshots to ${OUT}`);
+if (errors.length > 0) {
+  console.error("page errors during capture:", errors);
+}
+await browser.close();

--- a/web/src/api/wiki.ts
+++ b/web/src/api/wiki.ts
@@ -573,6 +573,113 @@ export function subscribeSectionsUpdated(
 }
 
 /**
+ * One category in the Wikipedia-style category nav. Maps 1:1 to Go's
+ * `team.DiscoveredCategory`. Categories are a many-to-many classification
+ * authored in each article's `categories:` frontmatter (markdown-authoritative)
+ * and surfaced from the derived article_categories index.
+ */
+export interface DiscoveredCategory {
+  slug: string;
+  title: string;
+  article_count: number;
+}
+
+/** A member article of a category. Maps to Go's `team.CategoryArticle`. */
+export interface CategoryArticle {
+  path: string;
+  title: string;
+}
+
+/**
+ * GET /wiki/categories/{slug} response. Maps to Go's `team.CategoryDetail`.
+ */
+export interface CategoryDetail {
+  slug: string;
+  title: string;
+  articles: CategoryArticle[];
+}
+
+export interface WikiCategoriesUpdatedEvent {
+  categories: DiscoveredCategory[];
+  timestamp: string;
+}
+
+/**
+ * GET /wiki/categories — the category nav list (slug, title, article count),
+ * sorted by slug. Empty array on backend error so the nav can fall back to the
+ * folder/section IA without blanking.
+ */
+export async function fetchCategories(): Promise<DiscoveredCategory[]> {
+  try {
+    const res = await get<{ categories: DiscoveredCategory[] }>(
+      "/wiki/categories",
+    );
+    return Array.isArray(res?.categories) ? res.categories : [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * GET /wiki/categories/{slug} — the member articles of one category. Throws on
+ * backend error so callers can surface a load failure for the category page.
+ */
+export async function fetchCategory(slug: string): Promise<CategoryDetail> {
+  return get<CategoryDetail>(`/wiki/categories/${encodeURIComponent(slug)}`);
+}
+
+/**
+ * Subscribe to `wiki:categories_updated` events on the shared `/events` SSE
+ * stream. Returns an unsubscribe function. Mirrors subscribeSectionsUpdated.
+ */
+export function subscribeCategoriesUpdated(
+  handler: (event: WikiCategoriesUpdatedEvent) => void,
+): () => void {
+  let closed = false;
+  let source: SharedEventStream | null = null;
+  let onEvent: ((ev: MessageEvent) => void) | null = null;
+
+  try {
+    source = openSharedEventStream();
+    if (!source)
+      return () => {
+        closed = true;
+      };
+    onEvent = (ev: MessageEvent) => {
+      if (closed) return;
+      try {
+        const data = JSON.parse(ev.data) as WikiCategoriesUpdatedEvent;
+        if (data && Array.isArray(data.categories)) {
+          handler(data);
+        }
+      } catch {
+        // ignore malformed events
+      }
+    };
+    source.addEventListener(
+      "wiki:categories_updated",
+      onEvent as EventListener,
+    );
+  } catch {
+    source = null;
+  }
+
+  return () => {
+    closed = true;
+    if (source && onEvent) {
+      source.removeEventListener(
+        "wiki:categories_updated",
+        onEvent as EventListener,
+      );
+    }
+    if (source) {
+      source.close();
+      source = null;
+    }
+  };
+}
+
+/**
  * Registered human identity surfaced by the broker at GET /humans. The
  * server grows this list as it observes new commits, so team installs
  * with multiple humans all show up without any client configuration.

--- a/web/src/api/wiki.ts
+++ b/web/src/api/wiki.ts
@@ -366,6 +366,13 @@ export interface WikiCatalogEntry {
   author_slug: string;
   last_edited_ts: string;
   group: string;
+  /**
+   * Many-to-many category slugs from the article's `categories:` frontmatter
+   * (markdown-authoritative). Always present from the broker (possibly empty);
+   * optional here for older fixtures. `group` (the folder) is the fallback nav
+   * key during the category migration.
+   */
+  categories?: string[];
   /** ISO-8601 timestamp of the last access by any reader. Null if never accessed. */
   last_read?: string | null;
   human_read_count?: number;

--- a/web/src/api/wiki.ts
+++ b/web/src/api/wiki.ts
@@ -589,6 +589,12 @@ export interface DiscoveredCategory {
   slug: string;
   title: string;
   article_count: number;
+  /**
+   * Parent category slugs (the subcategory tree). Always present from the
+   * broker (possibly empty); optional here for older fixtures. A category's
+   * children are the categories whose `parents` include its slug.
+   */
+  parents?: string[];
 }
 
 /** A member article of a category. Maps to Go's `team.CategoryArticle`. */

--- a/web/src/components/wiki/Wiki.tsx
+++ b/web/src/components/wiki/Wiki.tsx
@@ -1,9 +1,12 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 
 import {
+  type DiscoveredCategory,
   type DiscoveredSection,
   fetchCatalogStrict,
+  fetchCategories,
   fetchSections,
+  subscribeCategoriesUpdated,
   subscribeSectionsUpdated,
   type WikiCatalogEntry,
 } from "../../api/wiki";
@@ -122,6 +125,7 @@ export default function Wiki({
   onNavigate,
 }: WikiProps) {
   const [catalog, setCatalog] = useState<WikiCatalogEntry[]>([]);
+  const [categories, setCategories] = useState<DiscoveredCategory[]>([]);
   const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [loadNonce, setLoadNonce] = useState(0);
@@ -202,6 +206,26 @@ export default function Wiki({
     return () => unsubscribe();
   }, [refreshCatalog]);
 
+  // Categories drive the category-page tree (parents + subcategories). This is
+  // supplementary to the catalog, so it is best-effort: a failure leaves the
+  // category page on its catalog-derived membership without blanking the wiki.
+  const refreshCategories = useCallback(() => {
+    fetchCategories()
+      .then((c) => setCategories(c))
+      .catch(() => {
+        /* keep last-known categories */
+      });
+  }, []);
+  useEffect(() => {
+    refreshCategories();
+    const unsubscribe = subscribeCategoriesUpdated((event) => {
+      if (Array.isArray(event.categories)) {
+        setCategories(event.categories);
+      }
+    });
+    return () => unsubscribe();
+  }, [refreshCategories]);
+
   const view = wikiViewFor(articlePath);
   const editLogHistoryPath = wikiHistoryPath(articlePath, view);
   // The app view navigates with the APP_NAV_PREFIX sentinel; strip it so the
@@ -255,6 +279,7 @@ export default function Wiki({
           <WikiCategoryPage
             slug={categorySlug}
             catalog={catalog}
+            categories={categories}
             onNavigate={(path) => onNavigate(path)}
           />
         ) : view === "article" && articlePath ? (

--- a/web/src/components/wiki/WikiCategoryPage.stories.tsx
+++ b/web/src/components/wiki/WikiCategoryPage.stories.tsx
@@ -19,6 +19,16 @@ const CATALOG: WikiCatalogEntry[] = [
     last_edited_ts: "2026-06-10T12:00:00Z",
     group: "companies",
   },
+  // A playbook filed into People via its `categories:` frontmatter — appears
+  // in the People category page even though it lives in a different folder.
+  {
+    path: "team/playbooks/hiring-loop.md",
+    title: "Hiring Loop",
+    author_slug: "ceo",
+    last_edited_ts: "2026-06-11T12:00:00Z",
+    group: "playbooks",
+    categories: ["people"],
+  },
 ];
 
 /** Auto-generated alphabetical category index (Wikipedia category page). */

--- a/web/src/components/wiki/WikiCategoryPage.stories.tsx
+++ b/web/src/components/wiki/WikiCategoryPage.stories.tsx
@@ -1,8 +1,21 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import "../../styles/wiki.css";
-import type { WikiCatalogEntry } from "../../api/wiki";
+import type { DiscoveredCategory, WikiCatalogEntry } from "../../api/wiki";
 import WikiCategoryPage from "./WikiCategoryPage";
+
+// The subcategory tree: People is a child of the Org category and the parent
+// of Engineering. Drives the "Part of:" + "Subcategories" sections.
+const CATEGORIES: DiscoveredCategory[] = [
+  { slug: "org", title: "Org", article_count: 0, parents: [] },
+  { slug: "people", title: "People", article_count: 7, parents: ["org"] },
+  {
+    slug: "engineering",
+    title: "Engineering",
+    article_count: 0,
+    parents: ["people"],
+  },
+];
 
 const CATALOG: WikiCatalogEntry[] = [
   ...["Ana", "Arturo", "Eng", "Elena", "Nazz", "Zoe"].map((name) => ({
@@ -45,6 +58,7 @@ const meta: Meta<typeof WikiCategoryPage> = {
   ],
   args: {
     catalog: CATALOG,
+    categories: CATEGORIES,
     onNavigate: () => {},
   },
 };

--- a/web/src/components/wiki/WikiCategoryPage.test.tsx
+++ b/web/src/components/wiki/WikiCategoryPage.test.tsx
@@ -100,4 +100,58 @@ describe("<WikiCategoryPage>", () => {
     );
     expect(screen.getByText("No pages yet.")).toBeInTheDocument();
   });
+
+  it("includes cross-folder articles via explicit categories", () => {
+    // A playbook (different folder) filed into the People category via its
+    // `categories:` frontmatter shows alongside the folder members.
+    const catalog: WikiCatalogEntry[] = [
+      ...CATALOG,
+      {
+        path: "team/playbooks/onboarding.md",
+        title: "Onboarding",
+        author_slug: "ceo",
+        last_edited_ts: "2026-06-11T12:00:00Z",
+        group: "playbooks",
+        categories: ["people"],
+      },
+    ];
+    render(
+      <WikiCategoryPage
+        slug="people"
+        catalog={catalog}
+        onNavigate={() => {}}
+      />,
+    );
+    // 3 folder members + 1 cross-folder explicit member = 4.
+    expect(screen.getByText(/The following 4 pages are/)).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "Onboarding" }),
+    ).toBeInTheDocument();
+  });
+
+  it("lists sibling categories that exist only via explicit categories", () => {
+    const catalog: WikiCatalogEntry[] = [
+      ...CATALOG,
+      {
+        path: "team/playbooks/mql.md",
+        title: "MQL",
+        author_slug: "ceo",
+        last_edited_ts: "2026-06-11T12:00:00Z",
+        group: "playbooks",
+        categories: ["revenue-operations"],
+      },
+    ];
+    const onNavigate = vi.fn();
+    render(
+      <WikiCategoryPage
+        slug="people"
+        catalog={catalog}
+        onNavigate={onNavigate}
+      />,
+    );
+    // "Revenue Operations" is a real category (no matching folder) and appears
+    // as a sibling link.
+    fireEvent.click(screen.getByRole("link", { name: "Revenue Operations" }));
+    expect(onNavigate).toHaveBeenCalledWith("_category/revenue-operations");
+  });
 });

--- a/web/src/components/wiki/WikiCategoryPage.test.tsx
+++ b/web/src/components/wiki/WikiCategoryPage.test.tsx
@@ -1,7 +1,7 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
-import type { WikiCatalogEntry } from "../../api/wiki";
+import type { DiscoveredCategory, WikiCatalogEntry } from "../../api/wiki";
 import WikiCategoryPage, { categoryLabel } from "./WikiCategoryPage";
 
 const CATALOG: WikiCatalogEntry[] = [
@@ -127,6 +127,52 @@ describe("<WikiCategoryPage>", () => {
     expect(
       screen.getByRole("link", { name: "Onboarding" }),
     ).toBeInTheDocument();
+  });
+
+  it("renders the subcategory tree — parents and children", () => {
+    // sales ← (children) and sales → revenue (parent).
+    const categories: DiscoveredCategory[] = [
+      { slug: "sales", title: "Sales", article_count: 0, parents: ["revenue"] },
+      {
+        slug: "enterprise-sales",
+        title: "Enterprise Sales",
+        article_count: 0,
+        parents: ["sales"],
+      },
+      { slug: "revenue", title: "Revenue", article_count: 0, parents: [] },
+    ];
+    const onNavigate = vi.fn();
+    render(
+      <WikiCategoryPage
+        slug="sales"
+        catalog={CATALOG}
+        categories={categories}
+        onNavigate={onNavigate}
+      />,
+    );
+    // Parent link: "Part of: Revenue".
+    const parentBox = screen.getByLabelText("Parent categories");
+    fireEvent.click(within(parentBox).getByRole("link", { name: "Revenue" }));
+    expect(onNavigate).toHaveBeenCalledWith("_category/revenue");
+
+    // Subcategories section lists the child "Enterprise Sales".
+    const subcats = screen.getByLabelText("Subcategories");
+    fireEvent.click(
+      within(subcats).getByRole("link", { name: "Enterprise Sales" }),
+    );
+    expect(onNavigate).toHaveBeenCalledWith("_category/enterprise-sales");
+  });
+
+  it("hides the tree sections when no category data is provided", () => {
+    render(
+      <WikiCategoryPage
+        slug="people"
+        catalog={CATALOG}
+        onNavigate={() => {}}
+      />,
+    );
+    expect(screen.queryByLabelText("Parent categories")).toBeNull();
+    expect(screen.queryByLabelText("Subcategories")).toBeNull();
   });
 
   it("lists sibling categories that exist only via explicit categories", () => {

--- a/web/src/components/wiki/WikiCategoryPage.tsx
+++ b/web/src/components/wiki/WikiCategoryPage.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from "react";
 
-import type { WikiCatalogEntry } from "../../api/wiki";
+import type { DiscoveredCategory, WikiCatalogEntry } from "../../api/wiki";
 import { pluralize } from "../../lib/format";
 import { categoryPath } from "./wikiPaths";
 
@@ -18,6 +18,13 @@ interface WikiCategoryPageProps {
   /** Category slug, e.g. "people", "companies", "playbooks". */
   slug: string;
   catalog: WikiCatalogEntry[];
+  /**
+   * The full category list (with parent edges) from /wiki/categories. Drives
+   * the subcategory tree — parent categories of this page, and its children
+   * (categories whose `parents` include this slug). Optional; an empty list
+   * just hides the tree sections.
+   */
+  categories?: DiscoveredCategory[];
   onNavigate: (path: string) => void;
 }
 
@@ -40,9 +47,23 @@ function firstLetter(title: string): string {
 export default function WikiCategoryPage({
   slug,
   catalog,
+  categories = [],
   onNavigate,
 }: WikiCategoryPageProps) {
   const normalized = slug.toLowerCase();
+  const { parents, subcategories } = useMemo(() => {
+    const self = categories.find((c) => c.slug.toLowerCase() === normalized);
+    const parentSlugs = [...(self?.parents ?? [])].sort((a, b) =>
+      a.localeCompare(b),
+    );
+    const children = categories
+      .filter((c) =>
+        (c.parents ?? []).some((p) => p.toLowerCase() === normalized),
+      )
+      .map((c) => c.slug)
+      .sort((a, b) => a.localeCompare(b));
+    return { parents: parentSlugs, subcategories: children };
+  }, [categories, normalized]);
   const { letters, count, siblings } = useMemo(() => {
     // An article is in this category when its `categories:` frontmatter names
     // the slug, OR (fallback) its folder group matches — so links stay
@@ -98,6 +119,43 @@ export default function WikiCategoryPage({
         </div>
         <h1 className="wk-article-title">Category: {label}</h1>
         <hr className="wk-title-rule" />
+        {parents.length > 0 ? (
+          <div className="wk-categories" aria-label="Parent categories">
+            <span className="wk-label">Part of:</span>
+            {parents.map((p) => (
+              <a
+                key={p}
+                href={`#/wiki/${categoryPath(p)}`}
+                onClick={(e) => {
+                  e.preventDefault();
+                  onNavigate(categoryPath(p));
+                }}
+              >
+                {categoryLabel(p)}
+              </a>
+            ))}
+          </div>
+        ) : null}
+        {subcategories.length > 0 ? (
+          <section className="wk-category-subcats" aria-label="Subcategories">
+            <h2>Subcategories</h2>
+            <ul>
+              {subcategories.map((s) => (
+                <li key={s}>
+                  <a
+                    href={`#/wiki/${categoryPath(s)}`}
+                    onClick={(e) => {
+                      e.preventDefault();
+                      onNavigate(categoryPath(s));
+                    }}
+                  >
+                    {categoryLabel(s)}
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </section>
+        ) : null}
         <p className="wk-category-summary">
           The following {count} {pluralize(count, "page")}{" "}
           {count === 1 ? "is" : "are"} in this category.

--- a/web/src/components/wiki/WikiCategoryPage.tsx
+++ b/web/src/components/wiki/WikiCategoryPage.tsx
@@ -5,11 +5,13 @@ import { pluralize } from "../../lib/format";
 import { categoryPath } from "./wikiPaths";
 
 /**
- * Auto-generated Wikipedia-style category index page: every article whose
- * path kind (catalog `group`) matches the category, listed alphabetically
- * and grouped by first letter. Linked from each article's category line
- * and from the home page's Browse panel — categories replace folders as
- * the wiki's organizing surface.
+ * Auto-generated Wikipedia-style category index page: every article filed in
+ * this category, listed alphabetically and grouped by first letter. Membership
+ * is the article's many-to-many `categories:` frontmatter (catalog
+ * `categories`), with the folder `group` kept as a fallback so links stay
+ * populated during the migration to real categories. Linked from each
+ * article's category line and the home Browse panel — categories replace
+ * folders as the wiki's organizing surface.
  */
 
 interface WikiCategoryPageProps {
@@ -42,8 +44,14 @@ export default function WikiCategoryPage({
 }: WikiCategoryPageProps) {
   const normalized = slug.toLowerCase();
   const { letters, count, siblings } = useMemo(() => {
+    // An article is in this category when its `categories:` frontmatter names
+    // the slug, OR (fallback) its folder group matches — so links stay
+    // populated until articles carry explicit categories.
+    const inCategory = (entry: WikiCatalogEntry): boolean =>
+      (entry.categories ?? []).some((c) => c.toLowerCase() === normalized) ||
+      entry.group.toLowerCase() === normalized;
     const members = catalog
-      .filter((entry) => entry.group.toLowerCase() === normalized)
+      .filter(inCategory)
       .sort((a, b) => a.title.localeCompare(b.title));
     const byLetter = new Map<string, WikiCatalogEntry[]>();
     for (const entry of members) {
@@ -52,14 +60,21 @@ export default function WikiCategoryPage({
       if (bucket) bucket.push(entry);
       else byLetter.set(letter, [entry]);
     }
-    const otherGroups = [
-      ...new Set(catalog.map((entry) => entry.group)),
-    ].filter((g) => g.toLowerCase() !== normalized);
-    otherGroups.sort((a, b) => a.localeCompare(b));
+    // Sibling categories: the union of every article's real categories and its
+    // folder group, minus this one.
+    const allCategories = new Set<string>();
+    for (const entry of catalog) {
+      for (const c of entry.categories ?? []) allCategories.add(c);
+      if (entry.group) allCategories.add(entry.group);
+    }
+    const otherCategories = [...allCategories].filter(
+      (c) => c.toLowerCase() !== normalized,
+    );
+    otherCategories.sort((a, b) => a.localeCompare(b));
     return {
       letters: [...byLetter.entries()].sort(([a], [b]) => a.localeCompare(b)),
       count: members.length,
-      siblings: otherGroups,
+      siblings: otherCategories,
     };
   }, [catalog, normalized]);
 


### PR DESCRIPTION
## What & why

The Wikipedia-style wiki IA reorg (design: `docs/specs/wiki-wikipedia-ia.md`). The wiki is the agents' compounding knowledge substrate; today it's organized by **fixed top-level folders** under `team/`, so insight/concept articles get mis-filed into entity folders, the nav is rigid, and there's no home for non-entity **concept** articles.

This adds a **category layer + hierarchy** — many-to-many classification and a subcategory tree on top of the folder layout (the MediaWiki model) — **without breaking the substrate**. Folders stay on disk (preserving the `rm -rf index/` rebuild guarantee, `[[kind/slug]]` wikilinks, fact-log paths, Obsidian-vault compatibility); categories become the queryable, navigable layer.

## Phases

**0 — schema contract** — `WIKI-SCHEMA.md` amendment (`type`, `categories`, `parent_categories`, `redirect_to`, `team/concepts/`, `team/.categories/`) + the authoritative design spec.

**1 — article→category derived index** — `article_categories` on both backends (sqlite + in-memory), reconcile hook in `reconcileEntityBrief`, folded into `CanonicalHashAll` (backend-agnostic), `meta.Categories` populated.

**2 — category read API** — `GET /wiki/categories` (cached list) + `GET /wiki/categories/{slug}` (live members), mirroring `/wiki/sections` (debounced cache + `wiki:categories_updated` SSE). FE api stubs.

**3a — flip the category page to real categories** — catalog carries real `categories`; `WikiCategoryPage` filters by them with a folder-fallback for continuity (a playbook filed into People via frontmatter shows on the People page).

**3b — category pages + subcategory tree** — category-definition pages at `team/.categories/{slug}.md` whose `parent_categories:` frontmatter becomes the derived `category_parents` edges (a DAG). A dedicated reconcile path routes them **before** the entity-brief regex so they're never mis-indexed as entities/articles; catalog + entity reconcile exclude them. `GET /wiki/categories` returns each category's `parents` (and parent-only categories). `WikiCategoryPage` renders the tree — a "Part of:" parent line and a "Subcategories" section.

### Screenshots

The People category page — the **subcategory tree** ("Part of: Org", "Subcategories: Engineering"), folder members, **and** the cross-folder "Hiring Loop" (a `team/playbooks/` article filed into People via frontmatter):

![Category: People — tree + cross-folder](https://github.com/nex-crm/wuphf/raw/screenshots/pr-1112/02-category-people-tree-and-cross-folder.png)

The source article, filed into People + Revenue Operations rather than its Playbooks folder:

![Article with real category line](https://github.com/nex-crm/wuphf/raw/screenshots/pr-1112/01-article-categories.png)

## Notable decisions
- **Category layer, not a physical flatten** — respects the WIKI-SCHEMA substrate / single-writer / slug-immutability invariants. Every new index layer (`article_categories`, `category_parents`) folds into `CanonicalHashAll` identically across backends and is covered by `rm -rf index` rebuild-equality + parity tests.
- Category pages are a derived index with no producers yet (the librarian authors them in a later phase) — additive and forward-compatible; the tree is simply flat until pages exist.

## Verification
- Go: `gofmt`, `go vet`, `golangci-lint run` (0 issues), `go test ./internal/team` (pass).
- Web: `tsc --noEmit` (0 errors), `biome check`, full Vitest suite (2189 passing).
- Substrate: `rm -rf index` rebuild-equality + in-memory↔sqlite hash-parity tests for both new layers.
- Note: the `-race` suite's only red is the **pre-existing** `TestOfficeEvals` TempDir-cleanup flake — it fails identically on the base without this change, and `go-test` is not a required check.

## Test plan
- [ ] `GET /wiki/categories` lists categories with `parents`; `/{slug}` lists members.
- [ ] A category page's `parent_categories:` shows as "Part of:" and its children as "Subcategories".
- [ ] `rm -rf .wuphf/index` + restart rebuilds an identical category + tree index.
- [ ] Category pages never appear as articles in the catalog or as entities.

## Next (follow-up)
Concept articles + agent authoring (extraction recognizes concepts, librarian writes encyclopedic articles), insights-fold-under-headers, and re-file via redirects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Articles can now be organized with many-to-many categories driven by frontmatter.
  * Category pages now show related articles plus a “Part of”/subcategory tree.
  * Live category updates stream to connected clients.

* **Bug Fixes**
  * Category metadata is now consistently populated for wiki views.

* **Documentation**
  * Updated the Wikipedia-style wiki IA schema, including frontmatter fields and the re-filing (redirect) procedure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->