### PR TITLE
fix(integrations): verify API-key credentials before reporting connected

### DIFF
--- a/internal/action/composio_apikey.go
+++ b/internal/action/composio_apikey.go
@@ -23,7 +23,9 @@ package action
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"net/http"
 	"net/url"
 	"strings"
 )
@@ -255,9 +257,29 @@ func (c *ComposioREST) CompleteAPIKeyConnection(ctx context.Context, platform st
 		return IntegrationConnectResult{}, fmt.Errorf("parse connected account: %w", err)
 	}
 	status := connectionState(result.Status)
-	if status == "available" {
-		// A freshly created API-key account with no explicit status is active.
+
+	// Verify the credential actually works before declaring the toolkit
+	// connected. Composio accepts API-key credentials at creation time WITHOUT
+	// testing them — every API-key account is reported ACTIVE on create — so a
+	// bogus key would otherwise surface as a false "Connected".
+	switch c.validateAPIKeyConnection(ctx, result.ID) {
+	case verdictRejected:
+		// Composio checked the key and it failed. Remove the orphan account so a
+		// retry starts clean, then surface a clear error the UI shows instead of
+		// a fake success.
+		c.deleteConnectedAccountBestEffort(ctx, result.ID)
+		return IntegrationConnectResult{}, fmt.Errorf("%s rejected the credentials — double-check the key and try again", DisplayPlatformName(platform))
+	case verdictValid:
 		status = "connected"
+	case verdictUnverified:
+		// Composio's experimental validation path is unavailable for this
+		// toolkit/plan, so we could not test the key. Fall back to the
+		// create-time status rather than blocking a connection we couldn't
+		// check. A blank/unknown create status for a non-OAuth account is
+		// treated as active, matching prior behavior.
+		if status == "available" {
+			status = "connected"
+		}
 	}
 	return IntegrationConnectResult{
 		Provider:      c.Name(),
@@ -299,6 +321,79 @@ func (c *ComposioREST) createCustomAuthConfig(ctx context.Context, platform, mod
 		return id, nil
 	}
 	return "", fmt.Errorf("custom auth config response did not include id")
+}
+
+// apiKeyVerdict is the outcome of asking Composio to validate a freshly created
+// API-key connected account.
+type apiKeyVerdict int
+
+const (
+	// verdictUnverified: Composio could not (or would not) tell us whether the
+	// credential works. The validate path is experimental and not available for
+	// every toolkit/plan, so the caller keeps the create-time status rather than
+	// blocking a connection it simply could not test.
+	verdictUnverified apiKeyVerdict = iota
+	// verdictValid: Composio confirmed the credential is live.
+	verdictValid
+	// verdictRejected: Composio actively rejected the credential.
+	verdictRejected
+)
+
+// validateAPIKeyConnection asks Composio to verify the credential on a freshly
+// created connected account. Composio marks API-key accounts ACTIVE at creation
+// WITHOUT checking the key, so without this a bogus key reads as "Connected".
+// The refresh endpoint's experimental `validate_credentials` flag re-checks the
+// stored credential for API-key auth schemes specifically.
+func (c *ComposioREST) validateAPIKeyConnection(ctx context.Context, connectedAccountID string) apiKeyVerdict {
+	id := strings.TrimSpace(connectedAccountID)
+	if id == "" {
+		return verdictUnverified
+	}
+	raw, err := c.post(ctx, "/connected_accounts/"+url.PathEscape(id)+"/refresh", map[string]any{
+		"validate_credentials": true,
+	})
+	if err != nil {
+		// A definitive auth rejection (401/403) or unprocessable credential (422)
+		// means the key was checked and failed. Any other failure — 404 (toolkit
+		// has no validation path), 5xx, or a network error — means we could not
+		// test the key, so we treat it as unverified rather than blocking a
+		// connection that may be perfectly valid.
+		var apiErr *ComposioAPIError
+		if errors.As(err, &apiErr) {
+			switch apiErr.StatusCode {
+			case http.StatusUnauthorized, http.StatusForbidden, http.StatusUnprocessableEntity:
+				return verdictRejected
+			}
+		}
+		return verdictUnverified
+	}
+	var result struct {
+		Status string `json:"status"`
+	}
+	if err := json.Unmarshal(raw, &result); err != nil {
+		return verdictUnverified
+	}
+	switch connectionState(result.Status) {
+	case "connected":
+		return verdictValid
+	case "available":
+		// Empty/unknown status — nothing actionable to assert either way.
+		return verdictUnverified
+	default:
+		// failed, pending, disconnected, … — the credential did not come up live.
+		return verdictRejected
+	}
+}
+
+// deleteConnectedAccountBestEffort removes a connected account, ignoring errors.
+// Used to clean up an account whose credential Composio rejected so a retry is
+// not blocked by a dangling, non-working connection.
+func (c *ComposioREST) deleteConnectedAccountBestEffort(ctx context.Context, connectedAccountID string) {
+	id := strings.TrimSpace(connectedAccountID)
+	if id == "" {
+		return
+	}
+	_, _ = c.delete(ctx, "/connected_accounts/"+url.PathEscape(id))
 }
 
 func stringMapToAny(in map[string]string) map[string]any {

--- a/internal/action/composio_apikey_test.go
+++ b/internal/action/composio_apikey_test.go
@@ -223,6 +223,13 @@ func TestCompleteAPIKeyConnection_SendsCustomAuthAndKey(t *testing.T) {
 		_ = json.NewDecoder(r.Body).Decode(&accountBody)
 		_ = json.NewEncoder(w).Encode(map[string]any{"id": "ca_instantly", "status": "ACTIVE"})
 	})
+	// The credential is verified via the refresh endpoint before we claim
+	// "connected"; a live key comes back ACTIVE.
+	var refreshBody map[string]any
+	mux.HandleFunc("/connected_accounts/ca_instantly/refresh", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&refreshBody)
+		_ = json.NewEncoder(w).Encode(map[string]any{"id": "ca_instantly", "status": "ACTIVE"})
+	})
 	server := httptest.NewServer(mux)
 	defer server.Close()
 	client := &ComposioREST{APIKey: "cmp_test", UserID: "ceo@example.com", BaseURL: server.URL, Client: server.Client()}
@@ -233,6 +240,9 @@ func TestCompleteAPIKeyConnection_SendsCustomAuthAndKey(t *testing.T) {
 	}
 	if res.Status != "connected" {
 		t.Fatalf("expected connected, got %q (%+v)", res.Status, res)
+	}
+	if refreshBody["validate_credentials"] != true {
+		t.Fatalf("connect must ask Composio to validate the credential, got refresh body %v", refreshBody)
 	}
 	if res.ConnectionKey != "ca_instantly" {
 		t.Fatalf("expected connection key ca_instantly, got %q", res.ConnectionKey)
@@ -263,5 +273,99 @@ func TestCompleteAPIKeyConnection_SendsCustomAuthAndKey(t *testing.T) {
 	acRef, _ := accountBody["auth_config"].(map[string]any)
 	if acRef["id"] != "ac_custom" {
 		t.Fatalf("connected account must reference the created auth config, got %v", accountBody)
+	}
+}
+
+// apiKeyConnectMux builds the create-path mux (toolkit detail + auth config +
+// connected account create) shared by the verification tests. The caller
+// registers a /connected_accounts/ca_instantly/refresh handler to drive the
+// validation outcome and may inspect *deleted to assert cleanup.
+func apiKeyConnectMux(deleted *bool) *http.ServeMux {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/toolkits/instantly", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(instantlyToolkitDetail())
+	})
+	mux.HandleFunc("/auth_configs", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"auth_config": map[string]any{"id": "ac_custom"}})
+	})
+	mux.HandleFunc("/connected_accounts", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"id": "ca_instantly", "status": "ACTIVE"})
+	})
+	// DELETE /connected_accounts/ca_instantly — orphan cleanup after a rejection.
+	mux.HandleFunc("/connected_accounts/ca_instantly", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodDelete && deleted != nil {
+			*deleted = true
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"ok": true})
+	})
+	return mux
+}
+
+// A credential Composio rejects (refresh reports a non-live status) must NOT be
+// reported as connected: the connect call errors and the orphan account is
+// deleted so a retry starts clean. This is the core "random key says connected"
+// bug fix.
+func TestCompleteAPIKeyConnection_RejectsBadKey(t *testing.T) {
+	deleted := false
+	mux := apiKeyConnectMux(&deleted)
+	mux.HandleFunc("/connected_accounts/ca_instantly/refresh", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"id": "ca_instantly", "status": "FAILED"})
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+	client := &ComposioREST{APIKey: "cmp_test", UserID: "ceo@example.com", BaseURL: server.URL, Client: server.Client()}
+
+	_, err := client.CompleteAPIKeyConnection(context.Background(), "Instantly", map[string]string{"generic_api_key": "bogus"})
+	if err == nil {
+		t.Fatalf("a rejected credential must surface an error, not a connection")
+	}
+	if !deleted {
+		t.Fatalf("a rejected credential must delete the orphan connected account")
+	}
+}
+
+// Composio can signal a rejected credential with a 401/403/422 from the refresh
+// endpoint rather than a status body — that path must also fail closed.
+func TestCompleteAPIKeyConnection_RejectsBadKeyOnAuthError(t *testing.T) {
+	deleted := false
+	mux := apiKeyConnectMux(&deleted)
+	mux.HandleFunc("/connected_accounts/ca_instantly/refresh", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+	client := &ComposioREST{APIKey: "cmp_test", UserID: "ceo@example.com", BaseURL: server.URL, Client: server.Client()}
+
+	_, err := client.CompleteAPIKeyConnection(context.Background(), "Instantly", map[string]string{"generic_api_key": "bogus"})
+	if err == nil {
+		t.Fatalf("a 401 from validation must surface an error, not a connection")
+	}
+	if !deleted {
+		t.Fatalf("a rejected credential must delete the orphan connected account")
+	}
+}
+
+// When the experimental validation path is unavailable (404 / 5xx / network),
+// we must not block the connection: fall back to the create-time status so a
+// real key still connects on plans/toolkits without the validate endpoint.
+func TestCompleteAPIKeyConnection_UnverifiedFallsBackToConnected(t *testing.T) {
+	deleted := false
+	mux := apiKeyConnectMux(&deleted)
+	mux.HandleFunc("/connected_accounts/ca_instantly/refresh", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+	client := &ComposioREST{APIKey: "cmp_test", UserID: "ceo@example.com", BaseURL: server.URL, Client: server.Client()}
+
+	res, err := client.CompleteAPIKeyConnection(context.Background(), "Instantly", map[string]string{"generic_api_key": "ik_secret"})
+	if err != nil {
+		t.Fatalf("an unverifiable connection must not be blocked: %v", err)
+	}
+	if res.Status != "connected" {
+		t.Fatalf("expected connected fallback, got %q", res.Status)
+	}
+	if deleted {
+		t.Fatalf("an unverified (not rejected) credential must NOT be deleted")
 	}
 }


### PR DESCRIPTION
## Problem

Connecting an API-key toolkit (e.g. **Instantly**) with **any random string** reported **"Connected."** Composio's docs confirm the cause: *"API key connections are immediately active."* Composio stores whatever key you submit and marks the connected account `ACTIVE` **without testing it**, and `CompleteAPIKeyConnection` trusted that status.

(For Instantly the API-key form itself is correct — Instantly has no Composio-managed OAuth app. The bug was the missing verification, not the credential type.)

## Fix

After creating the connected account, verify the credential with Composio before claiming success, using the refresh endpoint's `validate_credentials` flag (Composio's own mechanism, scoped to API-key auth schemes):

- **Rejected** key (non-live status, or `401`/`403`/`422`) → connect **errors** with a clear message and the **orphan connected account is deleted** so a retry starts clean.
- **Confirmed** key (`ACTIVE`) → connected.
- **Validation unavailable** (`404`/`5xx`/network — the flag is experimental) → fall back to the create-time status so a real key still connects (fail-open on unverifiable, fail-closed on definitive rejection).

## Tests

`internal/action/composio_apikey_test.go`:
- happy path now asserts `validate_credentials:true` is sent;
- rejected-key via status body → errors + deletes orphan;
- rejected-key via `401` → errors + deletes orphan;
- unverifiable (`404`) → falls back to connected, no delete.

`gofmt`, `go vet`, `golangci-lint` (0 issues), and package tests are green.

## Caveat

`validate_credentials` is marked **experimental** by Composio. This handles both rejection signals (status body and 4xx), but if a toolkit returns `ACTIVE` even for a bad key (flag is a no-op there), it would slip through the fail-open fallback. Worth a live test with a real bad Instantly key; if needed, the heavier fallback is to execute one lightweight read tool and treat an auth error as rejection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added credential validation for API key toolkit connections. Invalid credentials are now rejected during connection setup, and incomplete connections are automatically cleaned up if validation fails.

* **Bug Fixes**
  * Fixed connection status handling to accurately reflect whether credentials are valid, invalid, or unverified rather than automatically marking connections as complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->