### PR TITLE
fix(analytics): mask only typed text in session recordings [release]

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,10 +264,10 @@ Connects SaaS accounts (Gmail, Slack, etc.) through Composio's hosted OAuth flow
 
 ## Privacy & Telemetry
 
-WUPHF can send anonymous product analytics and fully-masked session recordings
-to help us improve it. This is **optional**, controlled by you, and **off
-unless a PostHog key is configured** — a stock source build and every fork ship
-with no key, so they never phone home.
+WUPHF can send anonymous product analytics and session recordings (with typed
+text masked) to help us improve it. This is **optional**, controlled by you, and
+**off unless a PostHog key is configured** — a stock source build and every fork
+ship with no key, so they never phone home.
 
 Two independent toggles (onboarding and **Settings → Privacy & Analytics**),
 both on by default, both reversible at any time:
@@ -278,10 +278,11 @@ both on by default, both reversible at any time:
   secrets). Identity is an anonymous device id; workspaces are grouped by a
   hashed id. The single exception is the onboarding email, attached to your
   PostHog person once at finish and only if you leave "keep me posted" checked.
-- **Session recording** — every recording is **fully masked**: all text and all
-  inputs are obscured (`maskAllInputs`, `maskTextSelector: "*"`). We see layout,
-  cursor, clicks, scroll, and navigation to fix rough edges — never your text,
-  data, or secrets.
+- **Session recording** — recordings **mask everything you type**
+  (`maskAllInputs: true`, PostHog's default): passwords, API keys, and any form
+  field are obscured. We capture layout, cursor, clicks, scroll, navigation, and
+  the on-screen UI to fix rough edges. Want to mask more? Self-hosted operators
+  can set a stricter `maskTextSelector` in their own build.
 
 No autocapture, no cookies (localStorage only). Self-hosted operators can point
 at their own PostHog and flip either channel at runtime without rebuilding:

--- a/docs/specs/product-analytics.md
+++ b/docs/specs/product-analytics.md
@@ -23,14 +23,16 @@ question, and rich properties let one event answer many.
    README so the policy change is honest and visible.
 2. **Two independent toggles, both default ON, both dormant without a key:**
    - **Product analytics** (anonymous usage events) — `analytics_telemetry_enabled`
-   - **Session recording** (fully-masked replays) — `analytics_session_recording_enabled`
+   - **Session recording** (replays with typed text masked) — `analytics_session_recording_enabled`
    Honest separation: a user can keep usage events on while turning recording
    off, or vice-versa.
-3. **Strict replay masking.** All text and all inputs are masked in every
-   recording (`maskAllInputs: true`, `maskTextSelector: "*"`). Recordings show
-   layout, cursor, clicks, scroll, rage-clicks, and navigation — never readable
-   content, customer data, agent output, or secrets. Stated plainly in the
-   toggle copy and the README to win trust.
+3. **Typed-text masking (PostHog default).** Everything typed into a field is
+   masked in every recording (`maskAllInputs: true`) — passwords, API keys,
+   search terms, form entries. We intentionally do NOT set `maskTextSelector:
+   "*"`, so recordings capture layout, cursor, clicks, scroll, rage-clicks,
+   navigation, and on-screen UI. Operators who need to obscure rendered content
+   can set a stricter `maskTextSelector` in their own build. Stated plainly in
+   the toggle copy and the README to keep the promise honest.
 4. **Dormant by default, preserved.** No PostHog project key configured → every
    analytics call is a no-op. Stock source builds and forks never phone home.
 5. **Full Tier 1–3 event taxonomy** (below).
@@ -47,7 +49,7 @@ question, and rich properties let one event answer many.
 - **No content.** Event properties carry shapes and buckets (e.g.
   `length_bucket`, `mention_count`, `has_details`), never message text, wiki
   bodies, task titles, customer names, or secrets.
-- **Strict-masked recordings** (decision 3).
+- **Typed-text-masked recordings** (decision 3).
 - **Operator control.** A self-hosted operator can point at their own PostHog
   (`WUPHF_POSTHOG_KEY` / `WUPHF_POSTHOG_HOST`) or disable either channel at
   runtime via the toggles — no rebuild needed.
@@ -127,7 +129,7 @@ human-behavior product analytics, and would multiply volume.
 ## Consent surfaces
 
 - **Onboarding wizard:** two toggles on the final step, both default ON, with
-  one-line honest copy ("anonymous usage" / "fully-masked recordings"). Choices
+  one-line honest copy ("anonymous usage" / "recordings mask typed text"). Choices
   ride `/onboarding/complete` and persist to config.
 - **Settings:** the same two toggles, mirrored, so consent is revocable any
   time. Changing either fires `analytics_consent_set` and updates `/config`.
@@ -151,7 +153,7 @@ human-behavior product analytics, and would multiply volume.
       `/api-token` analytics block; Go tests (config + team + onboarding green).
 - [x] **P2 Frontend core** — `posthog-js@1.386` (dynamic-import, code-split into
       its own chunk so dormant builds ship 0 bytes), analytics module rewrite
-      (lazy init, typed `track`/`trackOn`, workspace group, strict-mask
+      (lazy init, typed `track`/`trackOn`, workspace group, typed-text-masked
       recording, live `setAnalyticsConsent`), dormant-default + existing
       onboarding events preserved; analytics.test.ts 17 green.
 - [x] **P3 Instrumentation + toggles** — events wired at the API-client layer

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -89,7 +89,7 @@ type Config struct {
 	PendingCompanySeed  bool     `json:"pending_company_seed,omitempty"`
 
 	// Product analytics consent (PostHog). Two independent channels:
-	// anonymous usage events and fully-masked session recordings. Both
+	// anonymous usage events and session recordings (typed text masked). Both
 	// default ON when unset (nil) so legacy installs keep the documented
 	// default, but the whole analytics layer is dormant unless a PostHog
 	// project key is configured (build-time VITE_PUBLIC_POSTHOG_KEY or
@@ -666,8 +666,9 @@ func (c Config) IsAnalyticsTelemetryEnabled() bool {
 	return c.AnalyticsTelemetryEnabled == nil || *c.AnalyticsTelemetryEnabled
 }
 
-// IsAnalyticsSessionRecordingEnabled reports whether fully-masked session
-// recordings may be captured. Default ON when not explicitly opted out (nil).
+// IsAnalyticsSessionRecordingEnabled reports whether session recordings
+// (with typed text masked) may be captured. Default ON when not explicitly
+// opted out (nil).
 func (c Config) IsAnalyticsSessionRecordingEnabled() bool {
 	return c.AnalyticsSessionRecordingEnabled == nil || *c.AnalyticsSessionRecordingEnabled
 }

--- a/web/src/components/apps/settings/PrivacySection.tsx
+++ b/web/src/components/apps/settings/PrivacySection.tsx
@@ -25,8 +25,9 @@ const consentCheckbox: CSSProperties = {
 /**
  * Two independent consent toggles for product analytics. Both default ON and
  * apply live (no reload): a flip stops/starts capture or recording immediately
- * and persists to config. Honest copy states plainly that we never collect
- * content and that recordings are fully masked. See docs/specs/product-analytics.md.
+ * and persists to config. Honest copy states plainly that analytics never
+ * collects content and that recordings mask everything you type (PostHog's
+ * default input masking). See docs/specs/product-analytics.md.
  */
 export function PrivacySection({ cfg, save }: SectionProps) {
   const telemetry = cfg.analytics_telemetry_enabled !== false;
@@ -60,9 +61,10 @@ export function PrivacySection({ cfg, save }: SectionProps) {
     <div>
       <h2 style={styles.sectionTitle}>Privacy &amp; Analytics</h2>
       <p style={styles.sectionDesc}>
-        Two independent, optional controls, both on by default. WUPHF never
-        collects your content, customer data, or secrets, and session recordings
-        are fully masked. Changes take effect immediately.
+        Two independent, optional controls, both on by default. Product
+        analytics never collects your content, and session recordings mask
+        everything you type — passwords, keys, and form fields. Changes take
+        effect immediately.
       </p>
 
       <Field
@@ -83,7 +85,7 @@ export function PrivacySection({ cfg, save }: SectionProps) {
 
       <Field
         label="Session recording"
-        hint="Fully-masked replays: we see layout, clicks, and navigation to fix rough edges, never your text, customer data, or secrets."
+        hint="Replays that mask everything you type — passwords, keys, and form fields — while capturing layout, clicks, and navigation to fix rough edges."
       >
         <label style={consentToggleRow}>
           <input
@@ -93,7 +95,7 @@ export function PrivacySection({ cfg, save }: SectionProps) {
             onChange={(e) => setRecording(e.target.checked)}
             data-testid="settings-recording-toggle"
           />
-          <span>Allow fully-masked session recordings</span>
+          <span>Allow session recordings (typed text masked)</span>
         </label>
       </Field>
 

--- a/web/src/components/onboarding/wizard/wizardSteps.ts
+++ b/web/src/components/onboarding/wizard/wizardSteps.ts
@@ -85,7 +85,7 @@ export interface OnboardingAnswers {
   /**
    * Product-analytics consent, two independent channels, both default ON.
    * `telemetryConsent` gates anonymous usage events; `recordingConsent` gates
-   * fully-masked session replays. Persisted to config via /onboarding/complete
+   * session replays that mask typed text. Persisted to config via /onboarding/complete
    * and applied live on finish. See docs/specs/product-analytics.md.
    */
   telemetryConsent: boolean;
@@ -187,17 +187,18 @@ export const ONBOARDING_EMAIL_COPY = {
 
 /**
  * Analytics-consent copy for the final step. Two honest, independent toggles,
- * both checked by default. The copy states plainly that we never collect
- * content and that recordings are fully masked, so the promise is visible at
- * the point of consent. Single source of truth; mirrored in the README.
+ * both checked by default. The copy states plainly that analytics never
+ * collects content and that recordings mask everything you type, so the
+ * promise is visible at the point of consent. Single source of truth;
+ * mirrored in the README.
  */
 export const ONBOARDING_ANALYTICS_CONSENT_COPY = {
   heading: "Help improve WUPHF",
-  note: "Both are optional, on by default, and easy to change anytime in Settings. WUPHF never collects your content, customer data, or secrets.",
+  note: "Both are optional, on by default, and easy to change anytime in Settings. Analytics never collects your content, and recordings mask everything you type.",
   telemetryLabel:
     "Share anonymous product analytics. Counts and shapes of what you do, never the content.",
   recordingLabel:
-    "Allow fully-masked session recordings. We see layout and clicks to fix rough edges, never your text, data, or secrets.",
+    "Allow session recordings. We mask everything you type — passwords, keys, form fields — and capture layout, clicks, and navigation to fix rough edges.",
 } as const;
 
 /** UI chrome labels for the wizard host. WUPHF voice, no contractions. */

--- a/web/src/lib/analytics.test.ts
+++ b/web/src/lib/analytics.test.ts
@@ -116,7 +116,7 @@ describe("configured via runtime injection", () => {
     expect(mockPosthog.startSessionRecording).not.toHaveBeenCalled();
   });
 
-  it("starts recording on load with strict masking when recording is on", async () => {
+  it("starts recording on load masking typed text (inputs) when recording is on", async () => {
     configureAnalytics({
       configured: true,
       posthog_key: "phc_runtime",
@@ -125,8 +125,9 @@ describe("configured via runtime injection", () => {
     });
     await vi.waitFor(() => expect(mockPosthog.init).toHaveBeenCalled());
     const cfg = mockPosthog.init.mock.calls[0][1];
+    // PostHog default: typed text (inputs) is masked, on-screen text is not.
     expect(cfg?.session_recording?.maskAllInputs).toBe(true);
-    expect(cfg?.session_recording?.maskTextSelector).toBe("*");
+    expect(cfg?.session_recording?.maskTextSelector).toBeUndefined();
     await vi.waitFor(() =>
       expect(mockPosthog.startSessionRecording).toHaveBeenCalledTimes(1),
     );

--- a/web/src/lib/analytics.ts
+++ b/web/src/lib/analytics.ts
@@ -18,10 +18,11 @@
  *   3. NO COOKIES, NO AUTOCAPTURE. `persistence: "localStorage"`, autocapture
  *      off, pageviews captured manually on route change. No surveys, no
  *      heatmaps, no dead-click capture.
- *   4. STRICT-MASKED RECORDINGS. Every recording masks all text and all inputs
- *      (`maskAllInputs: true`, `maskTextSelector: "*"`). Replays show layout,
- *      cursor, clicks, scroll, and navigation — never readable content,
- *      customer data, agent output, or secrets.
+ *   4. TYPED-TEXT MASKING. Recordings mask everything typed into a field
+ *      (`maskAllInputs: true`) — passwords, API keys, search terms, form
+ *      entries — which is PostHog's default. Replays capture layout, cursor,
+ *      clicks, scroll, navigation, and on-screen UI; operators who want to
+ *      mask more can set a stricter `maskTextSelector` via their own build.
  *   5. NO PII IN EVENTS. Event properties carry shapes and buckets, never
  *      content. The only personal datum that ever leaves is the onboarding
  *      email, attached to the PostHog person exactly once at finish and only
@@ -184,8 +185,10 @@ function ensurePostHog(): Promise<PostHog | null> {
         // channel is on (below + setAnalyticsConsent), never automatically.
         disable_session_recording: true,
         session_recording: {
+          // PostHog default: mask everything typed into a field (inputs),
+          // but capture on-screen layout and content. We intentionally do NOT
+          // set maskTextSelector: "*" — that would obscure all rendered text.
           maskAllInputs: true,
-          maskTextSelector: "*",
           blockSelector: undefined,
           recordCrossOriginIframes: false,
         },

--- a/web/src/styles/onboarding-wizard.css
+++ b/web/src/styles/onboarding-wizard.css
@@ -411,7 +411,7 @@
 }
 
 /* Analytics-consent block on the final step: two honest, independent toggles
-   (anonymous events, fully-masked recordings), both checked by default. Reuses
+   (anonymous events, typed-text-masked recordings), both checked by default. Reuses
    the keep-in-touch row primitives for the checkboxes. */
 .onboarding-analytics-consent {
   margin-top: var(--space-5);


### PR DESCRIPTION
## What

Session replays previously masked **all on-screen text** via `maskTextSelector: "*"`. This drops that override and keeps `maskAllInputs: true` — **PostHog's default**, which masks only **typed text** (passwords, API keys, search terms, form fields). Replays now capture layout, cursor, clicks, scroll, navigation, and on-screen UI.

## Why

The previous "fully masked" recording was so aggressive that replays showed only blurred layout — little actionable signal. Aligning with PostHog's default input masking keeps what users type private while making replays useful.

## Privacy note

This intentionally loosens the recording promise: on-screen content (message text, wiki bodies, customer data, agent output) now appears in replays; only typed input is masked. All consent copy, README, and the spec were rewritten to state this honestly. Operators who want stricter masking can set their own `maskTextSelector` at build time.

## Changes

- `web/src/lib/analytics.ts` — drop `maskTextSelector: "*"`, keep `maskAllInputs: true`; rewrite guarantee #4.
- `web/src/lib/analytics.test.ts` — recording test now asserts `maskAllInputs === true` **and** `maskTextSelector === undefined` (regression coverage at the init-config layer).
- `web/src/components/apps/settings/PrivacySection.tsx` — permission checkbox + copy ("Allow session recordings (typed text masked)").
- `web/src/components/onboarding/wizard/wizardSteps.ts` + `styles/onboarding-wizard.css` — onboarding consent copy.
- `README.md`, `docs/specs/product-analytics.md` — privacy policy/spec updated to "typed-text masking (PostHog default)".

## Test plan

- [x] `bash scripts/test-web.sh web/src/lib/analytics.test.ts` — 21/21 pass
- [x] `bunx tsc --noEmit` — clean
- [x] `bunx biome check` on touched files — only pre-existing `origin/main` findings

Copy-only UI deltas (checkbox label + hints); screenshots skipped as low visual signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified session recording privacy policy: typed text inputs (passwords, API keys, form fields) are masked, while UI interactions (clicks, scrolling, navigation) remain visible in session recordings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->