### PR TITLE
fix(team): stop agents silently stalling — release turn slot on panic + honest note on chat-reply failure

### DIFF
--- a/internal/team/headless_codex_queue.go
+++ b/internal/team/headless_codex_queue.go
@@ -427,6 +427,17 @@ func (l *Launcher) runHeadlessCodexQueue(lane headlessLane, stop <-chan struct{}
 				l.updateHeadlessProgress(slug, "idle", "idle", "waiting for work", headlessProgressMetrics{})
 				return
 			}
+			// Guarantee the active slot is released even if the turn body
+			// panics. finishHeadlessTurn clears active[lane] (freeing the
+			// concurrency-cap slot), respawns parked lanes, and wakes the
+			// lead/CEO after a specialist completes. If a panic in
+			// headlessCodexRunTurn, the recovery helpers, or
+			// recordTaskLedgerEntry skipped it, the slot leaked forever:
+			// under a cap every other agent's lane stayed parked and the CEO
+			// never reacted to completions — agents silently stalled with no
+			// reply. recoverPanicTo (deferred above, so it runs last) still
+			// swallows and logs the panic after this cleanup runs.
+			defer l.finishHeadlessTurn(lane)
 			appendHeadlessCodexLatency(slug, fmt.Sprintf("stage=started queue_wait_ms=%d", time.Since(turn.EnqueuedAt).Milliseconds()))
 			l.updateHeadlessProgress(slug, "active", "queued", "queued work packet received", headlessProgressMetrics{})
 
@@ -475,7 +486,6 @@ func (l *Launcher) runHeadlessCodexQueue(lane headlessLane, stop <-chan struct{}
 				l.recoverFailedHeadlessTurn(slug, turn, startedAt, detail)
 			}
 			l.recordTaskLedgerEntry(slug, turn, startedAt, err)
-			l.finishHeadlessTurn(lane)
 		}()
 		l.headless.mu.Lock()
 		_, stillRunning := l.headless.workers[lane]

--- a/internal/team/headless_codex_queue.go
+++ b/internal/team/headless_codex_queue.go
@@ -459,6 +459,7 @@ func (l *Launcher) runHeadlessCodexQueue(lane headlessLane, stop <-chan struct{}
 			case errors.Is(ctxErr, context.DeadlineExceeded) || errors.Is(err, context.DeadlineExceeded):
 				appendHeadlessCodexLog(slug, fmt.Sprintf("error: headless codex turn timed out after %s", timeout))
 				l.updateHeadlessProgress(slug, "error", "error", fmt.Sprintf("turn timed out after %s", timeout), headlessProgressMetrics{})
+				l.noteChatTurnStall(slug, turn, fmt.Sprintf("the reply timed out after %s", timeout))
 				l.recoverTimedOutHeadlessTurn(slug, turn, startedAt, timeout)
 			case errors.Is(ctxErr, context.Canceled) || errors.Is(err, context.Canceled):
 				appendHeadlessCodexLog(slug, "error: headless codex turn cancelled so newer queued work can run")
@@ -481,6 +482,13 @@ func (l *Launcher) runHeadlessCodexQueue(lane headlessLane, stop <-chan struct{}
 					// to parse raw `signal: killed` exhaust (Wave F2).
 					detail = turnKilledHumanDetail(slug)
 					l.postTurnKilledNote(slug, turn.Channel)
+				} else {
+					// Non-killed failure on a plain chat/DM reply (no task):
+					// surface one honest line so the user isn't left with
+					// silence. Task turns are skipped inside the helper —
+					// their failure already surfaces via BlockTask. The killed
+					// branch above posts its own note, so it's excluded here.
+					l.noteChatTurnStall(slug, turn, "the reply hit an error")
 				}
 				l.updateHeadlessProgress(slug, "error", "error", truncate(detail, 180), headlessProgressMetrics{})
 				l.recoverFailedHeadlessTurn(slug, turn, startedAt, detail)

--- a/internal/team/headless_codex_queue.go
+++ b/internal/team/headless_codex_queue.go
@@ -456,6 +456,11 @@ func (l *Launcher) runHeadlessCodexQueue(lane headlessLane, stop <-chan struct{}
 			}
 			switch {
 			case err == nil:
+				// Turn succeeded and is durable (or the durability guard
+				// doesn't apply). If a real person prompted this chat reply and
+				// the agent still posted nothing anywhere, surface one honest
+				// line so a human DM never vanishes into silence.
+				l.noteChatTurnNoReply(slug, turn, startedAt)
 			case errors.Is(ctxErr, context.DeadlineExceeded) || errors.Is(err, context.DeadlineExceeded):
 				appendHeadlessCodexLog(slug, fmt.Sprintf("error: headless codex turn timed out after %s", timeout))
 				l.updateHeadlessProgress(slug, "error", "error", fmt.Sprintf("turn timed out after %s", timeout), headlessProgressMetrics{})

--- a/internal/team/headless_parallel_test.go
+++ b/internal/team/headless_parallel_test.go
@@ -116,6 +116,78 @@ func TestParallelInstancesRunDistinctWorktreesConcurrently(t *testing.T) {
 	}
 }
 
+// TestHeadlessTurnPanicFreesActiveSlot pins the stall-recovery invariant: if a
+// turn's runner PANICS mid-execution, the lane's active slot must still be
+// released so other agents are not starved behind a zombie in-flight turn.
+//
+// Before the fix, finishHeadlessTurn was the last statement inside the worker's
+// panic-recovered closure, so any panic in headlessCodexRunTurn (or the recovery
+// / ledger calls after it) was swallowed by recoverPanicTo and finishHeadlessTurn
+// never ran. The active slot leaked forever; under a concurrency cap every other
+// agent's lane parked and never drained — the CEO and specialists silently
+// "stalled and never replied". This test reproduces that: eng's turn panics, and
+// a second agent (gtm) enqueued afterward under a global cap of 1 must still get
+// to run because the panicking lane freed its slot.
+func TestHeadlessTurnPanicFreesActiveSlot(t *testing.T) {
+	b := brokerWithTasks(t,
+		teamTask{ID: "task-eng", Title: "eng work", Owner: "eng", status: "in_progress", ExecutionMode: "office"},
+		teamTask{ID: "task-gtm", Title: "gtm work", Owner: "gtm", status: "in_progress", ExecutionMode: "office"},
+	)
+	// Register the second owner so its task resolves to a real member lane.
+	b.mu.Lock()
+	b.members = append(b.members, officeMember{Slug: "gtm", Name: "gtm"})
+	b.memberIndex = nil
+	b.mu.Unlock()
+
+	l := newHeadlessLauncherForTest(t)
+	l.broker = b
+	l.headless.maxConcurrent = 1 // a leaked slot would starve every other lane
+
+	started := make(chan string, 8)
+	setHeadlessCodexRunTurnForTest(t, func(_ *Launcher, ctx context.Context, slug, _ string, _ ...string) error {
+		select {
+		case started <- slug:
+		default:
+		}
+		if slug == "eng" {
+			// recoverPanicTo (the worker's deferred recover) swallows this and
+			// logs a stack to stderr — expected noise for this regression.
+			panic("simulated provider crash mid-turn")
+		}
+		<-ctx.Done()
+		return ctx.Err()
+	})
+
+	// Drive eng first and wait for its turn to start (and therefore panic),
+	// so the second agent is enqueued only after the slot should have freed.
+	l.enqueueHeadlessCodexTurnRecord("eng", headlessCodexTurn{Prompt: "work #task-eng", Channel: "general", TaskID: "task-eng"})
+	select {
+	case got := <-started:
+		if got != "eng" {
+			t.Fatalf("expected eng turn to start first, got %q", got)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("eng turn never started")
+	}
+
+	l.enqueueHeadlessCodexTurnRecord("gtm", headlessCodexTurn{Prompt: "work #task-gtm", Channel: "general", TaskID: "task-gtm"})
+	select {
+	case got := <-started:
+		if got != "gtm" {
+			t.Fatalf("expected gtm turn to run after the panicking slot freed, got %q", got)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("gtm turn never ran: the panicking turn leaked its active slot and starved the global cap")
+	}
+
+	// Drain the parked gtm turn so the test's idle-wait cleanup can finish.
+	l.headless.mu.Lock()
+	if active := l.headless.active[taskLane("gtm", "task-gtm")]; active != nil && active.Cancel != nil {
+		active.Cancel()
+	}
+	l.headless.mu.Unlock()
+}
+
 // TestParallelInstancesRunNonDependentOfficeTasksConcurrently proves the rule
 // "non-dependent tasks run together" extends to office/external work, not just
 // worktree tasks: one agent with two non-dependent office tasks runs both at

--- a/internal/team/headless_turn_kill.go
+++ b/internal/team/headless_turn_kill.go
@@ -49,3 +49,29 @@ func (l *Launcher) postTurnKilledNote(slug, channel string) {
 		"error",
 	)
 }
+
+// noteChatTurnStall posts one honest system note when a turn that is NOT
+// attached to a task — a plain chat or DM reply — ends without a reply because
+// it timed out or errored. Task turns are skipped: their failure already
+// surfaces through BlockTask + self-healing in the decision inbox, so this
+// helper reuses timedOutTaskForTurn (the same task/taskless split the recovery
+// layer uses) and only speaks up when there is genuinely no task behind the
+// turn. Without it, a chat reply that times out or errors leaves the user
+// staring at silence — the agent "stalled and never replied" with no visible
+// reason. Best-effort: a nil broker (tests) is a no-op.
+func (l *Launcher) noteChatTurnStall(slug string, turn headlessCodexTurn, reason string) {
+	if l == nil || l.broker == nil {
+		return
+	}
+	if task := l.timedOutTaskForTurn(slug, turn); task != nil && strings.TrimSpace(task.ID) != "" {
+		return
+	}
+	target := strings.TrimSpace(turn.Channel)
+	if target == "" {
+		target = "general"
+	}
+	l.broker.PostSystemMessage(target,
+		fmt.Sprintf("@%s couldn't finish replying — %s. Try asking again.", slug, strings.TrimSpace(reason)),
+		"error",
+	)
+}

--- a/internal/team/headless_turn_kill.go
+++ b/internal/team/headless_turn_kill.go
@@ -12,6 +12,7 @@ package team
 import (
 	"fmt"
 	"strings"
+	"time"
 )
 
 // isTurnKilledError reports whether a headless turn died to an external kill
@@ -50,20 +51,31 @@ func (l *Launcher) postTurnKilledNote(slug, channel string) {
 	)
 }
 
+// chatTurnIsTaskless reports whether a turn is a plain chat/DM reply with no
+// task behind it — the shared gate for the chat-turn surfacing helpers. It
+// reuses timedOutTaskForTurn so the task/taskless split stays identical to the
+// recovery layer's: a turn that resolves to a real task is left to BlockTask +
+// self-healing, not these chat notes.
+func (l *Launcher) chatTurnIsTaskless(slug string, turn headlessCodexTurn) bool {
+	if l == nil {
+		return false
+	}
+	task := l.timedOutTaskForTurn(slug, turn)
+	return task == nil || strings.TrimSpace(task.ID) == ""
+}
+
 // noteChatTurnStall posts one honest system note when a turn that is NOT
 // attached to a task — a plain chat or DM reply — ends without a reply because
 // it timed out or errored. Task turns are skipped: their failure already
-// surfaces through BlockTask + self-healing in the decision inbox, so this
-// helper reuses timedOutTaskForTurn (the same task/taskless split the recovery
-// layer uses) and only speaks up when there is genuinely no task behind the
-// turn. Without it, a chat reply that times out or errors leaves the user
-// staring at silence — the agent "stalled and never replied" with no visible
-// reason. Best-effort: a nil broker (tests) is a no-op.
+// surfaces through BlockTask + self-healing in the decision inbox. Without it,
+// a chat reply that times out or errors leaves the user staring at silence —
+// the agent "stalled and never replied" with no visible reason. Best-effort: a
+// nil broker (tests) is a no-op.
 func (l *Launcher) noteChatTurnStall(slug string, turn headlessCodexTurn, reason string) {
 	if l == nil || l.broker == nil {
 		return
 	}
-	if task := l.timedOutTaskForTurn(slug, turn); task != nil && strings.TrimSpace(task.ID) != "" {
+	if !l.chatTurnIsTaskless(slug, turn) {
 		return
 	}
 	target := strings.TrimSpace(turn.Channel)
@@ -72,6 +84,42 @@ func (l *Launcher) noteChatTurnStall(slug string, turn headlessCodexTurn, reason
 	}
 	l.broker.PostSystemMessage(target,
 		fmt.Sprintf("@%s couldn't finish replying — %s. Try asking again.", slug, strings.TrimSpace(reason)),
+		"error",
+	)
+}
+
+// noteChatTurnNoReply posts one honest line when a turn that a real person
+// directly prompted (a DM or @-mention, marked turn.FromHuman) completes
+// successfully yet the agent never posts a reply anywhere. The provider runners
+// already salvage a forgotten broadcast by posting the model's final text when
+// it ran but didn't call team_broadcast (postHeadlessFinalMessageIfSilent), so
+// this only fires in the narrower case where the turn returned with no
+// user-facing output at all — a genuine silent miss against a human who is owed
+// an answer (the human-priority prompt instructs the agent to always reply,
+// status, or acknowledge). Gated three ways to avoid false positives on
+// intentional silence: only human-prompted turns (agent-to-agent turns may
+// legitimately stay quiet), only taskless turns, and only when the agent posted
+// no substantive message in ANY channel since the turn began. Best-effort: a
+// nil broker (tests) is a no-op.
+func (l *Launcher) noteChatTurnNoReply(slug string, turn headlessCodexTurn, startedAt time.Time) {
+	if l == nil || l.broker == nil {
+		return
+	}
+	if !turn.FromHuman {
+		return
+	}
+	if !l.chatTurnIsTaskless(slug, turn) {
+		return
+	}
+	if l.agentPostedSubstantiveMessageSince(slug, startedAt) {
+		return
+	}
+	target := strings.TrimSpace(turn.Channel)
+	if target == "" {
+		target = "general"
+	}
+	l.broker.PostSystemMessage(target,
+		fmt.Sprintf("@%s finished without posting a reply — this is usually a hiccup, not a refusal. Try asking again.", slug),
 		"error",
 	)
 }

--- a/internal/team/headless_turn_kill_test.go
+++ b/internal/team/headless_turn_kill_test.go
@@ -83,6 +83,114 @@ func TestNoteChatTurnStallTasklessVsTask(t *testing.T) {
 	}
 }
 
+// TestNoteChatTurnNoReplyGating pins the three-way gate on the silent-success
+// note: it fires only for a human-prompted, taskless turn where the agent
+// posted nothing, and stays silent for agent-to-agent turns, task turns, and
+// turns where the agent already replied.
+func TestNoteChatTurnNoReplyGating(t *testing.T) {
+	b := brokerWithTasks(t,
+		teamTask{ID: "task-x", Title: "x", Owner: "eng", status: "in_progress", ExecutionMode: "office"},
+	)
+	l := newHeadlessLauncherForTest(t)
+	l.broker = b
+	start := time.Now().Add(-time.Minute)
+
+	noReplyNotes := func() int {
+		n := 0
+		for _, m := range b.AllMessages() {
+			if m.From == "system" && strings.Contains(m.Content, "finished without posting a reply") {
+				n++
+			}
+		}
+		return n
+	}
+
+	// Not human-prompted: agent-to-agent turns may legitimately stay silent.
+	l.noteChatTurnNoReply("ceo", headlessCodexTurn{Channel: "general"}, start)
+	// Task-attached (even if human-prompted): the task path owns surfacing.
+	l.noteChatTurnNoReply("eng", headlessCodexTurn{TaskID: "task-x", Channel: "general", FromHuman: true}, start)
+	if got := noReplyNotes(); got != 0 {
+		t.Fatalf("expected no notes for non-human / task turns, got %d", got)
+	}
+
+	// Human-prompted, taskless, silent: one honest note.
+	l.noteChatTurnNoReply("ceo", headlessCodexTurn{Channel: "general", FromHuman: true}, start)
+	if got := noReplyNotes(); got != 1 {
+		t.Fatalf("expected exactly one no-reply note, got %d", got)
+	}
+	var note string
+	for _, m := range b.AllMessages() {
+		if m.From == "system" && strings.Contains(m.Content, "finished without posting a reply") {
+			note = m.Content
+		}
+	}
+	if !strings.Contains(note, "@ceo") {
+		t.Fatalf("note must name the agent: %q", note)
+	}
+
+	// Human-prompted, taskless, but the agent already replied: no extra note.
+	b.mu.Lock()
+	b.counter++
+	b.messages = append(b.messages, channelMessage{
+		ID:        "seed-gtm",
+		From:      "gtm",
+		Channel:   "general",
+		Content:   "here is my answer",
+		Timestamp: time.Now().UTC().Format(time.RFC3339),
+	})
+	b.mu.Unlock()
+	l.noteChatTurnNoReply("gtm", headlessCodexTurn{Channel: "general", FromHuman: true}, start)
+	for _, m := range b.AllMessages() {
+		if m.From == "system" && strings.Contains(m.Content, "finished without posting a reply") && strings.Contains(m.Content, "@gtm") {
+			t.Fatalf("no note expected when the agent already replied: %q", m.Content)
+		}
+	}
+}
+
+// TestHeadlessQueueHumanChatSilentSuccessPostsNote drives the real worker: a
+// human-prompted chat turn that returns success but posts nothing must leave one
+// honest line so a human DM never vanishes into silence.
+func TestHeadlessQueueHumanChatSilentSuccessPostsNote(t *testing.T) {
+	setHeadlessCodexRunTurnForTest(t, func(_ *Launcher, _ context.Context, _ string, _ string, _ ...string) error {
+		return nil // success, but the agent posts nothing
+	})
+
+	l := newHeadlessLauncherForTest(t)
+	b := NewBrokerAt(filepath.Join(t.TempDir(), "state.json"))
+	l.installBroker(b)
+
+	l.enqueueHeadlessCodexTurnRecord("ceo", headlessCodexTurn{
+		Prompt:     "are you there?",
+		Channel:    "general",
+		FromHuman:  true,
+		EnqueuedAt: time.Now(),
+	})
+
+	deadline := time.After(2 * time.Second)
+	for {
+		b.mu.Lock()
+		var content string
+		for i := range b.messages {
+			if b.messages[i].From == "system" && strings.Contains(b.messages[i].Content, "finished without posting a reply") {
+				content = b.messages[i].Content
+				break
+			}
+		}
+		b.mu.Unlock()
+		if content != "" {
+			if !strings.Contains(content, "@ceo") {
+				t.Fatalf("silent-success note must name the agent: %q", content)
+			}
+			return
+		}
+		select {
+		case <-deadline:
+			t.Fatal("timed out waiting for the silent-success no-reply note")
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+}
+
 // TestHeadlessQueueChatTimeoutPostsStallNote drives the real worker: a taskless
 // chat turn that times out must leave one honest line in the channel instead of
 // silence. Before the fix the timeout recovery early-returned (no task to

--- a/internal/team/headless_turn_kill_test.go
+++ b/internal/team/headless_turn_kill_test.go
@@ -48,6 +48,81 @@ func TestTurnKilledHumanDetailHasNoRawExhaust(t *testing.T) {
 	}
 }
 
+// TestNoteChatTurnStallTasklessVsTask pins the gate: a chat/DM reply (no task)
+// that fails gets one honest system note, while a task-attached turn stays
+// silent here because its failure already surfaces via BlockTask + self-healing.
+func TestNoteChatTurnStallTasklessVsTask(t *testing.T) {
+	b := brokerWithTasks(t,
+		teamTask{ID: "task-x", Title: "x", Owner: "eng", status: "in_progress", ExecutionMode: "office"},
+	)
+	l := newHeadlessLauncherForTest(t)
+	l.broker = b
+
+	// Task-attached turn: no chat note (the task path owns the surfacing).
+	l.noteChatTurnStall("eng", headlessCodexTurn{TaskID: "task-x", Channel: "general"}, "the reply hit an error")
+	for _, m := range b.AllMessages() {
+		if m.From == "system" && strings.Contains(m.Content, "couldn't finish replying") {
+			t.Fatalf("task-attached turn must not post a chat stall note: %q", m.Content)
+		}
+	}
+
+	// Taskless chat reply (ceo has no active task): one honest note.
+	l.noteChatTurnStall("ceo", headlessCodexTurn{Channel: "general"}, "the reply timed out after 4m0s")
+	var note string
+	for _, m := range b.AllMessages() {
+		if m.From == "system" && strings.Contains(m.Content, "couldn't finish replying") {
+			note = m.Content
+			break
+		}
+	}
+	if note == "" {
+		t.Fatal("taskless chat reply must post a stall note")
+	}
+	if !strings.Contains(note, "@ceo") || !strings.Contains(note, "timed out") {
+		t.Fatalf("note must name the agent and the reason: %q", note)
+	}
+}
+
+// TestHeadlessQueueChatTimeoutPostsStallNote drives the real worker: a taskless
+// chat turn that times out must leave one honest line in the channel instead of
+// silence. Before the fix the timeout recovery early-returned (no task to
+// block) and the user was left staring at a stalled agent that never replied.
+func TestHeadlessQueueChatTimeoutPostsStallNote(t *testing.T) {
+	setHeadlessCodexRunTurnForTest(t, func(_ *Launcher, _ context.Context, _ string, _ string, _ ...string) error {
+		return context.DeadlineExceeded
+	})
+
+	l := newHeadlessLauncherForTest(t)
+	b := NewBrokerAt(filepath.Join(t.TempDir(), "state.json"))
+	l.installBroker(b)
+
+	l.enqueueHeadlessCodexTurn("fe", "are you there?")
+
+	deadline := time.After(2 * time.Second)
+	for {
+		b.mu.Lock()
+		var content string
+		for i := range b.messages {
+			if b.messages[i].From == "system" && strings.Contains(b.messages[i].Content, "couldn't finish replying") {
+				content = b.messages[i].Content
+				break
+			}
+		}
+		b.mu.Unlock()
+		if content != "" {
+			if !strings.Contains(content, "@fe") || !strings.Contains(content, "timed out") {
+				t.Fatalf("timeout stall note must name the agent and reason: %q", content)
+			}
+			return
+		}
+		select {
+		case <-deadline:
+			t.Fatal("timed out waiting for the chat-timeout stall note")
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+}
+
 func TestHeadlessQueueKilledTurnPostsHumanReadableNote(t *testing.T) {
 	setHeadlessCodexRunTurnForTest(t, func(_ *Launcher, _ context.Context, _ string, _ string, _ ...string) error {
 		return errors.New("signal: killed")


### PR DESCRIPTION
Fixes for agents (CEO included) that **silently stall and never reply**. Three verified fixes; one investigated candidate dismissed as a non-bug.

---

## Fix 1 — leaked turn slot on panic (the big one)

The per-lane headless worker (`runHeadlessCodexQueue`) called `finishHeadlessTurn(lane)` as the **last statement** inside its panic-recovered closure. Any panic in `headlessCodexRunTurn`, the recovery helpers, or `recordTaskLedgerEntry` was swallowed by `recoverPanicTo` (logs a stack, returns) so `finishHeadlessTurn` **never ran**.

`finishHeadlessTurn` (1) clears `active[lane]` → frees the global/per-agent concurrency-cap slot, (2) respawns lanes parked behind the cap, and (3) **wakes the lead/CEO after a specialist completes**. Skipping it on panic leaked the active slot forever: under a cap every other agent's lane stayed parked, and the CEO never reacted to completions → silent stall, no reply, no surfaced error.

**Fix:** `defer l.finishHeadlessTurn(lane)`, registered right after a turn begins. Cleanup always runs, even on panic; `recoverPanicTo` (deferred earlier, runs last) still logs. Happy path unchanged.

**Test:** `TestHeadlessTurnPanicFreesActiveSlot` — under a global cap of 1, a panicking turn must still free its slot so a later turn runs. Fails before, passes after.

## Fix 2 — chat/DM reply that times out or errors posts nothing

When a turn is a plain chat reply (no task) and it **times out** or **fails**, `recoverTimedOutHeadlessTurn` / `recoverFailedHeadlessTurn` early-return with only an internal log line. Task turns surface via `BlockTask` + the decision inbox, but a chat reply has no task — so the user who DM'd the CEO got silence.

**Fix:** `noteChatTurnStall` posts one honest line into the channel when the failing turn has no task. Wired into the worker's timeout branch and its non-killed error branch (killed already posts its own note).

**Tests:** `TestNoteChatTurnStallTasklessVsTask`, `TestHeadlessQueueChatTimeoutPostsStallNote`.

## Fix 3 — human-prompted turn that succeeds but posts no reply

The murkier silence: a turn returns success yet posts nothing. For non-coding agents the durability guard is skipped, so it's treated as complete and the user gets silence. The provider runners already salvage a forgotten broadcast (`postHeadlessFinalMessageIfSilent` posts the model's final text when it ran but didn't call `team_broadcast`), so the only remaining case is a turn that returned with **no user-facing output at all** — which the human-priority prompt contract says should never happen (it instructs the agent to always reply, status, or acknowledge).

**Fix:** `noteChatTurnNoReply`, gated three ways to avoid false positives on intentional silence:
- `turn.FromHuman` only — agent-to-agent turns may legitimately stay quiet;
- taskless only;
- only when the agent posted no substantive message in **any** channel since the turn began (`agentPostedSubstantiveMessageSince` scans all channels, so an agent that answered elsewhere or via the salvage path isn't flagged).

Wired into the worker's `err==nil` branch.

**Tests:** `TestNoteChatTurnNoReplyGating` (full gating matrix), `TestHeadlessQueueHumanChatSilentSuccessPostsNote`.

## Investigated and dismissed — provider call ignoring `ctx.Done()`

A sub-agent flagged the OpenAI-compat streaming reader as a "critical hang" because `http.Client.Timeout` is 0. Verified against the code: the request is built with `http.NewRequestWithContext(ctx, …)` from the turn ctx (4–12m deadline) over a standard `http.Transport`. In Go's `net/http` the request context governs the **entire** response lifetime, so when the deadline fires the connection closes and the body read unblocks. The other three runners use `exec.CommandContext` + an explicit `ctx.Done()` terminate-goroutine. **No real hang** — the claim rested on a `net/http` misconception. No change made.

## Verification

- New tests fail-before / pass-after where applicable; all green under `-race`
- `bash scripts/test-go.sh ./internal/team` — green (one intermittent pre-existing timing flake, not reproducible, unrelated)
- `go vet ./internal/team/` clean; `go build ./cmd/wuphf` OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Headless agent now posts system notifications when human-initiated chat requests receive no agent reply.
  * Headless agent now posts system notifications to report failed chat turns.

* **Bug Fixes**
  * Improved system reliability for concurrent turn execution and resource cleanup during failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->