### PR TITLE
docs(specs): LangGraph orchestration migration — evaluation + plan (1/3)

### DIFF
--- a/docs/specs/deepagents-harness-evaluation.md
+++ b/docs/specs/deepagents-harness-evaluation.md
@@ -1,0 +1,241 @@
+# Evaluation: LangChain `deepagents` for the WUPHF agent harness
+
+> Status: **assessment / decision pending**. No code changes.
+> Branch: `worktree-deepagents-harness-eval`. Base: `origin/main` @ `ec467159`.
+> Date: 2026-06-19.
+
+## TL;DR
+
+**Do not adopt `deepagents` as our harness. Adopt it as a reference design.**
+
+`deepagents` is a **Python-first** harness (with a JS port, `deepagentsjs`) built on
+**LangGraph**. WUPHF's harness is **100% Go** and ships as a single self-contained
+binary (the Wails desktop decision explicitly chose an *in-process broker, no
+sidecar*). There is no Go `deepagents`. So "use deepagents for our harness"
+reduces to three options, and the language/runtime boundary is the decisive fact:
+
+| Option | What it means | Verdict |
+|---|---|---|
+| **A. Replace** | Rewrite the harness in Python on LangGraph | ❌ No — kills the single-binary product + Wails in-process decision + ~all of `internal/agent` + provider + broker glue |
+| **B. Sidecar** | Run `deepagents` (Python or `deepagentsjs`) as an IPC/HTTP sidecar | ⚠️ Narrow — only for *foreign fleets* (the Slack "agents-from-anywhere" membrane) or hosted/Nex-cloud, **not** the core OSS binary |
+| **C. Borrow the design** | Port the 3 missing pillars into Go as MCP tools + loop changes | ✅ Yes — this is the real value, ships in-language, preserves deploy story |
+
+Recommendation: **Option C now; keep Option B on the table only for the membrane /
+hosted lane.** Reject Option A.
+
+---
+
+## DECISION (2026-06-19) — supersedes the TL;DR above
+
+The founder chose a **full move onto LangGraph**, not a borrow-the-design port. A
+`/plan-eng-review` scope challenge first mis-aimed at the *inner* loop; the founder
+corrected the target: **Claude Code/Codex are great inner harnesses and stay — the weak,
+hand-rolled layer is WUPHF's coordination *above* them.** Final shape (D4):
+
+- **LangGraph = orchestrator-of-record (Python).** Replaces the hand-rolled coordination:
+  the agent tick/turn-loop (`internal/agent`) and `internal/team`'s decomposition,
+  sequencing, lifecycle state machine, scheduling, escalation. Owns task lifecycle +
+  run-state via a LangGraph checkpointer.
+- **Inner execution kept:** Claude Code (via the Claude Agent SDK) / Codex, invoked from
+  graph nodes; they keep using `teammcp` tools over MCP.
+- **Go = host, not coordinator:** durable *business* store, API/WS transport, `teammcp`
+  tools, integrations. Run/orchestration state moves to LangGraph's checkpointer; business
+  records stay in Go; a one-way projection keeps the web unchanged.
+- **deepagents:** optional, only for the CEO decompose/delegate node (`write_todos`+`task`).
+- **Why lower-risk than the inner-loop framing:** the "can deepagents beat Claude Code" bet
+  is retired (inner harness untouched); the remaining bet is "LangGraph ≥ hand-rolled
+  coordination," a low bar.
+
+Rejected en route: replacing the inner CLIs (they're the strong part); full Python backend
+rewrite retiring the Go store/integrations; hybrid that leaves the weak coordination in Go.
+
+**Spike (Option A′) — DONE, seam validated.** See
+[`spikes/deepagents-seam/REPORT.md`](../../spikes/deepagents-seam/REPORT.md). Against the
+real `wuphf mcp-team`, no API key: deepagents bound **84 tools = 76 live teammcp tools
+(zero rewrite) + 8 deepagents builtins** (`write_todos`/`task`/virtual-FS); per-call seam
+cost **~1.9 ms median**; `interrupt_on` HITL fired before the tool. One flag: `mcp-team`
+cold start ≈ 6.3 s → hold one long-lived teammcp session per task, don't cold-spawn.
+
+The spike's core proof — a Python process reaching the real `teammcp` tools over MCP —
+still underpins the LangGraph target (both the orchestrator and the inner Claude/Codex
+nodes need that tool access). deepagents-specific bits are now relevant only if the CEO
+node uses deepagents.
+
+**NEXT:** migration plan written —
+[`deepagents-migration-plan.md`](./deepagents-migration-plan.md) (LangGraph
+orchestrator-of-record). Run the 4-section eng review against it; de-risk the P4 run-state
+migration (`broker-state.json` → checkpointer) and P6 deployment/Windows early.
+
+---
+
+## 1. What `deepagents` is
+
+LangChain frames it as *"the batteries-included agent harness"* — a layer above
+core LLM building blocks that adds production patterns so you don't rebuild them.
+Source: <https://docs.langchain.com/oss/python/deepagents/overview>, `langchain-ai/deepagentsjs`.
+
+Four pillars:
+
+1. **Planning / task decomposition** — built-in `write_todos` tool; the agent
+   writes a structured todo list (`pending`/`in_progress`/`completed`) before and
+   during execution, and adapts it as it learns.
+2. **Sub-agents (delegation)** — a `task` tool spawns **ephemeral** child agents
+   with **fresh, isolated context** that return a single final report. Default
+   `general-purpose` sub-agent auto-enabled; custom sub-agents definable.
+3. **Virtual filesystem** — `ls/read_file/write_file/edit_file/glob/grep` over a
+   **pluggable backend** (in-memory `StateBackend`, `StoreBackend`, on-disk
+   `FilesystemBackend`, composite). Used for intermediate offloading + cross-thread
+   memory. Plus automatic **summarization** of history and large tool results.
+4. **Context engineering** — `SKILL.md` skills (Agent Skills standard, loaded
+   progressively), `AGENTS.md` persistent memory, Anthropic prompt caching for
+   static sections, and human-in-the-loop via `interrupt_on={"edit_file": True}`.
+
+Runtime: Python package `deepagents` (and TS `deepagentsjs`), on **LangGraph** for
+durable execution/streaming/HITL. `create_deep_agent(model=..., tools=[...],
+system_prompt=...)` returns an invokable agent. **Model-agnostic**
+(`anthropic:` / `openai:` / `google_genai:` / Ollama / OpenRouter / Fireworks).
+
+Stated limits: sub-agents are stateless single-shot; `FilesystemMiddleware` and the
+`task` tool cannot be removed; permissions don't apply to sandbox backends.
+
+---
+
+## 2. What WUPHF's harness actually is
+
+There is **no single harness**. There is a **provider abstraction** with two very
+different execution paths:
+
+### Path 1 — Native Go loop (`internal/agent/`)
+A state machine: `AgentLoop.Tick()` cycles `Idle → BuildContext → StreamLLM →
+ExecuteTool → Done` (`internal/agent/loop.go`). One goroutine per agent
+(`service.go:runAgentWorker`). Calls a pluggable `StreamFn` **once per turn**.
+Agent-callable tools are a flat set of **15**, verified in `internal/agent/tools.go`:
+`read_file, grep_search, glob, write_file, bash, send_message, nex_search,
+nex_ask, nex_remember, nex_record_{list,get,create,update}, nex_gossip_{publish,query}`.
+**No `write_todos`. No `task`/sub-agent-spawn. No virtual-FS abstraction.** Memory
+is session JSONL + lossy "Office Insight" summarization + Nex gossip.
+→ This is the path used for raw-API providers (OpenAI/local/Gemini).
+
+### Path 2 — CLI providers + `teammcp` (the production path)
+For providers `claude` / `codex`, the provider layer shells out to the **Claude
+Code / Codex CLIs**, which connect to our **`internal/teammcp` MCP server**.
+`teammcp` exposes a *rich* surface (each file = a tool group): `notebook_tools`,
+`playbook_tools`, `skills`/`skill_compile`/`skill_crud`, `server_wiki_tools`,
+`server_memory_tools`, `policy_tools`, `learning_tools`, `routine_tools`,
+`rich_artifact_tools`, `entity_tools`, `context_tools`, action/approval gates,
+`server_request_tools`, `member_approval`.
+→ Here the **CLI is itself a deep-agent harness** (its own TodoWrite, Task
+sub-agents, filesystem, skills), and `teammcp` layers the *company context* on top.
+
+### Surrounding orchestration (`internal/team/`)
+The broker owns tasks + lifecycle. Planning today is a **gate**, not an in-loop
+todo tool: `LifecycleStatePlanning` (`broker_lifecycle_transition.go`, PR #1116
+"structured planning gate — plan-first") dispatches the owner to write a plan that a
+human approves before `Running`. Concurrency is worktree-keyed task lanes
+(per memory: real `depends_on` serializes, independent tasks run in parallel).
+Sub-agent decomposition is **message-driven** (CEO → agent via `send_message`),
+not runtime child-agent spawning.
+
+---
+
+## 3. Capability gap map
+
+| `deepagents` pillar | Native Go path (raw API) | CLI path (claude/codex + teammcp) |
+|---|---|---|
+| **Planning `write_todos`** | ❌ absent | ✅ CLI's own TodoWrite |
+| **Ephemeral sub-agents (`task`)** | ❌ absent | ✅ CLI's own Task tool |
+| **Virtual FS + offloading** | ⚠️ flat `read/write_file` + lossy summary; no pluggable backend | ✅ CLI FS + `notebook`/`wiki` via teammcp |
+| **Skills (`SKILL.md`)** | ⚠️ knowledge snippets in packs | ✅ `skills`/`skill_compile` in teammcp |
+| **Persistent memory (`AGENTS.md`)** | ✅ Nex `nex_remember` + gossip | ✅ Nex + `server_memory_tools` |
+| **Summarization** | ✅ "Office Insight" compaction | ✅ CLI + teammcp |
+| **HITL `interrupt_on`** | ⚠️ `PermissionMode: "plan"` gate (coarse) | ✅ action-approval gates in teammcp |
+| **Model-agnostic** | ✅ provider registry | ✅ |
+
+**Read-out:** `deepagents`' net-new value lands almost entirely on the **native
+raw-API path** — the path that has no planning loop, no sub-agent spawn, and no
+real VFS. The CLI path already gets deep-agent behavior *for free* from Claude
+Code/Codex, and `teammcp` already implements the company-context half. So the
+honest question is **not** "should we adopt deepagents," it's **"do we want the
+native raw-API path to be a real deep-agent harness, and if so, build it in Go or
+borrow a runtime?"**
+
+---
+
+## 4. The decisive constraints
+
+1. **Language.** deepagents is Python (`deepagentsjs` is TS). Our harness, broker,
+   providers, and MCP server are Go. No Go port exists.
+2. **Single-binary deploy.** WUPHF ships one self-contained Go binary (8 `go:embed`
+   sites; Wails desktop = 43MB single binary, *in-process broker, no sidecar* —
+   an explicit founder decision). A Python/Node runtime breaks that.
+3. **No-new-runtime rule** (global CLAUDE.md): "No new packages/services unless
+   truly shared across contexts," and *ask before committing to a library/system*.
+4. **We already have the CLI escape hatch.** Anyone wanting maximal deep-agent
+   behavior today runs the `claude`/`codex` provider and gets it. deepagents would
+   compete with that, not extend it.
+
+---
+
+## 5. The three options, in detail
+
+### Option A — Replace the harness with Python/LangGraph ❌
+Rewrites `internal/agent/*`, the provider abstraction, and the broker glue;
+introduces a Python runtime; destroys the single-binary + Wails story. Throws away
+a mature, working system for a reference design. Rejected on merit (and on the
+no-sunk-cost principle — this isn't sunk cost, it's *active working infrastructure*).
+
+### Option B — `deepagents` as a sidecar ⚠️ (narrow)
+Run `deepagentsjs` (TS — closer to our web stack than Python) as an IPC/HTTP
+service the broker talks to. Adds a runtime to ship + supervise; conflicts with the
+no-sidecar core decision. **Only justified where a foreign runtime is already part
+of the design:**
+- The **Slack "agents-from-anywhere" membrane** (per memory): the CEO is a membrane,
+  foreign fleets execute scoped, human-approved steps. A `deepagents` fleet is
+  exactly such a foreign fleet — it auths to the membrane, not into our process.
+- The **hosted / Nex-cloud multi-tenant** side, which is out of scope for the OSS
+  single-binary repo anyway.
+Not for the core OSS binary.
+
+### Option C — Borrow the design into Go ✅ (recommended)
+Treat deepagents as a validated blueprint for the native path's gaps. Port the 3
+missing pillars in-language, reusing what exists:
+- **`write_todos` →** a planning/todo MCP tool (in `teammcp`, so *both* paths get it)
+  backed by the existing notebook/task model; surfaces structured todos instead of
+  prose. Directly answers the founder's "prose substrate / no structured state" gap
+  (per `sota-gap-analysis` memory).
+- **`task` ephemeral sub-agent →** reuse `AgentService.Create` to spawn a scoped,
+  isolated-session child agent that returns a single final report; wire it as a tool
+  + a lifecycle/concurrency-lane entry. We already have worktree-keyed lanes to
+  isolate it.
+- **Virtual FS + offloading →** formalize a pluggable FS backend over the
+  notebook/wiki/worktree we already have, and make summarization offload to files
+  (not lossy in-memory compaction).
+This is incremental, testable, ships as MCP tools + loop changes, and keeps the
+single binary. It is the "steal/borrow/build → borrow the design, build in our
+stack" move (per memory rule), and folds cleanly into the existing **SOTA-uplift**
+lane rather than starting a parallel one.
+
+---
+
+## 6. Recommendation
+
+1. **Reject A.**
+2. **Do C** as the substance — and scope it as additions to the **SOTA-uplift**
+   lane, not a new initiative. Smallest first slice: a `write_todos`-equivalent
+   structured-planning tool in `teammcp` (benefits *both* execution paths), then
+   ephemeral sub-agent spawn, then the FS backend.
+3. **Hold B** for the membrane / hosted lane only. If we ever run foreign fleets,
+   `deepagentsjs` behind the CEO membrane is a clean fit — but that's the
+   agents-from-anywhere design, not "our harness."
+
+## 7. Open questions for the founder
+
+- Is the **native raw-API path** strategically important, or is the
+  `claude`/`codex` CLI path the real product? (If the CLI path is the product, C's
+  value drops and we mostly want the `write_todos`/sub-agent tools in `teammcp` for
+  the CLI agents to call — still worth it, smaller.)
+- Do we want `deepagents` evaluated specifically as the **foreign-fleet runtime**
+  for the Slack membrane? That's the one place adopting the *code* (not just the
+  design) is defensible.
+- Appetite for a tiny spike: a `write_todos` MCP tool + a one-shot ephemeral
+  sub-agent, behind a flag, to feel the ergonomics before committing the lane.

--- a/docs/specs/deepagents-migration-plan.md
+++ b/docs/specs/deepagents-migration-plan.md
@@ -1,0 +1,177 @@
+# Migration plan: WUPHF orchestration → LangGraph (orchestrator-of-record)
+
+> Branch `worktree-deepagents-harness-eval`. 2026-06-19. Base `origin/main` @ `ec467159`.
+> Re-aimed after the founder's clarification: the weak, hand-rolled layer is WUPHF's
+> **coordination above** Claude Code/Codex, not the inner loop. The inner CLIs are great
+> and stay. Companions: [`deepagents-harness-evaluation.md`](./deepagents-harness-evaluation.md)
+> (decision trail) and [`../../spikes/deepagents-seam/REPORT.md`](../../spikes/deepagents-seam/REPORT.md)
+> (Python↔teammcp-over-MCP proven). This is the artifact the 4-section eng review runs against.
+
+## 1. Scope & decision (D1–D4)
+
+Replace WUPHF's hand-rolled coordination with a **Python LangGraph orchestrator that is the
+orchestrator-of-record** (owns task lifecycle + run-state). Keep **Claude Code/Codex** as the
+inner execution, invoked from graph nodes. **Go** becomes the durable-store + transport + tools
++ CLI host. deepagents is optional sugar for the CEO decompose/delegate node.
+
+**Replace (→ LangGraph):** the agent tick/turn-loop (`internal/agent`), and the coordination
+logic in `internal/team` — CEO decomposition, multi-agent sequencing, dependency ordering,
+the lifecycle state machine, scheduling, escalation.
+
+**Keep:** Claude Code/Codex (inner harness), `teammcp` (76 tools), the durable business store,
+the web API/transport, integrations/membrane.
+
+**Explicit non-goals:** ❌ rewrite the inner harness; ❌ rewrite teammcp tools; ❌ replace the
+durable business store; ❌ port the *whole* Go backend to Python; ❌ big-bang cutover;
+❌ run two orchestrators that co-own the same task (per-task single ownership, §8).
+
+## 2. Why this target is lower-risk than the inner-loop framing
+
+The inner harness is the part hardest to beat and easiest to break. We keep it untouched.
+The bet shrinks from "deepagents on our models ≥ Claude Code" (unproven, probably false on day
+one) to "LangGraph ≥ WUPHF's hand-rolled coordination" — a low bar you've already called. The
+capability risk that dominated the earlier plan is mostly gone.
+
+## 3. Architecture
+
+```
+   TS web ◄──► Go host:  business store · API/WS transport · teammcp tools · integrations  (KEEP)
+                         ▲ task-status projection            ▲ tools (MCP, broker token)
+   ┌─────────────────────┴────────────────────────────────── ┴───────────────────────────┐
+   │  Python LangGraph orchestrator   (orchestrator-of-record — NEW)                       │
+   │   • task lifecycle = graph state; durable via LangGraph checkpointer                  │
+   │   • CEO decompose/plan node (optionally deepagents write_todos + task)                │
+   │   • multi-agent sequencing · dependencies · scheduling · escalation                   │
+   │   • HITL via interrupt() ─► existing approval surface ─► Command(resume=…)            │
+   │             │ each work-step node invokes the GREAT inner harness:                    │
+   │             ▼                                                                          │
+   │     Claude Code (Claude Agent SDK) / Codex (CLI)  ── use teammcp tools over MCP        │
+   └────────────────────────────────────────────────────────────────────────────────────────┘
+```
+
+**Data-ownership split (the rule that prevents dual-source-of-truth):**
+
+| Fact | Owner | Notes |
+|---|---|---|
+| Orchestration / run-state (task graph, node status, pending interrupts, turn cursors) | **LangGraph checkpointer** (NEW store) | "What is running and where." |
+| Business records (office members, integrations, wiki, skills, channels/messages, task *records*) | **Go store** (KEEP) | "The company." |
+| Web's view of task status | **Projection** | One-way LangGraph → Go task records → web. Web renders unchanged. |
+
+No single fact lives in two stores. Orchestration facts are LangGraph's; business facts are Go's;
+the projection is one-way and derived.
+
+## 4. Component inventory
+
+**New**
+| Component | Where | Notes |
+|---|---|---|
+| `orchestrator/` LangGraph app | Python | The graph: lifecycle, decomposition, sequencing, HITL. |
+| Checkpointer | Python | Official `langgraph-checkpoint-sqlite`/`-postgres`; this store = run-state source of truth. |
+| Node → inner-harness invokers | Python | `claude` node via **Claude Agent SDK**; `codex` node via CLI/exec. Pass teammcp MCP config + broker token. |
+| Projection bridge | Go ↔ Python | Orchestrator emits task-status events → Go persists as task records for the web. |
+| Run-state migration shim | both | `broker-state.json` lifecycle fields → LangGraph checkpoint (§8, prod fixtures per `TODOS.md`). |
+| Supervisor | Go (`internal/runtimebin`) | Start/health/restart the Python orchestrator sidecar. |
+
+**Reused unchanged** — Claude Code/Codex, `teammcp` + broker-token launch pattern, durable
+business store, web API/WS, integrations/membrane, `prompt_builder` logic (ported or called).
+
+**Deleted last (P5):** `internal/agent` loop + `internal/team` coordination logic.
+
+## 5. The three seams
+
+**5a. Run-state / checkpointer seam (highest-risk — now spiked, see
+[`../../spikes/langgraph-runstate/REPORT.md`](../../spikes/langgraph-runstate/REPORT.md)).**
+The spike round-tripped WUPHF's real 13-state lifecycle through a LangGraph checkpointer in
+both ownership variants (13/13). It picks the **re-hydrate** variant: the **Go broker record
+stays the single source of durable truth**; the LangGraph checkpoint is a *rebuildable cache*
+re-hydrated from the Go record on restart. This avoids physically migrating run-state into a
+new store, removes dual-source drift, and makes a lost checkpoint recoverable. It still
+satisfies D4 (LangGraph decides what runs; Go holds the record). Two rules the spike nailed:
+(1) **carry `lifecycle_state` directly, never re-derive from the 4-tuple** — derivation is
+lossy for 3 states (`intake→ready`, `decision→review`, `changes_requested→running`) and is a
+legacy-only fallback; (2) contradictory legacy tuples **fail loud to `unknown`** for operator
+triage, never a silent wrong state.
+
+**5b. Inner-execution seam.** A work-step node invokes the inner harness:
+- **Claude:** the **Claude Agent SDK** (Python) drives Claude Code in-process with an MCP config
+  (teammcp) + permission mode; cleaner than shelling the CLI from Python.
+- **Codex:** CLI/exec with the same MCP config.
+- Both get `WUPHF_BROKER_TOKEN` + `WUPHF_BROKER_ADDR` so teammcp tools authenticate to the broker
+  (same trust model as today). Node streams inner output back into graph state.
+
+**5c. Web/transport seam.** Keep the web unchanged: Go projects LangGraph run-state into the
+existing task/lifecycle shapes the web already consumes, and streams events over the existing WS.
+The web does not learn there's a Python orchestrator.
+
+## 6. HITL mapping
+
+Gated nodes call LangGraph `interrupt()`; the orchestrator surfaces it through Go's existing
+approval surface (the deterministic-integrations `ExternalActionApprovalCard`). Human decision →
+`Command(resume=…)`. Gate policy stays in one place (the broker's action classification), so we
+don't fork approval logic.
+
+## 7. Concurrency / scheduling mapping
+
+Today: worktree-keyed lanes; only real `depends_on` serializes; independent tasks run in parallel.
+Map onto LangGraph: dependencies → graph edges; independent tasks → concurrent branches; the
+worktree-per-task isolation stays (the inner CLI node runs in the task's worktree). Verify
+LangGraph's concurrency model honors the "independent ⇒ parallel, dependent ⇒ serialized" rule
+with a dedicated test; do not assume it.
+
+## 8. Migration sequencing (strangler-fig; per-task single ownership)
+
+During transition two orchestrators coexist, but **every task is owned by exactly one** — a
+per-task `orchestrator=langgraph|broker` flag, never both. That bounds the anti-pattern.
+
+| Phase | Deliverable | Gate |
+|---|---|---|
+| **P0** ✅ | Seam spike (Python↔teammcp over MCP) | Done. |
+| **P1a** ✅ | The `orchestrator/` Python package: real lifecycle model + LangGraph graph (re-hydrate → dispatch turn → transition, HITL via `interrupt()`) + wire contract + FastAPI service + 25 green tests, key-free. | Built — `orchestrator/`, `pytest` green. |
+| **P1b** | Go side: a `provider/deepagents`-style dispatch client + broker-state projection write-back + per-task `orchestrator=langgraph\|broker` flag, behind a flag, one task-type. Web renders via projection. | A real single-agent task completes through LangGraph and shows correctly in the web. |
+| **P2** | CEO decompose node + dependencies + multi-agent sequencing in LangGraph. | A goal decomposes into ordered tasks and runs to completion through LangGraph. |
+| **P3** | HITL interrupts + approval gates via LangGraph. | A task that hits an approval gate pauses and resumes correctly. |
+| **P4** | Run-state ownership (re-hydrate, §5a — spiked ✅): Go record stays authoritative, LangGraph rehydrates on restart; carry `lifecycle_state`; prod-fixture tests (`TODOS.md` item 0). | Existing in-flight tasks resume under LangGraph without state loss. |
+| **P5** | Expand to all task-types; retire `internal/agent` loop + `internal/team` coordination logic. | Parity sustained across task-types; old coordination deleted. |
+| **P6** | Deployment/bundling (Python sidecar + supervisor) incl. Windows. | `wuphf` ships with a working bundled orchestrator on macOS/Linux/Windows. |
+
+Each phase ships behind the per-task flag with E2E verification (global rule: incremental, no big-bang).
+
+## 9. Deployment / bundling
+
+The orchestrator is Python, so a runtime ships with the product (same tax as the earlier plan):
+self-contained Python (uv/PEX) bundled beside `wuphf`, supervised by Go (`internal/runtimebin`);
+Wails desktop spawns it as a sidecar (compromises "in-process, no sidecar" for the orchestrator,
+not the store); container for hosted; **Windows is the highest-risk platform — schedule early in P6.**
+
+## 10. Test strategy
+
+- **Python:** LangGraph graph unit tests (decomposition, ordering, HITL) with a fake inner-harness
+  node (no API key, spike pattern); checkpointer migration tests against **production `broker-state.json`
+  fixtures** (`TODOS.md` item 0); node→Claude-SDK/Codex integration tests.
+- **Go:** projection-bridge tests (LangGraph status → web shapes); supervisor lifecycle tests.
+- **Cross-language:** golden fixtures for the projection + run-state shapes; oracle both directions.
+- **E2E:** per task-type, a real run through LangGraph vs the broker path, compared; concurrency
+  rule (§7) verified explicitly.
+
+## 11. Risks & open questions
+
+| Risk | Mitigation |
+|---|---|
+| **Run-state migration** — the in-flight-task data move. | **De-risked (spike):** re-hydrate keeps Go authoritative (no data move); carry `lifecycle_state` (lossless 13/13); unmapped tuples fail loud to `unknown`. Remaining: real prod fixtures (`TODOS.md` #0). |
+| **Two orchestrators in transition** | Per-task single-ownership flag; never co-owned. |
+| **Web churn** | One-way projection keeps the web API shapes unchanged. |
+| **Concurrency semantics differ** | Explicit §7 test; don't assume LangGraph matches the lane rule. |
+| **Deployment / Windows** | P6 early; PEX/uv; container for hosted. |
+| **Capability** | Largely retired — the inner harness (Claude Code/Codex) is unchanged. |
+| **Security** | Broker token flows to the Python orchestrator + inner CLIs; same trust as today's CLI; only env-var names on the wire. |
+
+Open: does the CEO node use **deepagents** (write_todos + task) or a plain LangGraph supervisor?
+Decide at P2 by prototype; not load-bearing for the architecture.
+
+## 12. First concrete PR (P1)
+
+A `orchestrator/` LangGraph app running one single-agent task-type end-to-end behind a per-task
+flag: one Claude work-step node via the Claude Agent SDK (teammcp MCP + broker token), the official
+SQLite checkpointer, and a projection bridge that writes task status into the Go store so the existing
+web renders it. Reuses the spike's `seam_probe.py` MCP wiring. No change to the inner harness, the
+web, or teammcp.


### PR DESCRIPTION
## Migration specs (1/3 in stack)

Evaluation + plan for moving WUPHF's hand-rolled coordination onto a Python
LangGraph orchestrator, keeping Claude Code/Codex as the inner harness and the Go
broker as the durable host.

- `docs/specs/deepagents-harness-evaluation.md` — decision trail.
- `docs/specs/deepagents-migration-plan.md` — architecture, wire contract,
  6-phase strangler-fig rollout, tests, deployment, risks.

Stack: **1. specs** -> 2. spikes -> 3. orchestrator. Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)