### PR TITLE
chore(spikes): de-risk the MCP seam + run-state migration (2/3)

### DIFF
--- a/spikes/deepagents-seam/.gitignore
+++ b/spikes/deepagents-seam/.gitignore
@@ -1,0 +1,7 @@
+.venv/
+bin/
+results.json
+__pycache__/
+*.pyc
+uv.lock
+echo-server/

--- a/spikes/deepagents-seam/REPORT.md
+++ b/spikes/deepagents-seam/REPORT.md
@@ -1,0 +1,65 @@
+# Spike report: Go-broker ↔ Python-deepagents seam (Option A)
+
+> Throwaway spike. Branch `worktree-deepagents-harness-eval`. 2026-06-19.
+> Question: is "keep the Go broker, run the agent inner loop in Python deepagents,
+> reuse WUPHF tools over MCP" real and cheap — before we write a migration plan?
+
+## Verdict
+
+**Seam validated. Proceed to the migration plan.** A Python deepagents agent
+talks to the real `wuphf mcp-team` MCP server, reuses every WUPHF tool unchanged,
+and layers planning + subagents + virtual-FS on top. The per-call seam cost is
+~2 ms. One yellow flag (server cold start) that shapes the dispatch model, not the
+decision.
+
+## Setup
+
+- Real server: `wuphf mcp-team` (production `internal/teammcp`, stdio MCP, official
+  `modelcontextprotocol/go-sdk v1.6.1`). Built from `origin/main` @ `ec467159`.
+- Round-trip baseline: `echo-server` — a 30-line Go MCP server using the *same SDK
+  + StdioTransport*, so it isolates seam cost from broker + LLM cost.
+- Python: `deepagents 0.6.11`, `langchain-mcp-adapters`, `langgraph`, `mcp`, CPython 3.12.
+- No model API key. Deterministic fake chat models drive the loop, so every number
+  is **seam cost, not vendor LLM latency**.
+- Repro: `uv venv .venv && uv pip install -r <pyproject> && .venv/bin/python seam_probe.py`
+
+## Results
+
+| Layer | What it proves | Result |
+|---|---|---|
+| **L1 — MCP interop** | Python deepagents stack connects to real `teammcp` | ✅ **76 tools** discovered; `tools/list` **24.7 ms**; `initialize` **6.26 s** (cold start, see flag) |
+| **L1b — round-trip** | Per-call seam cost (same-SDK Go server, no broker) | ✅ **median 1.88 ms**, min 0.79, p95 12.0 (30 calls) |
+| **L2 — deepagents build** | deepagents wraps teammcp tools + adds its own | ✅ **84 bound = 76 teammcp + 8 deepagents builtins** (`write_todos`, `task`, `ls/read_file/write_file/edit_file/glob/grep`) |
+| **L3 — HITL** | `interrupt_on` pauses before a tool call | ✅ interrupted before `echo`; maps to the broker approval gate |
+
+`results.json` holds the raw output.
+
+## What this means
+
+1. **The keystone holds.** deepagents reuses all 76 live WUPHF tools by connecting to
+   `teammcp` as an MCP client — **zero tool rewrite** — and injects exactly the deep-agent
+   behaviors the native Go loop lacks: `write_todos` (planning), `task` (ephemeral
+   subagents), and a virtual filesystem. That is the entire thesis of Option A, demonstrated.
+2. **The seam is not a latency problem.** ~2 ms median per tool call over Python↔Go stdio
+   MCP. Dispatch overhead is noise next to model inference and tool work.
+3. **HITL transfers.** deepagents `interrupt_on` produces a LangGraph interrupt that the Go
+   broker can surface through its existing approval gate — no new approval UX needed.
+
+## Flags (inform the plan, do not block it)
+
+- 🟡 **`wuphf mcp-team` cold start ≈ 6.3 s.** Process spawn + teammcp init (likely a broker
+  reach with a timeout). Implication for the dispatch model: the Python executor should hold
+  **one long-lived `teammcp` session per task** (or a warm pool), never cold-spawn per call.
+  Worth a 30-min characterization of where the 6 s goes before locking dispatch.
+- ⚪ **76 vs 91 tools.** `teammcp` registers a mode-dependent subset; 91 is the all-branches
+  upper bound, 76 is this config (markdown backend, no slug/channel). Expected, not a bug.
+
+## NOT proven here (carry into the plan)
+
+- **Real LLM loop quality** — no API key; we proved wiring, not that deepagents-on-our-models
+  matches Claude Code/Codex on real tasks. This is the capability bet from the assessment.
+- **Live tool *execution*** — we proved discovery + binding + transport; executing a mutating
+  teammcp tool needs a running broker + token (the broker is the host, by design).
+- **End-to-end streaming** through a real `provider/deepagents` dispatch RPC (events back to
+  the broker UI). Standard work, but unmeasured here.
+- **Deployment** — bundling a Python runtime with the Go binary / Wails desktop sidecar.

--- a/spikes/deepagents-seam/pyproject.toml
+++ b/spikes/deepagents-seam/pyproject.toml
@@ -1,0 +1,12 @@
+[project]
+name = "deepagents-seam-spike"
+version = "0.0.0"
+description = "Throwaway spike: prove Go-broker <-> Python-deepagents seam over MCP."
+requires-python = ">=3.11"
+dependencies = [
+    "deepagents",
+    "langchain-mcp-adapters",
+    "langgraph",
+    "langchain-core",
+    "mcp",
+]

--- a/spikes/deepagents-seam/seam_probe.py
+++ b/spikes/deepagents-seam/seam_probe.py
@@ -1,0 +1,253 @@
+"""
+Spike probe: prove the Go-broker <-> Python-deepagents seam.
+
+Decision under test (D3=A): keep the Go broker as coordinator; run the agent
+INNER loop in Python deepagents (LangGraph), reusing WUPHF's existing tools by
+connecting to the Go `teammcp` MCP server. This script measures whether that
+seam actually works and how much it costs.
+
+Layers (each independent; each prints a real number even if a later layer fails):
+
+  L1  MCP interop      Python MCP client spawns real `wuphf mcp-team` over stdio,
+                       handshakes, lists tools.  -> initialize ms, tools/list ms, tool count
+  L1b MCP round-trip   N calls to a same-SDK Go echo server.  -> median / p95 round-trip ms
+                       (isolates OUR seam cost from broker + LLM cost)
+  L2  deepagents build create_deep_agent(tools=<teammcp tools over MCP>) and capture
+                       exactly which tools deepagents binds. -> proves deepagents wraps
+                       teammcp tools AND injects planning/filesystem/subagent tools.
+  L3  HITL             interrupt_on={tool: True} pauses before a tool call.
+                       -> proves human-in-the-loop maps onto the broker's approval gate.
+
+No model API key needed: deterministic fake chat models drive any live turn, so we
+measure the SEAM, not vendor LLM latency.
+"""
+
+import asyncio
+import json
+import os
+import pathlib
+import statistics
+import time
+import traceback
+from typing import Any, List
+
+HERE = pathlib.Path(__file__).parent
+WUPHF = HERE / "bin" / "wuphf"
+ECHO = HERE / "bin" / "echo-server"
+
+results: dict[str, Any] = {}
+
+
+def teammcp_env() -> dict:
+    # markdown backend surfaces notebook tools; everything else inherited.
+    return {**os.environ, "WUPHF_MEMORY_BACKEND": "markdown"}
+
+
+# --------------------------------------------------------------------------- #
+# Fake chat models (no API key) — just enough to drive the LangGraph loop.
+# --------------------------------------------------------------------------- #
+def _make_models():
+    from langchain_core.language_models.chat_models import BaseChatModel
+    from langchain_core.messages import AIMessage
+    from langchain_core.outputs import ChatGeneration, ChatResult
+    from pydantic import Field
+
+    class CaptureModel(BaseChatModel):
+        """Records the tool surface deepagents binds, then ends the turn."""
+
+        bound_tool_names: List[str] = Field(default_factory=list)
+        n_calls: int = 0
+
+        def bind_tools(self, tools, **kwargs):
+            names = []
+            for tl in tools:
+                n = getattr(tl, "name", None)
+                if n is None and isinstance(tl, dict):
+                    n = tl.get("name") or tl.get("function", {}).get("name")
+                if n is None:
+                    n = getattr(tl, "__name__", "<unknown>")
+                names.append(n)
+            self.bound_tool_names = names
+            return self
+
+        def _generate(self, messages, stop=None, run_manager=None, **kwargs):
+            self.n_calls += 1
+            return ChatResult(generations=[ChatGeneration(message=AIMessage(content="spike-final"))])
+
+        @property
+        def _llm_type(self):
+            return "capture-fake"
+
+    class ToolCallOnceModel(BaseChatModel):
+        """Emits exactly one tool call (to trigger an interrupt), then finishes."""
+
+        tool_name: str = "echo"
+        n_calls: int = 0
+
+        def bind_tools(self, tools, **kwargs):
+            return self
+
+        def _generate(self, messages, stop=None, run_manager=None, **kwargs):
+            self.n_calls += 1
+            if self.n_calls == 1:
+                msg = AIMessage(
+                    content="",
+                    tool_calls=[{"name": self.tool_name, "args": {"text": "hi"}, "id": "call_1", "type": "tool_call"}],
+                )
+            else:
+                msg = AIMessage(content="done")
+            return ChatResult(generations=[ChatGeneration(message=msg)])
+
+        @property
+        def _llm_type(self):
+            return "toolcall-once"
+
+    return CaptureModel, ToolCallOnceModel
+
+
+# --------------------------------------------------------------------------- #
+# L1: real teammcp interop
+# --------------------------------------------------------------------------- #
+async def layer1_teammcp_interop():
+    from mcp import ClientSession, StdioServerParameters
+    from mcp.client.stdio import stdio_client
+
+    params = StdioServerParameters(command=str(WUPHF), args=["mcp-team"], env=teammcp_env())
+    async with stdio_client(params) as (r, w):
+        async with ClientSession(r, w) as s:
+            t0 = time.perf_counter()
+            await s.initialize()
+            init_ms = (time.perf_counter() - t0) * 1000
+            t0 = time.perf_counter()
+            tl = await s.list_tools()
+            list_ms = (time.perf_counter() - t0) * 1000
+            names = [t.name for t in tl.tools]
+            return {
+                "ok": True,
+                "server": "wuphf mcp-team (real teammcp)",
+                "initialize_ms": round(init_ms, 1),
+                "list_tools_ms": round(list_ms, 1),
+                "tool_count": len(names),
+                "sample_tools": sorted(names)[:18],
+            }
+
+
+# --------------------------------------------------------------------------- #
+# L1b: clean round-trip against same-SDK echo server
+# --------------------------------------------------------------------------- #
+async def layer1b_echo_roundtrip(n: int = 30):
+    from mcp import ClientSession, StdioServerParameters
+    from mcp.client.stdio import stdio_client
+
+    params = StdioServerParameters(command=str(ECHO), args=[], env={**os.environ})
+    async with stdio_client(params) as (r, w):
+        async with ClientSession(r, w) as s:
+            await s.initialize()
+            await s.call_tool("echo", {"text": "warmup"})  # discard cold start
+            times = []
+            for i in range(n):
+                t0 = time.perf_counter()
+                await s.call_tool("echo", {"text": f"ping-{i}"})
+                times.append((time.perf_counter() - t0) * 1000)
+            times.sort()
+            return {
+                "ok": True,
+                "server": "echo-server (same Go MCP SDK, no broker)",
+                "calls": n,
+                "median_ms": round(statistics.median(times), 2),
+                "min_ms": round(times[0], 2),
+                "p95_ms": round(times[min(int(n * 0.95), n - 1)], 2),
+            }
+
+
+# --------------------------------------------------------------------------- #
+# L2: deepagents builds over teammcp tools; capture the bound tool surface
+# --------------------------------------------------------------------------- #
+async def layer2_deepagents_over_teammcp():
+    from langchain_mcp_adapters.client import MultiServerMCPClient
+
+    client = MultiServerMCPClient(
+        {"teammcp": {"command": str(WUPHF), "args": ["mcp-team"], "transport": "stdio", "env": teammcp_env()}}
+    )
+    mcp_tools = await client.get_tools()
+
+    from deepagents import create_deep_agent
+
+    CaptureModel, _ = _make_models()
+    cm = CaptureModel()
+    agent = create_deep_agent(model=cm, tools=mcp_tools)
+    await agent.ainvoke({"messages": [{"role": "user", "content": "ping"}]})
+
+    bound = list(cm.bound_tool_names)
+    deep_builtins = sorted(
+        n for n in bound if n in {"write_todos", "ls", "read_file", "write_file", "edit_file", "glob", "grep", "task"}
+    )
+    teammcp_bound = sorted(n for n in bound if n not in set(deep_builtins))
+    return {
+        "ok": True,
+        "mcp_tools_loaded": len(mcp_tools),
+        "total_tools_bound_by_deepagents": len(bound),
+        "deepagents_builtins_present": deep_builtins,
+        "teammcp_tools_reused_sample": teammcp_bound[:12],
+        "teammcp_tools_reused_count": len(teammcp_bound),
+    }
+
+
+# --------------------------------------------------------------------------- #
+# L3: HITL interrupt before a tool call
+# --------------------------------------------------------------------------- #
+async def layer3_hitl_interrupt():
+    # Use the echo MCP tool so the interrupt fires without needing a broker.
+    from langchain_mcp_adapters.client import MultiServerMCPClient
+
+    client = MultiServerMCPClient(
+        {"echo": {"command": str(ECHO), "args": [], "transport": "stdio", "env": {**os.environ}}}
+    )
+    tools = await client.get_tools()
+
+    from deepagents import create_deep_agent
+    from langgraph.checkpoint.memory import MemorySaver
+
+    _, ToolCallOnceModel = _make_models()
+    model = ToolCallOnceModel(tool_name="echo")
+    agent = create_deep_agent(
+        model=model,
+        tools=tools,
+        interrupt_on={"echo": True},
+        checkpointer=MemorySaver(),
+    )
+    cfg = {"configurable": {"thread_id": "spike-hitl-1"}}
+    state = await agent.ainvoke({"messages": [{"role": "user", "content": "echo hi"}]}, config=cfg)
+    interrupted = "__interrupt__" in state if isinstance(state, dict) else False
+    return {
+        "ok": True,
+        "interrupted_before_tool": bool(interrupted),
+        "mechanism": "deepagents interrupt_on -> LangGraph interrupt; maps to broker approval gate",
+    }
+
+
+# --------------------------------------------------------------------------- #
+async def run_layer(name, coro_fn, *args):
+    print(f"\n=== {name} ===", flush=True)
+    try:
+        out = await coro_fn(*args)
+        results[name] = out
+        print(json.dumps(out, indent=2), flush=True)
+    except Exception as e:  # noqa: BLE001 — spike wants the failure recorded, not raised
+        results[name] = {"ok": False, "error": f"{type(e).__name__}: {e}", "trace": traceback.format_exc()[-800:]}
+        print(f"FAILED: {type(e).__name__}: {e}", flush=True)
+
+
+async def main():
+    print(f"wuphf binary : {WUPHF} ({'present' if WUPHF.exists() else 'MISSING'})")
+    print(f"echo binary  : {ECHO} ({'present' if ECHO.exists() else 'MISSING'})")
+    await run_layer("L1_mcp_interop", layer1_teammcp_interop)
+    await run_layer("L1b_echo_roundtrip", layer1b_echo_roundtrip)
+    await run_layer("L2_deepagents_over_teammcp", layer2_deepagents_over_teammcp)
+    await run_layer("L3_hitl_interrupt", layer3_hitl_interrupt)
+    (HERE / "results.json").write_text(json.dumps(results, indent=2))
+    print("\nWrote results.json")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/spikes/langgraph-runstate/.gitignore
+++ b/spikes/langgraph-runstate/.gitignore
@@ -1,0 +1,4 @@
+results.json
+_runstate.sqlite
+__pycache__/
+*.pyc

--- a/spikes/langgraph-runstate/REPORT.md
+++ b/spikes/langgraph-runstate/REPORT.md
@@ -1,0 +1,67 @@
+# Spike report: P4 run-state migration (LangGraph checkpointer ↔ WUPHF lifecycle)
+
+> Throwaway spike. Branch `worktree-deepagents-harness-eval`. 2026-06-19.
+> Question: can WUPHF's real 13-state task lifecycle round-trip through a LangGraph
+> checkpointer without losing the lifecycle position — the highest-risk part of the
+> orchestration move (TODOS.md #0: "task moves to unknown and refuses to start")?
+
+## Verdict
+
+**Run-state seam validated, and it picks a winner.** WUPHF's real lifecycle (ported
+faithfully from `broker_lifecycle_transition.go`: 13 states, the 4-tuple forward map, the
+migration map, the fail-loud `unknown`) round-trips through LangGraph **in both ownership
+variants, for all 13 states.** The evidence favors the **re-hydrate** variant. Two concrete
+design rules fall out, below.
+
+## Setup
+
+- Faithful port: `lifecycle_model.py` mirrors the Go state set + `lifecycleDerivedFields` +
+  `lifecycleMigrationMap` + `deriveLifecycleStateFromLegacy` + the bare-status fallback.
+- LangGraph `0.x` + `langgraph-checkpoint-sqlite 3.1.0`. No broker, no API key — pure
+  orchestration-state mechanics.
+- Fixtures synthesized from the canonical map + adversarial tuples (no real `~/.wuphf` state
+  read — exactly the anonymized-tuple approach TODOS.md #0 prescribes).
+- Repro: `../deepagents-seam/.venv/bin/python runstate_probe.py`
+
+## Results
+
+| Layer | What it proves | Result |
+|---|---|---|
+| **A — lossiness** | Is the legacy 4-tuple enough to recover the state? | **10/13 lossless; 3 collapse** if `lifecycle_state` is dropped: `intake→ready`, `decision→review`, `changes_requested→running` |
+| **B — pure** | LangGraph SqliteSaver as run-state store: migrate → restart → resume | ✅ **13/13** restored + resumed to the correct next state |
+| **C — re-hydrate** | Go record authoritative; ephemeral saver rebuilt on restart | ✅ **13/13** rehydrated + resumed correctly |
+| **D — adversarial** | Contradictory/garbage tuples must fail loud | ✅ all 3 contradictions → `unknown` (operator triage); legacy alias *names* (`merged`, `blocked_on_pr_merge`) normalize losslessly |
+
+`results.json` holds the raw per-state output.
+
+## Two design rules this nails down
+
+1. **Carry `lifecycle_state` directly — never re-derive from the 4-tuple.** The 4-tuple is
+   lossy for 3 states (A). Modern `broker-state.json` already persists `lifecycle_state`, so
+   the migration is lossless for all 13 by just carrying that field. 4-tuple derivation is a
+   *legacy-only fallback* (pre-Lane-A snapshots with no state field), where the 3 collapses
+   are the documented, accepted loss.
+
+2. **Prefer the re-hydrate variant (C) over pure-checkpoint (B).** Both pass 13/13, but
+   re-hydrate keeps the **Go broker record as the single source of durable truth** and treats
+   the LangGraph checkpoint as a rebuildable cache. That:
+   - removes the scary physical migration (no moving durable run-state into a new SQLite store);
+   - eliminates dual-source-of-truth drift (the checkpoint is derived, not authoritative);
+   - makes a lost/corrupt checkpoint *recoverable* (rebuild from the Go record) instead of data loss.
+   It still satisfies D4 ("LangGraph owns orchestration") — LangGraph decides what runs; Go just
+   holds the durable record it rehydrates from. The only thing pure-checkpoint buys (arbitrary
+   sub-step time-travel) isn't needed: lifecycle-granularity rebuild is enough.
+
+## What this de-risks
+
+The TODOS.md #0 failure mode — "task lands in `unknown` and refuses to start" — is now a
+**safe, surfaced** failure, not silent corruption: contradictory tuples resolve to `unknown`
+for operator triage (D), and modern tasks never hit derivation at all (rule 1). The migration's
+worst case is a flagged task, not a wrong one.
+
+## NOT covered here (carry into P4 build)
+
+- Real production `broker-state.json` fixtures (still TODOS.md #0 — synthesized tuples here).
+- The full task record beyond lifecycle position (owner, deps, messages, packet) — the
+  orchestrator needs those too; this spike isolated the lifecycle state.
+- Concurrency/lane semantics (separate §7 risk in the plan).

--- a/spikes/langgraph-runstate/lifecycle_model.py
+++ b/spikes/langgraph-runstate/lifecycle_model.py
@@ -1,0 +1,125 @@
+"""
+Faithful port of WUPHF's lifecycle state machine for the P4 run-state spike.
+
+Source of truth: internal/team/broker_lifecycle_transition.go @ origin/main ec467159.
+We mirror the REAL data so the spike tests the actual migration, not a toy:
+  - the 13 canonical lifecycle states (+ "unknown" fail-loud fallback)
+  - FORWARD: state -> (pipeline_stage, review_state, status, blocked) 4-tuple
+  - MIGRATION: legacy 4-tuple -> state (incl. legacy aliases / bare statuses)
+  - derive_lifecycle_state_from_legacy(): the migration shim's core
+  - bare-status fallback (migrateLifecycleStatesLocked)
+
+If broker_lifecycle_transition.go changes these maps, re-port them here.
+"""
+
+UNKNOWN = "unknown"
+
+CANONICAL_STATES = [
+    "drafting", "intake", "ready", "planning", "running", "review",
+    "decision", "blocked", "queued_behind_owner", "changes_requested",
+    "approved", "rejected", "archived",
+]
+
+# state -> (pipeline_stage, review_state, status, blocked)   [lifecycleDerivedFields]
+FORWARD = {
+    "drafting":            ("draft", "pending_review", "open", False),
+    "planning":            ("plan", "pending_review", "in_progress", False),
+    "intake":              ("triage", "pending_review", "open", False),
+    "ready":               ("triage", "pending_review", "open", False),
+    "running":             ("implement", "pending_review", "in_progress", False),
+    "review":              ("review", "ready_for_review", "in_progress", False),
+    "decision":            ("review", "ready_for_review", "in_progress", False),
+    "blocked":             ("review", "ready_for_review", "blocked", True),
+    "queued_behind_owner": ("triage", "pending_review", "open", True),
+    "changes_requested":   ("implement", "pending_review", "in_progress", False),
+    "approved":            ("ship", "approved", "done", False),
+    "rejected":            ("review", "rejected", "rejected", True),
+    "archived":            ("archived", "approved", "archived", False),
+}
+
+# legacy 4-tuple -> state   [lifecycleMigrationMap]; keys are lower-cased.
+MIGRATION = {
+    ("draft", "pending_review", "open", False): "drafting",
+    ("triage", "pending_review", "open", False): "ready",
+    ("implement", "pending_review", "in_progress", False): "running",
+    ("review", "ready_for_review", "in_progress", False): "review",
+    ("review", "ready_for_review", "blocked", True): "blocked",
+    ("triage", "pending_review", "open", True): "queued_behind_owner",
+    ("ship", "approved", "done", False): "approved",
+    ("review", "rejected", "rejected", True): "rejected",
+    ("plan", "pending_review", "in_progress", False): "planning",
+    ("implement", "changes_requested", "in_progress", False): "changes_requested",
+    # blocked variants
+    ("", "", "blocked", True): "blocked",
+    ("", "", "blocked", False): "blocked",
+    ("implement", "pending_review", "blocked", True): "blocked",
+    ("implement", "pending_review", "blocked", False): "blocked",
+    ("review", "ready_for_review", "blocked", False): "blocked",
+    # bare statuses
+    ("", "", "open", False): "ready",
+    ("", "", "open", True): "queued_behind_owner",
+    ("", "", "in_progress", False): "running",
+    ("", "", "review", False): "review",
+    ("", "", "done", False): "approved",
+    ("", "", "completed", False): "approved",
+    ("", "", "canceled", False): "approved",
+    ("", "", "cancelled", False): "approved",
+    ("", "", "archived", False): "archived",
+    ("archived", "approved", "archived", False): "archived",
+}
+
+# normalizeLegacyLifecycleStateName
+LEGACY_NAME_ALIAS = {"merged": "approved", "blocked_on_pr_merge": "blocked"}
+
+
+def normalize_legacy_state_name(s: str) -> str:
+    return LEGACY_NAME_ALIAS.get((s or "").strip().lower(), s)
+
+
+def derive_lifecycle_state_from_legacy(pipeline_stage, review_state, status, blocked) -> str:
+    key = (
+        (pipeline_stage or "").strip().lower(),
+        (review_state or "").strip().lower(),
+        (status or "").strip().lower(),
+        bool(blocked),
+    )
+    return MIGRATION.get(key, UNKNOWN)
+
+
+_TERMINAL = {"done", "approved", "archived", "completed", "canceled", "cancelled"}
+
+
+def migrate_state(record: dict) -> tuple[str, str]:
+    """Mirror migrateLifecycleStatesLocked. Returns (state, how).
+
+    how ∈ {carried, derived, bare_status_fallback, unknown}.
+    Modern broker-state.json carries lifecycle_state directly (lossless);
+    legacy snapshots derive from the 4-tuple; unmapped tuples fail loud.
+    """
+    carried = (record.get("lifecycle_state") or "").strip()
+    if carried:
+        return normalize_legacy_state_name(carried), "carried"
+    ps = record.get("pipeline_stage", "")
+    rs = record.get("review_state", "")
+    st = record.get("status", "")
+    bl = bool(record.get("blocked", False))
+    derived = derive_lifecycle_state_from_legacy(ps, rs, st, bl)
+    if derived != UNKNOWN:
+        return derived, "derived"
+    by_status = derive_lifecycle_state_from_legacy("", "", st, bl)
+    if by_status != UNKNOWN:
+        return by_status, "bare_status_fallback"
+    return UNKNOWN, "unknown"
+
+
+def make_broker_record(state: str, *, carry_state: bool = True, task_id: str = None) -> dict:
+    """A broker-state.json-shaped task at `state`. carry_state=False simulates a
+    pre-Lane-A snapshot that has only the legacy 4-tuple, no lifecycle_state."""
+    ps, rs, st, bl = FORWARD[state]
+    rec = {
+        "task_id": task_id or f"task-{state}",
+        "pipeline_stage": ps, "review_state": rs, "status": st, "blocked": bl,
+    }
+    if carry_state:
+        rec["lifecycle_state"] = state
+    return rec

--- a/spikes/langgraph-runstate/runstate_probe.py
+++ b/spikes/langgraph-runstate/runstate_probe.py
@@ -1,0 +1,208 @@
+"""
+P4 run-state spike: can WUPHF's real task lifecycle round-trip through a LangGraph
+checkpointer, in both ownership variants, without losing the lifecycle position?
+
+Layers:
+  A  Lossiness analysis  — for each canonical state, forward to the legacy 4-tuple
+                           and derive back. Shows where the 4-tuple is lossy, hence
+                           whether the migration must carry the lifecycle_state field.
+  B  PURE variant        — LangGraph SqliteSaver IS the run-state store. Seed a task
+                           into a thread, "restart" (reopen the db), resume. Per state.
+  C  RE-HYDRATE variant  — Go broker record stays authoritative; ephemeral MemorySaver
+                           rebuilt from the record on restart. Per state.
+  D  Adversarial tuples  — contradictory/garbage legacy tuples must land UNKNOWN
+                           (fail loud), never a silent wrong state.
+
+No API key, no broker. Pure orchestration-state mechanics.
+"""
+
+import json
+import pathlib
+import sqlite3
+import traceback
+
+from langgraph.graph import START, END, StateGraph
+from langgraph.checkpoint.memory import MemorySaver
+from langgraph.checkpoint.sqlite import SqliteSaver
+from typing import TypedDict
+
+import lifecycle_model as lc
+
+HERE = pathlib.Path(__file__).parent
+results: dict = {}
+
+
+class TaskRun(TypedDict, total=False):
+    task_id: str
+    lifecycle_state: str
+    pipeline_stage: str
+    review_state: str
+    status: str
+    blocked: bool
+    history: list
+
+
+# Representative forward transitions so a resumed graph does something verifiable.
+FORWARD_TRANSITION = {
+    "planning": "running", "running": "review", "review": "decision",
+    "decision": "approved", "changes_requested": "running", "blocked": "review",
+    "intake": "ready", "ready": "running", "queued_behind_owner": "running",
+}
+
+
+def advance(state: TaskRun) -> dict:
+    cur = state.get("lifecycle_state")
+    nxt = FORWARD_TRANSITION.get(cur, cur)  # terminal states stay put
+    hist = list(state.get("history") or [])
+    hist.append(cur)
+    return {"lifecycle_state": nxt, "history": hist}
+
+
+def build_graph(checkpointer):
+    g = StateGraph(TaskRun)
+    g.add_node("advance", advance)
+    g.add_edge(START, "advance")
+    g.add_edge("advance", END)
+    # interrupt BEFORE advance so the first invoke seeds + checkpoints the run-state
+    # and pauses; resume runs the transition. This is the canonical durable-resume flow.
+    return g.compile(checkpointer=checkpointer, interrupt_before=["advance"])
+
+
+# --------------------------------------------------------------------------- #
+def layer_a_lossiness():
+    lossless, collapses = [], {}
+    for s in lc.CANONICAL_STATES:
+        back = lc.derive_lifecycle_state_from_legacy(*lc.FORWARD[s])
+        if back == s:
+            lossless.append(s)
+        else:
+            collapses[s] = back
+    return {
+        "ok": True,
+        "states": len(lc.CANONICAL_STATES),
+        "lossless_via_4tuple": len(lossless),
+        "collapses_if_state_field_dropped": collapses,
+        "conclusion": (
+            "Carry lifecycle_state directly => lossless for all 13. "
+            "Deriving from the 4-tuple alone collapses these states."
+        ),
+    }
+
+
+def layer_b_pure(dbfile: pathlib.Path):
+    per_state = {}
+    ok_all = True
+    for s in lc.CANONICAL_STATES:
+        cfg = {"configurable": {"thread_id": f"pure-{s}"}}
+        rec = lc.make_broker_record(s)
+        migrated, how = lc.migrate_state(rec)
+        try:
+            # MIGRATE: seed the run-state into a durable thread, pause before advance.
+            conn = sqlite3.connect(str(dbfile), check_same_thread=False)
+            cp = SqliteSaver(conn)
+            cp.setup()
+            build_graph(cp).invoke(
+                {"task_id": rec["task_id"], "lifecycle_state": migrated,
+                 "pipeline_stage": rec["pipeline_stage"], "review_state": rec["review_state"],
+                 "status": rec["status"], "blocked": rec["blocked"], "history": []},
+                cfg,
+            )
+            conn.close()
+            # RESTART: fresh connection to the same file. Restore + resume one transition.
+            conn2 = sqlite3.connect(str(dbfile), check_same_thread=False)
+            cp2 = SqliteSaver(conn2)
+            cp2.setup()
+            g2 = build_graph(cp2)
+            restored = g2.get_state(cfg).values.get("lifecycle_state")
+            resumed = g2.invoke(None, cfg).get("lifecycle_state")
+            conn2.close()
+            ok = restored == s and resumed == FORWARD_TRANSITION.get(s, s)
+            per_state[s] = {"restored": restored, "resumed_to": resumed, "ok": ok}
+            ok_all = ok_all and ok
+        except Exception as e:  # noqa: BLE001
+            per_state[s] = {"ok": False, "error": f"{type(e).__name__}: {e}"}
+            ok_all = False
+    return {"ok": ok_all, "store": "SqliteSaver (LangGraph owns run-state)", "per_state": per_state}
+
+
+def layer_c_rehydrate():
+    per_state = {}
+    ok_all = True
+    for s in lc.CANONICAL_STATES:
+        cfg = {"configurable": {"thread_id": f"rehydrate-{s}"}}
+        rec = lc.make_broker_record(s)  # the Go broker record = authoritative
+        migrated, _ = lc.migrate_state(rec)
+        try:
+            # RESTART: fresh ephemeral saver (lost on restart). Rebuild thread FROM the
+            # Go record, then resume — proves we never need a persisted LG checkpoint.
+            saver = MemorySaver()
+            g = build_graph(saver)
+            g.invoke(
+                {"task_id": rec["task_id"], "lifecycle_state": migrated,
+                 "pipeline_stage": rec["pipeline_stage"], "review_state": rec["review_state"],
+                 "status": rec["status"], "blocked": rec["blocked"], "history": []},
+                cfg,
+            )
+            restored = g.get_state(cfg).values.get("lifecycle_state")
+            resumed = g.invoke(None, cfg).get("lifecycle_state")
+            ok = restored == s and resumed == FORWARD_TRANSITION.get(s, s)
+            per_state[s] = {"rehydrated": restored, "resumed_to": resumed, "ok": ok}
+            ok_all = ok_all and ok
+        except Exception as e:  # noqa: BLE001
+            per_state[s] = {"ok": False, "error": f"{type(e).__name__}: {e}"}
+            ok_all = False
+    return {"ok": ok_all, "store": "Go broker record authoritative; MemorySaver ephemeral", "per_state": per_state}
+
+
+def layer_d_adversarial():
+    # Contradictory / garbage tuples that should fail loud as UNKNOWN.
+    cases = [
+        {"label": "in_progress AND blocked (contradiction)",
+         "rec": {"pipeline_stage": "implement", "review_state": "pending_review", "status": "in_progress", "blocked": True}},
+        {"label": "unknown future pipeline stage 'act'",
+         "rec": {"pipeline_stage": "act", "review_state": "verifying", "status": "verifying", "blocked": False}},
+        {"label": "garbage status",
+         "rec": {"pipeline_stage": "qux", "review_state": "zonk", "status": "frobnicate", "blocked": False}},
+        {"label": "legacy alias name 'merged' carried as state",
+         "rec": {"lifecycle_state": "merged"}},
+        {"label": "legacy 'blocked_on_pr_merge' carried as state",
+         "rec": {"lifecycle_state": "blocked_on_pr_merge"}},
+    ]
+    out = []
+    for c in cases:
+        state, how = lc.migrate_state(c["rec"])
+        out.append({"case": c["label"], "resolved_to": state, "how": how})
+    return {
+        "ok": True,
+        "cases": out,
+        "note": "Contradictory/garbage tuples must resolve to 'unknown' (operator triage), "
+                "never a silent wrong state. Legacy alias NAMES normalize losslessly.",
+    }
+
+
+def run(name, fn, *a):
+    print(f"\n=== {name} ===", flush=True)
+    try:
+        out = fn(*a)
+    except Exception as e:  # noqa: BLE001
+        out = {"ok": False, "error": f"{type(e).__name__}: {e}", "trace": traceback.format_exc()[-700:]}
+    results[name] = out
+    print(json.dumps(out, indent=2), flush=True)
+
+
+def main():
+    dbfile = HERE / "_runstate.sqlite"
+    if dbfile.exists():
+        dbfile.unlink()
+    run("A_lossiness", layer_a_lossiness)
+    run("B_pure_checkpoint", layer_b_pure, dbfile)
+    run("C_rehydrate", layer_c_rehydrate)
+    run("D_adversarial", layer_d_adversarial)
+    (HERE / "results.json").write_text(json.dumps(results, indent=2))
+    if dbfile.exists():
+        dbfile.unlink()
+    print("\nWrote results.json")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## De-risk spikes (2/3 in stack)

Reproducible spikes that validated the two highest-risk seams. Both green.
(The seam spike's throwaway Go echo-server source is gitignored to keep this PR
Go-free; its round-trip numbers + description live in the REPORT.)

- `spikes/deepagents-seam/` — Python <-> real `wuphf mcp-team` over MCP: 76 tools
  reused (zero rewrite), ~1.9 ms round-trip, HITL interrupt fires.
- `spikes/langgraph-runstate/` — real 13-state lifecycle round-trips a LangGraph
  checkpointer 13/13 in both variants; picks re-hydrate; fail-loud to `unknown`.

Base: `deepagents/01-migration-specs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)