### PR TITLE
feat(orchestrator): LangGraph orchestrator package — P1a (3/3)

### DIFF
--- a/orchestrator/.gitignore
+++ b/orchestrator/.gitignore
@@ -1,0 +1,5 @@
+.venv/
+__pycache__/
+*.pyc
+.pytest_cache/
+*.egg-info/

--- a/orchestrator/README.md
+++ b/orchestrator/README.md
@@ -1,0 +1,57 @@
+# wuphf-orchestrator
+
+LangGraph orchestrator that owns WUPHF's task lifecycle + coordination on top of
+Claude Code/Codex. The Go broker stays the durable host; this orchestrator
+re-hydrates run-state from the Go record each step (the P4 spike decision). It is
+the production home of the logic the two spikes validated.
+
+See `docs/specs/deepagents-migration-plan.md` for the architecture and phase plan.
+
+## Layout
+
+```
+src/orchestrator/
+  lifecycle.py   real lifecycle model (13 states, forward/migration maps, migrate_record)
+                 + P1 orchestration policy (route / outcome+decision transitions)
+  runstate.py    TaskRun schema; from_broker_record (re-hydrate) + to_projection (-> Go)
+  harness.py     Harness protocol; FakeHarness (tests/key-free) + ClaudeAgentHarness (P2)
+  graph.py       the LangGraph graph: route -> dispatch_turn -> (human_gate | continue)
+  wire.py        Go<->Python contract (DispatchRequest / ResumeRequest / StepResult)
+  service.py     FastAPI: POST /run, POST /resume, GET /health
+tests/           25 tests: lifecycle round-trip/lossiness/adversarial, graph HITL, service, wire
+```
+
+## Run
+
+```bash
+uv venv .venv
+uv pip install langgraph langgraph-checkpoint-sqlite fastapi sse-starlette uvicorn pydantic pytest httpx
+.venv/bin/pytest -q
+.venv/bin/uvicorn orchestrator.service:app --app-dir src   # local service
+```
+
+## What lands in this increment (P1 foundation)
+
+- The real lifecycle model + migration, faithful to `broker_lifecycle_transition.go`.
+- The orchestration graph: re-hydrate -> dispatch a turn to the inner harness ->
+  transition, with human gates via LangGraph `interrupt()`.
+- The Go<->Python wire contract (secrets cross as env-var *names* only).
+- The FastAPI service surface the Go dispatch client will target.
+- Runs green with **no model key** (FakeHarness drives the loop).
+
+## Deferred (next increments — explicit, not hidden)
+
+- **P1b Go side:** a `provider/deepagents`-style dispatch client + the broker-state
+  projection write-back + the per-task `orchestrator=langgraph|broker` flag.
+- **P2:** `ClaudeAgentHarness.run_turn` — drive Claude Code via the Claude Agent SDK,
+  wired to teammcp + broker token; classify the real turn outcome.
+- **SSE streaming** of incremental events (the service returns the terminal StepResult today).
+- **CI wiring** (pytest + golden wire fixtures) scoped to `orchestrator/**`.
+
+## P1 policy deviations (revisited in P2/P3)
+
+- `route()` treats `drafting/intake/ready/queued/blocked` as IDLE — activation and
+  unblock stay the broker's job in P1.
+- Plan approval and work approval are one `human_gate` distinguished by `gate_kind`
+  (`plan` approve -> running, `review` approve -> approved). Faithful enough for P1;
+  the full transition set (dependencies, reviewer resolution) is P2/P3.

--- a/orchestrator/pyproject.toml
+++ b/orchestrator/pyproject.toml
@@ -1,0 +1,23 @@
+[project]
+name = "wuphf-orchestrator"
+version = "0.1.0"
+description = "WUPHF agent orchestrator (LangGraph). Owns task lifecycle on top of Claude Code/Codex; Go broker stays the durable host."
+requires-python = ">=3.11"
+dependencies = [
+    "langgraph>=0.2",
+    "langgraph-checkpoint-sqlite>=2",
+    "fastapi>=0.110",
+    "sse-starlette>=2",
+    "uvicorn>=0.29",
+    "pydantic>=2",
+]
+
+[project.optional-dependencies]
+# Real inner-harness execution. Optional so the package installs + tests green
+# without it; ClaudeAgentHarness imports it lazily.
+claude = ["claude-agent-sdk"]
+dev = ["pytest>=8", "httpx>=0.27"]
+
+[tool.pytest.ini_options]
+pythonpath = ["src"]
+testpaths = ["tests"]

--- a/orchestrator/src/orchestrator/__init__.py
+++ b/orchestrator/src/orchestrator/__init__.py
@@ -1,0 +1,11 @@
+"""WUPHF agent orchestrator (LangGraph).
+
+Owns task lifecycle + coordination on top of Claude Code/Codex (the inner harness,
+untouched). The Go broker stays the durable host; this orchestrator re-hydrates from
+the Go record each step (P4 spike decision). See docs/specs/deepagents-migration-plan.md.
+"""
+
+from . import graph, harness, lifecycle, runstate, wire
+from .lifecycle import State
+
+__all__ = ["graph", "harness", "lifecycle", "runstate", "wire", "State"]

--- a/orchestrator/src/orchestrator/graph.py
+++ b/orchestrator/src/orchestrator/graph.py
@@ -1,0 +1,108 @@
+"""The LangGraph orchestration graph — WUPHF's coordination, rebuilt.
+
+One invocation = one orchestration step for a task that has been re-hydrated from
+the Go record:
+
+    START ─route─▶ dispatch_turn ─▶ (human_gate | apply_continue) ─▶ END
+              └──▶ human_gate (already awaiting a decision)
+              └──▶ END (idle: nothing to do this tick)
+
+dispatch_turn calls the inner harness (Claude Code/Codex — untouched). Human gates
+use LangGraph interrupt(), which the Go broker surfaces through its existing approval
+surface and resolves via Command(resume=decision).
+"""
+
+from __future__ import annotations
+
+from langgraph.checkpoint.memory import MemorySaver
+from langgraph.graph import END, START, StateGraph
+from langgraph.types import Command, interrupt
+
+from . import lifecycle as lc
+from .harness import Harness
+from .runstate import TaskRun
+
+
+def _route_entry(state: TaskRun) -> str:
+    return lc.route(lc.State(state["lifecycle_state"])).value  # dispatch | human | idle
+
+
+def _dispatch_turn(state: TaskRun, harness: Harness) -> dict:
+    res = harness.run_turn(state)
+    cur = lc.State(state["lifecycle_state"])
+    out: dict = {
+        "last_outcome": res.outcome.value,
+        "last_text": res.text,
+        "history": list(state.get("history") or []) + [state["lifecycle_state"]],
+    }
+    gate = lc.gate_for_outcome(cur, res.outcome)
+    if gate is not None:
+        out["gate_kind"] = gate.value
+    return out
+
+
+def _after_dispatch(state: TaskRun) -> str:
+    cur = lc.State(state["lifecycle_state"])
+    outcome = lc.TurnOutcome(state["last_outcome"])
+    return "human" if lc.gate_for_outcome(cur, outcome) is not None else "continue"
+
+
+def _human_gate(state: TaskRun) -> dict:
+    gate = lc.GateKind(state.get("gate_kind") or lc.GateKind.REVIEW.value)
+    decision = interrupt(
+        {
+            "type": "approval_required",
+            "task_id": state.get("task_id", ""),
+            "gate_kind": gate.value,
+            "text": state.get("last_text", ""),
+        }
+    )
+    dec = decision.get("decision") if isinstance(decision, dict) else decision
+    new_state = lc.apply_human_decision(gate, lc.HumanDecision(dec))
+    return {"lifecycle_state": new_state.value}
+
+
+def _apply_continue(state: TaskRun) -> dict:
+    cur = lc.State(state["lifecycle_state"])
+    outcome = lc.TurnOutcome(state["last_outcome"])
+    return {"lifecycle_state": lc.apply_turn_outcome(cur, outcome).value}
+
+
+def build_graph(harness: Harness, checkpointer=None):
+    g = StateGraph(TaskRun)
+    g.add_node("dispatch_turn", lambda s: _dispatch_turn(s, harness))
+    g.add_node("human_gate", _human_gate)
+    g.add_node("apply_continue", _apply_continue)
+    g.add_conditional_edges(
+        START, _route_entry, {"dispatch": "dispatch_turn", "human": "human_gate", "idle": END}
+    )
+    g.add_conditional_edges(
+        "dispatch_turn", _after_dispatch, {"human": "human_gate", "continue": "apply_continue"}
+    )
+    g.add_edge("human_gate", END)
+    g.add_edge("apply_continue", END)
+    return g.compile(checkpointer=checkpointer or MemorySaver())
+
+
+def _collect_interrupts(snapshot) -> list:
+    out = []
+    for tsk in (snapshot.tasks or ()):
+        for it in (getattr(tsk, "interrupts", ()) or ()):
+            out.append(it.value)
+    return out
+
+
+def drive(graph, run: TaskRun | None, thread_id: str, resume=None) -> dict:
+    """Run one orchestration step (resume=None) or resume a human gate.
+
+    Returns {status: 'done'|'interrupted', state: <values>, interrupt?: <payload>}.
+    'interrupted' means a human gate is pending; the broker should surface it and
+    call drive(..., resume=<decision>) once the human decides.
+    """
+    cfg = {"configurable": {"thread_id": thread_id}}
+    graph.invoke(Command(resume=resume) if resume is not None else run, cfg)
+    snap = graph.get_state(cfg)
+    interrupts = _collect_interrupts(snap)
+    if interrupts:
+        return {"status": "interrupted", "interrupt": interrupts[0], "state": dict(snap.values)}
+    return {"status": "done", "state": dict(snap.values)}

--- a/orchestrator/src/orchestrator/harness.py
+++ b/orchestrator/src/orchestrator/harness.py
@@ -1,0 +1,68 @@
+"""Inner-harness interface — the seam that keeps Claude Code/Codex as the real
+execution engine. A graph dispatch node calls run_turn(); the harness runs ONE
+agent turn (the great inner harness, untouched) and reports a structured outcome.
+
+  - Harness        : the protocol.
+  - FakeHarness    : scripted outcomes for tests + key-free local runs.
+  - ClaudeAgentHarness : drives Claude Code via the Claude Agent SDK (lazy import;
+                     only used when claude-agent-sdk is installed + a key is set).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+from .lifecycle import TurnOutcome
+from .runstate import TaskRun
+
+
+@dataclass
+class TurnResult:
+    outcome: TurnOutcome
+    text: str = ""
+
+
+class Harness(Protocol):
+    def run_turn(self, task: TaskRun) -> TurnResult:  # pragma: no cover - protocol
+        ...
+
+
+class FakeHarness:
+    """Returns a scripted outcome. Used by tests and key-free local runs so the
+    whole orchestration loop is exercisable without a model."""
+
+    def __init__(self, outcome: TurnOutcome = TurnOutcome.SUBMITTED_FOR_REVIEW, text: str = "fake turn"):
+        self._outcome = outcome
+        self._text = text
+
+    def run_turn(self, task: TaskRun) -> TurnResult:
+        return TurnResult(outcome=self._outcome, text=self._text)
+
+
+class ClaudeAgentHarness:
+    """Drives Claude Code for one turn via the Claude Agent SDK, wired to teammcp.
+
+    Lazy-imports claude-agent-sdk so the package installs and tests run without it.
+    The teammcp MCP server + broker token are passed exactly as the existing CLI
+    providers do (see internal/provider/claude.go) so tool calls authenticate to
+    the broker. Outcome classification (submitted_for_review / plan_ready / ...)
+    is parsed from the run result — P1 stub returns COMPLETED; P2 wires real
+    classification."""
+
+    def __init__(self, *, model: str, mcp_config: dict, broker_env: dict):
+        self._model = model
+        self._mcp_config = mcp_config
+        self._broker_env = broker_env
+
+    def run_turn(self, task: TaskRun) -> TurnResult:  # pragma: no cover - needs key
+        try:
+            import claude_agent_sdk  # noqa: F401  (lazy: optional dependency)
+        except ImportError as e:
+            raise RuntimeError(
+                "ClaudeAgentHarness requires the 'claude' extra (claude-agent-sdk)"
+            ) from e
+        # P2: build a ClaudeAgentOptions with the teammcp MCP server + broker env,
+        # run one turn over task['messages'] under task['system_prompt'], stream
+        # results, and classify the outcome. Intentionally not implemented in P1.
+        raise NotImplementedError("ClaudeAgentHarness.run_turn lands in P2")

--- a/orchestrator/src/orchestrator/lifecycle.py
+++ b/orchestrator/src/orchestrator/lifecycle.py
@@ -1,0 +1,223 @@
+"""WUPHF task lifecycle — production port.
+
+Source of truth: internal/team/broker_lifecycle_transition.go @ origin/main ec467159.
+This is the canonical Python copy (the spike under spikes/langgraph-runstate is
+superseded by this module). The migration round-trip is validated by the P4 spike:
+13/13 states round-trip; carry `lifecycle_state` (lossless); fail loud to `unknown`.
+
+Two responsibilities:
+  1. State data + migration (mirrors the Go maps): FORWARD, MIGRATION, migrate_record.
+  2. Orchestration policy (P1): route(), apply_turn_outcome(), apply_human_decision().
+     Policy intentionally simplified for P1; deviations from the Go transitions are
+     documented inline and revisited in P2/P3.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+
+
+class State(str, Enum):
+    UNKNOWN = "unknown"
+    DRAFTING = "drafting"
+    INTAKE = "intake"
+    READY = "ready"
+    PLANNING = "planning"
+    RUNNING = "running"
+    REVIEW = "review"
+    DECISION = "decision"
+    BLOCKED = "blocked"
+    QUEUED_BEHIND_OWNER = "queued_behind_owner"
+    CHANGES_REQUESTED = "changes_requested"
+    APPROVED = "approved"
+    REJECTED = "rejected"
+    ARCHIVED = "archived"
+
+
+CANONICAL: tuple[State, ...] = (
+    State.DRAFTING, State.INTAKE, State.READY, State.PLANNING, State.RUNNING,
+    State.REVIEW, State.DECISION, State.BLOCKED, State.QUEUED_BEHIND_OWNER,
+    State.CHANGES_REQUESTED, State.APPROVED, State.REJECTED, State.ARCHIVED,
+)
+
+# state -> (pipeline_stage, review_state, status, blocked)   [lifecycleDerivedFields]
+FORWARD: dict[State, tuple[str, str, str, bool]] = {
+    State.DRAFTING:            ("draft", "pending_review", "open", False),
+    State.PLANNING:            ("plan", "pending_review", "in_progress", False),
+    State.INTAKE:              ("triage", "pending_review", "open", False),
+    State.READY:               ("triage", "pending_review", "open", False),
+    State.RUNNING:             ("implement", "pending_review", "in_progress", False),
+    State.REVIEW:              ("review", "ready_for_review", "in_progress", False),
+    State.DECISION:            ("review", "ready_for_review", "in_progress", False),
+    State.BLOCKED:             ("review", "ready_for_review", "blocked", True),
+    State.QUEUED_BEHIND_OWNER: ("triage", "pending_review", "open", True),
+    State.CHANGES_REQUESTED:   ("implement", "pending_review", "in_progress", False),
+    State.APPROVED:            ("ship", "approved", "done", False),
+    State.REJECTED:            ("review", "rejected", "rejected", True),
+    State.ARCHIVED:            ("archived", "approved", "archived", False),
+}
+
+# legacy 4-tuple -> state   [lifecycleMigrationMap]; keys lower-cased.
+MIGRATION: dict[tuple[str, str, str, bool], State] = {
+    ("draft", "pending_review", "open", False): State.DRAFTING,
+    ("triage", "pending_review", "open", False): State.READY,
+    ("implement", "pending_review", "in_progress", False): State.RUNNING,
+    ("review", "ready_for_review", "in_progress", False): State.REVIEW,
+    ("review", "ready_for_review", "blocked", True): State.BLOCKED,
+    ("triage", "pending_review", "open", True): State.QUEUED_BEHIND_OWNER,
+    ("ship", "approved", "done", False): State.APPROVED,
+    ("review", "rejected", "rejected", True): State.REJECTED,
+    ("plan", "pending_review", "in_progress", False): State.PLANNING,
+    ("implement", "changes_requested", "in_progress", False): State.CHANGES_REQUESTED,
+    ("", "", "blocked", True): State.BLOCKED,
+    ("", "", "blocked", False): State.BLOCKED,
+    ("implement", "pending_review", "blocked", True): State.BLOCKED,
+    ("implement", "pending_review", "blocked", False): State.BLOCKED,
+    ("review", "ready_for_review", "blocked", False): State.BLOCKED,
+    ("", "", "open", False): State.READY,
+    ("", "", "open", True): State.QUEUED_BEHIND_OWNER,
+    ("", "", "in_progress", False): State.RUNNING,
+    ("", "", "review", False): State.REVIEW,
+    ("", "", "done", False): State.APPROVED,
+    ("", "", "completed", False): State.APPROVED,
+    ("", "", "canceled", False): State.APPROVED,
+    ("", "", "cancelled", False): State.APPROVED,
+    ("", "", "archived", False): State.ARCHIVED,
+    ("archived", "approved", "archived", False): State.ARCHIVED,
+}
+
+_LEGACY_NAME_ALIAS = {"merged": State.APPROVED, "blocked_on_pr_merge": State.BLOCKED}
+_TERMINAL = frozenset({State.APPROVED, State.REJECTED, State.ARCHIVED})
+_EXECUTABLE = frozenset({State.RUNNING, State.PLANNING, State.APPROVED})  # isExecutableTeamTaskStatus
+_PRE_EXECUTION = frozenset({
+    State.DRAFTING, State.INTAKE, State.READY, State.QUEUED_BEHIND_OWNER, State.PLANNING,
+})
+
+
+def normalize_legacy_name(s: str) -> str:
+    alias = _LEGACY_NAME_ALIAS.get((s or "").strip().lower())
+    return alias.value if alias is not None else s
+
+
+def _norm(s: str | None) -> str:
+    return (s or "").strip().lower()
+
+
+def derive_from_legacy(pipeline_stage, review_state, status, blocked) -> State:
+    """Mirror deriveLifecycleStateFromLegacy: legacy 4-tuple -> state, else UNKNOWN."""
+    return MIGRATION.get(
+        (_norm(pipeline_stage), _norm(review_state), _norm(status), bool(blocked)),
+        State.UNKNOWN,
+    )
+
+
+def migrate_record(record: dict) -> tuple[State, str]:
+    """Resolve a broker-state.json task record to a lifecycle State.
+
+    Returns (state, how). how in {carried, derived, bare_status_fallback, unknown}.
+    Carrying lifecycle_state is lossless (preferred); derivation is the legacy-only
+    fallback; unmapped tuples fail loud to UNKNOWN for operator triage.
+    """
+    carried = _norm(record.get("lifecycle_state"))
+    if carried:
+        alias = _LEGACY_NAME_ALIAS.get(carried)
+        if alias is not None:
+            return alias, "carried"
+        try:
+            return State(carried), "carried"
+        except ValueError:
+            pass  # fall through to legacy derivation
+    derived = derive_from_legacy(
+        record.get("pipeline_stage"), record.get("review_state"),
+        record.get("status"), record.get("blocked", False),
+    )
+    if derived is not State.UNKNOWN:
+        return derived, "derived"
+    by_status = derive_from_legacy("", "", record.get("status"), record.get("blocked", False))
+    if by_status is not State.UNKNOWN:
+        return by_status, "bare_status_fallback"
+    return State.UNKNOWN, "unknown"
+
+
+def derived_fields(state: State) -> tuple[str, str, str, bool]:
+    return FORWARD[state]
+
+
+def is_executable(state: State) -> bool:
+    return state in _EXECUTABLE
+
+
+def is_pre_execution(state: State) -> bool:
+    return state in _PRE_EXECUTION
+
+
+def is_terminal(state: State) -> bool:
+    return state in _TERMINAL
+
+
+# --------------------------------------------------------------------------- #
+# Orchestration policy (P1). Documented simplifications vs the Go transitions.
+# --------------------------------------------------------------------------- #
+class Route(str, Enum):
+    DISPATCH = "dispatch"      # wake the owner: a plan turn (planning) or work turn (running)
+    HUMAN = "human"            # awaiting a reviewer decision
+    IDLE = "idle"             # nothing for the orchestrator to do this tick
+
+
+class TurnOutcome(str, Enum):
+    PLAN_READY = "plan_ready"                  # planning turn produced a plan to approve
+    SUBMITTED_FOR_REVIEW = "submitted_for_review"
+    COMPLETED = "completed"
+    CONTINUE = "continue"                      # needs another work turn
+    BLOCKED = "blocked"
+
+
+class HumanDecision(str, Enum):
+    APPROVE = "approve"
+    REQUEST_CHANGES = "request_changes"
+    REJECT = "reject"
+
+
+class GateKind(str, Enum):
+    PLAN = "plan"      # approving a plan -> Running
+    REVIEW = "review"  # approving delivered work -> Approved
+
+
+def route(state: State) -> Route:
+    """P1 routing. drafting/intake/ready/queued/blocked are IDLE — activation and
+    unblock stay the broker's job in P1 (revisited in P2)."""
+    if is_terminal(state):
+        return Route.IDLE
+    if state in (State.REVIEW, State.DECISION):
+        return Route.HUMAN
+    if state in (State.RUNNING, State.PLANNING, State.CHANGES_REQUESTED):
+        return Route.DISPATCH
+    return Route.IDLE
+
+
+def gate_for_outcome(state: State, outcome: TurnOutcome) -> GateKind | None:
+    """Does this turn outcome require a human gate, and of what kind?"""
+    if outcome is TurnOutcome.PLAN_READY:
+        return GateKind.PLAN
+    if outcome in (TurnOutcome.SUBMITTED_FOR_REVIEW, TurnOutcome.COMPLETED):
+        return GateKind.REVIEW
+    return None
+
+
+def apply_turn_outcome(state: State, outcome: TurnOutcome) -> State:
+    """Non-gated outcomes only (CONTINUE/BLOCKED). Gated outcomes go through a
+    human gate first (see apply_human_decision)."""
+    if outcome is TurnOutcome.BLOCKED:
+        return State.BLOCKED
+    if outcome is TurnOutcome.CONTINUE:
+        return State.RUNNING if state is not State.PLANNING else State.PLANNING
+    raise ValueError(f"{outcome} is a gated outcome; route through a human gate")
+
+
+def apply_human_decision(gate: GateKind, decision: HumanDecision) -> State:
+    if decision is HumanDecision.REJECT:
+        return State.REJECTED
+    if decision is HumanDecision.REQUEST_CHANGES:
+        return State.CHANGES_REQUESTED
+    # APPROVE
+    return State.RUNNING if gate is GateKind.PLAN else State.APPROVED

--- a/orchestrator/src/orchestrator/runstate.py
+++ b/orchestrator/src/orchestrator/runstate.py
@@ -1,0 +1,58 @@
+"""TaskRun: the LangGraph run-state, re-hydrated from the authoritative Go record.
+
+Per the P4 spike decision (re-hydrate variant): the Go broker record is the single
+source of durable truth. The orchestrator rebuilds TaskRun from it on every dispatch;
+the LangGraph checkpoint is a within-run cache, never authoritative. `to_projection`
+emits the status shape the Go store persists for the web (one-way projection).
+"""
+
+from __future__ import annotations
+
+from typing import Any, TypedDict
+
+from . import lifecycle as lc
+
+
+class TaskRun(TypedDict, total=False):
+    task_id: str
+    lifecycle_state: str          # canonical State value
+    owner: str
+    system_prompt: str
+    messages: list[dict]          # [{role, content}]
+    # turn / gate bookkeeping
+    gate_kind: str                # set before a human interrupt
+    last_outcome: str
+    last_text: str
+    history: list[str]            # lifecycle states visited this run
+
+
+def from_broker_record(record: dict) -> TaskRun:
+    """Re-hydrate TaskRun from a broker-state.json-shaped task record.
+
+    Carries lifecycle_state losslessly; falls back to legacy derivation. An
+    unmappable record yields lifecycle_state='unknown' (the caller must surface
+    it for operator triage, never dispatch it)."""
+    state, _how = lc.migrate_record(record)
+    return TaskRun(
+        task_id=str(record.get("task_id") or record.get("id") or ""),
+        lifecycle_state=state.value,
+        owner=str(record.get("owner") or ""),
+        system_prompt=str(record.get("system_prompt") or ""),
+        messages=list(record.get("messages") or []),
+        history=[],
+    )
+
+
+def to_projection(run: TaskRun) -> dict[str, Any]:
+    """One-way projection back to the Go store: the typed state + its derived
+    4-tuple, so the existing web renders unchanged."""
+    state = lc.State(run["lifecycle_state"])
+    ps, rs, st, blocked = lc.derived_fields(state)
+    return {
+        "task_id": run.get("task_id", ""),
+        "lifecycle_state": state.value,
+        "pipeline_stage": ps,
+        "review_state": rs,
+        "status": st,
+        "blocked": blocked,
+    }

--- a/orchestrator/src/orchestrator/service.py
+++ b/orchestrator/src/orchestrator/service.py
@@ -1,0 +1,84 @@
+"""FastAPI service: the Go broker dispatches orchestration steps here.
+
+  POST /run     — re-hydrate from the record, run one step, return StepResult
+  POST /resume  — resolve a pending human gate, continue, return StepResult
+  GET  /health  — liveness
+
+The harness is injected via a factory so tests override it with FakeHarness and the
+process default builds a ClaudeAgentHarness when keys/SDK are present. The Go-side
+dispatch client, the broker-state projection write-back, and SSE streaming are the
+next increments; this skeleton is the contract surface they target.
+"""
+
+from __future__ import annotations
+
+from typing import Callable
+
+from fastapi import FastAPI
+
+from .graph import build_graph, drive
+from .harness import FakeHarness, Harness
+from .lifecycle import State
+from .runstate import from_broker_record, to_projection
+from .wire import DispatchRequest, ResumeRequest, StepResult
+
+# Per-process harness factory; overridable for tests / wiring.
+HarnessFactory = Callable[[DispatchRequest], Harness]
+
+
+def _default_harness_factory(_req: DispatchRequest) -> Harness:
+    # P1 default: FakeHarness keeps the service runnable without a model key.
+    # P2 swaps in ClaudeAgentHarness(model=req.model, mcp_config=..., broker_env=...).
+    return FakeHarness()
+
+
+def create_app(harness_factory: HarnessFactory = _default_harness_factory) -> FastAPI:
+    app = FastAPI(title="wuphf-orchestrator", version="0.1.0")
+    # One shared in-memory checkpointer across requests so /resume finds the thread.
+    from langgraph.checkpoint.memory import MemorySaver
+
+    checkpointer = MemorySaver()
+
+    @app.get("/health")
+    def health() -> dict:
+        return {"status": "ok", "version": "0.1.0"}
+
+    @app.post("/run", response_model=StepResult)
+    def run(req: DispatchRequest) -> StepResult:
+        run_state = from_broker_record(req.record)
+        run_state["system_prompt"] = req.system_prompt or run_state.get("system_prompt", "")
+        if req.messages:
+            run_state["messages"] = req.messages
+        if run_state["lifecycle_state"] == State.UNKNOWN.value:
+            # Fail loud: never dispatch an unmappable task.
+            return StepResult(
+                status="done",
+                thread_id=req.task_id,
+                projection={"task_id": req.task_id, "lifecycle_state": State.UNKNOWN.value},
+            )
+        graph = build_graph(harness_factory(req), checkpointer=checkpointer)
+        result = drive(graph, run_state, thread_id=req.task_id)
+        return StepResult(
+            status=result["status"],
+            thread_id=req.task_id,
+            projection=to_projection(result["state"]),
+            interrupt=result.get("interrupt"),
+        )
+
+    @app.post("/resume", response_model=StepResult)
+    def resume(req: ResumeRequest) -> StepResult:
+        # The harness is not invoked on resume (the graph continues at human_gate),
+        # so a FakeHarness placeholder is fine; the shared checkpointer holds the thread.
+        graph = build_graph(FakeHarness(), checkpointer=checkpointer)
+        result = drive(graph, None, thread_id=req.thread_id, resume={"decision": req.decision})
+        return StepResult(
+            status=result["status"],
+            thread_id=req.thread_id,
+            projection=to_projection(result["state"]),
+            interrupt=result.get("interrupt"),
+        )
+
+    return app
+
+
+app = create_app()

--- a/orchestrator/src/orchestrator/wire.py
+++ b/orchestrator/src/orchestrator/wire.py
@@ -1,0 +1,50 @@
+"""The Go <-> Python wire contract (protocol-grade — golden-tested).
+
+Secrets never cross in the body: the broker token is passed to the orchestrator
+process via env and named (not valued) here, mirroring SlackProviderBinding.BotTokenEnv.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+SCHEMA_VERSION = 1
+
+
+class McpServer(BaseModel):
+    command: str
+    args: list[str] = Field(default_factory=list)
+    # ENV VAR NAMES to pass through to the teammcp subprocess (never values).
+    env_passthrough: list[str] = Field(default_factory=list)
+
+
+class DispatchRequest(BaseModel):
+    schema_version: int = SCHEMA_VERSION
+    task_id: str
+    # The authoritative broker record (re-hydrate source). Carries lifecycle_state
+    # plus the legacy 4-tuple; the orchestrator never trusts a derived state when
+    # the field is present.
+    record: dict[str, Any]
+    model: str = ""
+    system_prompt: str = ""
+    messages: list[dict] = Field(default_factory=list)
+    mcp: dict[str, McpServer] = Field(default_factory=dict)
+
+
+class ResumeRequest(BaseModel):
+    schema_version: int = SCHEMA_VERSION
+    task_id: str
+    thread_id: str
+    decision: Literal["approve", "request_changes", "reject"]
+
+
+class StepResult(BaseModel):
+    """Non-streaming result of one orchestration step (the SSE stream carries the
+    same information incrementally; this is the terminal summary the broker persists)."""
+
+    status: Literal["done", "interrupted"]
+    thread_id: str
+    projection: dict[str, Any]            # one-way -> Go store (task status shape)
+    interrupt: dict[str, Any] | None = None

--- a/orchestrator/tests/test_graph.py
+++ b/orchestrator/tests/test_graph.py
@@ -1,0 +1,68 @@
+"""Orchestration graph tests — re-hydrate, dispatch, transitions, HITL, idle."""
+
+from orchestrator.graph import build_graph, drive
+from orchestrator.harness import FakeHarness
+from orchestrator.lifecycle import State, TurnOutcome
+from orchestrator.runstate import from_broker_record
+
+
+def _run(record, harness):
+    g = build_graph(harness)
+    run = from_broker_record(record)
+    return drive(g, run, thread_id=record["task_id"])
+
+
+def test_running_submit_interrupts_then_approve_to_approved():
+    g = build_graph(FakeHarness(TurnOutcome.SUBMITTED_FOR_REVIEW))
+    run = from_broker_record({"task_id": "t1", "lifecycle_state": "running"})
+    step = drive(g, run, thread_id="t1")
+    assert step["status"] == "interrupted"
+    assert step["interrupt"]["gate_kind"] == "review"
+
+    resumed = drive(g, None, thread_id="t1", resume={"decision": "approve"})
+    assert resumed["status"] == "done"
+    assert resumed["state"]["lifecycle_state"] == State.APPROVED.value
+
+
+def test_planning_plan_ready_interrupts_then_approve_to_running():
+    g = build_graph(FakeHarness(TurnOutcome.PLAN_READY))
+    run = from_broker_record({"task_id": "t2", "lifecycle_state": "planning"})
+    step = drive(g, run, thread_id="t2")
+    assert step["status"] == "interrupted"
+    assert step["interrupt"]["gate_kind"] == "plan"
+
+    resumed = drive(g, None, thread_id="t2", resume={"decision": "approve"})
+    assert resumed["state"]["lifecycle_state"] == State.RUNNING.value
+
+
+def test_review_request_changes_routes_to_changes_requested():
+    g = build_graph(FakeHarness(TurnOutcome.SUBMITTED_FOR_REVIEW))
+    run = from_broker_record({"task_id": "t3", "lifecycle_state": "running"})
+    drive(g, run, thread_id="t3")
+    resumed = drive(g, None, thread_id="t3", resume={"decision": "request_changes"})
+    assert resumed["state"]["lifecycle_state"] == State.CHANGES_REQUESTED.value
+
+
+def test_continue_outcome_stays_running_no_interrupt():
+    step = _run({"task_id": "t4", "lifecycle_state": "running"}, FakeHarness(TurnOutcome.CONTINUE))
+    assert step["status"] == "done"
+    assert step["state"]["lifecycle_state"] == State.RUNNING.value
+
+
+def test_blocked_outcome_transitions_to_blocked():
+    step = _run({"task_id": "t5", "lifecycle_state": "running"}, FakeHarness(TurnOutcome.BLOCKED))
+    assert step["state"]["lifecycle_state"] == State.BLOCKED.value
+
+
+def test_terminal_task_is_idle():
+    step = _run({"task_id": "t6", "lifecycle_state": "approved"}, FakeHarness(TurnOutcome.CONTINUE))
+    assert step["status"] == "done"
+    assert step["state"]["lifecycle_state"] == State.APPROVED.value
+
+
+def test_already_in_review_interrupts_for_decision():
+    g = build_graph(FakeHarness())
+    run = from_broker_record({"task_id": "t7", "lifecycle_state": "review"})
+    step = drive(g, run, thread_id="t7")
+    assert step["status"] == "interrupted"
+    assert step["interrupt"]["gate_kind"] == "review"

--- a/orchestrator/tests/test_lifecycle.py
+++ b/orchestrator/tests/test_lifecycle.py
@@ -1,0 +1,87 @@
+"""Lifecycle model tests — the P4 spike findings, now real regression tests."""
+
+import pytest
+
+from orchestrator import lifecycle as lc
+from orchestrator.lifecycle import GateKind, HumanDecision, Route, State, TurnOutcome
+
+
+def test_carry_state_is_lossless_for_all_canonical_states():
+    for s in lc.CANONICAL:
+        rec = {"task_id": f"t-{s.value}", "lifecycle_state": s.value, **dict(
+            zip(("pipeline_stage", "review_state", "status", "blocked"), lc.FORWARD[s]))}
+        state, how = lc.migrate_record(rec)
+        assert state is s
+        assert how == "carried"
+
+
+def test_4tuple_derivation_collapses_exactly_three_states():
+    collapses = {}
+    for s in lc.CANONICAL:
+        rec = dict(zip(("pipeline_stage", "review_state", "status", "blocked"), lc.FORWARD[s]))
+        derived = lc.derive_from_legacy(*lc.FORWARD[s])
+        if derived is not s:
+            collapses[s] = derived
+    assert collapses == {
+        State.INTAKE: State.READY,
+        State.DECISION: State.REVIEW,
+        State.CHANGES_REQUESTED: State.RUNNING,
+    }
+
+
+@pytest.mark.parametrize("rec", [
+    {"pipeline_stage": "implement", "review_state": "pending_review", "status": "in_progress", "blocked": True},
+    {"pipeline_stage": "act", "review_state": "verifying", "status": "verifying", "blocked": False},
+    {"pipeline_stage": "qux", "review_state": "zonk", "status": "frobnicate", "blocked": False},
+])
+def test_contradictory_tuples_fail_loud_to_unknown(rec):
+    state, how = lc.migrate_record(rec)
+    assert state is State.UNKNOWN
+    assert how == "unknown"
+
+
+@pytest.mark.parametrize("name,expected", [
+    ("merged", State.APPROVED),
+    ("blocked_on_pr_merge", State.BLOCKED),
+])
+def test_legacy_alias_names_normalize(name, expected):
+    state, how = lc.migrate_record({"lifecycle_state": name})
+    assert state is expected
+    assert how == "carried"
+
+
+def test_bare_status_fallback():
+    # Full tuple unmapped (future 'act' pipeline stage), but the bare status rescues
+    # it — mirrors migrateLifecycleStatesLocked's fallback for newer template stages.
+    state, how = lc.migrate_record(
+        {"pipeline_stage": "act", "review_state": "verifying", "status": "in_progress", "blocked": False}
+    )
+    assert state is State.RUNNING
+    assert how == "bare_status_fallback"
+
+
+def test_bare_status_direct_derivation():
+    # A record with only a status maps directly via the bare tuple (derived, not fallback).
+    state, how = lc.migrate_record({"status": "in_progress"})
+    assert state is State.RUNNING
+    assert how == "derived"
+
+
+def test_routing_policy():
+    assert lc.route(State.RUNNING) is Route.DISPATCH
+    assert lc.route(State.PLANNING) is Route.DISPATCH
+    assert lc.route(State.REVIEW) is Route.HUMAN
+    assert lc.route(State.DECISION) is Route.HUMAN
+    assert lc.route(State.APPROVED) is Route.IDLE
+    assert lc.route(State.BLOCKED) is Route.IDLE
+
+
+def test_gate_classification_and_decisions():
+    assert lc.gate_for_outcome(State.PLANNING, TurnOutcome.PLAN_READY) is GateKind.PLAN
+    assert lc.gate_for_outcome(State.RUNNING, TurnOutcome.SUBMITTED_FOR_REVIEW) is GateKind.REVIEW
+    assert lc.gate_for_outcome(State.RUNNING, TurnOutcome.CONTINUE) is None
+
+    assert lc.apply_human_decision(GateKind.PLAN, HumanDecision.APPROVE) is State.RUNNING
+    assert lc.apply_human_decision(GateKind.REVIEW, HumanDecision.APPROVE) is State.APPROVED
+    assert lc.apply_human_decision(GateKind.REVIEW, HumanDecision.REQUEST_CHANGES) is State.CHANGES_REQUESTED
+    assert lc.apply_human_decision(GateKind.REVIEW, HumanDecision.REJECT) is State.REJECTED

--- a/orchestrator/tests/test_service.py
+++ b/orchestrator/tests/test_service.py
@@ -1,0 +1,45 @@
+"""Service-surface tests: /health, /run (dispatch + interrupt), /resume, fail-loud."""
+
+from fastapi.testclient import TestClient
+
+from orchestrator.harness import FakeHarness
+from orchestrator.lifecycle import State, TurnOutcome
+from orchestrator.service import create_app
+
+
+def _client(outcome=TurnOutcome.SUBMITTED_FOR_REVIEW):
+    return TestClient(create_app(harness_factory=lambda req: FakeHarness(outcome)))
+
+
+def test_health():
+    assert _client().get("/health").json()["status"] == "ok"
+
+
+def test_run_dispatch_interrupts_then_resume_approves():
+    c = _client(TurnOutcome.SUBMITTED_FOR_REVIEW)
+    run = c.post("/run", json={"task_id": "svc1", "record": {"task_id": "svc1", "lifecycle_state": "running"}}).json()
+    assert run["status"] == "interrupted"
+    assert run["interrupt"]["gate_kind"] == "review"
+
+    resumed = c.post("/resume", json={"task_id": "svc1", "thread_id": "svc1", "decision": "approve"}).json()
+    assert resumed["status"] == "done"
+    assert resumed["projection"]["lifecycle_state"] == State.APPROVED.value
+    assert resumed["projection"]["status"] == "done"  # derived 4-tuple in the projection
+
+
+def test_run_projection_shape():
+    c = _client(TurnOutcome.CONTINUE)
+    out = c.post("/run", json={"task_id": "svc2", "record": {"task_id": "svc2", "lifecycle_state": "running"}}).json()
+    proj = out["projection"]
+    assert set(proj) == {"task_id", "lifecycle_state", "pipeline_stage", "review_state", "status", "blocked"}
+    assert proj["lifecycle_state"] == "running"
+
+
+def test_unknown_record_fails_loud_not_dispatched():
+    c = _client()
+    out = c.post("/run", json={
+        "task_id": "svc3",
+        "record": {"task_id": "svc3", "pipeline_stage": "act", "status": "verifying", "blocked": False},
+    }).json()
+    assert out["status"] == "done"
+    assert out["projection"]["lifecycle_state"] == State.UNKNOWN.value

--- a/orchestrator/tests/test_wire.py
+++ b/orchestrator/tests/test_wire.py
@@ -1,0 +1,38 @@
+"""Wire-contract golden tests — the Go <-> Python shapes the broker encodes/decodes."""
+
+from orchestrator.wire import DispatchRequest, McpServer, ResumeRequest, StepResult
+
+
+def test_dispatch_request_golden():
+    req = DispatchRequest(
+        task_id="task-7",
+        record={"task_id": "task-7", "lifecycle_state": "running", "status": "in_progress"},
+        model="anthropic:claude-sonnet-4-6",
+        system_prompt="You are the engineer.",
+        mcp={"teammcp": McpServer(
+            command="wuphf", args=["mcp-team"],
+            env_passthrough=["WUPHF_BROKER_TOKEN", "WUPHF_BROKER_ADDR"],
+        )},
+    )
+    d = req.model_dump()
+    assert d["schema_version"] == 1
+    assert d["mcp"]["teammcp"]["command"] == "wuphf"
+    # secrets are NEVER values — only env var names cross the wire
+    assert d["mcp"]["teammcp"]["env_passthrough"] == ["WUPHF_BROKER_TOKEN", "WUPHF_BROKER_ADDR"]
+    assert DispatchRequest.model_validate(d) == req
+
+
+def test_resume_request_rejects_unknown_decision():
+    import pytest
+    from pydantic import ValidationError
+
+    ResumeRequest(task_id="t", thread_id="t", decision="approve")  # ok
+    with pytest.raises(ValidationError):
+        ResumeRequest(task_id="t", thread_id="t", decision="yolo")
+
+
+def test_step_result_shape():
+    sr = StepResult(status="interrupted", thread_id="t",
+                    projection={"task_id": "t", "lifecycle_state": "review"},
+                    interrupt={"gate_kind": "review"})
+    assert sr.model_dump()["status"] == "interrupted"


### PR DESCRIPTION
## orchestrator package — P1a (3/3 in stack)

First real implementation increment: a tested LangGraph orchestrator that owns
task lifecycle on top of Claude Code/Codex. **25 tests green, no model key.**

- `lifecycle.py` — real lifecycle model (faithful to broker_lifecycle_transition.go) + P1 policy.
- `runstate.py` — re-hydrate from the Go record + one-way projection back.
- `graph.py` — route -> dispatch_turn -> (human_gate | continue); HITL via interrupt().
- `harness.py` — Harness protocol; FakeHarness + ClaudeAgentHarness (P2 stub).
- `wire.py` — Go<->Python contract (secrets cross as env-var names only).
- `service.py` — FastAPI /run, /resume, /health.

Run: `cd orchestrator && uv venv .venv && uv pip install langgraph langgraph-checkpoint-sqlite fastapi sse-starlette uvicorn pydantic pytest httpx && .venv/bin/pytest -q`

Deferred (next stacked PRs): P1b Go dispatch client + projection + flag; P2 real
Claude Agent SDK harness; SSE streaming; CI. Base: `deepagents/02-spikes`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)