### PR TITLE
feat: surface rank-sensitive retrieval metrics in slice-1 bench (OFFICE-671)

### DIFF
--- a/bench/slice-1/runner/runner.go
+++ b/bench/slice-1/runner/runner.go
@@ -95,14 +95,36 @@ type QueryResult struct {
 	// Classifier output for sanity.
 	ClassifierClass      string
 	ClassifierConfidence float64
+	// Rank-sensitive metrics computed from the ORDERED got list against the
+	// binary-relevant expected set. recall@20 is saturated on this corpus
+	// (every query returns its full expected set inside top-20), so these are
+	// the metrics that actually move when fusion/rerank reorder the union.
+	// Defined only for in-scope queries (len(expected) > 0); OOS queries leave
+	// them at zero and are excluded from the macro-averages.
+	NDCG10     float64
+	RecallAt1  float64
+	RecallAt3  float64
+	RecallAt5  float64
+	RecallAt10 float64
+	MRR        float64
 }
 
 // Aggregate is the final scoreboard.
 type Aggregate struct {
-	TotalQueries       int
-	PassingQueries     int
-	MicroRecall        float64 // sum(intersection) / sum(|expected|)
-	PassRate           float64 // passingQueries / totalQueries
+	TotalQueries   int
+	PassingQueries int
+	MicroRecall    float64 // sum(intersection) / sum(|expected|)
+	PassRate       float64 // passingQueries / totalQueries
+	// Macro-averaged rank-sensitive metrics over in-scope queries only.
+	// These are the discriminating baselines for the RRF-fusion and
+	// cross-encoder-rerank changes; recall@20 / pass-rate are saturated.
+	ScoredQueries      int // in-scope queries (len(expected) > 0)
+	MeanNDCG10         float64
+	MeanRecallAt1      float64
+	MeanRecallAt3      float64
+	MeanRecallAt5      float64
+	MeanRecall10       float64
+	MeanMRR            float64
 	RetrievalP50Ms     float64
 	RetrievalP95Ms     float64
 	ClassifyP95Micros  int64
@@ -391,6 +413,12 @@ func Run(ctx context.Context, cfg Config) (*Aggregate, []QueryResult, error) {
 			ClassifyMicros:       classifyMicros,
 			ClassifierClass:      string(klass),
 			ClassifierConfidence: conf,
+			NDCG10:               scoreNDCG(q.ExpectedFactIDs, got, 10),
+			RecallAt1:            scoreRecallAtK(q.ExpectedFactIDs, got, 1),
+			RecallAt3:            scoreRecallAtK(q.ExpectedFactIDs, got, 3),
+			RecallAt5:            scoreRecallAtK(q.ExpectedFactIDs, got, 5),
+			RecallAt10:           scoreRecallAtK(q.ExpectedFactIDs, got, 10),
+			MRR:                  scoreMRR(q.ExpectedFactIDs, got),
 		}
 		results = append(results, res)
 		_ = qi
@@ -406,6 +434,7 @@ func Run(ctx context.Context, cfg Config) (*Aggregate, []QueryResult, error) {
 	}
 
 	var totalExpected, totalHit int
+	var sumNDCG, sumR1, sumR3, sumR5, sumR10, sumMRR float64
 	classBuckets := map[string]*ClassBreakdown{}
 	for _, r := range results {
 		if r.Passed {
@@ -415,6 +444,17 @@ func Run(ctx context.Context, cfg Config) (*Aggregate, []QueryResult, error) {
 		}
 		totalExpected += len(r.Query.ExpectedFactIDs)
 		totalHit += r.Intersection
+		// Rank-sensitive metrics are only meaningful where there are relevant
+		// docs to rank; OOS queries (no expected facts) are excluded.
+		if len(r.Query.ExpectedFactIDs) > 0 {
+			agg.ScoredQueries++
+			sumNDCG += r.NDCG10
+			sumR1 += r.RecallAt1
+			sumR3 += r.RecallAt3
+			sumR5 += r.RecallAt5
+			sumR10 += r.RecallAt10
+			sumMRR += r.MRR
+		}
 
 		cb, ok := classBuckets[r.Query.QueryClass]
 		if !ok {
@@ -454,6 +494,15 @@ func Run(ctx context.Context, cfg Config) (*Aggregate, []QueryResult, error) {
 		agg.MicroRecall = float64(totalHit) / float64(totalExpected)
 	} else {
 		agg.MicroRecall = 1.0
+	}
+	if agg.ScoredQueries > 0 {
+		n := float64(agg.ScoredQueries)
+		agg.MeanNDCG10 = sumNDCG / n
+		agg.MeanRecallAt1 = sumR1 / n
+		agg.MeanRecallAt3 = sumR3 / n
+		agg.MeanRecallAt5 = sumR5 / n
+		agg.MeanRecall10 = sumR10 / n
+		agg.MeanMRR = sumMRR / n
 	}
 	agg.RetrievalP50Ms = percentile(allLatencyMs, 0.50)
 	agg.RetrievalP95Ms = percentile(allLatencyMs, 0.95)
@@ -593,6 +642,19 @@ func FormatReport(agg *Aggregate, results []QueryResult) string {
 	fmt.Fprintf(&b, "  Reconcile wall time      : %d ms\n", agg.ReconcileWallMs)
 	fmt.Fprintf(&b, "  SQLite size              : %d bytes\n", agg.IndexBytesSQLite)
 	fmt.Fprintf(&b, "  Bleve size               : %d bytes\n\n", agg.IndexBytesBleve)
+
+	// Rank-sensitive retrieval quality — the discriminating baseline for
+	// fusion/rerank changes. recall@20 above is saturated on this corpus;
+	// these macro-averages (in-scope queries only) are what a reranker swap
+	// must actually move. Observability layer, OFFICE-671.
+	fmt.Fprintf(&b, "Rank-sensitive retrieval quality (macro avg, %d in-scope queries)\n", agg.ScoredQueries)
+	fmt.Fprintf(&b, "----------------------------------------------------------------\n")
+	fmt.Fprintf(&b, "  nDCG@10                  : %.4f\n", agg.MeanNDCG10)
+	fmt.Fprintf(&b, "  recall@1                 : %.4f\n", agg.MeanRecallAt1)
+	fmt.Fprintf(&b, "  recall@3                 : %.4f\n", agg.MeanRecallAt3)
+	fmt.Fprintf(&b, "  recall@5                 : %.4f\n", agg.MeanRecallAt5)
+	fmt.Fprintf(&b, "  recall@10                : %.4f\n", agg.MeanRecall10)
+	fmt.Fprintf(&b, "  MRR                      : %.4f\n\n", agg.MeanMRR)
 
 	fmt.Fprintf(&b, "Per-class breakdown\n-------------------\n")
 	classes := make([]string, 0, len(agg.PerClass))

--- a/bench/slice-1/runner/scoring.go
+++ b/bench/slice-1/runner/scoring.go
@@ -1,0 +1,105 @@
+package runner
+
+import "math"
+
+// scoring.go — rank-sensitive retrieval metrics for the Slice 1 observability
+// layer. recall@20 / pass-rate are saturated on this corpus (every in-scope
+// query returns its full expected set inside top-20), so they cannot show
+// whether a fusion or rerank change actually reordered the union toward the
+// top. These metrics can: they reward putting relevant facts at low ranks.
+//
+// All metrics use binary relevance (a fact is relevant iff its ID is in the
+// query's expected set) and operate on the ORDERED `got` list as returned by
+// WikiIndex.Search. No LLM, no external credential, fully deterministic.
+
+// scoreRecallAtK computes recall@k = |expected ∩ got[:k]| / |expected|: the
+// fraction of relevant facts that appear within the top-k retrieved results.
+//
+// Returns 0 for out-of-scope queries (empty expected set) — those carry no
+// relevant docs to rank and are excluded from the macro-averages by the
+// caller. Note recall@1 is bounded above by 1/|expected| on multi-fact
+// queries, so on this corpus nDCG@10 and MRR are the sharper discriminators;
+// recall@1/@3 still move when a rerank lifts a single relevant fact to the top.
+func scoreRecallAtK(expected, got []string, k int) float64 {
+	if len(expected) == 0 {
+		return 0
+	}
+	if k > len(got) {
+		k = len(got)
+	}
+	gset := make(map[string]struct{}, len(expected))
+	for _, e := range expected {
+		gset[e] = struct{}{}
+	}
+	hit := 0
+	for i := 0; i < k; i++ {
+		if _, ok := gset[got[i]]; ok {
+			hit++
+		}
+	}
+	return float64(hit) / float64(len(expected))
+}
+
+// scoreNDCG computes the normalised discounted cumulative gain at rank k with
+// binary relevance:
+//
+//	DCG@k  = Σ_{i=1..k} rel_i / log2(i+1)
+//	IDCG@k = Σ_{i=1..min(k,|expected|)} 1 / log2(i+1)   (ideal ordering)
+//	nDCG@k = DCG@k / IDCG@k
+//
+// rel_i is 1 when got[i-1] is in the expected set, else 0. Returns 0 for
+// out-of-scope queries (no ideal gain exists to normalise against).
+func scoreNDCG(expected, got []string, k int) float64 {
+	if len(expected) == 0 {
+		return 0
+	}
+	gset := make(map[string]struct{}, len(expected))
+	for _, e := range expected {
+		gset[e] = struct{}{}
+	}
+	limit := k
+	if limit > len(got) {
+		limit = len(got)
+	}
+	var dcg float64
+	for i := 0; i < limit; i++ {
+		if _, ok := gset[got[i]]; ok {
+			// rank position is i+1; discount uses log2(position+1).
+			dcg += 1.0 / math.Log2(float64(i+2))
+		}
+	}
+	// Ideal DCG: as many relevant docs as possible packed at the top, capped
+	// by both k and the number of relevant docs available.
+	ideal := len(expected)
+	if ideal > k {
+		ideal = k
+	}
+	var idcg float64
+	for i := 0; i < ideal; i++ {
+		idcg += 1.0 / math.Log2(float64(i+2))
+	}
+	if idcg == 0 {
+		return 0
+	}
+	return dcg / idcg
+}
+
+// scoreMRR computes the reciprocal rank of the FIRST relevant fact in the
+// ordered got list (1/rank, 1-indexed). Returns 0 when no relevant fact is
+// retrieved or the query is out of scope. MRR is the cleanest single-number
+// signal for "did the retriever put a right answer near the top".
+func scoreMRR(expected, got []string) float64 {
+	if len(expected) == 0 {
+		return 0
+	}
+	gset := make(map[string]struct{}, len(expected))
+	for _, e := range expected {
+		gset[e] = struct{}{}
+	}
+	for i, g := range got {
+		if _, ok := gset[g]; ok {
+			return 1.0 / float64(i+1)
+		}
+	}
+	return 0
+}

--- a/bench/slice-1/runner/scoring_test.go
+++ b/bench/slice-1/runner/scoring_test.go
@@ -1,0 +1,84 @@
+package runner
+
+import (
+	"math"
+	"testing"
+)
+
+const eps = 1e-9
+
+func almostEqual(a, b float64) bool { return math.Abs(a-b) < eps }
+
+func TestScoreRecallAtK(t *testing.T) {
+	cases := []struct {
+		name     string
+		expected []string
+		got      []string
+		k        int
+		want     float64
+	}{
+		{"out of scope returns zero", nil, []string{"a", "b"}, 3, 0},
+		{"perfect single fact at top", []string{"a"}, []string{"a", "b", "c"}, 1, 1},
+		{"relevant fact below k misses", []string{"c"}, []string{"a", "b", "c"}, 2, 0},
+		{"relevant fact within k hits", []string{"c"}, []string{"a", "b", "c"}, 3, 1},
+		{"two of three relevant in topk", []string{"a", "b", "z"}, []string{"a", "b", "c"}, 3, 2.0 / 3.0},
+		{"recall@1 capped by expected size", []string{"a", "b"}, []string{"a", "b"}, 1, 0.5},
+		{"k larger than got is clamped", []string{"b"}, []string{"a", "b"}, 50, 1},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := scoreRecallAtK(c.expected, c.got, c.k); !almostEqual(got, c.want) {
+				t.Fatalf("scoreRecallAtK(%v,%v,%d) = %v, want %v", c.expected, c.got, c.k, got, c.want)
+			}
+		})
+	}
+}
+
+func TestScoreNDCG(t *testing.T) {
+	// IDCG@k constants for binary relevance, ideal ordering.
+	idcg1 := 1.0                    // 1/log2(2)
+	idcg2 := 1.0 + 1.0/math.Log2(3) // ranks 1,2
+	cases := []struct {
+		name     string
+		expected []string
+		got      []string
+		k        int
+		want     float64
+	}{
+		{"out of scope returns zero", nil, []string{"a"}, 10, 0},
+		{"single relevant at top is perfect", []string{"a"}, []string{"a", "b", "c"}, 10, 1},
+		{"single relevant at rank 2", []string{"b"}, []string{"a", "b", "c"}, 10, (1.0 / math.Log2(3)) / idcg1},
+		{"two relevant ideally ordered", []string{"a", "b"}, []string{"a", "b", "c"}, 10, idcg2 / idcg2},
+		{"two relevant reordered", []string{"a", "c"}, []string{"a", "b", "c"}, 10, (1.0 + 1.0/math.Log2(4)) / idcg2},
+		{"none retrieved", []string{"z"}, []string{"a", "b", "c"}, 10, 0},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := scoreNDCG(c.expected, c.got, c.k); !almostEqual(got, c.want) {
+				t.Fatalf("scoreNDCG(%v,%v,%d) = %v, want %v", c.expected, c.got, c.k, got, c.want)
+			}
+		})
+	}
+}
+
+func TestScoreMRR(t *testing.T) {
+	cases := []struct {
+		name     string
+		expected []string
+		got      []string
+		want     float64
+	}{
+		{"out of scope returns zero", nil, []string{"a"}, 0},
+		{"first relevant at rank 1", []string{"a"}, []string{"a", "b", "c"}, 1},
+		{"first relevant at rank 3", []string{"c"}, []string{"a", "b", "c"}, 1.0 / 3.0},
+		{"earliest of several wins", []string{"b", "c"}, []string{"a", "b", "c"}, 0.5},
+		{"none retrieved", []string{"z"}, []string{"a", "b", "c"}, 0},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := scoreMRR(c.expected, c.got); !almostEqual(got, c.want) {
+				t.Fatalf("scoreMRR(%v,%v) = %v, want %v", c.expected, c.got, got, c.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

Finishes the **retrieval observability layer** for the slice-1 bench. The rank-sensitive metric fields (`NDCG10`, `MRR`, `RecallAt5/10`) were wired into the structs and call sites in a prior turn but the scorers were never implemented and the report never printed them — so the runner package did not even build.

This PR:
- Implements `scoreNDCG`, `scoreRecallAtK`, `scoreMRR` in a new `scoring.go`.
- Extends the report with **recall@1 / recall@3 / nDCG@10 / MRR** alongside the existing recall@20.
- Surfaces all rank-sensitive means in `FormatReport`.
- Adds unit tests (`scoring_test.go`).

## Why

`bench/slice-1` previously computed only **recall@20** — a coarse in-set gate that a reranker swap (OFFICE-464) cannot move. The reranker delta lives in **rank-sensitive** metrics. This layer is the measurement substrate the ranking work depends on.

## Test plan
- `go build ./bench/slice-1/...` — passes
- `go test ./bench/slice-1/runner/` — all 18 subtests pass
- `gofmt` — clean

Part of OFFICE-459 (RAG gaps plan). Closes OFFICE-671.

🤖 Generated with [Claude Code](https://claude.com/claude-code)