### PR TITLE
feat(orchestrator): SSE streaming for a dispatch turn (POST /run/stream)

### DIFF
--- a/internal/provider/deepagents.go
+++ b/internal/provider/deepagents.go
@@ -20,6 +20,7 @@ package provider
 // SlackProviderBinding.BotTokenEnv.
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -211,6 +212,87 @@ func (c *DispatchClient) Run(ctx context.Context, req DispatchRequest) (*StepRes
 		req.SchemaVersion = OrchestratorSchemaVersion
 	}
 	return c.postStep(ctx, "/run", req)
+}
+
+// RunStream dispatches a step against the streaming endpoint (POST /run/stream)
+// and consumes the SSE event stream. onEvent (optional) is called for each
+// intermediate "turn" event with its raw JSON data, for live observability; the
+// terminal "result" event is decoded into the returned StepResult. The result is
+// identical to what Run would return — streaming only adds the live events.
+func (c *DispatchClient) RunStream(ctx context.Context, req DispatchRequest, onEvent func(event string, data []byte)) (*StepResult, error) {
+	if strings.TrimSpace(req.TaskID) == "" {
+		return nil, errors.New("deepagents: RunStream requires a task_id")
+	}
+	if req.SchemaVersion == 0 {
+		req.SchemaVersion = OrchestratorSchemaVersion
+	}
+	payload, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("deepagents: marshal /run/stream request: %w", err)
+	}
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/run/stream", bytes.NewReader(payload))
+	if err != nil {
+		return nil, fmt.Errorf("deepagents: build /run/stream request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Accept", "text/event-stream")
+
+	resp, err := c.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("deepagents: POST %s/run/stream: %w (is the orchestrator sidecar running?)", c.baseURL, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		snippet, _ := io.ReadAll(io.LimitReader(resp.Body, 8<<10))
+		return nil, fmt.Errorf("deepagents: HTTP %d from %s/run/stream: %s", resp.StatusCode, c.baseURL, strings.TrimSpace(string(snippet)))
+	}
+
+	// Parse the SSE stream: "event:" + "data:" lines, dispatched on a blank line.
+	var result *StepResult
+	scanner := bufio.NewScanner(resp.Body)
+	scanner.Buffer(make([]byte, 0, 64<<10), 1<<20)
+	var event string
+	var data string
+	flush := func() error {
+		if data == "" {
+			event = ""
+			return nil
+		}
+		if event == "result" {
+			var sr StepResult
+			if err := json.Unmarshal([]byte(data), &sr); err != nil {
+				return fmt.Errorf("deepagents: decode /run/stream result: %w", err)
+			}
+			result = &sr
+		} else if onEvent != nil {
+			onEvent(event, []byte(data))
+		}
+		event, data = "", ""
+		return nil
+	}
+	for scanner.Scan() {
+		line := scanner.Text()
+		switch {
+		case line == "":
+			if err := flush(); err != nil {
+				return nil, err
+			}
+		case strings.HasPrefix(line, "event:"):
+			event = strings.TrimSpace(line[len("event:"):])
+		case strings.HasPrefix(line, "data:"):
+			data = strings.TrimSpace(line[len("data:"):])
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("deepagents: read /run/stream: %w", err)
+	}
+	if err := flush(); err != nil {
+		return nil, err
+	}
+	if result == nil {
+		return nil, errors.New("deepagents: /run/stream ended without a result event")
+	}
+	return result, nil
 }
 
 // Resume resolves a pending human gate on an interrupted thread (POST /resume)

--- a/internal/provider/deepagents_test.go
+++ b/internal/provider/deepagents_test.go
@@ -326,6 +326,59 @@ func TestDispatchClientCoordinate_SurfacesCycle(t *testing.T) {
 	}
 }
 
+func TestDispatchClientRunStream_ConsumesSSE(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/run/stream" {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		// Mirror the orchestrator's SSE shape: start, a turn event, then result.
+		io.WriteString(w, "event: start\ndata: {\"task_id\":\"t1\"}\n\n")
+		io.WriteString(w, "event: turn\ndata: {\"type\":\"tool_use\",\"name\":\"mcp__office__team_task\",\"action\":\"submit_for_review\"}\n\n")
+		io.WriteString(w, "event: result\ndata: {\"status\":\"interrupted\",\"thread_id\":\"t1\",\"projection\":{\"task_id\":\"t1\",\"lifecycle_state\":\"review\"},\"interrupt\":{\"gate_kind\":\"review\"}}\n\n")
+	}))
+	defer srv.Close()
+	c := NewDispatchClient(srv.URL, WithHTTPClient(srv.Client()))
+
+	var turnActions []string
+	res, err := c.RunStream(context.Background(),
+		DispatchRequest{TaskID: "t1", Record: map[string]any{"lifecycle_state": "running"}},
+		func(event string, data []byte) {
+			var ev map[string]any
+			_ = json.Unmarshal(data, &ev)
+			if event == "turn" {
+				if a, _ := ev["action"].(string); a != "" {
+					turnActions = append(turnActions, a)
+				}
+			}
+		})
+	if err != nil {
+		t.Fatalf("RunStream: %v", err)
+	}
+	if res.Status != StepStatusInterrupted || res.Projection.LifecycleState != "review" {
+		t.Fatalf("result = %+v, want interrupted/review", res)
+	}
+	if len(turnActions) != 1 || turnActions[0] != "submit_for_review" {
+		t.Fatalf("turn events = %v, want [submit_for_review]", turnActions)
+	}
+}
+
+func TestDispatchClientRunStream_NoResultFailsLoud(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		io.WriteString(w, "event: start\ndata: {\"task_id\":\"t1\"}\n\n")
+	}))
+	defer srv.Close()
+	c := NewDispatchClient(srv.URL, WithHTTPClient(srv.Client()))
+	if _, err := c.RunStream(context.Background(), DispatchRequest{TaskID: "t1", Record: map[string]any{}}, nil); err == nil {
+		t.Fatal("expected error when the stream ends without a result event")
+	}
+}
+
 func TestProjectionWireShape(t *testing.T) {
 	t.Parallel()
 	const fromPython = `{"task_id":"t","lifecycle_state":"approved","pipeline_stage":"ship","review_state":"approved","status":"done","blocked":false}`

--- a/orchestrator/README.md
+++ b/orchestrator/README.md
@@ -95,8 +95,12 @@ key-free; install the SDK + set a key for real `ClaudeAgentHarness` turns.
   pure `classify_outcome` keyed on the agent's real `team_task` actions. Live runs
   need `pip install claude-agent-sdk` + a key; without the SDK the service degrades
   to `FakeHarness`.
-- **SSE streaming** of incremental events (the service returns the terminal StepResult today).
-- **CI wiring** (pytest + golden wire fixtures) scoped to `orchestrator/**`.
+- ~~**SSE streaming**~~ — **done.** `POST /run/stream` emits SSE: `start`, live `turn`
+  events (tool_use/text as the agent acts), then a terminal `result` carrying the same
+  projection `/run` returns. Turn→state resolution is shared via `lifecycle.resolve_turn`
+  (composes the same gate/continue functions the graph uses), so streamed and non-streamed
+  results agree. Go consumer: `DispatchClient.RunStream`.
+- **CI wiring** (pytest) scoped to `orchestrator/**`.
 
 ## P1 policy deviations (revisited in P2/P3)
 

--- a/orchestrator/src/orchestrator/harness.py
+++ b/orchestrator/src/orchestrator/harness.py
@@ -22,6 +22,7 @@ import asyncio
 import logging
 import os
 from dataclasses import dataclass, field
+from collections.abc import AsyncIterator
 from typing import Protocol
 
 from .lifecycle import State, TurnOutcome
@@ -39,6 +40,12 @@ class TurnResult:
 
 class Harness(Protocol):
     def run_turn(self, task: TaskRun) -> TurnResult:  # pragma: no cover - protocol
+        ...
+
+    def stream_turn(self, task: TaskRun) -> AsyncIterator[dict]:  # pragma: no cover - protocol
+        """Async-iterate a turn's events. Each yielded dict has a "type": "tool_use"
+        / "text" for live progress, and a final {"type": "turn_complete", "outcome",
+        "text"} carrying the classified outcome. Powers POST /run/stream (SSE)."""
         ...
 
 
@@ -168,6 +175,10 @@ class FakeHarness:
     def run_turn(self, task: TaskRun) -> TurnResult:
         return TurnResult(outcome=self._outcome, text=self._text)
 
+    async def stream_turn(self, task: TaskRun) -> AsyncIterator[dict]:
+        yield {"type": "text", "text": self._text}
+        yield {"type": "turn_complete", "outcome": self._outcome.value, "text": self._text}
+
 
 class ClaudeAgentHarness:
     """Drives Claude Code for one turn via the Claude Agent SDK, wired to teammcp.
@@ -254,6 +265,33 @@ class ClaudeAgentHarness:
         options = self._build_options(task.get("system_prompt", ""), _permission_mode_for(state))  # pragma: no cover
         transcript = asyncio.run(self._collect_transcript(prompt, options))  # pragma: no cover - needs SDK + key
         return TurnResult(outcome=classify_outcome(state, transcript), text=transcript.text)  # pragma: no cover
+
+    async def stream_turn(self, task: TaskRun) -> AsyncIterator[dict]:  # pragma: no cover - needs SDK + key
+        from claude_agent_sdk import query  # lazy
+
+        self._require_sdk()
+        state = State(task["lifecycle_state"])
+        prompt = _prompt_for(task)
+        options = self._build_options(task.get("system_prompt", ""), _permission_mode_for(state))
+        tool_calls: list[ToolCall] = []
+        texts: list[str] = []
+        async for message in query(prompt=prompt, options=options):
+            for block in getattr(message, "content", None) or []:
+                kind = type(block).__name__
+                if kind == "ToolUseBlock":
+                    raw = getattr(block, "input", None)
+                    args = raw if isinstance(raw, dict) else {}
+                    action = str(args.get("action", ""))
+                    name = getattr(block, "name", "")
+                    tool_calls.append(ToolCall(name=name, action=action, args=args))
+                    yield {"type": "tool_use", "name": name, "action": action}
+                elif kind == "TextBlock":
+                    text = getattr(block, "text", "")
+                    if text:
+                        texts.append(text)
+                        yield {"type": "text", "text": text}
+        transcript = TurnTranscript(tool_calls=tool_calls, text="\n".join(texts))
+        yield {"type": "turn_complete", "outcome": classify_outcome(state, transcript).value, "text": transcript.text}
 
 
 def build_harness(model: str, mcp: dict[str, McpServer]) -> Harness:

--- a/orchestrator/src/orchestrator/lifecycle.py
+++ b/orchestrator/src/orchestrator/lifecycle.py
@@ -240,6 +240,21 @@ def apply_turn_outcome(state: State, outcome: TurnOutcome) -> State:
     raise ValueError(f"{outcome} is a gated outcome; route through a human gate")
 
 
+def resolve_turn(state: State, outcome: TurnOutcome) -> tuple[State, str, dict | None]:
+    """Map (current state, turn outcome) -> (new_state, status, interrupt). Composes
+    the same gate/continue functions the graph nodes use (gate_for_outcome +
+    gate_pending_state, else apply_turn_outcome), so the streaming path and the
+    graph agree by construction. status is 'interrupted' at a human gate (with an
+    interrupt payload), else 'done'."""
+    gate = gate_for_outcome(state, outcome)
+    if gate is not None:
+        return gate_pending_state(gate), "interrupted", {
+            "type": "approval_required",
+            "gate_kind": gate.value,
+        }
+    return apply_turn_outcome(state, outcome), "done", None
+
+
 def apply_human_decision(gate: GateKind, decision: HumanDecision) -> State:
     if decision is HumanDecision.REJECT:
         return State.REJECTED

--- a/orchestrator/src/orchestrator/service.py
+++ b/orchestrator/src/orchestrator/service.py
@@ -13,14 +13,16 @@ next increments; this skeleton is the contract surface they target.
 
 from __future__ import annotations
 
+import json
 from typing import Callable
 
 from fastapi import FastAPI, HTTPException
+from sse_starlette.sse import EventSourceResponse
 
 from .coordination import TaskGraph, coordinate
 from .graph import build_graph, drive
 from .harness import FakeHarness, Harness, build_harness
-from .lifecycle import State
+from .lifecycle import Route, State, TurnOutcome, resolve_turn, route
 from .runstate import from_broker_record, to_projection
 from .wire import (
     SCHEMA_VERSION,
@@ -88,6 +90,53 @@ def create_app(harness_factory: HarnessFactory = _default_harness_factory) -> Fa
             projection=to_projection(result["state"]),
             interrupt=result.get("interrupt"),
         )
+
+    @app.post("/run/stream")
+    async def run_stream(req: DispatchRequest) -> EventSourceResponse:
+        # Streaming twin of /run: emits SSE events as the turn progresses (tool_use,
+        # text), then a terminal `result` event carrying the same projection /run
+        # returns. The turn-to-state resolution uses lifecycle.resolve_turn, which
+        # composes the same gate/continue functions the graph uses, so the streamed
+        # result matches /run. Re-hydrate model: a gate is projected (review/decision),
+        # not held — the broker resolves it and re-dispatches.
+        _check_schema_version(req.schema_version)
+        run_state = from_broker_record(req.record)
+        run_state["system_prompt"] = req.system_prompt or run_state.get("system_prompt", "")
+        if req.messages:
+            run_state["messages"] = req.messages
+        harness = harness_factory(req)
+
+        def _event(name: str, payload: dict) -> dict:
+            return {"event": name, "data": json.dumps(payload)}
+
+        def _result_event(status: str, state_value: str, interrupt: dict | None) -> dict:
+            run_state["lifecycle_state"] = state_value
+            payload: dict = {
+                "status": status,
+                "thread_id": req.task_id,
+                "projection": to_projection(run_state),
+            }
+            if interrupt is not None:
+                payload["interrupt"] = interrupt
+            return _event("result", payload)
+
+        async def generate():
+            yield _event("start", {"task_id": req.task_id})
+            state = State(run_state["lifecycle_state"])
+            # Fail loud / nothing-to-run paths project the current state, no turn.
+            if state is State.UNKNOWN or route(state) is not Route.DISPATCH:
+                yield _result_event("done", state.value, None)
+                return
+            outcome = TurnOutcome.CONTINUE
+            async for ev in harness.stream_turn(run_state):
+                if ev.get("type") == "turn_complete":
+                    outcome = TurnOutcome(ev["outcome"])
+                else:
+                    yield _event("turn", ev)
+            new_state, status, interrupt = resolve_turn(state, outcome)
+            yield _result_event(status, new_state.value, interrupt)
+
+        return EventSourceResponse(generate())
 
     @app.post("/coordinate", response_model=CoordinationPlan)
     def coordinate_goal(req: CoordinateRequest) -> CoordinationPlan:

--- a/orchestrator/tests/test_harness.py
+++ b/orchestrator/tests/test_harness.py
@@ -96,6 +96,22 @@ def test_decomposed_children_extracts_specs_in_order():
     assert specs[1].depends_on == ("c1",)  # blank dep is dropped
 
 
+def test_fake_harness_stream_turn_yields_text_then_complete():
+    import asyncio
+
+    from orchestrator.harness import FakeHarness
+
+    async def collect():
+        out = []
+        async for ev in FakeHarness(TurnOutcome.SUBMITTED_FOR_REVIEW, text="hi").stream_turn({"lifecycle_state": "running"}):
+            out.append(ev)
+        return out
+
+    evs = asyncio.run(collect())
+    assert evs[0] == {"type": "text", "text": "hi"}
+    assert evs[-1] == {"type": "turn_complete", "outcome": "submitted_for_review", "text": "hi"}
+
+
 def test_decomposed_children_empty_when_no_create():
     t = TurnTranscript(tool_calls=[tc("submit_for_review"), tc("comment")])
     assert t.decomposed_children() == []

--- a/orchestrator/tests/test_lifecycle.py
+++ b/orchestrator/tests/test_lifecycle.py
@@ -95,6 +95,18 @@ def test_continue_preserves_working_state():
     assert lc.apply_turn_outcome(State.RUNNING, TurnOutcome.CONTINUE) is State.RUNNING
 
 
+def test_resolve_turn_matches_graph_gate_and_continue():
+    # Gated outcomes -> the gate state + interrupted; non-gated -> the continued
+    # state + done. Composed from the same functions the graph uses.
+    s, status, interrupt = lc.resolve_turn(State.RUNNING, TurnOutcome.SUBMITTED_FOR_REVIEW)
+    assert (s, status) == (State.REVIEW, "interrupted") and interrupt["gate_kind"] == "review"
+    s, status, interrupt = lc.resolve_turn(State.PLANNING, TurnOutcome.PLAN_READY)
+    assert (s, status) == (State.DECISION, "interrupted") and interrupt["gate_kind"] == "plan"
+    assert lc.resolve_turn(State.RUNNING, TurnOutcome.CONTINUE) == (State.RUNNING, "done", None)
+    assert lc.resolve_turn(State.RUNNING, TurnOutcome.DECOMPOSED) == (State.RUNNING, "done", None)
+    assert lc.resolve_turn(State.RUNNING, TurnOutcome.BLOCKED) == (State.BLOCKED, "done", None)
+
+
 def test_decomposed_is_non_gated_and_runs():
     # A decompose turn is not human-gated and leaves the goal RUNNING (it now
     # coordinates its children) regardless of the source state.

--- a/orchestrator/tests/test_service.py
+++ b/orchestrator/tests/test_service.py
@@ -1,4 +1,6 @@
-"""Service-surface tests: /health, /run (dispatch + interrupt), /resume, fail-loud."""
+"""Service-surface tests: /health, /run (dispatch + interrupt), /resume, fail-loud, /run/stream."""
+
+import json
 
 from fastapi.testclient import TestClient
 
@@ -119,3 +121,46 @@ def test_coordinate_schema_version_mismatch_rejected():
     c = _client()
     resp = c.post("/coordinate", json={"schema_version": 999, "goal_id": "G3", "children": []})
     assert resp.status_code == 400
+
+
+def _sse_events(client, body):
+    """POST /run/stream and parse the SSE stream into (event, json-data) pairs."""
+    events = []
+    with client.stream("POST", "/run/stream", json=body) as r:
+        assert r.status_code == 200
+        name = None
+        for line in r.iter_lines():
+            if line.startswith("event:"):
+                name = line.split(":", 1)[1].strip()
+            elif line.startswith("data:"):
+                events.append((name, json.loads(line.split(":", 1)[1].strip())))
+    return events
+
+
+def test_run_stream_emits_turn_then_review_gate():
+    c = _client(TurnOutcome.SUBMITTED_FOR_REVIEW)
+    evs = _sse_events(c, {"task_id": "s1", "record": {"task_id": "s1", "lifecycle_state": "running"}})
+    names = [n for n, _ in evs]
+    assert names[0] == "start"
+    assert "turn" in names  # live progress streamed
+    assert names[-1] == "result"
+    result = evs[-1][1]
+    assert result["status"] == "interrupted"
+    assert result["projection"]["lifecycle_state"] == "review"
+
+
+def test_run_stream_continue_projects_running():
+    c = _client(TurnOutcome.CONTINUE)
+    evs = _sse_events(c, {"task_id": "s2", "record": {"task_id": "s2", "lifecycle_state": "running"}})
+    result = evs[-1][1]
+    assert result["status"] == "done"
+    assert result["projection"]["lifecycle_state"] == "running"
+
+
+def test_run_stream_non_dispatch_state_runs_no_turn():
+    # A task already in review has nothing to dispatch: stream just projects it.
+    c = _client(TurnOutcome.SUBMITTED_FOR_REVIEW)
+    evs = _sse_events(c, {"task_id": "s3", "record": {"task_id": "s3", "lifecycle_state": "review"}})
+    names = [n for n, _ in evs]
+    assert "turn" not in names
+    assert evs[-1][1]["projection"]["lifecycle_state"] == "review"


### PR DESCRIPTION
## SSE streaming (stacked on #1133)

Streams a turn's progress instead of only returning the terminal `StepResult`.

- **`POST /run/stream`** → SSE: `start` → live `turn` events (`tool_use`/`text` as the agent acts) → terminal `result` carrying the same projection `/run` returns. Non-dispatch states (unknown/review/idle) stream straight to a result with no turn.
- **`harness.stream_turn`** — async generator of per-message events + a final `turn_complete`. `ClaudeAgentHarness` streams the real SDK messages; `FakeHarness` yields a synthetic text + completion (key-free, tested).
- **`lifecycle.resolve_turn`** — composes the *same* gate/continue functions the graph uses, so streamed and non-streamed results agree by construction (no divergent logic).
- **Go `DispatchClient.RunStream`** — consumes the SSE stream, fires a per-event callback for live observability, returns the terminal `StepResult` (identical to `Run`); fails loud if the stream ends with no result event.

### Tests
`resolve_turn` parity, `FakeHarness.stream_turn` shape, `/run/stream` events (review-gate / continue / non-dispatch) via TestClient SSE parsing, Go `RunStream` consume + no-result-fails-loud. `pytest` 94 passed / 3 skipped; `go vet` + `golangci-lint` clean; provider green under `-race`.

Not yet wired into the broker dispatch (the broker keeps using `Run` for projection); `RunStream` is ready for a future live-UI wire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)