### PR TITLE
ci(orchestrator): pytest workflow scoped to orchestrator/**

### DIFF
--- a/.github/workflows/orchestrator.yml
+++ b/.github/workflows/orchestrator.yml
@@ -1,0 +1,41 @@
+name: orchestrator
+
+# Scoped to the Python orchestrator package so it runs only when orchestrator/**
+# (or this workflow) changes — a Go/web/docs PR pays nothing here. Fires on every
+# PR regardless of base branch (stacked PRs included), matching ci.yml's rationale.
+on:
+  push:
+    branches: [main]
+    paths:
+      - "orchestrator/**"
+      - ".github/workflows/orchestrator.yml"
+  pull_request:
+    paths:
+      - "orchestrator/**"
+      - ".github/workflows/orchestrator.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: orchestrator-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: orchestrator
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
+      - name: Set up venv + install (base + dev, NOT the `claude` extra)
+        # Deliberately omit the `claude` extra: claude-agent-sdk is NOT installed
+        # in CI so the SDK-absent degrade tests run here (they skip locally once
+        # the SDK is installed). A venv sidesteps PEP 668 externally-managed pip.
+        run: |
+          python3 -m venv .venv
+          .venv/bin/python -m pip install --upgrade pip
+          .venv/bin/python -m pip install -e '.[dev]'
+      - name: pytest
+        run: .venv/bin/python -m pytest -q


### PR DESCRIPTION
## CI scoped to `orchestrator/**` (stacked on #1134)

A standalone GitHub Actions workflow running the orchestrator's pytest suite, **path-filtered** to `orchestrator/**` (+ the workflow file) so Go/web/docs PRs pay nothing. Fires on every PR regardless of base branch (stacked PRs included), matching `ci.yml`'s rationale; `permissions: contents: read`.

- Installs base + dev deps in a venv (PEP 668-safe), **omits the `claude` extra** on purpose — `claude-agent-sdk` is absent in CI, so the SDK-absent degrade tests run here (they skip locally once the SDK is installed for live runs).
- `actions/checkout` is SHA-pinned with a ratchet comment; no third-party actions; no untrusted input in `run:` steps.

### Verified
Reproduced the CI environment locally (fresh venv, no `claude` extra): **96 passed, 1 skipped** (the SDK-present complement skips; the 3 SDK-absent degrade tests run and pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)