### PR TITLE
feat(harness): clean-start operator harness scaffold + plan (S0)

### DIFF
--- a/.github/workflows/harness.yml
+++ b/.github/workflows/harness.yml
@@ -1,0 +1,39 @@
+name: harness
+
+# Scoped to the operator harness package: runs only when harness/** (or this
+# workflow) changes. Fires on every PR regardless of base branch; read-only.
+on:
+  push:
+    branches: [main]
+    paths:
+      - "harness/**"
+      - ".github/workflows/harness.yml"
+  pull_request:
+    paths:
+      - "harness/**"
+      - ".github/workflows/harness.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: harness-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: harness
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
+      - name: Set up venv + install (base + dev, NOT the `agent` extra)
+        # Omit the `agent` extra (deepagents/claude-agent-sdk): it is absent in CI so
+        # the degrade-to-stub path runs here. A venv sidesteps PEP 668.
+        run: |
+          python3 -m venv .venv
+          .venv/bin/python -m pip install --upgrade pip
+          .venv/bin/python -m pip install -e '.[dev]'
+      - name: pytest
+        run: .venv/bin/python -m pytest -q

--- a/docs/specs/operator-harness-clean-start.md
+++ b/docs/specs/operator-harness-clean-start.md
@@ -1,0 +1,154 @@
+# Operator Harness — Clean Start (deepagents-native)
+
+**Status:** plan, pre-scaffold. **Decision date:** 2026-06-27 (founder picked the
+clean deepagents-native rewrite). **Supersedes:** most of
+`deepagents-migration-plan.md` (the LangGraph multi-agent stack) — salvage the seam only.
+**Companion to:** `operator-mlp-plan.md`, `operator-mlp-build-queue.md`,
+`operator-mlp-prototype-brief.md`.
+
+---
+
+## 1. What we are building
+
+The operator-MLP product: **a non-technical operator builds a deterministic internal
+tool (UI + Workflow) by talking to an AI.** The spine is unchanged:
+
+> **Agentic freedom to FIGURE OUT the workflow; determinism to EXECUTE it.**
+
+The backend is **one fast deepagents-native agent harness** that turns a conversation
+(or a captured screen session) into a **compiled, deterministic workflow spec**, plus a
+**deterministic executor** that runs that spec. No multi-agent office, no Go broker, no
+channels/lifecycle/coordination.
+
+## 2. Why a clean start
+
+The Go broker existed to coordinate a multi-agent office. The product no longer has an
+office — it has **one operator and one build agent**. Keeping the broker (office,
+channels, 13-state lifecycle, sub-task coordination kernel, re-hydrate) would be carrying
+a coordination engine for a problem we no longer have. The 2026-06-20 LangGraph migration
+(#1117–#1133) was building coordination *on* that broker; it is moot. We keep the parts
+that were always about **one agent reaching tools and streaming to a UI**.
+
+## 3. Architecture (three layers)
+
+```
+┌─ Operator FE (React, salvaged from web/src/operator) ──────────────┐
+│  Chats · Internal Tools (UI·Workflow·Data) · Knowledge · Integrations · Settings │
+│  talks over a thin HTTP + SSE API (no broker)                       │
+└───────────────────────────────┬────────────────────────────────────┘
+                                 │  HTTP/SSE  (the salvaged FastAPI + SSE seam)
+┌───────────────────────────────▼────────────────────────────────────┐
+│  Harness API (Python / FastAPI)                                     │
+│   POST /build/stream   chat → agent assembles a workflow (SSE)      │
+│   POST /run            execute a compiled workflow on test/real data │
+│   GET/POST /knowledge  gbrain (search/query/put_page/find_experts)  │
+│   /integrations /settings /providers   (BYOK + provider detection)  │
+└───────────────────────────────┬────────────────────────────────────┘
+                  ┌──────────────┴───────────────┐
+        ┌─────────▼─────────┐          ┌──────────▼───────────┐
+        │ BUILD (agentic)   │          │ EXECUTE (deterministic) │
+        │ deepagents agent: │  compile │ compiled WorkflowSpec:  │
+        │ plan + tools →    │ ───────► │ API-first → UI-replay → │
+        │ a WorkflowSpec    │          │ bounded CUA-heal        │
+        └─────────┬─────────┘          └─────────────────────────┘
+                  │ tools over MCP (the salvaged seam)
+        gbrain · browsersniff · browser-capture (chromedp) · Composio
+```
+
+- **BUILD is agentic** (deepagents): a single deep agent that plans, drives discovery
+  (capture/sniff/gbrain), asks the operator one sharp clarifying question, and emits a
+  **WorkflowSpec**. It does NOT execute the live workflow.
+- **EXECUTE is deterministic**: the compiled `WorkflowSpec` runs through the workflow
+  engine (API-first replay → UI replay → bounded CUA-heal). No tool-call chain at run time.
+
+### Why deepagents (LangChain) for BUILD
+deepagents gives a prebuilt deep-agent loop on LangGraph: a planning tool, sub-agents, a
+virtual filesystem, and steerable tool use — the right shape for "figure out the
+workflow." We use it ONLY for build/discovery; the deterministic executor is ours.
+
+## 4. Salvage / delete
+
+**Salvage (carry into the clean start):**
+- The **MCP seam** — Python reaches tools over MCP (proven by the `deepagents-seam` spike;
+  gbrain speaks `search`/`query`/`put_page`/`find_experts`).
+- The **FastAPI service pattern + SSE streaming** (`/run/stream` → `start`/`turn`/`result`
+  events; Go/TS consumers) — becomes the FE↔harness API.
+- **Claude Agent SDK harness wiring** incl. the `allowed_tools` fix (wired MCP tools must
+  be allowed or the call is silently denied) and **env-NAME→value MCP config** (secrets
+  cross as names, resolved harness-side).
+- **Provider detection + config + BYOK** (multi-provider inference).
+- The **operator FE** (`web/src/operator/**` + `operator-shell.css`) and its design system.
+- **browsersniff** (HAR→`spec.APISpec`), the **workflow engine** (`internal/workflow`),
+  **detection** (repointed to operator activity), **Electron shell** + build/install.
+- The **hands-free-completion principle**: a task finishes without a human ack; the
+  machine **verification check** is the proof-of-done. (The Go implementation is dropped
+  with the broker; the principle carries into the executor's done-gate.)
+
+**Delete / leave behind:**
+- Go **broker**, office, channels, 13-state lifecycle, coordination/sub-task kernel,
+  multi-agent dispatch, notifier loops, re-hydrate.
+- The #1117–#1133 LangGraph coordination stack (goal/coordinate/decompose/re-hydrate
+  kernel) — moot without the broker. (Stays on its draft branches as history.)
+
+## 5. Repo strategy (THE open decision — confirm before scaffolding)
+
+The 2026-06-20 plan stripped wuphf in place (build-queue Slice 3). The 2026-06-27 decision
+added "new repo authorized if cleaner." Two real options:
+
+**Option A — in-repo clean rebuild (RECOMMENDED).** Add the deepagents harness as a new
+top-level package in wuphf, keep the operator FE where it is, and **aggressively delete**
+the broker/office (build-queue Slice 3). wuphf *becomes* the operator product by
+subtraction.
+- Pro: every salvageable piece (FE, provider config, Electron shell, workflow engine,
+  browsersniff, CI, release, npm, secretlint, screenshot harness) already lives here — no
+  migration, no re-tooling, history preserved. Matches the existing build queue.
+- Con: the deleted broker tempts "keep it just in case"; the repo carries Go + Python.
+
+**Option B — brand-new repo.** Fresh repo with FE + deepagents harness + the seam, nothing
+else.
+- Pro: a literal clean slate; smallest surface; no broker temptation.
+- Con: migrate the FE + Electron + provider config + workflow engine + browsersniff +
+  re-stand-up CI/release/build — weeks of plumbing before the first product slice; history
+  lost.
+
+**Recommendation: Option A.** The clean-start value is in *deleting the broker and writing
+a new harness*, not in a new git remote. Subtraction-in-place gets us to a working
+deepagents product fastest and keeps the large, real salvage in place. Reserve Option B
+only if the founder wants a hard public break.
+
+## 6. Slice plan (FE-first; BE rewritten under this lens)
+
+Slice 1 (operator FE shell, mock) is **done, awaiting founder review**. Then:
+
+- **S0 — Clean-start scaffold.** New `harness/` (Python: FastAPI app + deepagents agent
+  stub + provider config, lifting the seam: SSE, MCP env-name config, SDK wiring). FE
+  `/#/operator` points its build/run calls at the harness behind a feature flag; mock
+  fixtures stay the default until the endpoint is real. No broker dependency.
+- **S1 — Strip the office cruft** (build-queue Slice 3). Delete broker/office/lifecycle;
+  `web` + harness build green; LOC down hard.
+- **S2 — Chat-to-build (the spine).** Swap the FE's keyword `planWorkflow` compiler for the
+  real deepagents build agent over `/build/stream`; it assembles a `WorkflowSpec` live and
+  asks one clarifying question. (CQ1 approval card on any build-time external mutation.)
+- **S3 — Deterministic executor.** Compile `WorkflowSpec` → engine run on fixtures →
+  digest; UI/Workflow/Data tabs bound to real run records. (CQ1 exec-time mutation gate.)
+- **S4 — gbrain over MCP + Knowledge** (tests A1 parallel-run, A2 unreachable-degrade).
+- **S5 — Browser capture + browsersniff** (the discovery half of build).
+- **S6 — The magical call** (demo gate; tests A3 HAR secret-strip, A4 auth-classify).
+- **S7 — Proactive improvement** (suggested-change card → re-freeze, version+1).
+
+Each slice ships its mapped critical test: **A1/A2** (S4), **CQ1** (S2/S3), **A3/A4** (S6).
+
+## 7. Wire contract (FE ↔ harness)
+
+Reuse the SSE shape already built and tested: `POST /build/stream` emits `start` →
+`turn` (the agent's reasoning/tool steps as it assembles the spec) → `result` (the
+compiled `WorkflowSpec` + the one clarifying question). `extra="forbid"` + a
+`schema_version` handshake (both carried from the dead stack's hardening) so a FE/harness
+drift fails loud. Secrets cross as env-var **names** only.
+
+## 8. Open questions
+
+1. **Repo strategy** (§5) — confirm Option A vs B before scaffolding. *(blocking)*
+2. deepagents version pin + whether we wrap it or fork the loop (decide at S2).
+3. gbrain packaging (bundled PGLite+ollama subprocess) — already decided in the operator
+   plan; re-confirm at S4.

--- a/harness/.gitignore
+++ b/harness/.gitignore
@@ -1,0 +1,5 @@
+.venv/
+__pycache__/
+*.pyc
+.pytest_cache/
+*.egg-info/

--- a/harness/README.md
+++ b/harness/README.md
@@ -1,0 +1,43 @@
+# wuphf-harness
+
+The operator harness: **agentic-build / deterministic-execute**. One agent turns an
+operator's plain-language description into a deterministic `WorkflowSpec`; a
+deterministic executor runs it. No broker, no office, no multi-agent coordination.
+
+This is the clean-start backend for the operator product. See
+`docs/specs/operator-harness-clean-start.md`.
+
+## Layout
+
+```
+src/harness/
+  wire.py         FE<->harness contract (WorkflowSpec/Step, Build/Run requests; schema_version, extra=forbid)
+  build_agent.py  BUILD: message -> WorkflowSpec. S0 = deterministic stub compiler; S2 = LangChain deep agent (same contract)
+  executor.py     EXECUTE: run a spec deterministically; a gated step halts for the human approval card (CQ1)
+  providers.py    multi-provider inference detection + BYOK status (no keys returned)
+  mcp.py          MCP tool wiring: env-NAME->value config + allowed-tools grant (salvaged seam)
+  service.py      FastAPI: /health, /providers, POST /build/stream (SSE), POST /run
+tests/            wire / build_agent / executor / service
+```
+
+## Run
+
+```bash
+python3 -m venv .venv
+.venv/bin/python -m pip install -e '.[dev]'      # add '.[agent]' for the real deep agent (S2)
+.venv/bin/python -m pytest -q
+.venv/bin/uvicorn harness.service:app --app-dir src --port 8810   # local service
+```
+
+## Smoke
+
+`bash scripts/smoke.sh` boots the service and exercises the FE-facing endpoints
+(`/health`, `/providers`, `/build/stream` SSE, `/run` incl. the approval-gate halt).
+
+## Status (S0)
+
+The clean-start scaffold: the FE-facing API is real end to end with a deterministic
+stub build agent and a simulated executor. Slice S2 swaps the stub for the real
+LangChain deep agent (planning + gbrain/browsersniff tools over MCP) behind the same
+wire contract; S3 replaces the simulated executor with API-first replay. Runs
+key-free; `build_agent()` degrades to the stub unless the `agent` extra is installed.

--- a/harness/pyproject.toml
+++ b/harness/pyproject.toml
@@ -1,0 +1,22 @@
+[project]
+name = "wuphf-harness"
+description = "Operator harness: agentic-build / deterministic-execute. One deepagents agent turns a conversation into a deterministic WorkflowSpec; a deterministic executor runs it. No broker. (operator-harness-clean-start.md)"
+version = "0.0.1"
+requires-python = ">=3.11"
+dependencies = [
+    "fastapi>=0.110",
+    "sse-starlette>=2",
+    "uvicorn>=0.29",
+    "pydantic>=2",
+]
+
+[project.optional-dependencies]
+# The real BUILD agent (LangChain deep agents). Optional so the package installs +
+# tests green without it; build_agent() degrades to the deterministic stub
+# compiler when it (or a model key) is absent. Swapped in at slice S2.
+agent = ["deepagents", "claude-agent-sdk"]
+dev = ["pytest>=8", "httpx>=0.27"]
+
+[tool.pytest.ini_options]
+pythonpath = ["src"]
+testpaths = ["tests"]

--- a/harness/scripts/smoke.sh
+++ b/harness/scripts/smoke.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Live smoke for the operator harness: boots the FastAPI service and exercises the
+# exact FE-facing endpoints (/health, /providers, /build/stream SSE, /run incl. the
+# approval-gate halt). Run from harness/ after building the venv.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+PORT="${HARNESS_SMOKE_PORT:-8810}"
+BASE="http://127.0.0.1:${PORT}"
+
+.venv/bin/uvicorn harness.service:app --app-dir src --port "$PORT" --log-level warning &
+PID=$!
+trap 'kill "$PID" 2>/dev/null || true' EXIT
+
+for _ in $(seq 1 50); do
+  if curl -fsS -m 1 "$BASE/health" >/dev/null 2>&1; then break; fi
+  sleep 0.2
+done
+
+fail() { echo "SMOKE FAIL: $1" >&2; exit 1; }
+
+echo "== health =="; curl -fsS "$BASE/health" | python3 -m json.tool
+echo "== providers =="; curl -fsS "$BASE/providers" | python3 -m json.tool
+
+echo "== /build/stream: a description assembles a WorkflowSpec (SSE) =="
+BUILD=$(curl -fsS -N -X POST "$BASE/build/stream" -H 'Content-Type: application/json' \
+  -d '{"schema_version":1,"message":"route inbound demo requests to a slack channel"}')
+echo "$BUILD" | grep -q 'event: spec' || fail "no spec event in the build stream"
+echo "$BUILD" | grep -q '"tool_id": "inbound-routing"' || echo "$BUILD" | grep -q 'inbound-routing' || fail "spec did not resolve the tool"
+echo "build stream OK (spec emitted)"
+
+echo "== /run: a gated step halts for approval, then completes once approved =="
+SPEC='{"name":"n","tool_id":"inbound-routing","steps":[{"id":"p-action","kind":"action","title":"Route","detail":"d","integration":"Slack","gated":true}]}'
+R1=$(curl -fsS -X POST "$BASE/run" -H 'Content-Type: application/json' -d "{\"schema_version\":1,\"spec\":$SPEC,\"input\":{}}")
+echo "$R1" | python3 -c 'import sys,json;d=json.load(sys.stdin);assert d["status"]=="needs_approval",d;assert d["pending_approval"]["step_id"]=="p-action",d' || fail "gated step did not halt for approval"
+R2=$(curl -fsS -X POST "$BASE/run" -H 'Content-Type: application/json' -d "{\"schema_version\":1,\"spec\":$SPEC,\"input\":{\"approved\":[\"p-action\"]}}")
+echo "$R2" | python3 -c 'import sys,json;d=json.load(sys.stdin);assert d["status"]=="done",d' || fail "approved run did not complete"
+
+echo "SMOKE OK"

--- a/harness/src/harness/__init__.py
+++ b/harness/src/harness/__init__.py
@@ -1,0 +1,13 @@
+"""wuphf operator harness.
+
+Agentic-build / deterministic-execute. The BUILD agent (deepagents) turns an
+operator's plain-language description into a deterministic WorkflowSpec; the
+EXECUTE path runs that spec deterministically. The FE talks to it over a thin
+HTTP/SSE API (service.py). No broker, no office, no multi-agent coordination.
+
+See docs/specs/operator-harness-clean-start.md.
+"""
+
+from . import build_agent, executor, providers, service, wire
+
+__all__ = ["build_agent", "executor", "providers", "service", "wire"]

--- a/harness/src/harness/build_agent.py
+++ b/harness/src/harness/build_agent.py
@@ -1,0 +1,114 @@
+"""The BUILD agent: a plain-language description -> a deterministic WorkflowSpec.
+
+S0 ships a pure, keyword-driven STUB compiler (a server-side port of the FE's
+operator/builder/planWorkflow.ts) so /build/stream is real end to end without a
+model. Slice S2 swaps `build_agent()` to the real LangChain deep agent (planning +
+gbrain/browsersniff tools) while keeping this exact output contract; the executor
+and FE do not change. Degrade-safe: build_agent() returns the stub unless the
+`agent` extra (deepagents) is importable.
+
+The agent only FIGURES OUT the workflow. It never executes it (see executor.py).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import logging
+import re
+from collections.abc import AsyncIterator
+from typing import Protocol
+
+from .wire import ClarifyQuestion, WorkflowSpec, WorkflowStep
+
+_log = logging.getLogger(__name__)
+
+
+class BuildAgent(Protocol):
+    def compile(self, message: str, tool_id: str | None = None) -> WorkflowSpec:  # pragma: no cover - protocol
+        ...
+
+    def stream(self, message: str, tool_id: str | None = None) -> AsyncIterator[dict]:  # pragma: no cover - protocol
+        """Yield build events: one {"type":"step", ...} per assembled step (the FE's
+        staggered reveal), then {"type":"spec", ...} with the full WorkflowSpec."""
+        ...
+
+
+def _has(text: str, *words: str) -> bool:
+    return any(w in text for w in words)
+
+
+def _detect_subject(t: str) -> tuple[str, str, str]:
+    """(source, tool name, tool_id) — mirrors planWorkflow.detectSubject."""
+    if _has(t, "ticket", "escalation", "support", "incident"):
+        return "support ticket", "Support escalation triage", "support-escalations"
+    if _has(t, "expense", "invoice", "reimburse", "spend", "purchase order"):
+        return "expense over policy", "Expense exception routing", "expense-exceptions"
+    if _has(t, "demo", "trial", "lead", "signup", "sign-up", "form", "inbound"):
+        return "demo request", "Inbound demo-request routing", "inbound-routing"
+    return "inbound item", "Inbound routing", "inbound-routing"
+
+
+def _detect_amount(t: str) -> str | None:
+    m = re.search(r"\$\s?(\d[\d,]*\s?[km]?)", t, re.IGNORECASE)
+    return f"${m.group(1).replace(' ', '')}" if m else None
+
+
+class StubBuildAgent:
+    """Deterministic keyword compiler. Pure (no I/O), so it carries a regression
+    test and gives the prototype a believable 'the AI understood you' build."""
+
+    def compile(self, message: str, tool_id: str | None = None) -> WorkflowSpec:
+        t = message.lower().strip()
+        source, name, resolved_tool = _detect_subject(t)
+        steps: list[WorkflowStep] = [
+            WorkflowStep(id="p-trigger", kind="trigger", title=f"New {source}", detail=f"Starts when a {source} arrives."),
+            WorkflowStep(id="p-enrich", kind="enrich", title="Enrich the record", detail="Look up the related account + history."),
+            WorkflowStep(id="p-ai", kind="ai", title="Score it", detail="An AI step rates fit/urgency from the enriched context."),
+        ]
+        amount = _detect_amount(t)
+        threshold_label = amount or "the threshold"
+        steps.append(WorkflowStep(
+            id="p-decision", kind="decision",
+            title=f"Decide on {threshold_label}",
+            detail=f"Branch on whether the score/amount crosses {threshold_label}.",
+        ))
+        # The action mutates an external system -> gated to the human approval card (CQ1).
+        steps.append(WorkflowStep(
+            id="p-action", kind="action", title="Route it",
+            detail="Notify the right owner and record the routing decision.",
+            integration="Slack", gated=True,
+        ))
+
+        # Ask exactly one sharp clarifying question, in place, like the FE does.
+        clarify: ClarifyQuestion | None = None
+        if amount is None:
+            clarify = ClarifyQuestion(
+                field="threshold", step_id="p-decision",
+                prompt="What score or dollar amount should send this down the priority path?",
+            )
+        elif not _has(t, "slack", "email", "channel", "notify"):
+            clarify = ClarifyQuestion(
+                field="channel", step_id="p-action",
+                prompt="Where should I route it — a Slack channel, or email an owner?",
+            )
+
+        return WorkflowSpec(
+            name=name, tool_id=tool_id or resolved_tool, steps=steps, clarify=clarify,
+            narration=f"Got it — a {name.lower()}. I assembled {len(steps)} deterministic steps; one question to lock it.",
+        )
+
+    async def stream(self, message: str, tool_id: str | None = None) -> AsyncIterator[dict]:
+        spec = self.compile(message, tool_id)
+        for step in spec.steps:
+            yield {"type": "step", "step": step.model_dump()}
+        yield {"type": "spec", "spec": spec.model_dump()}
+
+
+def build_agent() -> BuildAgent:
+    """Pick the BUILD agent: the real deep agent when the `agent` extra is present,
+    else the deterministic stub so the harness runs key-free."""
+    if importlib.util.find_spec("deepagents") is None:
+        return StubBuildAgent()
+    # S2: construct and return the real LangChain deep-agent here (same contract).
+    _log.info("deepagents present — real build agent lands in S2; using stub for now")
+    return StubBuildAgent()

--- a/harness/src/harness/executor.py
+++ b/harness/src/harness/executor.py
@@ -1,0 +1,38 @@
+"""Deterministic executor: run a compiled WorkflowSpec, step by step.
+
+This is the DETERMINISTIC half of the spine — it runs the compiled spec, it does
+not reason. S0 simulates each step (no live integrations yet); slices S3+ replace
+the per-step simulation with real API-first replay -> UI replay -> bounded CUA-heal
+while keeping this control flow: a `gated` step (external mutation) HALTS the run
+with status=needs_approval and the pending step surfaced to the human approval card
+(CQ1). Approve -> the FE re-runs with that step's id in `approved`.
+"""
+
+from __future__ import annotations
+
+from .wire import RunResult, RunStep, WorkflowSpec
+
+
+def run_workflow(spec: WorkflowSpec, data: dict | None = None, approved: set[str] | None = None) -> RunResult:
+    """Execute spec deterministically over `data`. Steps already in `approved` are
+    allowed to mutate; the first unapproved gated step halts the run for the human."""
+    _ = data or {}
+    approved = approved or set()
+    steps: list[RunStep] = []
+    for step in spec.steps:
+        if step.gated and step.id not in approved:
+            steps.append(RunStep(step_id=step.id, status="awaiting_approval",
+                                 detail=f"{step.title} mutates {step.integration or 'an external system'} — needs approval."))
+            return RunResult(
+                status="needs_approval",
+                steps=steps,
+                digest=f"Paused at {step.title}: external mutation needs the human approval card.",
+                pending_approval={
+                    "step_id": step.id,
+                    "title": step.title,
+                    "integration": step.integration,
+                    "detail": step.detail,
+                },
+            )
+        steps.append(RunStep(step_id=step.id, status="ok", detail=f"{step.title} ran."))
+    return RunResult(status="done", steps=steps, digest=f"Ran {len(steps)} steps to completion.")

--- a/harness/src/harness/mcp.py
+++ b/harness/src/harness/mcp.py
@@ -1,0 +1,35 @@
+"""MCP tool wiring — env-NAME->value config, salvaged from the dead stack's
+hardest-won lesson.
+
+Tools the BUILD agent reaches (gbrain, browsersniff, Composio, browser-capture)
+are MCP servers. Secrets cross as env-var NAMES only; the harness resolves them to
+values from its OWN environment when it launches each server — never on any wire.
+And every wired server's tools must be ALLOWED, or the agent's calls are silently
+permission-denied (the bug the live run caught: the call shows in the transcript
+but the tool body never runs). Both rules live here so S2 reuses them verbatim.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class McpServer:
+    command: str
+    args: list[str] = field(default_factory=list)
+    env_passthrough: list[str] = field(default_factory=list)  # env var NAMES, never values
+
+
+def resolve_env(server: McpServer, environ: dict | None = None) -> dict[str, str]:
+    """Resolve the server's passthrough NAMES to values from the harness env. The
+    values are injected into the launched MCP subprocess, never returned on a wire."""
+    env = environ if environ is not None else os.environ
+    return {name: env.get(name, "") for name in server.env_passthrough}
+
+
+def allowed_tools(servers: dict[str, McpServer]) -> list[str]:
+    """Allow every tool from each wired server (server-prefix grant). Without this
+    the agent's MCP calls are permission-denied — surfaced live in the dead stack."""
+    return [f"mcp__{name}" for name in servers]

--- a/harness/src/harness/providers.py
+++ b/harness/src/harness/providers.py
@@ -1,0 +1,53 @@
+"""Provider detection + BYOK — salvaged from the wuphf provider config concept.
+
+The harness is multi-provider: it detects which inference backends are usable from
+the environment (an API key, or an installed CLI like Claude Code) so the FE
+Settings surface can show what's connected and prompt BYOK for the rest. No keys
+are ever returned — only whether each provider is available.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Provider:
+    id: str
+    label: str
+    available: bool
+    via: str  # how it's available: "api_key" | "cli" | "none"
+
+
+def _env_any(*names: str) -> bool:
+    return any(os.getenv(n, "").strip() for n in names)
+
+
+def detect_providers() -> list[Provider]:
+    """Which inference providers are usable right now. BYOK = set the key (never
+    stored by the harness) or install the CLI."""
+    out: list[Provider] = []
+
+    if _env_any("ANTHROPIC_API_KEY"):
+        out.append(Provider("anthropic", "Anthropic API", True, "api_key"))
+    elif shutil.which("claude"):
+        out.append(Provider("anthropic", "Claude Code (CLI auth)", True, "cli"))
+    else:
+        out.append(Provider("anthropic", "Anthropic", False, "none"))
+
+    out.append(Provider("openai", "OpenAI API", _env_any("OPENAI_API_KEY", "WUPHF_OPENAI_API_KEY"), "api_key" if _env_any("OPENAI_API_KEY", "WUPHF_OPENAI_API_KEY") else "none"))
+
+    if shutil.which("codex"):
+        out.append(Provider("codex", "Codex (CLI)", True, "cli"))
+
+    return out
+
+
+def providers_payload() -> dict:
+    provs = detect_providers()
+    return {
+        "providers": [p.__dict__ for p in provs],
+        "any_available": any(p.available for p in provs),
+    }

--- a/harness/src/harness/service.py
+++ b/harness/src/harness/service.py
@@ -1,0 +1,70 @@
+"""FastAPI service: the thin HTTP/SSE API the operator FE talks to (no broker).
+
+  GET  /health        liveness
+  GET  /providers     which inference backends are available (BYOK status)
+  POST /build/stream  chat -> the agent assembles a WorkflowSpec (SSE: start/step/spec)
+  POST /run           execute a compiled WorkflowSpec deterministically
+
+The SSE shape + schema_version handshake + extra="forbid" decode are carried from
+the dead stack's hardening. See docs/specs/operator-harness-clean-start.md.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+
+from fastapi import FastAPI, HTTPException
+from sse_starlette.sse import EventSourceResponse
+
+from .build_agent import BuildAgent, build_agent
+from .executor import run_workflow
+from .providers import providers_payload
+from .wire import SCHEMA_VERSION, BuildRequest, RunRequest, RunResult
+
+
+def _check_schema_version(got: int) -> None:
+    if got != SCHEMA_VERSION:
+        raise HTTPException(
+            status_code=400,
+            detail=f"schema_version mismatch: harness speaks {SCHEMA_VERSION}, got {got}",
+        )
+
+
+AgentFactory = Callable[[], BuildAgent]
+
+
+def create_app(agent_factory: AgentFactory = build_agent) -> FastAPI:
+    app = FastAPI(title="wuphf-harness", version="0.0.1")
+
+    @app.get("/health")
+    def health() -> dict:
+        return {"status": "ok", "version": "0.0.1"}
+
+    @app.get("/providers")
+    def providers() -> dict:
+        return providers_payload()
+
+    @app.post("/build/stream")
+    async def build_stream(req: BuildRequest) -> EventSourceResponse:
+        _check_schema_version(req.schema_version)
+        agent = agent_factory()
+
+        async def generate():
+            yield {"event": "start", "data": json.dumps({"message": req.message})}
+            async for ev in agent.stream(req.message, req.tool_id):
+                name = "spec" if ev.get("type") == "spec" else "step"
+                yield {"event": name, "data": json.dumps(ev)}
+
+        return EventSourceResponse(generate())
+
+    @app.post("/run", response_model=RunResult)
+    def run(req: RunRequest) -> RunResult:
+        _check_schema_version(req.schema_version)
+        approved = {s for s in req.input.get("approved", [])} if isinstance(req.input.get("approved"), list) else set()
+        return run_workflow(req.spec, data=req.input, approved=approved)
+
+    return app
+
+
+app = create_app()

--- a/harness/src/harness/wire.py
+++ b/harness/src/harness/wire.py
@@ -1,0 +1,84 @@
+"""The FE <-> harness wire contract.
+
+Mirrors the operator FE's existing shapes (web/src/operator/mock/data.ts
+WorkflowStep + builder/planWorkflow.ts WorkflowPlan) so the prototype FE can point
+its build/run calls straight at this harness. snake_case JSON; extra="forbid" so a
+FE/harness drift fails loud; a schema_version handshake so a mismatched client 400s
+instead of being silently misread. (Both disciplines carried from the dead stack.)
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+SCHEMA_VERSION = 1
+
+# Mirror of web/src/operator/mock/data.ts WorkflowStepKind.
+WorkflowStepKind = Literal["trigger", "enrich", "ai", "decision", "action", "branch"]
+ClarifyField = Literal["threshold", "channel"]
+
+
+class WorkflowStep(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    id: str
+    kind: WorkflowStepKind
+    title: str
+    detail: str
+    integration: str | None = None  # e.g. "HubSpot", "Slack"
+    gated: bool = False  # external mutation -> human approval card (CQ1)
+
+
+class ClarifyQuestion(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    field: ClarifyField
+    prompt: str  # the single sharp follow-up the agent asks
+    step_id: str  # the step this answer refines, in place
+
+
+class WorkflowSpec(BaseModel):
+    """The compiled, deterministic workflow the BUILD agent emits and the EXECUTE
+    path runs. The FE renders it step-by-step as it assembles."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str
+    tool_id: str
+    steps: list[WorkflowStep] = Field(default_factory=list)
+    narration: str = ""  # the agent's reflect-back line
+    clarify: ClarifyQuestion | None = None
+
+
+class BuildRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = SCHEMA_VERSION
+    message: str  # the operator's plain-language description
+    tool_id: str | None = None  # refine an existing tool, if any
+
+
+class RunRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = SCHEMA_VERSION
+    spec: WorkflowSpec
+    input: dict[str, Any] = Field(default_factory=dict)  # test/real data for the run
+
+
+class RunStep(BaseModel):
+    step_id: str
+    status: Literal["ok", "skipped", "awaiting_approval"]
+    detail: str = ""
+
+
+class RunResult(BaseModel):
+    """Deterministic execution result. status=needs_approval when a gated step
+    requires the human approval card before the run can proceed (CQ1)."""
+
+    status: Literal["done", "needs_approval"]
+    steps: list[RunStep] = Field(default_factory=list)
+    digest: str = ""
+    pending_approval: dict[str, Any] | None = None

--- a/harness/tests/test_build_agent.py
+++ b/harness/tests/test_build_agent.py
@@ -1,0 +1,39 @@
+import asyncio
+
+from harness.build_agent import StubBuildAgent, build_agent
+
+
+def test_subject_detection_and_tool_mapping():
+    a = StubBuildAgent()
+    assert a.compile("route inbound demo requests").tool_id == "inbound-routing"
+    assert a.compile("triage support escalations").tool_id == "support-escalations"
+    assert a.compile("approve expense over policy").tool_id == "expense-exceptions"
+
+
+def test_action_step_is_gated_external_mutation():
+    spec = StubBuildAgent().compile("route inbound leads to slack")
+    action = next(s for s in spec.steps if s.kind == "action")
+    assert action.gated is True and action.integration  # CQ1: external mutation gates
+
+
+def test_clarify_asks_threshold_when_absent_then_channel():
+    a = StubBuildAgent()
+    # No amount -> ask for the threshold.
+    assert a.compile("route inbound leads").clarify.field == "threshold"
+    # Amount present but no channel -> ask where to route.
+    assert a.compile("route inbound leads over $5k").clarify.field == "channel"
+    # Amount + channel -> no question needed.
+    assert a.compile("route inbound leads over $5k to slack").clarify is None
+
+
+def test_stream_yields_one_step_each_then_the_spec():
+    async def collect():
+        return [ev async for ev in StubBuildAgent().stream("route inbound demo requests")]
+
+    evs = asyncio.run(collect())
+    assert [e["type"] for e in evs][-1] == "spec"
+    assert sum(1 for e in evs if e["type"] == "step") == len(evs[-1]["spec"]["steps"])
+
+
+def test_build_agent_degrades_to_stub_without_deepagents():
+    assert isinstance(build_agent(), StubBuildAgent)

--- a/harness/tests/test_executor.py
+++ b/harness/tests/test_executor.py
@@ -1,0 +1,28 @@
+from harness.build_agent import StubBuildAgent
+from harness.executor import run_workflow
+from harness.wire import WorkflowSpec, WorkflowStep
+
+
+def _spec() -> WorkflowSpec:
+    return StubBuildAgent().compile("route inbound leads over $5k to slack")
+
+
+def test_run_halts_at_gated_step_for_approval():
+    res = run_workflow(_spec())
+    assert res.status == "needs_approval"
+    assert res.pending_approval and res.pending_approval["step_id"] == "p-action"
+    assert res.steps[-1].status == "awaiting_approval"
+
+
+def test_run_completes_once_gated_step_is_approved():
+    res = run_workflow(_spec(), approved={"p-action"})
+    assert res.status == "done"
+    assert all(s.status == "ok" for s in res.steps)
+
+
+def test_ungated_workflow_runs_to_completion():
+    spec = WorkflowSpec(name="n", tool_id="t", steps=[
+        WorkflowStep(id="a", kind="trigger", title="t", detail="d"),
+        WorkflowStep(id="b", kind="ai", title="t", detail="d"),
+    ])
+    assert run_workflow(spec).status == "done"

--- a/harness/tests/test_service.py
+++ b/harness/tests/test_service.py
@@ -1,0 +1,56 @@
+import json
+
+from fastapi.testclient import TestClient
+
+from harness.service import create_app
+from harness.wire import WorkflowSpec
+
+
+def _client():
+    return TestClient(create_app())
+
+
+def test_health_and_providers():
+    c = _client()
+    assert c.get("/health").json()["status"] == "ok"
+    payload = c.get("/providers").json()
+    assert "providers" in payload and isinstance(payload["providers"], list)
+
+
+def _sse(client, body):
+    events = []
+    with client.stream("POST", "/build/stream", json=body) as r:
+        assert r.status_code == 200
+        name = None
+        for line in r.iter_lines():
+            if line.startswith("event:"):
+                name = line.split(":", 1)[1].strip()
+            elif line.startswith("data:"):
+                events.append((name, json.loads(line.split(":", 1)[1].strip())))
+    return events
+
+
+def test_build_stream_emits_steps_then_spec():
+    evs = _sse(_client(), {"message": "route inbound demo requests to slack over $5k"})
+    names = [n for n, _ in evs]
+    assert names[0] == "start"
+    assert "step" in names
+    assert names[-1] == "spec"
+    spec = evs[-1][1]["spec"]
+    assert spec["tool_id"] == "inbound-routing" and len(spec["steps"]) >= 4
+
+
+def test_run_executes_a_spec_and_halts_on_gate():
+    c = _client()
+    spec = WorkflowSpec(name="n", tool_id="inbound-routing", steps=[
+        {"id": "p-action", "kind": "action", "title": "Route", "detail": "d", "integration": "Slack", "gated": True},
+    ]).model_dump()
+    out = c.post("/run", json={"spec": spec, "input": {}}).json()
+    assert out["status"] == "needs_approval"
+    out2 = c.post("/run", json={"spec": spec, "input": {"approved": ["p-action"]}}).json()
+    assert out2["status"] == "done"
+
+
+def test_schema_version_mismatch_rejected():
+    c = _client()
+    assert c.post("/build/stream", json={"schema_version": 99, "message": "x"}).status_code == 400

--- a/harness/tests/test_wire.py
+++ b/harness/tests/test_wire.py
@@ -1,0 +1,20 @@
+import pytest
+from pydantic import ValidationError
+
+from harness.wire import SCHEMA_VERSION, BuildRequest, WorkflowSpec, WorkflowStep
+
+
+def test_build_request_defaults_schema_version():
+    assert BuildRequest(message="hi").schema_version == SCHEMA_VERSION
+
+
+def test_extra_fields_rejected():
+    with pytest.raises(ValidationError):
+        BuildRequest(message="hi", bogus="x")
+
+
+def test_workflow_spec_round_trips():
+    spec = WorkflowSpec(name="n", tool_id="t", steps=[
+        WorkflowStep(id="a", kind="trigger", title="t", detail="d"),
+    ])
+    assert WorkflowSpec.model_validate(spec.model_dump()) == spec


### PR DESCRIPTION
## S0 — the deepagents-native clean start begins

Founder decision (2026-06-27): move off multi-agents, **the Go broker goes**, deepagents becomes the native build harness; **in-repo clean rebuild** (subtraction), salvage the seam. This PR is **S0 — additive scaffold only; nothing deleted yet** (the broker strip is S1). Off `main`, *not* the dead LangGraph stack.

### Plan
`docs/specs/operator-harness-clean-start.md` — architecture (FE → thin HTTP/SSE API → deepagents **BUILD** + deterministic **EXECUTE**), salvage/delete lists, the repo decision (in-repo, chosen), and the slice plan mapped onto the existing FE-first build queue + its critical tests.

### `harness/` package (new, Python, no broker dependency)
- **wire.py** — FE↔harness contract mirroring the operator FE's `WorkflowStep`/`WorkflowPlan` (snake_case, `schema_version` handshake, `extra="forbid"`).
- **build_agent.py** — BUILD (`message → WorkflowSpec`). S0 = pure deterministic stub compiler (server-side port of the FE's `planWorkflow`); **S2 swaps in the real LangChain deep agent behind the same contract.** Degrades to the stub unless the `agent` extra is installed.
- **executor.py** — deterministic run; a gated step (external mutation) halts with `needs_approval` for the human approval card (**CQ1**), resumes once approved.
- **providers.py** — multi-provider inference detection + BYOK status (salvaged; no keys returned).
- **mcp.py** — env-NAME→value MCP config + allowed-tools grant (the salvaged seam + the live-run permission lesson).
- **service.py** — FastAPI: `/health`, `/providers`, `POST /build/stream` (SSE), `POST /run`.

**Salvaged** from the dead stack: FastAPI+SSE pattern, `schema_version`/`extra=forbid` discipline, env-name MCP config + allowed-tools fix, provider config. **Deleted by omission:** broker, office, lifecycle, the #1117–#1133 coordination stack.

### Verified
15 pytest green; live `SMOKE OK` (`/health`, `/providers`, `/build/stream` SSE, `/run` approval-gate halt→approve→done); shellcheck clean. CI: `.github/workflows/harness.yml` scoped to `harness/**` (omits the `agent` extra so the degrade-to-stub path runs in CI).

### Next
S1 strip the broker/office · S2 real deepagents build agent · S3 deterministic executor (API replay) · S4 gbrain · S5 capture/sniff · S6 the call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)