### PR TITLE
feat(harness): real BUILD agent — key-free Claude Code/Codex headless + deepagents BYOK (S2)

### DIFF
--- a/harness/src/harness/build_agent.py
+++ b/harness/src/harness/build_agent.py
@@ -13,9 +13,12 @@ The agent only FIGURES OUT the workflow. It never executes it (see executor.py).
 from __future__ import annotations
 
 import importlib.util
+import json
 import logging
 import os
 import re
+import shutil
+import subprocess
 from collections.abc import AsyncIterator
 from typing import Any, Protocol
 
@@ -175,6 +178,91 @@ class DeepAgentBuildAgent:
         yield {"type": "spec", "spec": spec.model_dump()}
 
 
+_CLI_SCHEMA_PROMPT = """You are the BUILD agent for an operator tool-builder. The \
+operator will describe an internal workflow. FIGURE OUT a small deterministic \
+pipeline and OUTPUT ONLY a single JSON object (no prose, no code fence) of this shape:
+
+{"name": str, "tool_id": str, "narration": str,
+ "steps": [{"id": str, "kind": "trigger|enrich|ai|decision|action|branch",
+            "title": str, "detail": str, "integration": str|null, "gated": bool}],
+ "clarify": {"field": "threshold|channel", "prompt": str, "step_id": str} | null}
+
+Rules: 3-6 steps; any step that mutates an external system MUST have gated=true and \
+an integration; include at most one clarify question (only if you truly cannot \
+proceed); tool_id is a slug. Output the JSON object and nothing else."""
+
+
+def _extract_json(text: str) -> dict[str, Any]:
+    """Pull the first balanced JSON object out of CLI stdout (which may carry log
+    preamble). Raises if none parses."""
+    start = text.find("{")
+    while start != -1:
+        depth, in_str, esc = 0, False, False
+        for i in range(start, len(text)):
+            c = text[i]
+            if in_str:
+                esc = (c == "\\") and not esc
+                if c == '"' and not esc:
+                    in_str = False
+            elif c == '"':
+                in_str = True
+            elif c == "{":
+                depth += 1
+            elif c == "}":
+                depth -= 1
+                if depth == 0:
+                    try:
+                        return json.loads(text[start:i + 1])
+                    except json.JSONDecodeError:
+                        break  # try the next "{"
+        start = text.find("{", start + 1)
+    raise ValueError("no JSON object found in CLI output")
+
+
+class CliBuildAgent:
+    """Key-free BUILD agent: drives Claude Code (`claude -p`) or Codex (`codex exec`)
+    in HEADLESS mode using the operator's existing CLI login — no API key. Asks for a
+    JSON WorkflowSpec and validates it. Same contract as the other agents; multi-
+    provider (the founder's 'keep Claude Code/Codex as the inner harness' stance)."""
+
+    def __init__(self, provider: str, timeout: int = 180):
+        self._provider = provider  # "claude" | "codex"
+        self._timeout = timeout
+
+    def _argv(self, prompt: str) -> list[str]:
+        if self._provider == "codex":
+            return ["codex", "exec", prompt]
+        return ["claude", "-p", prompt]
+
+    def compile(self, message: str, tool_id: str | None = None) -> WorkflowSpec:
+        prompt = _CLI_SCHEMA_PROMPT + "\n\nOPERATOR REQUEST:\n" + message.strip()
+        if tool_id:
+            prompt += f"\n\n(Refine the existing tool: {tool_id})"
+        proc = subprocess.run(self._argv(prompt), capture_output=True, text=True, timeout=self._timeout)  # noqa: S603
+        if proc.returncode != 0:
+            raise RuntimeError(f"{self._provider} headless build failed (exit {proc.returncode}): {proc.stderr[:500]}")
+        return _spec_from_capture(_extract_json(proc.stdout), tool_id)
+
+    async def stream(self, message: str, tool_id: str | None = None) -> AsyncIterator[dict]:
+        spec = self.compile(message, tool_id)
+        for step in spec.steps:
+            yield {"type": "step", "step": step.model_dump()}
+        yield {"type": "spec", "spec": spec.model_dump()}
+
+
+def _cli_provider() -> str | None:
+    """Which headless CLI to drive, if any. Honours HARNESS_BUILD_PROVIDER, else
+    prefers Claude Code, then Codex. Both run key-free off the operator's login."""
+    pref = os.getenv("HARNESS_BUILD_PROVIDER", "").strip().lower()
+    if pref in ("claude", "codex") and shutil.which(pref):
+        return pref
+    if shutil.which("claude"):
+        return "claude"
+    if shutil.which("codex"):
+        return "codex"
+    return None
+
+
 def _model_key_available() -> bool:
     """Whether a real LangChain model can authenticate (an api_key provider). Claude
     Code CLI auth does NOT count — deepagents/LangChain needs a key."""
@@ -182,12 +270,16 @@ def _model_key_available() -> bool:
 
 
 def build_agent() -> BuildAgent:
-    """Pick the BUILD agent: the real deepagents agent when it is installed AND a model
-    key is configured (BYOK); otherwise the deterministic stub so the harness always
-    runs key-free. Keyless authoring uses the stub today; a key unlocks the real agent."""
-    if importlib.util.find_spec("deepagents") is None:
-        return StubBuildAgent()
-    if not _model_key_available():
-        _log.info("deepagents installed but no model key — using the deterministic stub (set a provider key for the real agent)")
-        return StubBuildAgent()
-    return DeepAgentBuildAgent()
+    """Pick the BUILD agent, key-free first:
+      1. A headless CLI (Claude Code / Codex) using the operator's existing login —
+         no API key. This is the primary, activation-friendly path.
+      2. deepagents (LangChain) when installed AND a model key is set (BYOK).
+      3. The deterministic stub, so the harness always runs (CI, no CLI, no key).
+    """
+    provider = _cli_provider()
+    if provider is not None:
+        return CliBuildAgent(provider)
+    if importlib.util.find_spec("deepagents") is not None and _model_key_available():
+        return DeepAgentBuildAgent()
+    _log.info("no headless CLI and no model key — using the deterministic stub")
+    return StubBuildAgent()

--- a/harness/src/harness/build_agent.py
+++ b/harness/src/harness/build_agent.py
@@ -14,10 +14,12 @@ from __future__ import annotations
 
 import importlib.util
 import logging
+import os
 import re
 from collections.abc import AsyncIterator
-from typing import Protocol
+from typing import Any, Protocol
 
+from .providers import detect_providers
 from .wire import ClarifyQuestion, WorkflowSpec, WorkflowStep
 
 _log = logging.getLogger(__name__)
@@ -104,11 +106,88 @@ class StubBuildAgent:
         yield {"type": "spec", "spec": spec.model_dump()}
 
 
+_BUILD_SYSTEM_PROMPT = """You are the BUILD agent for an operator tool-builder. The \
+operator describes, in plain language, an internal workflow they want. Your job is to \
+FIGURE OUT a small, deterministic workflow and emit it — you do NOT execute anything.
+
+Design an ordered pipeline of steps. Each step has a kind:
+- trigger : what starts the workflow (an inbound item, a form, a ticket)
+- enrich  : look up related context
+- ai      : a model step that scores/classifies from the enriched context
+- decision: branch on a threshold/condition
+- action  : do something in an external system (set gated=true — it needs human approval)
+- branch  : a conditional fork
+
+Keep it tight (3-6 steps). Any step that mutates an external system MUST be gated.
+Ask AT MOST ONE sharp clarifying question (a threshold or a destination channel) only \
+if you genuinely cannot proceed. When done, call submit_workflow exactly once with the \
+full spec. Do not narrate after the tool call."""
+
+
+def _spec_from_capture(captured: dict[str, Any], fallback_tool_id: str | None) -> WorkflowSpec:
+    """Build a validated WorkflowSpec from the agent's submit_workflow arguments. Pure
+    + tolerant of missing optional fields, so it is unit-testable without a model."""
+    steps = [WorkflowStep(**s) if not isinstance(s, WorkflowStep) else s for s in captured.get("steps", [])]
+    clarify_raw = captured.get("clarify")
+    clarify = ClarifyQuestion(**clarify_raw) if isinstance(clarify_raw, dict) else None
+    return WorkflowSpec(
+        name=str(captured.get("name") or "Untitled workflow"),
+        tool_id=str(captured.get("tool_id") or fallback_tool_id or "inbound-routing"),
+        steps=steps,
+        narration=str(captured.get("narration") or ""),
+        clarify=clarify,
+    )
+
+
+class DeepAgentBuildAgent:
+    """The real BUILD agent: a LangChain deep agent (deepagents) that plans and emits a
+    WorkflowSpec via a submit_workflow tool. Same output contract as the stub, so the
+    executor and FE are unchanged. Requires a model API key (deepagents/LangChain does
+    NOT use Claude Code auth) — `build_agent()` only selects this when one is present."""
+
+    def __init__(self, model: str | None = None):
+        self._model = model or os.getenv("HARNESS_MODEL") or "anthropic:claude-sonnet-4-5"
+
+    def _invoke(self, message: str, tool_id: str | None) -> dict[str, Any]:  # pragma: no cover - needs a model key
+        from deepagents import create_deep_agent
+
+        captured: dict[str, Any] = {}
+
+        def submit_workflow(name: str, tool_id: str, steps: list[dict], narration: str = "", clarify: dict | None = None) -> str:
+            """Record the final deterministic workflow spec. Call exactly once."""
+            captured.update(name=name, tool_id=tool_id, steps=steps, narration=narration, clarify=clarify)
+            return "workflow recorded"
+
+        agent = create_deep_agent(model=self._model, tools=[submit_workflow], system_prompt=_BUILD_SYSTEM_PROMPT)
+        prompt = message if not tool_id else f"{message}\n\n(Refine the existing tool: {tool_id})"
+        agent.invoke({"messages": [{"role": "user", "content": prompt}]})
+        if "name" not in captured:
+            raise RuntimeError("deep agent finished without calling submit_workflow")
+        return captured
+
+    def compile(self, message: str, tool_id: str | None = None) -> WorkflowSpec:  # pragma: no cover - needs a model key
+        return _spec_from_capture(self._invoke(message, tool_id), tool_id)
+
+    async def stream(self, message: str, tool_id: str | None = None) -> AsyncIterator[dict]:  # pragma: no cover - needs a model key
+        spec = self.compile(message, tool_id)
+        for step in spec.steps:
+            yield {"type": "step", "step": step.model_dump()}
+        yield {"type": "spec", "spec": spec.model_dump()}
+
+
+def _model_key_available() -> bool:
+    """Whether a real LangChain model can authenticate (an api_key provider). Claude
+    Code CLI auth does NOT count — deepagents/LangChain needs a key."""
+    return any(p.available and p.via == "api_key" for p in detect_providers())
+
+
 def build_agent() -> BuildAgent:
-    """Pick the BUILD agent: the real deep agent when the `agent` extra is present,
-    else the deterministic stub so the harness runs key-free."""
+    """Pick the BUILD agent: the real deepagents agent when it is installed AND a model
+    key is configured (BYOK); otherwise the deterministic stub so the harness always
+    runs key-free. Keyless authoring uses the stub today; a key unlocks the real agent."""
     if importlib.util.find_spec("deepagents") is None:
         return StubBuildAgent()
-    # S2: construct and return the real LangChain deep-agent here (same contract).
-    _log.info("deepagents present — real build agent lands in S2; using stub for now")
-    return StubBuildAgent()
+    if not _model_key_available():
+        _log.info("deepagents installed but no model key — using the deterministic stub (set a provider key for the real agent)")
+        return StubBuildAgent()
+    return DeepAgentBuildAgent()

--- a/harness/tests/test_build_agent.py
+++ b/harness/tests/test_build_agent.py
@@ -2,8 +2,10 @@ import asyncio
 
 from harness import build_agent as ba
 from harness.build_agent import (
+    CliBuildAgent,
     DeepAgentBuildAgent,
     StubBuildAgent,
+    _extract_json,
     _spec_from_capture,
     build_agent,
 )
@@ -41,21 +43,53 @@ def test_stream_yields_one_step_each_then_the_spec():
     assert sum(1 for e in evs if e["type"] == "step") == len(evs[-1]["spec"]["steps"])
 
 
-def test_build_agent_degrades_to_stub_without_model_key(monkeypatch):
-    # No api_key provider (Claude Code CLI auth doesn't count for LangChain) -> stub,
-    # whether or not deepagents is installed.
-    monkeypatch.setattr(ba, "_model_key_available", lambda: False)
-    assert isinstance(build_agent(), StubBuildAgent)
+def test_build_agent_prefers_headless_cli(monkeypatch):
+    # Key-free path wins: a headless CLI (Claude Code / Codex) is selected first.
+    monkeypatch.setattr(ba, "_cli_provider", lambda: "claude")
+    assert isinstance(build_agent(), CliBuildAgent)
 
 
-def test_build_agent_uses_deep_agent_when_installed_and_keyed(monkeypatch):
+def test_build_agent_falls_back_to_deepagents_with_key(monkeypatch):
+    # No CLI, but deepagents + a model key -> the BYOK deep agent.
     if ba.importlib.util.find_spec("deepagents") is None:
         import pytest
 
         pytest.skip("deepagents not installed (the `agent` extra)")
+    monkeypatch.setattr(ba, "_cli_provider", lambda: None)
     monkeypatch.setattr(ba, "_model_key_available", lambda: True)
-    agent = build_agent()
-    assert isinstance(agent, DeepAgentBuildAgent)  # constructed; no live model call
+    assert isinstance(build_agent(), DeepAgentBuildAgent)
+
+
+def test_build_agent_degrades_to_stub_with_no_cli_and_no_key(monkeypatch):
+    # CI / no inner harness at all -> the deterministic stub keeps the harness running.
+    monkeypatch.setattr(ba, "_cli_provider", lambda: None)
+    monkeypatch.setattr(ba, "_model_key_available", lambda: False)
+    assert isinstance(build_agent(), StubBuildAgent)
+
+
+def test_extract_json_pulls_object_from_noisy_output():
+    text = 'log line\nthinking...\n{"name": "X", "n": {"a": 1}}\ntrailing log'
+    assert _extract_json(text) == {"name": "X", "n": {"a": 1}}
+
+
+def test_cli_build_agent_parses_headless_json(monkeypatch):
+    out = (
+        'codex preamble...\n'
+        '{"name":"Inbound routing","tool_id":"inbound-routing","narration":"n",'
+        '"steps":[{"id":"t","kind":"trigger","title":"New lead","detail":"d"},'
+        '{"id":"a","kind":"action","title":"Route","detail":"d","integration":"Slack","gated":true}]}'
+    )
+
+    class _Proc:
+        returncode = 0
+        stdout = out
+        stderr = ""
+
+    monkeypatch.setattr(ba.subprocess, "run", lambda *a, **k: _Proc())
+    spec = CliBuildAgent("codex").compile("route inbound leads to slack")
+    assert spec.tool_id == "inbound-routing"
+    assert [s.kind for s in spec.steps] == ["trigger", "action"]
+    assert spec.steps[1].gated is True
 
 
 def test_spec_from_capture_builds_validated_spec():

--- a/harness/tests/test_build_agent.py
+++ b/harness/tests/test_build_agent.py
@@ -1,6 +1,12 @@
 import asyncio
 
-from harness.build_agent import StubBuildAgent, build_agent
+from harness import build_agent as ba
+from harness.build_agent import (
+    DeepAgentBuildAgent,
+    StubBuildAgent,
+    _spec_from_capture,
+    build_agent,
+)
 
 
 def test_subject_detection_and_tool_mapping():
@@ -35,5 +41,37 @@ def test_stream_yields_one_step_each_then_the_spec():
     assert sum(1 for e in evs if e["type"] == "step") == len(evs[-1]["spec"]["steps"])
 
 
-def test_build_agent_degrades_to_stub_without_deepagents():
+def test_build_agent_degrades_to_stub_without_model_key(monkeypatch):
+    # No api_key provider (Claude Code CLI auth doesn't count for LangChain) -> stub,
+    # whether or not deepagents is installed.
+    monkeypatch.setattr(ba, "_model_key_available", lambda: False)
     assert isinstance(build_agent(), StubBuildAgent)
+
+
+def test_build_agent_uses_deep_agent_when_installed_and_keyed(monkeypatch):
+    if ba.importlib.util.find_spec("deepagents") is None:
+        import pytest
+
+        pytest.skip("deepagents not installed (the `agent` extra)")
+    monkeypatch.setattr(ba, "_model_key_available", lambda: True)
+    agent = build_agent()
+    assert isinstance(agent, DeepAgentBuildAgent)  # constructed; no live model call
+
+
+def test_spec_from_capture_builds_validated_spec():
+    spec = _spec_from_capture(
+        {
+            "name": "Inbound routing",
+            "tool_id": "inbound-routing",
+            "steps": [
+                {"id": "t", "kind": "trigger", "title": "New lead", "detail": "d"},
+                {"id": "a", "kind": "action", "title": "Route", "detail": "d", "integration": "Slack", "gated": True},
+            ],
+            "narration": "done",
+            "clarify": {"field": "channel", "prompt": "where?", "step_id": "a"},
+        },
+        fallback_tool_id=None,
+    )
+    assert spec.tool_id == "inbound-routing"
+    assert spec.steps[1].gated is True
+    assert spec.clarify.field == "channel"

--- a/harness/tests/test_service.py
+++ b/harness/tests/test_service.py
@@ -2,12 +2,14 @@ import json
 
 from fastapi.testclient import TestClient
 
+from harness.build_agent import StubBuildAgent
 from harness.service import create_app
 from harness.wire import WorkflowSpec
 
 
 def _client():
-    return TestClient(create_app())
+    # Pin the deterministic stub so unit tests never shell out to a live CLI agent.
+    return TestClient(create_app(agent_factory=lambda: StubBuildAgent()))
 
 
 def test_health_and_providers():


### PR DESCRIPTION
## S2 — the real BUILD agent (stacked on #1136)

Swaps the deterministic stub for a real agent behind the same `WorkflowSpec` contract, **key-free first**.

### Engines (selected key-free first)
1. **`CliBuildAgent` — Claude Code (`claude -p`) or Codex (`codex exec`) headless.** Runs off the operator's **existing CLI login — no API key**. This is the activation path. Asks the CLI for a JSON `WorkflowSpec` and validates it (`_extract_json` tolerates noisy stdout). Multi-provider via `HARNESS_BUILD_PROVIDER` / auto-detect.
2. **`DeepAgentBuildAgent` — deepagents (LangChain), BYOK.** Needs a model API key (LangChain doesn't use Claude Code auth), so it's the fallback when a key is set.
3. **Stub** — deterministic keyword compiler; keeps the harness running in CI / with no CLI and no key.

### Proven live, key-free
`claude -p` compiled a real spec from *"score the demo lead, if over \$5000 route to the sales-priority Slack channel, else nurture"* → trigger → score → `$5,000` decision → **gated** Slack action + **gated** HubSpot action (CQ1 external-mutation gating, correct). No API key.

### Tests
20 pytest green: `_extract_json`, CLI compile (mocked subprocess), key-free-first selection (CLI → deepagents+key → stub), service tests pinned to the stub so they never shell out.

The engine is pluggable behind the `BuildAgent` protocol — Claude Code / Codex / deepagents / a future custom harness are all swappable without touching the executor or FE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)