### PR TITLE
feat(agent): thin HTTP/SSE service on the pi-mono engine (FE ↔ real backend)

### DIFF
--- a/agent/README.md
+++ b/agent/README.md
@@ -13,11 +13,15 @@ data.ts`) and the Python harness, so it drops in behind the same `/build/stream`
 ## Layout
 
 ```
-src/wire.ts        WorkflowSpec/Step types + the build prompt + extractJson + validateSpec
+src/wire.ts        WorkflowSpec/Step + Build/Run request + RunResult; the build prompt; extractJson; validateSpec
 src/model.ts       model resolution: Ollama (key-free default) | subscription | BYOK
 src/buildAgent.ts  buildWorkflow(message) -> WorkflowSpec via pi-ai `complete`; streamWorkflow()
+src/executor.ts    deterministic run of a spec; a gated step halts for the approval card (CQ1)
+src/providers.ts   inference-path detection for the FE Settings surface (subscription / BYOK / local)
+src/service.ts     Bun.serve HTTP/SSE: /health, /providers, POST /build/stream (SSE), POST /run
 src/run.ts         CLI runner (compile a description live)
-src/buildAgent.test.ts  pure tests (extractJson / validateSpec)
+scripts/smoke.sh   live smoke (boots the service; /build/stream key-free against Ollama)
+src/*.test.ts      pure + service tests (offline; the service test stubs the engine)
 ```
 
 ## Run
@@ -41,9 +45,22 @@ the model; default is local Ollama so it always runs out of the box.
 Note: Anthropic now bills third-party subscription use as per-token "extra usage" — BYOK or
 ChatGPT/Codex/Copilot subscriptions are the cost-neutral paths (badlogic/pi-mono#3372).
 
-## Status (S2, pi-mono engine)
+## Service
 
-`buildWorkflow` is verified live key-free against Ollama. The narrow BUILD task uses one
-structured `pi-ai` call; the full agentic tool-loop (gbrain / browsersniff tools via
-`pi-agent-core`) lands at the discovery slice. Next: wire `streamWorkflow` into the
-service `/build/stream` and run a subscription model head-to-head on spec quality.
+```bash
+bun run serve     # http://127.0.0.1:8820  (PORT to override)
+bun run smoke     # boots it + exercises /health /providers /run /build/stream (live, key-free)
+```
+
+The FE points its build/run calls here (same `WorkflowSpec` contract as the mock). This
+replaces the Python `harness/` as the operator backend; the Python build agents remain a
+fallback until removed.
+
+## Status
+
+`buildWorkflow` + the full service (`/build/stream` SSE, `/run` executor, `/providers`)
+are verified live, key-free, against Ollama (`scripts/smoke.sh` → `SMOKE OK`). The narrow
+BUILD task uses one structured `pi-ai` call; the full agentic tool-loop (gbrain /
+browsersniff via `pi-agent-core`) lands at the discovery slice. Next: run a *subscription*
+model head-to-head on spec quality (operator `/login`), then the real deterministic
+executor (API-first replay).

--- a/agent/package.json
+++ b/agent/package.json
@@ -7,7 +7,9 @@
   "scripts": {
     "test": "bun test",
     "typecheck": "tsc --noEmit",
-    "build:run": "bun run src/run.ts"
+    "build:run": "bun run src/run.ts",
+    "serve": "bun run src/service.ts",
+    "smoke": "bash scripts/smoke.sh"
   },
   "dependencies": {
     "@mariozechner/pi-ai": "0.73.1",

--- a/agent/scripts/smoke.sh
+++ b/agent/scripts/smoke.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Live smoke for the operator agent service: boots it and exercises the FE-facing
+# endpoints, including a real key-free /build/stream against a local model.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+PORT="${AGENT_SMOKE_PORT:-8821}"
+BASE="http://127.0.0.1:${PORT}"
+
+PORT="$PORT" bun run src/service.ts &
+PID=$!
+trap 'kill "$PID" 2>/dev/null || true' EXIT
+
+for _ in $(seq 1 50); do curl -fsS -m 1 "$BASE/health" >/dev/null 2>&1 && break; sleep 0.2; done
+fail() { echo "SMOKE FAIL: $1" >&2; exit 1; }
+
+echo "== health =="; curl -fsS "$BASE/health" | python3 -m json.tool
+echo "== providers =="; curl -fsS "$BASE/providers" | python3 -m json.tool
+
+echo "== /run: gated step halts, then completes when approved =="
+SPEC='{"name":"n","tool_id":"t","narration":"","clarify":null,"steps":[{"id":"a","kind":"action","title":"Route","detail":"d","integration":"Slack","gated":true}]}'
+curl -fsS -X POST "$BASE/run" -H 'content-type: application/json' -d "{\"spec\":$SPEC,\"input\":{}}" | python3 -c 'import sys,json;d=json.load(sys.stdin);assert d["status"]=="needs_approval",d' || fail "gate did not halt"
+curl -fsS -X POST "$BASE/run" -H 'content-type: application/json' -d "{\"spec\":$SPEC,\"input\":{\"approved\":[\"a\"]}}" | python3 -c 'import sys,json;d=json.load(sys.stdin);assert d["status"]=="done",d' || fail "approved run did not complete"
+
+echo "== /build/stream: pi-mono compiles a spec LIVE (key-free, local model) =="
+BUILD=$(curl -fsS -N -m 150 -X POST "$BASE/build/stream" -H 'content-type: application/json' \
+  -d '{"schema_version":1,"message":"route inbound demo requests to a slack channel"}')
+echo "$BUILD" | grep -q 'event: spec' || fail "no spec event from /build/stream"
+echo "build stream OK (spec emitted)"
+echo "SMOKE OK"

--- a/agent/src/executor.test.ts
+++ b/agent/src/executor.test.ts
@@ -1,0 +1,29 @@
+import { expect, test } from "bun:test";
+import { runWorkflow } from "./executor.js";
+import type { WorkflowSpec } from "./wire.js";
+
+const gatedSpec: WorkflowSpec = {
+	name: "n", tool_id: "t", narration: "", clarify: null,
+	steps: [
+		{ id: "s1", kind: "trigger", title: "Start", detail: "d" },
+		{ id: "s2", kind: "action", title: "Route", detail: "d", integration: "Slack", gated: true },
+	],
+};
+
+test("halts at a gated step for approval (CQ1)", () => {
+	const r = runWorkflow(gatedSpec);
+	expect(r.status).toBe("needs_approval");
+	expect(r.pending_approval?.step_id).toBe("s2");
+	expect(r.steps.at(-1)?.status).toBe("awaiting_approval");
+});
+
+test("completes once the gated step is approved", () => {
+	const r = runWorkflow(gatedSpec, { approved: ["s2"] });
+	expect(r.status).toBe("done");
+	expect(r.steps.every((s) => s.status === "ok")).toBe(true);
+});
+
+test("ungated workflow runs to completion", () => {
+	const r = runWorkflow({ ...gatedSpec, steps: [{ id: "a", kind: "trigger", title: "t", detail: "d" }] });
+	expect(r.status).toBe("done");
+});

--- a/agent/src/executor.ts
+++ b/agent/src/executor.ts
@@ -1,0 +1,33 @@
+// Deterministic executor: run a compiled WorkflowSpec step by step.
+//
+// The DETERMINISTIC half of the spine — it runs the compiled spec, it does not
+// reason. S-now simulates each step (no live integrations yet); the discovery
+// slices replace the per-step simulation with real API-first replay -> UI replay
+// -> bounded CUA-heal while keeping this control flow: a `gated` step (external
+// mutation) HALTS with status="needs_approval" and the pending step surfaced to
+// the human approval card (CQ1). Approve -> the FE re-runs with that id in
+// input.approved.
+
+import type { RunResult, RunStep, WorkflowSpec } from "./wire.js";
+
+export function runWorkflow(spec: WorkflowSpec, input: Record<string, unknown> = {}): RunResult {
+	const approved = new Set<string>(Array.isArray(input.approved) ? (input.approved as unknown[]).map(String) : []);
+	const steps: RunStep[] = [];
+	for (const step of spec.steps) {
+		if (step.gated && !approved.has(step.id)) {
+			steps.push({
+				step_id: step.id,
+				status: "awaiting_approval",
+				detail: `${step.title} mutates ${step.integration ?? "an external system"} — needs approval.`,
+			});
+			return {
+				status: "needs_approval",
+				steps,
+				digest: `Paused at ${step.title}: external mutation needs the human approval card.`,
+				pending_approval: { step_id: step.id, title: step.title, integration: step.integration, detail: step.detail },
+			};
+		}
+		steps.push({ step_id: step.id, status: "ok", detail: `${step.title} ran.` });
+	}
+	return { status: "done", steps, digest: `Ran ${steps.length} steps to completion.`, pending_approval: null };
+}

--- a/agent/src/providers.ts
+++ b/agent/src/providers.ts
@@ -1,0 +1,42 @@
+// Provider detection for the FE Settings surface. Reports which inference paths
+// are usable — subscription CLIs the operator is already logged into, BYOK keys,
+// and local Ollama — so the FE can show what's connected and prompt /login or BYOK
+// for the rest. No secrets are returned, only availability.
+
+import { existsSync } from "node:fs";
+
+export interface Provider {
+	id: string;
+	label: string;
+	available: boolean;
+	via: "subscription_cli" | "api_key" | "local" | "none";
+}
+
+function onPath(bin: string): boolean {
+	const dirs = (process.env.PATH ?? "").split(":");
+	return dirs.some((d) => d && existsSync(`${d}/${bin}`));
+}
+
+function envAny(...names: string[]): boolean {
+	return names.some((n) => (process.env[n] ?? "").trim().length > 0);
+}
+
+export function detectProviders(): Provider[] {
+	const out: Provider[] = [];
+
+	if (envAny("ANTHROPIC_API_KEY")) out.push({ id: "anthropic", label: "Anthropic API", available: true, via: "api_key" });
+	else if (onPath("claude")) out.push({ id: "anthropic", label: "Claude Code (subscription)", available: true, via: "subscription_cli" });
+	else out.push({ id: "anthropic", label: "Anthropic", available: false, via: "none" });
+
+	if (envAny("OPENAI_API_KEY")) out.push({ id: "openai", label: "OpenAI API", available: true, via: "api_key" });
+	else if (onPath("codex")) out.push({ id: "codex", label: "Codex (subscription)", available: true, via: "subscription_cli" });
+
+	out.push({ id: "ollama", label: "Ollama (local / open-weight)", available: onPath("ollama"), via: onPath("ollama") ? "local" : "none" });
+
+	return out;
+}
+
+export function providersPayload(): { providers: Provider[]; any_available: boolean } {
+	const providers = detectProviders();
+	return { providers, any_available: providers.some((p) => p.available) };
+}

--- a/agent/src/service.test.ts
+++ b/agent/src/service.test.ts
@@ -1,0 +1,56 @@
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import { createServer } from "./service.js";
+import type { WorkflowSpec } from "./wire.js";
+
+// Stub the build engine so the service test never hits a live model.
+async function* fakeBuild() {
+	const spec: WorkflowSpec = {
+		name: "Inbound routing", tool_id: "inbound-routing", narration: "n", clarify: null,
+		steps: [
+			{ id: "t", kind: "trigger", title: "New lead", detail: "d" },
+			{ id: "a", kind: "action", title: "Route", detail: "d", integration: "Slack", gated: true },
+		],
+	};
+	for (const step of spec.steps) yield { type: "step" as const, step };
+	yield { type: "spec" as const, spec };
+}
+
+let server: ReturnType<typeof createServer>;
+let base: string;
+beforeAll(() => {
+	server = createServer({ port: 0, buildStream: fakeBuild });
+	base = server.url.toString().replace(/\/$/, "");
+});
+afterAll(() => server.stop(true));
+
+test("/health and /providers", async () => {
+	expect((await (await fetch(`${base}/health`)).json()).status).toBe("ok");
+	const p = await (await fetch(`${base}/providers`)).json();
+	expect(Array.isArray(p.providers)).toBe(true);
+});
+
+test("/build/stream emits start, steps, then spec", async () => {
+	const res = await fetch(`${base}/build/stream`, {
+		method: "POST", headers: { "content-type": "application/json" },
+		body: JSON.stringify({ schema_version: 1, message: "route inbound leads" }),
+	});
+	const text = await res.text();
+	const events = [...text.matchAll(/event: (\w+)/g)].map((m) => m[1]);
+	expect(events[0]).toBe("start");
+	expect(events).toContain("step");
+	expect(events.at(-1)).toBe("spec");
+});
+
+test("/run halts on a gate then completes when approved", async () => {
+	const spec = { name: "n", tool_id: "t", narration: "", clarify: null,
+		steps: [{ id: "a", kind: "action", title: "Route", detail: "d", integration: "Slack", gated: true }] };
+	const r1 = await (await fetch(`${base}/run`, { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ spec, input: {} }) })).json();
+	expect(r1.status).toBe("needs_approval");
+	const r2 = await (await fetch(`${base}/run`, { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ spec, input: { approved: ["a"] } }) })).json();
+	expect(r2.status).toBe("done");
+});
+
+test("schema_version mismatch is rejected", async () => {
+	const res = await fetch(`${base}/build/stream`, { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ schema_version: 99, message: "x" }) });
+	expect(res.status).toBe(400);
+});

--- a/agent/src/service.ts
+++ b/agent/src/service.ts
@@ -1,0 +1,80 @@
+// Thin HTTP/SSE service the operator FE talks to (no broker). Bun.serve, no
+// framework. Mirrors the Python harness contract so the FE is unchanged:
+//   GET  /health        liveness
+//   GET  /providers     which inference paths are available (subscription/BYOK/local)
+//   POST /build/stream  description -> the pi-mono agent assembles a WorkflowSpec (SSE)
+//   POST /run           execute a compiled spec deterministically (gated step -> CQ1)
+
+import { streamWorkflow } from "./buildAgent.js";
+import { runWorkflow } from "./executor.js";
+import { providersPayload } from "./providers.js";
+import { type BuildRequest, type RunRequest, SCHEMA_VERSION, type WorkflowSpec } from "./wire.js";
+
+type BuildEvent = { type: "step"; step: WorkflowSpec["steps"][number] } | { type: "spec"; spec: WorkflowSpec };
+type BuildStream = (message: string, opts: { toolId?: string }) => AsyncGenerator<BuildEvent>;
+
+export interface ServerOptions {
+	port?: number;
+	// Override the build engine in tests so they never hit a live model.
+	buildStream?: BuildStream;
+}
+
+function json(data: unknown, status = 200): Response {
+	return new Response(JSON.stringify(data), { status, headers: { "content-type": "application/json" } });
+}
+
+function sse(name: string, data: unknown): string {
+	return `event: ${name}\ndata: ${JSON.stringify(data)}\n\n`;
+}
+
+function schemaMismatch(v: number | undefined): boolean {
+	return v != null && v !== SCHEMA_VERSION;
+}
+
+export function createServer(opts: ServerOptions = {}) {
+	const buildStream: BuildStream = opts.buildStream ?? (streamWorkflow as BuildStream);
+
+	return Bun.serve({
+		port: opts.port ?? Number(process.env.PORT ?? 8820),
+		async fetch(req) {
+			const url = new URL(req.url);
+			const { pathname } = url;
+
+			if (req.method === "GET" && pathname === "/health") return json({ status: "ok", version: "0.0.1" });
+			if (req.method === "GET" && pathname === "/providers") return json(providersPayload());
+
+			if (req.method === "POST" && pathname === "/build/stream") {
+				const body = (await req.json()) as BuildRequest;
+				if (schemaMismatch(body.schema_version)) return json({ error: "schema_version mismatch" }, 400);
+				const stream = new ReadableStream({
+					async start(controller) {
+						const enc = new TextEncoder();
+						controller.enqueue(enc.encode(sse("start", { message: body.message })));
+						try {
+							for await (const ev of buildStream(body.message, { toolId: body.tool_id })) {
+								controller.enqueue(enc.encode(sse(ev.type === "spec" ? "spec" : "step", ev)));
+							}
+						} catch (e) {
+							controller.enqueue(enc.encode(sse("error", { message: String(e) })));
+						}
+						controller.close();
+					},
+				});
+				return new Response(stream, { headers: { "content-type": "text/event-stream", "cache-control": "no-cache" } });
+			}
+
+			if (req.method === "POST" && pathname === "/run") {
+				const body = (await req.json()) as RunRequest;
+				if (schemaMismatch(body.schema_version)) return json({ error: "schema_version mismatch" }, 400);
+				return json(runWorkflow(body.spec, body.input ?? {}));
+			}
+
+			return json({ error: "not found" }, 404);
+		},
+	});
+}
+
+if (import.meta.main) {
+	const server = createServer();
+	console.log(`wuphf-agent service on ${server.url}`);
+}

--- a/agent/src/wire.ts
+++ b/agent/src/wire.ts
@@ -28,6 +28,33 @@ export interface WorkflowSpec {
 	clarify: ClarifyQuestion | null;
 }
 
+export const SCHEMA_VERSION = 1;
+
+export interface BuildRequest {
+	schema_version?: number;
+	message: string;
+	tool_id?: string;
+}
+
+export interface RunRequest {
+	schema_version?: number;
+	spec: WorkflowSpec;
+	input?: Record<string, unknown>;
+}
+
+export interface RunStep {
+	step_id: string;
+	status: "ok" | "skipped" | "awaiting_approval";
+	detail: string;
+}
+
+export interface RunResult {
+	status: "done" | "needs_approval";
+	steps: RunStep[];
+	digest: string;
+	pending_approval: { step_id: string; title: string; integration?: string; detail: string } | null;
+}
+
 // The BUILD brief: identical intent to the Python harness so any engine produces
 // the same shape. The agent must output ONLY this JSON object.
 export const SCHEMA_PROMPT = `You are the BUILD agent for an operator tool-builder. The operator describes an internal workflow. FIGURE OUT a small deterministic pipeline and OUTPUT ONLY a single JSON object (no prose, no code fence) of this shape:


### PR DESCRIPTION
## S4 — the operator backend on pi-mono (stacked on #1138)

Wires the pi-mono build agent into a **Bun.serve HTTP/SSE service** (no framework, no broker) so the operator FE drives the **real** engine. Mirrors the Python harness contract — FE unchanged:

- `GET /health` · `GET /providers` (subscription CLI / BYOK / local Ollama)
- `POST /build/stream` — description → pi-mono assembles a `WorkflowSpec` (SSE: `start`/`step`/`spec`)
- `POST /run` — deterministic execution; a **gated** step halts for the human approval card (CQ1), resumes when approved

### Pieces
`executor.ts` (deterministic run, gate→needs_approval, ported from the Python harness), `providers.ts` (detect Claude Code/Codex subscriptions + keys + Ollama), `service.ts` (Bun.serve; build engine injectable so tests stay offline).

### Verified live, key-free, end-to-end
`scripts/smoke.sh` → **SMOKE OK**: `/providers` detects Claude Code + Codex subscriptions + Ollama; `/run` halts on the gate then completes when approved; **`/build/stream` compiles a `WorkflowSpec` via pi-mono → local Ollama over HTTP, no key/login**. `bun test` 10/10 (offline — the service test stubs the engine), `tsc` clean, shellcheck clean.

This is the operator backend on the chosen engine; it supersedes the Python `harness/` (kept as fallback until removed).

### Next
Run a **subscription** model head-to-head on spec quality (operator `/login`), then the real deterministic executor (API-first replay), then the discovery loop (gbrain / capture+sniff) where pi-mono's full `pi-agent-core` tool-loop earns its keep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)