### PR TITLE
feat(operator): converge the FE onto the pi-mono engine (clickable, real)

### DIFF
--- a/web/src/operator/OperatorApp.tsx
+++ b/web/src/operator/OperatorApp.tsx
@@ -1,0 +1,95 @@
+// OperatorApp — the operator-MLP product shell, mounted full-bleed at
+// /#/operator (see RootRoute). Self-contained: all navigation is local state,
+// all data is mock. This is the frontend-first slice — the shape to react to
+// before any backend exists. See docs/specs/operator-mlp-plan.md.
+
+import { useState } from "react";
+
+import "../styles/operator-shell.css";
+
+import { CallModal } from "./components/CallModal";
+import { OperatorSidebar, type OperatorSurface } from "./OperatorSidebar";
+import { ChatsSurface } from "./surfaces/ChatsSurface";
+import { IntegrationsSurface } from "./surfaces/IntegrationsSurface";
+import { InternalToolDetail } from "./surfaces/InternalToolDetail";
+import { InternalToolsSurface } from "./surfaces/InternalToolsSurface";
+import { KnowledgeSurface } from "./surfaces/KnowledgeSurface";
+import { SettingsSurface } from "./surfaces/SettingsSurface";
+import { WorkflowBuilder } from "./surfaces/WorkflowBuilder";
+import { getTool } from "./mock/data";
+
+export function OperatorApp() {
+  const [surface, setSurface] = useState<OperatorSurface>("tools");
+  const [selectedToolId, setSelectedToolId] = useState<string | null>(null);
+  const [callOpen, setCallOpen] = useState(false);
+  const [building, setBuilding] = useState(false);
+
+  function go(next: OperatorSurface) {
+    setSurface(next);
+    setSelectedToolId(null);
+    setBuilding(false);
+  }
+
+  function openTool(id: string) {
+    setSelectedToolId(id);
+    setSurface("tools");
+    setBuilding(false);
+  }
+
+  const selectedTool = selectedToolId ? getTool(selectedToolId) : undefined;
+
+  return (
+    <div className="opr-root">
+      <OperatorSidebar
+        active={surface}
+        onSelect={go}
+        onStartCall={() => setCallOpen(true)}
+        onBuild={() => setBuilding(true)}
+      />
+
+      <main className="opr-main">
+        {building ? (
+          <WorkflowBuilder
+            onClose={() => setBuilding(false)}
+            onFinish={openTool}
+          />
+        ) : surface === "chats" ? (
+          <ChatsSurface
+            onStartCall={() => setCallOpen(true)}
+            onBuild={() => setBuilding(true)}
+          />
+        ) : (
+          <div className="opr-surface">
+            {surface === "tools" &&
+              (selectedTool ? (
+                <InternalToolDetail
+                  tool={selectedTool}
+                  onBack={() => setSelectedToolId(null)}
+                  onStartCall={() => setCallOpen(true)}
+                />
+              ) : (
+                <InternalToolsSurface
+                  onOpen={openTool}
+                  onStartCall={() => setCallOpen(true)}
+                  onBuild={() => setBuilding(true)}
+                />
+              ))}
+            {surface === "knowledge" && <KnowledgeSurface />}
+            {surface === "integrations" && <IntegrationsSurface />}
+            {surface === "settings" && <SettingsSurface />}
+          </div>
+        )}
+      </main>
+
+      {callOpen ? (
+        <CallModal
+          onClose={() => setCallOpen(false)}
+          onBuild={() => {
+            setCallOpen(false);
+            openTool("inbound-routing");
+          }}
+        />
+      ) : null}
+    </div>
+  );
+}

--- a/web/src/operator/OperatorSidebar.tsx
+++ b/web/src/operator/OperatorSidebar.tsx
@@ -1,0 +1,115 @@
+// The operator shell's left nav — deliberately small: five surfaces, a call
+// CTA, and the operator's identity. No agents, channels, skills, or wiki
+// vocabulary; this is the whole product.
+
+import {
+  BookOpen,
+  MessageSquare,
+  PhoneCall,
+  Plug,
+  Plus,
+  Settings,
+  Workflow,
+  type LucideIcon,
+} from "lucide-react";
+
+export type OperatorSurface =
+  | "chats"
+  | "tools"
+  | "knowledge"
+  | "integrations"
+  | "settings";
+
+interface NavDef {
+  id: OperatorSurface;
+  label: string;
+  icon: LucideIcon;
+  count?: number;
+}
+
+const NAV: readonly NavDef[] = [
+  { id: "chats", label: "Chats", icon: MessageSquare, count: 1 },
+  { id: "tools", label: "Internal tools", icon: Workflow, count: 3 },
+  { id: "knowledge", label: "Knowledge", icon: BookOpen },
+  { id: "integrations", label: "Integrations", icon: Plug },
+  { id: "settings", label: "Settings", icon: Settings },
+];
+
+interface OperatorSidebarProps {
+  active: OperatorSurface;
+  onSelect: (surface: OperatorSurface) => void;
+  onStartCall: () => void;
+  onBuild: () => void;
+}
+
+export function OperatorSidebar({
+  active,
+  onSelect,
+  onStartCall,
+  onBuild,
+}: OperatorSidebarProps) {
+  return (
+    <aside className="opr-sidebar">
+      <div className="opr-brand">
+        <img
+          className="opr-brand-mark"
+          src="/favicon.svg"
+          alt="wuphf"
+          width={27}
+          height={27}
+        />
+        <div>
+          <div className="opr-brand-name">wuphf</div>
+        </div>
+      </div>
+
+      <nav className="opr-nav" aria-label="Primary">
+        {NAV.map((item) => (
+          // Icons mirror the manual's sparse instrumentation controls: small,
+          // utilitarian, and subordinate to the label.
+          <button
+            key={item.id}
+            type="button"
+            className={`opr-nav-item${item.id === active ? " is-active" : ""}`}
+            onClick={() => onSelect(item.id)}
+          >
+            <span className="opr-nav-icon" aria-hidden>
+              <item.icon size={15} strokeWidth={1.8} />
+            </span>
+            {item.label}
+            {item.count ? (
+              <span className="opr-nav-count">{item.count}</span>
+            ) : null}
+          </button>
+        ))}
+      </nav>
+
+      <div className="opr-sidebar-spacer" />
+
+      <button
+        type="button"
+        className="opr-btn opr-btn-primary opr-build-cta"
+        onClick={onBuild}
+      >
+        <Plus size={14} strokeWidth={1.9} aria-hidden />
+        Build a tool
+      </button>
+      <button
+        type="button"
+        className="opr-call-cta opr-call-cta-secondary"
+        onClick={onStartCall}
+      >
+        <PhoneCall size={14} strokeWidth={1.9} aria-hidden />
+        Teach your workflow to Nex
+      </button>
+
+      <div className="opr-user">
+        <div className="opr-user-avatar">M</div>
+        <div>
+          <div className="opr-user-name">Maya</div>
+          <div className="opr-user-role">RevOps · your workspace</div>
+        </div>
+      </div>
+    </aside>
+  );
+}

--- a/web/src/operator/builder/agentClient.ts
+++ b/web/src/operator/builder/agentClient.ts
@@ -1,0 +1,85 @@
+// agentClient — talks to the real pi-mono build agent (agent/ service) over the
+// same WorkflowSpec contract the mock produces. Frontend-first + graceful: if the
+// service is unreachable, fall back to the deterministic mock planWorkflow so the
+// prototype always works. When the service is up, the operator gets the real
+// engine (key-free via the operator's subscription /login, or local Ollama).
+
+import type { WorkflowStep } from "../mock/data";
+import { planWorkflow, type ClarifyQuestion, type WorkflowPlan } from "./planWorkflow";
+
+// Vite env; defaults to the local agent service.
+const AGENT_URL =
+	(import.meta as unknown as { env?: Record<string, string> }).env?.VITE_AGENT_URL ?? "http://127.0.0.1:8820";
+
+interface WireSpec {
+	name?: string;
+	tool_id?: string;
+	steps?: WorkflowStep[];
+	narration?: string;
+	clarify?: { field?: string; prompt?: string; step_id?: string } | null;
+}
+
+function toPlan(spec: WireSpec): WorkflowPlan {
+	const clarify: ClarifyQuestion | null =
+		spec.clarify && (spec.clarify.field === "threshold" || spec.clarify.field === "channel")
+			? { field: spec.clarify.field, prompt: String(spec.clarify.prompt ?? ""), stepId: String(spec.clarify.step_id ?? "") }
+			: null;
+	return {
+		name: String(spec.name ?? "Untitled workflow"),
+		toolId: String(spec.tool_id ?? "inbound-routing"),
+		steps: Array.isArray(spec.steps) ? spec.steps : [],
+		narration: String(spec.narration ?? ""),
+		clarify,
+	};
+}
+
+/** Parse the SSE body for the terminal `spec` event's payload. */
+function specFromSse(text: string): WireSpec {
+	let event = "";
+	for (const block of text.split("\n\n")) {
+		for (const line of block.split("\n")) {
+			if (line.startsWith("event:")) event = line.slice(6).trim();
+			else if (line.startsWith("data:") && event === "spec") {
+				const data = JSON.parse(line.slice(5).trim()) as { spec?: WireSpec };
+				if (data.spec) return data.spec;
+			}
+		}
+	}
+	throw new Error("no spec event in build stream");
+}
+
+async function buildPlanViaService(description: string): Promise<WorkflowPlan> {
+	const res = await fetch(`${AGENT_URL}/build/stream`, {
+		method: "POST",
+		headers: { "content-type": "application/json" },
+		body: JSON.stringify({ schema_version: 1, message: description }),
+	});
+	if (!res.ok) throw new Error(`agent service ${res.status}`);
+	return toPlan(specFromSse(await res.text()));
+}
+
+/** Real engine when the service is reachable, else the deterministic mock. */
+export async function buildPlanSmart(description: string): Promise<WorkflowPlan> {
+	try {
+		return await buildPlanViaService(description);
+	} catch {
+		return planWorkflow(description);
+	}
+}
+
+/** Execute a built workflow on the agent service; returns the run result JSON. */
+export async function runWorkflowViaService(spec: {
+	name: string;
+	tool_id: string;
+	steps: WorkflowStep[];
+	narration?: string;
+	clarify?: unknown;
+}, input: Record<string, unknown> = {}): Promise<unknown> {
+	const res = await fetch(`${AGENT_URL}/run`, {
+		method: "POST",
+		headers: { "content-type": "application/json" },
+		body: JSON.stringify({ schema_version: 1, spec, input }),
+	});
+	if (!res.ok) throw new Error(`agent service ${res.status}`);
+	return res.json();
+}

--- a/web/src/operator/builder/planWorkflow.ts
+++ b/web/src/operator/builder/planWorkflow.ts
@@ -1,0 +1,301 @@
+// planWorkflow — the "AI understanding" behind chat-to-build authoring.
+//
+// FRONTEND-FIRST RULE: this is a mock of the agentic build phase. It reads the
+// operator's plain-language description and compiles it into a deterministic
+// workflow (an ordered list of steps), the way the real build phase will once
+// gbrain + browsersniff are wired. It is keyword-driven so the prototype feels
+// like it understood the request, not like it returned a canned reply. Kept
+// pure (no React, no side effects) so it can carry a regression test later.
+
+import type { WorkflowStep } from "../mock/data";
+
+export type ClarifyField = "threshold" | "channel";
+
+export interface ClarifyQuestion {
+  field: ClarifyField;
+  prompt: string; // the single sharp follow-up the AI asks
+  stepId: string; // the step this answer will refine, in place
+}
+
+export interface WorkflowPlan {
+  name: string; // the tool name the AI proposes
+  toolId: string; // the existing mock tool this maps to on finish
+  steps: WorkflowStep[];
+  narration: string; // the AI's reflect-back line once steps are assembled
+  clarify: ClarifyQuestion | null;
+}
+
+const TRIGGER_ID = "p-trigger";
+const ENRICH_ID = "p-enrich";
+const AI_ID = "p-ai";
+const DECISION_ID = "p-decision";
+const ACTION_ID = "p-action";
+const BRANCH_ID = "p-branch";
+
+function has(text: string, ...words: string[]): boolean {
+  return words.some((w) => text.includes(w));
+}
+
+// What kind of thing kicks this off, derived from the operator's words.
+function detectSubject(t: string): {
+  source: string;
+  name: string;
+  toolId: string;
+} {
+  if (has(t, "ticket", "escalation", "support", "incident")) {
+    return {
+      source: "support ticket",
+      name: "Support escalation triage",
+      toolId: "support-escalations",
+    };
+  }
+  if (has(t, "expense", "invoice", "reimburse", "spend", "purchase order")) {
+    return {
+      source: "expense over policy",
+      name: "Expense exception routing",
+      toolId: "expense-exceptions",
+    };
+  }
+  if (has(t, "demo", "trial", "lead", "signup", "sign-up", "form", "inbound")) {
+    return {
+      source: "demo request",
+      name: "Inbound demo-request routing",
+      toolId: "inbound-routing",
+    };
+  }
+  return {
+    source: "inbound item",
+    name: "Inbound routing",
+    toolId: "inbound-routing",
+  };
+}
+
+interface Threshold {
+  kind: "score" | "amount";
+  label: string; // e.g. "70" or "$5k"
+}
+
+function detectThreshold(t: string, scoreContext: boolean): Threshold | null {
+  const amount = t.match(/\$\s?(\d[\d,]*\s?[km]?)/i);
+  if (amount) {
+    return { kind: "amount", label: `$${amount[1].replace(/\s/g, "")}` };
+  }
+  if (scoreContext) {
+    const num = t.match(/\b(\d{2,3})\b/);
+    if (num) return { kind: "score", label: num[1] };
+  }
+  return null;
+}
+
+/** Compile a plain-language description into a deterministic workflow. */
+export function planWorkflow(description: string): WorkflowPlan {
+  const t = description.toLowerCase();
+  const subject = detectSubject(t);
+  const steps: WorkflowStep[] = [];
+
+  // 1. Trigger — always present. The workflow needs a thing to react to.
+  steps.push({
+    id: TRIGGER_ID,
+    kind: "trigger",
+    title: `New ${subject.source}`,
+    detail: `When a ${subject.source} arrives (or fire manually on test data).`,
+  });
+
+  // 2. Enrich — look the subject up in a system of record.
+  const wantsEnrich = has(
+    t,
+    "look up",
+    "lookup",
+    "look it up",
+    "find",
+    "enrich",
+    "pull",
+    "match",
+    "crm",
+    "company",
+    "account",
+    "hubspot",
+    "salesforce",
+  );
+  if (wantsEnrich) {
+    const onCrm = has(t, "crm", "hubspot", "salesforce", "account", "company");
+    steps.push({
+      id: ENRICH_ID,
+      kind: "enrich",
+      title: "Look up the record",
+      detail: "Find the matching account and its details before deciding.",
+      integration: onCrm ? "HubSpot" : undefined,
+    });
+  }
+
+  // 3. AI judgment — score for fit, or classify/triage.
+  const wantsScore = has(t, "score", "rate", "qualify", "fit", "rank", "grade");
+  const wantsClassify = has(
+    t,
+    "classif",
+    "severity",
+    "categor",
+    "triage",
+    "priorit",
+    "sort",
+  );
+  if (wantsScore) {
+    steps.push({
+      id: AI_ID,
+      kind: "ai",
+      title: "Score fit 0 to 100",
+      detail:
+        "Rate fit from size, industry, and what they asked for, and explain the score.",
+    });
+  } else if (wantsClassify) {
+    steps.push({
+      id: AI_ID,
+      kind: "ai",
+      title: "Classify and explain",
+      detail:
+        "Read the item, assign a category or severity, and write the reason.",
+    });
+  }
+
+  // 4. Decision — a gate the operator hinted at (or that scoring implies).
+  const hasAiStep = wantsScore || wantsClassify;
+  const wantsDecision =
+    hasAiStep ||
+    has(
+      t,
+      " if ",
+      "above",
+      "over",
+      "threshold",
+      "good",
+      "strong",
+      "hot",
+      "qualified",
+      "high",
+      "worst",
+      "urgent",
+      "sev 1",
+      "sev1",
+    );
+  const threshold = detectThreshold(t, wantsScore);
+  if (wantsDecision) {
+    const title = threshold
+      ? threshold.kind === "amount"
+        ? `Is it over ${threshold.label}?`
+        : `Is the score at least ${threshold.label}?`
+      : "Does it clear the bar?";
+    const detail = threshold
+      ? "Above the bar moves on; everything else takes the other branch."
+      : "Set the cutoff that decides what moves on.";
+    steps.push({ id: DECISION_ID, kind: "decision", title, detail });
+  }
+
+  // 5. Action — the external thing it does. Sends are gated on a human.
+  const onSlack = has(t, "slack", "channel", "#", "post", "ping", "page");
+  const onEmail = has(t, "email", "gmail", "mail");
+  let actionTitle = "Send the result to you";
+  let integration: string | undefined;
+  if (has(t, "page")) {
+    actionTitle = "Page the on-call engineer";
+    integration = "Slack";
+  } else if (has(t, "route", "assign", "hand off", "handoff", "send the")) {
+    actionTitle = "Route to the on-call owner";
+    integration = onSlack ? "Slack" : onEmail ? "Gmail" : undefined;
+  } else if (has(t, "approve", "approval", "exception")) {
+    actionTitle = "Route exceptions to you for approval";
+  } else if (onSlack) {
+    actionTitle = "Post it to the team channel";
+    integration = "Slack";
+  } else if (onEmail) {
+    actionTitle = "Email the owner";
+    integration = "Gmail";
+  }
+  steps.push({
+    id: ACTION_ID,
+    kind: "action",
+    title: actionTitle,
+    detail: "Include the reason so the person on the other end has context.",
+    integration,
+    gated: Boolean(integration),
+  });
+
+  // 6. Branch — the "otherwise" path, if implied.
+  if (has(t, "otherwise", "else", "nurture", "queue", "ignore", "rest", "low")) {
+    const nurture = has(t, "nurture");
+    steps.push({
+      id: BRANCH_ID,
+      kind: "branch",
+      title: nurture ? "Otherwise: add to nurture" : "Otherwise: queue it",
+      detail: nurture
+        ? "Below the bar gets tagged for the nurture sequence, no handoff."
+        : "Everything else waits in a queue for a person to look at.",
+      integration: nurture ? "HubSpot" : undefined,
+    });
+  }
+
+  // The one sharp follow-up worth asking. Prefer a missing numeric cutoff,
+  // then a missing channel for a send. Only ever one, to keep it collaborative.
+  let clarify: ClarifyQuestion | null = null;
+  const decision = steps.find((s) => s.id === DECISION_ID);
+  const action = steps.find((s) => s.id === ACTION_ID);
+  if (decision && !threshold) {
+    clarify = {
+      field: "threshold",
+      stepId: DECISION_ID,
+      prompt: wantsScore
+        ? "One thing to lock in: at what fit score should it move on to a person? Most teams start around 70."
+        : "One thing to lock in: where should the line be between handling it automatically and routing it to a person?",
+    };
+  } else if (action && action.integration && !has(t, "#")) {
+    clarify = {
+      field: "channel",
+      stepId: ACTION_ID,
+      prompt:
+        action.integration === "Slack"
+          ? "Which Slack channel should the handoff post to?"
+          : "Who should the handoff email go to?",
+    };
+  }
+
+  const narration = `Here is the workflow I put together from that, ${steps.length} steps, each one scripted so it runs the same way every time.`;
+
+  return {
+    name: subject.name,
+    toolId: subject.toolId,
+    steps,
+    narration,
+    clarify,
+  };
+}
+
+/** Apply the operator's answer to a clarifying question, in place. Pure. */
+export function applyClarify(
+  steps: WorkflowStep[],
+  field: ClarifyField,
+  answer: string,
+): WorkflowStep[] {
+  if (field === "threshold") {
+    const num = answer.match(/\d{1,3}/)?.[0] ?? "70";
+    return steps.map((s) =>
+      s.id === DECISION_ID
+        ? {
+            ...s,
+            title: `Is the score at least ${num}?`,
+            detail: `At or above ${num} routes to a person; everything else takes the other branch.`,
+          }
+        : s,
+    );
+  }
+  // channel
+  const channel =
+    answer.match(/#[\w-]+/)?.[0] ??
+    (answer.trim().startsWith("#") ? answer.trim() : `#${answer.trim()}`);
+  return steps.map((s) =>
+    s.id === ACTION_ID
+      ? {
+          ...s,
+          detail: `Post to ${channel} with the reason so the owner has context.`,
+        }
+      : s,
+  );
+}

--- a/web/src/operator/components/ApprovalCard.tsx
+++ b/web/src/operator/components/ApprovalCard.tsx
@@ -1,0 +1,54 @@
+// Human approval card — the shared gate for external mutations (CQ1).
+//
+// Both at build-explore time and at execution, any action that mutates an
+// outside system (posting to Slack, writing to the CRM) surfaces this same
+// card before it runs. Mock/presentational: the buttons just resolve locally.
+
+import { Check, X } from "lucide-react";
+
+interface ApprovalCardProps {
+  title: string;
+  detail: string;
+  integration: string;
+  onApprove: () => void;
+  onSkip: () => void;
+}
+
+export function ApprovalCard({
+  title,
+  detail,
+  integration,
+  onApprove,
+  onSkip,
+}: ApprovalCardProps) {
+  return (
+    <div className="opr-approval" role="group" aria-label="Approval needed">
+      <span className="opr-approval-icon" aria-hidden>
+        !
+      </span>
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div className="opr-eyebrow">Approve · {integration}</div>
+        <div style={{ fontWeight: 600, margin: "2px 0 1px" }}>{title}</div>
+        <div className="opr-step-detail">{detail}</div>
+        <div className="opr-approval-actions">
+          <button
+            type="button"
+            className="opr-btn opr-btn-primary opr-btn-sm"
+            onClick={onApprove}
+          >
+            <Check size={13} strokeWidth={1.9} aria-hidden />
+            Approve &amp; send
+          </button>
+          <button
+            type="button"
+            className="opr-btn opr-btn-sm"
+            onClick={onSkip}
+          >
+            <X size={13} strokeWidth={1.9} aria-hidden />
+            Skip
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/operator/components/CallModal.tsx
+++ b/web/src/operator/components/CallModal.tsx
@@ -1,0 +1,142 @@
+// The "magical call" — primary activation surface (mock).
+//
+// In the real product this is a screen-share + free-voice session where the
+// operator narrates their process while the AI watches and asks questions,
+// then drafts a deterministic tool. Here it is a presentational mock so the
+// shape of the hero moment can be seen and reacted to. Nothing is captured.
+
+import { useEffect, useRef, useState } from "react";
+import { ArrowRight, PhoneOff, SkipForward } from "lucide-react";
+
+interface CallLine {
+  who: "you" | "ai";
+  text: string;
+}
+
+const SCRIPT: CallLine[] = [
+  { who: "ai", text: "Walk me through how you handle a new demo request. I'm watching your screen." },
+  { who: "you", text: "So a request comes into this form. First I check the company in HubSpot..." },
+  { who: "ai", text: "What makes one worth sending to an AE versus nurturing?" },
+  { who: "you", text: "Size and industry, mostly. 200+ people in our core verticals, and they named a use case." },
+  { who: "ai", text: "And where does a hot one go from there?" },
+  { who: "you", text: "I post it in #ae-handoffs in Slack with the reason, and it gets assigned." },
+  { who: "ai", text: "Got it. I've drafted a tool: enrich from HubSpot, score fit 0 to 100, route 70 and up to an AE, nurture the rest. Want to see it?" },
+];
+
+interface CallModalProps {
+  onClose: () => void;
+  onBuild: () => void;
+}
+
+export function CallModal({ onClose, onBuild }: CallModalProps) {
+  const dialogRef = useRef<HTMLDivElement>(null);
+
+  // a11y: close on Escape, focus the dialog on open, restore focus on close,
+  // and keep Tab focus inside the dialog (a minimal focus trap).
+  useEffect(() => {
+    const prev = document.activeElement as HTMLElement | null;
+    dialogRef.current?.focus();
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        onClose();
+        return;
+      }
+      if (e.key !== "Tab") return;
+      const focusables = dialogRef.current?.querySelectorAll<HTMLElement>(
+        'button, [href], input, [tabindex]:not([tabindex="-1"])',
+      );
+      if (!focusables || focusables.length === 0) return;
+      const first = focusables[0];
+      const last = focusables[focusables.length - 1];
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    }
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("keydown", onKey);
+      prev?.focus();
+    };
+  }, [onClose]);
+
+  // Reveal the scripted exchange progressively so the call feels alive.
+  const [revealed, setRevealed] = useState(SCRIPT.length);
+  const lines = SCRIPT.slice(0, revealed);
+  const last = lines[lines.length - 1];
+  const done = last?.who === "ai" && revealed === SCRIPT.length;
+
+  return (
+    <div
+      className="opr-modal-scrim"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Build a tool on a call"
+      onClick={onClose}
+    >
+      <div
+        className="opr-call"
+        ref={dialogRef}
+        tabIndex={-1}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="opr-call-stage">
+          <div className="opr-call-rec">
+            <span className="opr-led" />
+            rec · screen share
+          </div>
+          <div className="opr-call-screenshare">
+            operator screen: inbound demo requests
+          </div>
+          <div className="opr-call-wave" aria-hidden>
+            ▁▂▃▅▇▅▃▂▁ ▁▂▃▅▇▅▃▂▁ ▁▂▃▅▇▅▃▂▁
+          </div>
+          <div className="opr-call-caption">
+            <b>{last?.who === "ai" ? "your ai" : "you"}</b> {last?.text}
+          </div>
+        </div>
+
+        <div className="opr-call-body">
+          <div className="opr-eyebrow">Live call · building with you</div>
+          <div className="opr-call-transcript">
+            {lines.map((l, i) => (
+              <div className="opr-call-line" key={i}>
+                <b>{l.who === "ai" ? "Your AI" : "You"}</b>
+                {l.text}
+              </div>
+            ))}
+          </div>
+
+          <div className="opr-detail-actions" style={{ justifyContent: "flex-end" }}>
+            {!done ? (
+              <button
+                type="button"
+                className="opr-btn opr-btn-sm"
+                onClick={() => setRevealed(SCRIPT.length)}
+              >
+                <SkipForward size={13} strokeWidth={1.9} aria-hidden />
+                Skip ahead
+              </button>
+            ) : null}
+            <button type="button" className="opr-btn" onClick={onClose}>
+              <PhoneOff size={14} strokeWidth={1.9} aria-hidden />
+              End call
+            </button>
+            <button
+              type="button"
+              className="opr-btn opr-btn-primary"
+              onClick={onBuild}
+              disabled={!done}
+            >
+              See the drafted tool
+              <ArrowRight size={14} strokeWidth={1.9} aria-hidden />
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/operator/components/EmptyState.tsx
+++ b/web/src/operator/components/EmptyState.tsx
@@ -1,0 +1,39 @@
+// Empty state — warmth + context + a primary action, never a dead-end line.
+// Presentational; the action is optional.
+
+interface EmptyStateProps {
+  glyph: string;
+  title: string;
+  hint: string;
+  actionLabel?: string;
+  onAction?: () => void;
+}
+
+export function EmptyState({
+  glyph,
+  title,
+  hint,
+  actionLabel,
+  onAction,
+}: EmptyStateProps) {
+  return (
+    <div className="opr-empty">
+      <span className="opr-empty-glyph" aria-hidden>
+        {glyph}
+      </span>
+      <div className="opr-empty-title">{title}</div>
+      <div className="opr-empty-hint">{hint}</div>
+      {actionLabel ? (
+        <div className="opr-empty-actions">
+          <button
+            type="button"
+            className="opr-btn opr-btn-primary opr-btn-sm"
+            onClick={onAction}
+          >
+            {actionLabel}
+          </button>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/web/src/operator/components/primitives.tsx
+++ b/web/src/operator/components/primitives.tsx
@@ -1,0 +1,171 @@
+// Shared visual primitives for the operator shell. Token-driven, presentational
+// only — no data fetching. See operator-shell.css for the matching styles.
+
+import type { ReactNode } from "react";
+
+import type {
+  IntegrationStatus,
+  RequestStatus,
+  ToolStatus,
+} from "../mock/data";
+
+export function Eyebrow({ children }: { children: ReactNode }) {
+  return <div className="opr-eyebrow">{children}</div>;
+}
+
+// Two-letter monospace sigil derived from a name — the terminal-aesthetic
+// stand-in for an icon/emoji (e.g. "Inbound demo-request routing" → "ID").
+export function sigil(name: string): string {
+  const words = name
+    .replace(/[^a-zA-Z ]/g, " ")
+    .split(/\s+/)
+    .filter(Boolean);
+  if (words.length === 0) return "··";
+  if (words.length === 1) return words[0].slice(0, 2).toUpperCase();
+  return (words[0][0] + words[1][0]).toUpperCase();
+}
+
+// ── Fit score chip (the hero signal) ────────────────────────────────────
+
+function scoreTier(score: number): "hot" | "mid" | "low" {
+  if (score >= 70) return "hot";
+  if (score >= 50) return "mid";
+  return "low";
+}
+
+export function ScorePill({ score }: { score: number | null }) {
+  if (score === null) {
+    return <span className="opr-score opr-score-low">n/a</span>;
+  }
+  return (
+    <span className={`opr-score opr-score-${scoreTier(score)}`}>{score}</span>
+  );
+}
+
+// ── Request status pill ─────────────────────────────────────────────────
+
+const REQUEST_STATUS: Record<
+  RequestStatus,
+  { label: string; tone: string }
+> = {
+  new: { label: "New", tone: "opr-pill-muted" },
+  scored: { label: "Scored", tone: "opr-pill-info" },
+  routed: { label: "Routed", tone: "opr-pill-good" },
+  nurturing: { label: "Nurturing", tone: "opr-pill-muted" },
+  "needs-you": { label: "Needs you", tone: "opr-pill-warn" },
+};
+
+export function RequestStatusPill({ status }: { status: RequestStatus }) {
+  const s = REQUEST_STATUS[status];
+  return <span className={`opr-pill ${s.tone}`}>{s.label}</span>;
+}
+
+// ── Tool status (LED + label) ───────────────────────────────────────────
+
+const TOOL_STATUS: Record<
+  ToolStatus,
+  { label: string; led: string }
+> = {
+  enabled: { label: "Enabled", led: "opr-led-live" },
+  disabled: { label: "Disabled", led: "opr-led-draft" },
+  draft: { label: "Draft", led: "opr-led-draft" },
+  suggested: { label: "Suggested", led: "opr-led-suggested" },
+};
+
+export function ToolStatusBadge({ status }: { status: ToolStatus }) {
+  const s = TOOL_STATUS[status];
+  return (
+    <span className="opr-pill opr-pill-muted">
+      <span className={`opr-led ${s.led}`} />
+      {s.label}
+    </span>
+  );
+}
+
+// ── Integration status pill ─────────────────────────────────────────────
+
+const INT_STATUS: Record<
+  IntegrationStatus,
+  { label: string; tone: string }
+> = {
+  connected: { label: "Connected", tone: "opr-pill-good" },
+  available: { label: "Available", tone: "opr-pill-muted" },
+  "needs-attention": { label: "Needs attention", tone: "opr-pill-warn" },
+};
+
+export function IntegrationStatusPill({
+  status,
+}: {
+  status: IntegrationStatus;
+}) {
+  const s = INT_STATUS[status];
+  return <span className={`opr-pill ${s.tone}`}>{s.label}</span>;
+}
+
+// ── Tabs ────────────────────────────────────────────────────────────────
+
+export interface TabDef<T extends string> {
+  id: T;
+  label: string;
+}
+
+interface TabsProps<T extends string> {
+  tabs: readonly TabDef<T>[];
+  active: T;
+  onSelect: (id: T) => void;
+  hint?: string;
+}
+
+export function Tabs<T extends string>({
+  tabs,
+  active,
+  onSelect,
+  hint,
+}: TabsProps<T>) {
+  return (
+    <div className="opr-tabs" role="tablist">
+      {tabs.map((t) => (
+        <button
+          key={t.id}
+          type="button"
+          role="tab"
+          id={`opr-tab-${t.id}`}
+          aria-controls={`opr-panel-${t.id}`}
+          aria-selected={t.id === active}
+          className={`opr-tab${t.id === active ? " is-active" : ""}`}
+          onClick={() => onSelect(t.id)}
+        >
+          {t.label}
+        </button>
+      ))}
+      {hint ? <span className="opr-tab-hint">{hint}</span> : null}
+    </div>
+  );
+}
+
+// ── Surface header ──────────────────────────────────────────────────────
+
+interface SurfaceHeaderProps {
+  eyebrow: string;
+  title: string;
+  lede?: string;
+  actions?: ReactNode;
+}
+
+export function SurfaceHeader({
+  eyebrow,
+  title,
+  lede,
+  actions,
+}: SurfaceHeaderProps) {
+  return (
+    <div className="opr-surface-head">
+      <div>
+        <Eyebrow>{eyebrow}</Eyebrow>
+        <h1 className="opr-surface-title">{title}</h1>
+        {lede ? <p className="opr-surface-lede">{lede}</p> : null}
+      </div>
+      {actions ? <div className="opr-detail-actions">{actions}</div> : null}
+    </div>
+  );
+}

--- a/web/src/operator/mock/data.ts
+++ b/web/src/operator/mock/data.ts
@@ -1,0 +1,754 @@
+// Mock data for the operator-MLP frontend prototype.
+//
+// FRONTEND-FIRST RULE: this slice ships the operator shell with mock data only,
+// so the product shape can be seen and clicked before any backend exists. None
+// of this is wired to the broker. Everything here is a fixture centered on the
+// "Maya, RevOps — inbound demo-request routing" acceptance scenario from
+// docs/specs/operator-mlp-plan.md. When the shape is validated, real data
+// models replace these fixtures.
+
+export type ToolStatus = "enabled" | "disabled" | "draft" | "suggested";
+
+export type RequestStatus =
+  | "new"
+  | "scored"
+  | "routed"
+  | "nurturing"
+  | "needs-you";
+
+export interface InboundRequest {
+  id: string;
+  company: string;
+  contact: string;
+  email: string;
+  source: string;
+  receivedAt: string; // human label, e.g. "9:02am"
+  fitScore: number | null; // 0-100, null = not yet scored
+  status: RequestStatus;
+  reason: string; // AI rationale for the score / routing
+  routedTo?: string; // AE name when routed
+}
+
+export type WorkflowStepKind =
+  | "trigger"
+  | "enrich"
+  | "ai"
+  | "decision"
+  | "action"
+  | "branch";
+
+export interface WorkflowStep {
+  id: string;
+  kind: WorkflowStepKind;
+  title: string;
+  detail: string;
+  integration?: string; // e.g. "HubSpot", "Slack"
+  gated?: boolean; // external mutation → human approval card
+}
+
+export interface WorkflowRun {
+  id: string;
+  ranAt: string;
+  trigger: string;
+  outcome: "routed" | "nurtured" | "needs-you";
+  durationMs: number;
+  summary: string;
+}
+
+export interface ToolVersion {
+  version: number;
+  label: string;
+  at: string;
+  author: "you" | "your AI";
+  note: string;
+}
+
+export interface DataColumn {
+  key: string;
+  label: string;
+  type: "text" | "email" | "number" | "status" | "date";
+}
+
+export interface InternalTool {
+  id: string;
+  name: string;
+  emoji: string;
+  status: ToolStatus;
+  summary: string;
+  version: number;
+  lastRun: string;
+  runsToday: number;
+  builtFrom: "call" | "chat" | "detected";
+  steps: WorkflowStep[];
+  runs: WorkflowRun[];
+  versions: ToolVersion[];
+  dataColumns: DataColumn[];
+}
+
+// ── The hero tool: Maya's inbound-routing internal tool ─────────────────
+
+export const INBOUND_REQUESTS: InboundRequest[] = [
+  {
+    id: "req-1",
+    company: "Acme Robotics",
+    contact: "Dana Whitfield",
+    email: "dana@acmerobotics.com",
+    source: "Demo form",
+    receivedAt: "9:02am",
+    fitScore: 92,
+    status: "routed",
+    reason: "500+ employees, manufacturing, asked about API access. Strong ICP fit.",
+    routedTo: "Priya (AE)",
+  },
+  {
+    id: "req-2",
+    company: "Northwind Health",
+    contact: "Sam Ortega",
+    email: "s.ortega@northwindhealth.org",
+    source: "Demo form",
+    receivedAt: "9:14am",
+    fitScore: 88,
+    status: "routed",
+    reason: "Mid-market healthcare, named budget, timeline this quarter.",
+    routedTo: "Marco (AE)",
+  },
+  {
+    id: "req-3",
+    company: "Bright Tutors",
+    contact: "Lena Park",
+    email: "lena@brighttutors.co",
+    source: "Pricing page",
+    receivedAt: "9:31am",
+    fitScore: 41,
+    status: "nurturing",
+    reason: "Solo founder, 2 employees. Below size threshold, added to nurture.",
+  },
+  {
+    id: "req-4",
+    company: "Vela Logistics",
+    contact: "Owen Drake",
+    email: "owen@velalogistics.com",
+    source: "Demo form",
+    receivedAt: "9:48am",
+    fitScore: 76,
+    status: "scored",
+    reason: "Good fit but no company match in CRM, confirm before routing.",
+  },
+  {
+    id: "req-5",
+    company: "(unknown)",
+    contact: "h.tanaka",
+    email: "h.tanaka@gmail.com",
+    source: "Demo form",
+    receivedAt: "10:05am",
+    fitScore: null,
+    status: "needs-you",
+    reason: "Free email, no company in CRM. Could not score — needs your call.",
+  },
+  {
+    id: "req-6",
+    company: "Cobalt Finance",
+    contact: "Reese Aldridge",
+    email: "reese@cobaltfinance.com",
+    source: "Demo form",
+    receivedAt: "10:22am",
+    fitScore: 84,
+    status: "scored",
+    reason: "Fintech, 300 employees, compliance use case. Routing on next run.",
+  },
+];
+
+const INBOUND_TOOL: InternalTool = {
+  id: "inbound-routing",
+  name: "Inbound demo-request routing",
+  emoji: "🎯",
+  status: "enabled",
+  summary:
+    "Scores every inbound demo request for fit, routes hot ones to an AE in Slack, nurtures the rest, and flags anything it cannot place.",
+  version: 4,
+  lastRun: "10:22am today",
+  runsToday: 14,
+  builtFrom: "call",
+  steps: [
+    {
+      id: "s1",
+      kind: "trigger",
+      title: "New inbound request",
+      detail: "When a demo form is submitted (or fire manually on test data).",
+    },
+    {
+      id: "s2",
+      kind: "enrich",
+      title: "Look up the company",
+      detail: "Find the account + firmographics for the request's domain.",
+      integration: "HubSpot",
+    },
+    {
+      id: "s3",
+      kind: "ai",
+      title: "Score fit 0 to 100",
+      detail:
+        "Rate fit from company size, industry, and what they asked for. Explain the score.",
+    },
+    {
+      id: "s4",
+      kind: "decision",
+      title: "Is the score at least 70?",
+      detail: "Hot leads route to an AE; everything else goes to nurture.",
+    },
+    {
+      id: "s5",
+      kind: "action",
+      title: "Route to the on-call AE",
+      detail: "Post the lead + score + reason to #ae-handoffs and assign an AE.",
+      integration: "Slack",
+      gated: true,
+    },
+    {
+      id: "s6",
+      kind: "branch",
+      title: "Otherwise: add to nurture",
+      detail: "Tag the contact for the nurture sequence; no AE handoff.",
+      integration: "HubSpot",
+    },
+  ],
+  runs: [
+    {
+      id: "run-1",
+      ranAt: "10:22am",
+      trigger: "Cobalt Finance — demo form",
+      outcome: "routed",
+      durationMs: 2400,
+      summary: "Scored 84, routed to Priya (AE).",
+    },
+    {
+      id: "run-2",
+      ranAt: "10:05am",
+      trigger: "h.tanaka@gmail.com — demo form",
+      outcome: "needs-you",
+      durationMs: 1900,
+      summary: "No company match in CRM, flagged for you.",
+    },
+    {
+      id: "run-3",
+      ranAt: "9:48am",
+      trigger: "Vela Logistics — demo form",
+      outcome: "routed",
+      durationMs: 2600,
+      summary: "Scored 76, routed to Marco (AE).",
+    },
+    {
+      id: "run-4",
+      ranAt: "9:31am",
+      trigger: "Bright Tutors — pricing page",
+      outcome: "nurtured",
+      durationMs: 1700,
+      summary: "Scored 41, below threshold, added to nurture.",
+    },
+  ],
+  versions: [
+    {
+      version: 4,
+      label: "Threshold lowered to 70",
+      at: "Yesterday, 4:12pm",
+      author: "you",
+      note: '"Lower the threshold to 70. We were missing good mid-market leads."',
+    },
+    {
+      version: 3,
+      label: "Added the CRM-miss flag",
+      at: "Yesterday, 11:40am",
+      author: "your AI",
+      note: "Now flags requests with no company match instead of guessing.",
+    },
+    {
+      version: 2,
+      label: "Route reason included in Slack",
+      at: "2 days ago",
+      author: "you",
+      note: '"Put the why in the Slack message so the AE has context."',
+    },
+    {
+      version: 1,
+      label: "Built on a call",
+      at: "2 days ago",
+      author: "your AI",
+      note: "Captured from your screen-share walkthrough of inbound triage.",
+    },
+  ],
+  dataColumns: [
+    { key: "company", label: "Company", type: "text" },
+    { key: "contact", label: "Contact", type: "text" },
+    { key: "email", label: "Email", type: "email" },
+    { key: "source", label: "Source", type: "text" },
+    { key: "fitScore", label: "Fit score", type: "number" },
+    { key: "status", label: "Status", type: "status" },
+    { key: "receivedAt", label: "Received", type: "date" },
+  ],
+};
+
+const ESCALATION_TOOL: InternalTool = {
+  id: "support-escalations",
+  name: "Support escalation triage",
+  emoji: "🛟",
+  status: "draft",
+  summary:
+    "Reads incoming support escalations, tags severity, and drafts the routing to the right on-call engineer. Built from chat, not yet published.",
+  version: 1,
+  lastRun: "not run yet",
+  runsToday: 0,
+  builtFrom: "chat",
+  steps: [
+    {
+      id: "e1",
+      kind: "trigger",
+      title: "New escalation",
+      detail: "When a ticket is tagged 'escalation' in the help desk.",
+    },
+    {
+      id: "e2",
+      kind: "ai",
+      title: "Classify severity",
+      detail: "Rate sev 1 to 3 from the ticket text and account tier.",
+    },
+    {
+      id: "e3",
+      kind: "action",
+      title: "Page the on-call engineer",
+      detail: "Sev 1 pages the on-call engineer; sev 2 and 3 go to the queue.",
+      integration: "Slack",
+      gated: true,
+    },
+  ],
+  runs: [],
+  versions: [
+    {
+      version: 1,
+      label: "Drafted from chat",
+      at: "1 hour ago",
+      author: "your AI",
+      note: "Draft. Run it on test data before publishing.",
+    },
+  ],
+  dataColumns: [
+    { key: "ticket", label: "Ticket", type: "text" },
+    { key: "account", label: "Account", type: "text" },
+    { key: "severity", label: "Severity", type: "number" },
+    { key: "status", label: "Status", type: "status" },
+  ],
+};
+
+const EXPENSE_TOOL: InternalTool = {
+  id: "expense-exceptions",
+  name: "Expense exception routing",
+  emoji: "🧾",
+  status: "suggested",
+  summary:
+    "Your AI noticed you approve the same expense exceptions every Friday. Want a tool that pre-sorts them and routes only the edge cases to you?",
+  version: 0,
+  lastRun: "not run yet",
+  runsToday: 0,
+  builtFrom: "detected",
+  steps: [
+    {
+      id: "x1",
+      kind: "trigger",
+      title: "New expense over policy",
+      detail: "When an expense exceeds the category limit.",
+    },
+    {
+      id: "x2",
+      kind: "ai",
+      title: "Check against policy",
+      detail: "Auto-approve within tolerance; route the rest to you.",
+    },
+  ],
+  runs: [],
+  versions: [],
+  dataColumns: [
+    { key: "employee", label: "Employee", type: "text" },
+    { key: "amount", label: "Amount", type: "number" },
+    { key: "status", label: "Status", type: "status" },
+  ],
+};
+
+export const TOOLS: InternalTool[] = [
+  INBOUND_TOOL,
+  ESCALATION_TOOL,
+  EXPENSE_TOOL,
+];
+
+export function getTool(id: string): InternalTool | undefined {
+  return TOOLS.find((t) => t.id === id);
+}
+
+// ── Chats ───────────────────────────────────────────────────────────────
+
+export interface ChatMessage {
+  id: string;
+  from: "you" | "ai";
+  body: string;
+  at: string;
+}
+
+export interface ChatThread {
+  id: string;
+  title: string;
+  subtitle: string;
+  updatedAt: string;
+  unread?: boolean;
+  messages: ChatMessage[];
+}
+
+export const CHATS: ChatThread[] = [
+  {
+    id: "chat-inbound",
+    title: "Inbound routing",
+    subtitle: "Tuning the fit threshold",
+    updatedAt: "10:24am",
+    unread: true,
+    messages: [
+      {
+        id: "m1",
+        from: "ai",
+        body: "Morning digest: 14 requests processed, 5 routed hot, 1 needs you. I couldn't find “h.tanaka@gmail.com” in the CRM.",
+        at: "9:00am",
+      },
+      {
+        id: "m2",
+        from: "you",
+        body: "For free-email signups with no company, just nurture them instead of flagging me.",
+        at: "10:20am",
+      },
+      {
+        id: "m3",
+        from: "ai",
+        body: "Got it. I'll add a rule: no company match + free email goes to nurture, no flag. That's a small change. Want me to apply it and bump the tool to v5?",
+        at: "10:21am",
+      },
+      {
+        id: "m4",
+        from: "you",
+        body: "Yes, do it.",
+        at: "10:24am",
+      },
+    ],
+  },
+  {
+    id: "chat-escalations",
+    title: "Support escalations",
+    subtitle: "Building the triage tool",
+    updatedAt: "1 hour ago",
+    messages: [
+      {
+        id: "m5",
+        from: "you",
+        body: "I want to auto-triage support escalations by severity and page the on-call engineer for sev 1s.",
+        at: "11:02am",
+      },
+      {
+        id: "m6",
+        from: "ai",
+        body: "I drafted “Support escalation triage”: trigger on escalation tag, classify sev 1 to 3, page on sev 1. It's a draft, so run it on a few real tickets before we publish. Open it?",
+        at: "11:03am",
+      },
+    ],
+  },
+];
+
+export function getChat(id: string): ChatThread | undefined {
+  return CHATS.find((c) => c.id === id);
+}
+
+// ── Integrations ────────────────────────────────────────────────────────
+
+export type IntegrationStatus = "connected" | "available" | "needs-attention";
+
+export interface Integration {
+  id: string;
+  name: string;
+  emoji: string;
+  category: string;
+  status: IntegrationStatus;
+  detail: string;
+}
+
+export const INTEGRATIONS: Integration[] = [
+  {
+    id: "hubspot",
+    name: "HubSpot",
+    emoji: "🟠",
+    category: "CRM",
+    status: "connected",
+    detail: "Reading accounts & contacts. Used by Inbound routing.",
+  },
+  {
+    id: "slack",
+    name: "Slack",
+    emoji: "💬",
+    category: "Messaging",
+    status: "connected",
+    detail: "Posting AE handoffs to #ae-handoffs. Used by Inbound routing.",
+  },
+  {
+    id: "gmail",
+    name: "Gmail",
+    emoji: "✉️",
+    category: "Email",
+    status: "connected",
+    detail: "Sending your daily digest.",
+  },
+  {
+    id: "salesforce",
+    name: "Salesforce",
+    emoji: "☁️",
+    category: "CRM",
+    status: "available",
+    detail: "Connect to route from Salesforce leads instead of HubSpot.",
+  },
+  {
+    id: "zendesk",
+    name: "Zendesk",
+    emoji: "🎫",
+    category: "Support",
+    status: "available",
+    detail: "Connect to power the support-escalation tool.",
+  },
+  {
+    id: "stripe",
+    name: "Stripe",
+    emoji: "💳",
+    category: "Finance",
+    status: "needs-attention",
+    detail: "Token expired. Reconnect to keep expense routing working.",
+  },
+];
+
+// ── Knowledge (gbrain-backed, wikipedia-style reader) ────────────────────
+
+// Wikipedia-style: every claim that came from somewhere in the company brain
+// carries a citation. `[[n]]` markers in prose resolve to the references list.
+export type KnowledgeSourceKind =
+  | "chat"
+  | "document"
+  | "crm"
+  | "decision"
+  | "roster";
+
+export interface KnowledgeRef {
+  n: number;
+  title: string; // the source in the brain
+  detail: string; // where / when
+  kind: KnowledgeSourceKind; // what kind of source this is
+  snippet: string; // the actual excerpt the fact was drawn from
+  why: string; // why the brain chose this source for the fact
+}
+
+export interface KnowledgeSection {
+  heading?: string;
+  paras: string[]; // may contain [[n]] citation markers
+}
+
+export interface KnowledgePage {
+  id: string;
+  title: string;
+  category: string;
+  updatedAt: string;
+  summary: string;
+  infobox: { label: string; value: string }[];
+  lead: string; // intro paragraph, may contain [[n]]
+  sections: KnowledgeSection[];
+  references: KnowledgeRef[];
+  categories: string[];
+  seeAlso: string[]; // page ids
+}
+
+export const KNOWLEDGE: KnowledgePage[] = [
+  {
+    id: "icp",
+    title: "Ideal customer profile",
+    category: "Sales",
+    updatedAt: "Last edited yesterday by your AI",
+    summary:
+      "The company most likely to buy: mid-market and up, in a core industry, with a named use case.",
+    infobox: [
+      { label: "Size floor", value: "200 employees" },
+      { label: "Core industries", value: "Manufacturing, Healthcare, Fintech, Logistics" },
+      { label: "Fit threshold", value: "70 / 100" },
+      { label: "Owner", value: "Maya (RevOps)" },
+    ],
+    lead:
+      "The ideal customer profile (ICP) is the shape of company most likely to become a customer. It is the basis on which the inbound-routing tool scores every demo request and decides whether to route it to an account executive.[[1]]",
+    sections: [
+      {
+        heading: "Definition",
+        paras: [
+          "An ideal customer is a company of 200 or more employees in manufacturing, healthcare, fintech, or logistics, evaluating the product for a named, time-bound use case.[[1]] The size floor was raised from 50 to 200 after mid-market deals closed at roughly three times the rate of small business.[[2]]",
+        ],
+      },
+      {
+        heading: "Signals",
+        paras: [
+          "Strong signals include API or integration questions, a stated budget, a buying timeline within the quarter, and a work email on a company domain.[[3]]",
+          "Weak signals include solo founders, free email addresses, fewer than 10 employees, or “just looking” with no use case. These are nurtured rather than routed to an account executive.[[3]]",
+        ],
+      },
+      {
+        heading: "Use in routing",
+        paras: [
+          "The inbound-routing tool encodes this profile as a 0 to 100 fit score; anything at or above 70 routes to an account executive.[[4]] The threshold was lowered from 80 to 70 in June 2026 to catch good mid-market leads that were being missed.[[2]]",
+        ],
+      },
+    ],
+    references: [
+      {
+        n: 1,
+        title: "RevOps onboarding deck",
+        detail: "slide 4, “Who we sell to”",
+        kind: "document",
+        snippet:
+          "Who we sell to: mid-market and up (200+ employees), in manufacturing, healthcare, fintech, or logistics, with a named, time-bound use case.",
+        why: "This slide is RevOps' own canonical statement of the target buyer, so the brain treats it as the authoritative definition of the ICP rather than inferring one.",
+      },
+      {
+        n: 2,
+        title: "Chat with Maya · fit threshold",
+        detail: "2026-06-26, in #inbound-routing",
+        kind: "chat",
+        snippet:
+          "Maya: Lower the threshold to 70. We were missing good mid-market leads. — You: Yes, do it.",
+        why: "You decided this directly in chat while tuning the tool, and confirmed it. The brain chose this message over the older deck because it is more recent, came from the tool's owner, and was acted on (the tool moved to v4).",
+      },
+      {
+        n: 3,
+        title: "Won/lost analysis Q1 to Q2 2026",
+        detail: "HubSpot export, processed in brain",
+        kind: "crm",
+        snippet:
+          "Close rate by size: 200–2000 employees closed at 31%, sub-50 at 11%, over Q1–Q2 2026 (n=412 opportunities).",
+        why: "This export quantifies the close-rate gap that justified raising the size floor, so it is the evidence behind the “roughly three times” claim about mid-market.",
+      },
+      {
+        n: 4,
+        title: "Inbound demo-request routing",
+        detail: "tool spec, step “Score fit 0 to 100”",
+        kind: "document",
+        snippet:
+          "Step “Score fit 0–100”: rate fit from company size, industry, and the stated use case, then explain the score.",
+        why: "The routing tool's own spec is where the 0–100 fit score is defined, so it is the source for how the ICP gets applied at runtime.",
+      },
+    ],
+    categories: ["Sales", "Routing", "Definitions"],
+    seeAlso: ["routing-policy", "nurture"],
+  },
+  {
+    id: "routing-policy",
+    title: "AE routing policy",
+    category: "Sales",
+    updatedAt: "Last edited 2 days ago by Maya",
+    summary: "How hot leads are assigned to account executives.",
+    infobox: [
+      { label: "Channel", value: "#ae-handoffs (Slack)" },
+      { label: "Assignment", value: "Round-robin, on-call list" },
+    ],
+    lead:
+      "The routing policy governs how a request that clears the fit threshold reaches a specific account executive.[[1]]",
+    sections: [
+      {
+        heading: "Handoff",
+        paras: [
+          "Hot leads (fit score at or above 70) are posted to #ae-handoffs in Slack with the company, contact, score, and the reason for the score.[[1]] Account executives are assigned round-robin from the on-call list, skipping anyone marked out of office.[[2]]",
+        ],
+      },
+      {
+        heading: "Edge cases",
+        paras: [
+          "If no company can be matched in the CRM, the request is flagged for a human rather than routed, to avoid sending an account executive a dead end.[[1]]",
+        ],
+      },
+    ],
+    references: [
+      {
+        n: 1,
+        title: "Inbound demo-request routing",
+        detail: "tool spec, step “Route to the on-call AE”",
+        kind: "document",
+        snippet:
+          "Step “Route to the on-call AE”: post the lead, score, and reason to #ae-handoffs and assign an AE.",
+        why: "The handoff behavior is defined in the tool spec itself, so it is the source of record for how a hot lead reaches an account executive.",
+      },
+      {
+        n: 2,
+        title: "On-call roster",
+        detail: "Slack user group @ae-oncall",
+        kind: "roster",
+        snippet: "@ae-oncall: Priya, Marco, Dana — rotates weekly, OOO members skipped.",
+        why: "Assignments pull live from this Slack group, so it is the source for who is currently on call and eligible for a handoff.",
+      },
+    ],
+    categories: ["Sales", "Routing"],
+    seeAlso: ["icp"],
+  },
+  {
+    id: "nurture",
+    title: "Nurture sequence",
+    category: "Marketing",
+    updatedAt: "Last edited last week by your AI",
+    summary: "What happens to leads that are not yet a fit.",
+    infobox: [
+      { label: "Tool", value: "HubSpot workflow" },
+      { label: "Re-entry", value: "On firmographic change" },
+    ],
+    lead:
+      "The nurture sequence holds leads that do not yet clear the fit threshold and keeps them warm until they might.[[1]]",
+    sections: [
+      {
+        heading: "Behavior",
+        paras: [
+          "Leads below the fit threshold are tagged for the nurture sequence in HubSpot and receive the standard onboarding-education emails.[[1]] A lead can re-enter routing if its firmographics change, for example if the company grows past the size floor.[[2]]",
+        ],
+      },
+    ],
+    references: [
+      {
+        n: 1,
+        title: "Nurture workflow",
+        detail: "HubSpot, “Inbound nurture v3”",
+        kind: "document",
+        snippet:
+          "Inbound nurture v3: education sequence on a 5-touch cadence, re-entry on firmographic change.",
+        why: "The nurture behavior lives in this HubSpot workflow, so it is the source for what actually happens to a below-threshold lead.",
+      },
+      {
+        n: 2,
+        title: "Ideal customer profile",
+        detail: "this wiki, “Use in routing”",
+        kind: "document",
+        snippet:
+          "A lead can re-enter routing if its firmographics change, for example if the company grows past the size floor.",
+        why: "This re-entry rule is defined on the ICP page, so the nurture page cites that page instead of restating the rule and risking drift.",
+      },
+    ],
+    categories: ["Marketing", "Routing"],
+    seeAlso: ["icp"],
+  },
+];
+
+export function getKnowledgePage(id: string): KnowledgePage | undefined {
+  return KNOWLEDGE.find((k) => k.id === id);
+}
+
+// ── The morning digest (what lands in Slack/email) ───────────────────────
+
+export interface DigestItem {
+  label: string;
+  value: string;
+  tone: "neutral" | "good" | "warn";
+}
+
+export const TODAY_DIGEST: DigestItem[] = [
+  { label: "processed", value: "14", tone: "neutral" },
+  { label: "routed", value: "5", tone: "good" },
+  { label: "nurtured", value: "8", tone: "neutral" },
+  { label: "needs you", value: "1", tone: "warn" },
+];

--- a/web/src/operator/surfaces/ChatsSurface.tsx
+++ b/web/src/operator/surfaces/ChatsSurface.tsx
@@ -1,0 +1,136 @@
+// Chats — talk to your AI to build and tune tools. Post-call iteration lives
+// here; the call itself is the primary way to start. Mock data; the composer
+// appends locally so the surface is clickable.
+
+import { useMemo, useState } from "react";
+import { PhoneCall, Plus, Send } from "lucide-react";
+
+import { Eyebrow } from "../components/primitives";
+import { type ChatMessage, CHATS } from "../mock/data";
+
+interface ChatsSurfaceProps {
+  onStartCall: () => void;
+  onBuild: () => void;
+}
+
+export function ChatsSurface({ onStartCall, onBuild }: ChatsSurfaceProps) {
+  const [activeId, setActiveId] = useState(CHATS[0]?.id ?? "");
+  const [draft, setDraft] = useState("");
+  const [extra, setExtra] = useState<Record<string, ChatMessage[]>>({});
+
+  const active = useMemo(
+    () => CHATS.find((c) => c.id === activeId),
+    [activeId],
+  );
+  const messages = useMemo(
+    () => [...(active?.messages ?? []), ...(extra[activeId] ?? [])],
+    [active, extra, activeId],
+  );
+
+  function send() {
+    const text = draft.trim();
+    if (!text) return;
+    setExtra((prev) => ({
+      ...prev,
+      [activeId]: [
+        ...(prev[activeId] ?? []),
+        { id: `local-${Date.now()}`, from: "you", body: text, at: "now" },
+      ],
+    }));
+    setDraft("");
+  }
+
+  return (
+    <div className="opr-chat-layout">
+      <div className="opr-chat-list">
+        <button
+          type="button"
+          className="opr-btn opr-btn-primary opr-build-cta"
+          onClick={onBuild}
+          style={{ marginBottom: "var(--space-2)" }}
+        >
+          <Plus size={14} strokeWidth={1.9} aria-hidden />
+          Describe a new tool
+        </button>
+        <button
+          type="button"
+          className="opr-call-cta opr-call-cta-secondary"
+          onClick={onStartCall}
+          style={{ marginBottom: "var(--space-3)" }}
+        >
+          <PhoneCall size={14} strokeWidth={1.9} aria-hidden />
+          Teach your workflow to Nex
+        </button>
+        <Eyebrow>Conversations</Eyebrow>
+        <div style={{ marginTop: "var(--space-2)" }}>
+          {CHATS.map((c) => (
+            <button
+              key={c.id}
+              type="button"
+              className={`opr-chat-listitem${
+                c.id === activeId ? " is-active" : ""
+              }`}
+              onClick={() => setActiveId(c.id)}
+            >
+              <div className="opr-chat-listitem-title">
+                {c.title}
+                {c.unread ? (
+                  <span
+                    className="opr-led opr-led-suggested"
+                    style={{ width: 6, height: 6 }}
+                  />
+                ) : null}
+              </div>
+              <div className="opr-chat-listitem-sub">{c.subtitle}</div>
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="opr-chat-main">
+        <div className="opr-banner">{active?.title ?? "Conversation"}</div>
+        <div className="opr-chat-scroll">
+          {messages.map((m) => (
+            <div key={m.id} style={{ display: "contents" }}>
+              <div
+                className={`opr-msg ${
+                  m.from === "ai" ? "opr-msg-ai" : "opr-msg-you"
+                }`}
+              >
+                {m.body}
+              </div>
+              <div
+                className="opr-msg-meta"
+                style={{
+                  alignSelf: m.from === "you" ? "flex-end" : "flex-start",
+                }}
+              >
+                {m.at}
+              </div>
+            </div>
+          ))}
+        </div>
+        <div className="opr-composer">
+          <input
+            className="opr-composer-input"
+            aria-label="Message your AI"
+            placeholder="Ask your AI to change a tool, or describe a new one..."
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") send();
+            }}
+          />
+          <button
+            type="button"
+            className="opr-btn opr-btn-primary"
+            onClick={send}
+          >
+            <Send size={14} strokeWidth={1.9} aria-hidden />
+            Send
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/operator/surfaces/IntegrationsSurface.tsx
+++ b/web/src/operator/surfaces/IntegrationsSurface.tsx
@@ -1,0 +1,75 @@
+// Integrations — the apps a tool can read from and act on. Capture discovers
+// which apps the operator uses; Composio is the preferred way to connect them.
+// Mock data only.
+
+import {
+  Eyebrow,
+  IntegrationStatusPill,
+  sigil,
+  SurfaceHeader,
+} from "../components/primitives";
+import { INTEGRATIONS, type Integration } from "../mock/data";
+
+export function IntegrationsSurface() {
+  const connected = INTEGRATIONS.filter((i) => i.status === "connected");
+  const rest = INTEGRATIONS.filter((i) => i.status !== "connected");
+
+  return (
+    <div className="opr-surface-wide">
+      <SurfaceHeader
+        eyebrow="Integrations"
+        title="Connected apps"
+        lede="Your tools read from and act on these. When a tool needs an app you haven't connected, your AI asks you to connect it here."
+      />
+
+      <div className="opr-section-label">
+        <Eyebrow>Connected</Eyebrow>
+        <div className="opr-section-rule" />
+      </div>
+      <div className="opr-int-grid">
+        {connected.map((i) => (
+          <IntegrationCard key={i.id} integration={i} />
+        ))}
+      </div>
+
+      <div className="opr-section-label">
+        <Eyebrow>Available</Eyebrow>
+        <div className="opr-section-rule" />
+      </div>
+      <div className="opr-int-grid">
+        {rest.map((i) => (
+          <IntegrationCard key={i.id} integration={i} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function IntegrationCard({ integration }: { integration: Integration }) {
+  const connected = integration.status === "connected";
+  const needsAttn = integration.status === "needs-attention";
+  return (
+    <div className="opr-int-card">
+      <span className="opr-int-emoji" aria-hidden>
+        {sigil(integration.name)}
+      </span>
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+          <span style={{ fontWeight: 600 }}>{integration.name}</span>
+          <IntegrationStatusPill status={integration.status} />
+        </div>
+        <div className="opr-cell-sub" style={{ marginTop: 2 }}>
+          {integration.detail}
+        </div>
+      </div>
+      {connected ? null : (
+        <button
+          type="button"
+          className={`opr-btn opr-btn-sm${needsAttn ? " opr-btn-primary" : ""}`}
+        >
+          {needsAttn ? "Reconnect" : "Connect"}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/web/src/operator/surfaces/InternalToolDetail.tsx
+++ b/web/src/operator/surfaces/InternalToolDetail.tsx
@@ -1,0 +1,488 @@
+// Internal Tool detail — the core object. Three tabs:
+//   UI       — the built mini-app the operator runs (a live request table)
+//   Workflow — the deterministic spec + run history + version history
+//   Data     — the operator-owned typed tables behind the tool
+//
+// Mock data only. The UI tab demonstrates the human approval gate (CQ1) when
+// routing a hot lead to an external system.
+
+import { useState } from "react";
+import {
+  ArrowLeft,
+  ArrowRight,
+  CheckCircle2,
+  Pencil,
+  Play,
+  Plus,
+  Power,
+  Send,
+} from "lucide-react";
+
+import { ApprovalCard } from "../components/ApprovalCard";
+import { EmptyState } from "../components/EmptyState";
+import { ToolEditChat } from "./ToolEditChat";
+import {
+  Eyebrow,
+  RequestStatusPill,
+  ScorePill,
+  sigil,
+  Tabs,
+  ToolStatusBadge,
+  type TabDef,
+} from "../components/primitives";
+import {
+  INBOUND_REQUESTS,
+  type InboundRequest,
+  type InternalTool,
+  TODAY_DIGEST,
+  type WorkflowStep,
+} from "../mock/data";
+
+type ToolTab = "ui" | "workflow" | "data";
+
+const TABS: readonly TabDef<ToolTab>[] = [
+  { id: "ui", label: "UI" },
+  { id: "workflow", label: "Workflow" },
+  { id: "data", label: "Data" },
+];
+
+interface InternalToolDetailProps {
+  tool: InternalTool;
+  onBack: () => void;
+  onStartCall: () => void;
+}
+
+export function InternalToolDetail({
+  tool,
+  onBack,
+  onStartCall,
+}: InternalToolDetailProps) {
+  const [tab, setTab] = useState<ToolTab>("ui");
+  const [editing, setEditing] = useState(false);
+  const isInbound = tool.id === "inbound-routing";
+  const canEdit = tool.status !== "suggested";
+
+  return (
+    <div className={`opr-detail-wrap${editing ? " is-editing" : ""}`}>
+      <div className="opr-surface-wide">
+      <button type="button" className="opr-back" onClick={onBack}>
+        <ArrowLeft size={13} strokeWidth={1.9} aria-hidden />
+        All tools
+      </button>
+
+      <div className="opr-detail-head">
+        <span className="opr-tool-emoji" aria-hidden>
+          {sigil(tool.name)}
+        </span>
+        <div className="opr-detail-titles">
+          <div className="opr-detail-name">{tool.name}</div>
+          <p className="opr-tool-summary">{tool.summary}</p>
+          <div className="opr-tool-meta">
+            <ToolStatusBadge status={tool.status} />
+            <span className="opr-meta-dot">
+              v{tool.version} · built from {tool.builtFrom}
+            </span>
+            <span className="opr-meta-dot">{tool.runsToday} runs today</span>
+          </div>
+        </div>
+        <div className="opr-detail-actions">
+          {canEdit && (
+            <button
+              type="button"
+              className="opr-btn opr-btn-sm"
+              onClick={() => setEditing(true)}
+            >
+              <Pencil size={13} strokeWidth={1.9} aria-hidden />
+              Edit with AI
+            </button>
+          )}
+          {tool.status === "enabled" && (
+            <>
+              <button type="button" className="opr-btn opr-btn-sm">
+                <Power size={13} strokeWidth={1.9} aria-hidden />
+                Disable
+              </button>
+              <button
+                type="button"
+                className="opr-btn opr-btn-primary opr-btn-sm"
+              >
+                <CheckCircle2 size={13} strokeWidth={1.9} aria-hidden />
+                Publish new version
+              </button>
+            </>
+          )}
+          {tool.status === "disabled" && (
+            <>
+              <button
+                type="button"
+                className="opr-btn opr-btn-primary opr-btn-sm"
+              >
+                <Power size={13} strokeWidth={1.9} aria-hidden />
+                Enable
+              </button>
+              <button type="button" className="opr-btn opr-btn-sm">
+                <CheckCircle2 size={13} strokeWidth={1.9} aria-hidden />
+                Publish new version
+              </button>
+            </>
+          )}
+          {tool.status === "draft" && (
+            <>
+              <button type="button" className="opr-btn opr-btn-sm">
+                <Play size={13} strokeWidth={1.9} aria-hidden />
+                Run on test data
+              </button>
+              <button
+                type="button"
+                className="opr-btn opr-btn-primary opr-btn-sm"
+              >
+                <CheckCircle2 size={13} strokeWidth={1.9} aria-hidden />
+                Publish
+              </button>
+            </>
+          )}
+          {tool.status === "suggested" && (
+            <button
+              type="button"
+              className="opr-btn opr-btn-primary opr-btn-sm"
+            >
+              <Plus size={13} strokeWidth={1.9} aria-hidden />
+              Build it
+            </button>
+          )}
+        </div>
+      </div>
+
+      <Tabs
+        tabs={TABS}
+        active={tab}
+        onSelect={setTab}
+        hint={tab === "workflow" ? "deterministic · audited" : undefined}
+      />
+
+      <div
+        role="tabpanel"
+        id={`opr-panel-${tab}`}
+        aria-labelledby={`opr-tab-${tab}`}
+      >
+        {tab === "ui" &&
+          (isInbound ? (
+            <UITab />
+          ) : (
+            <EmptyState
+              glyph="◧"
+              title="No screen built yet"
+              hint="Build the screen your team will use to run this tool. Talk it through on a call and your AI assembles it."
+              actionLabel="Teach your workflow to Nex"
+              onAction={onStartCall}
+            />
+          ))}
+        {tab === "workflow" && <WorkflowTab tool={tool} />}
+        {tab === "data" &&
+          (isInbound ? (
+            <DataTab tool={tool} />
+          ) : (
+            <EmptyState
+              glyph="▦"
+              title="No data yet"
+              hint="Run this tool on test data. The rows it produces, with their statuses, show up here as a table you own."
+              actionLabel="Run on test data"
+            />
+          ))}
+      </div>
+      </div>
+
+      {editing ? (
+        <ToolEditChat tool={tool} onClose={() => setEditing(false)} />
+      ) : null}
+    </div>
+  );
+}
+
+// ── UI tab: the built mini-app ──────────────────────────────────────────
+
+function UITab() {
+  // Local copy so the approval demo can mutate a row's status on approve.
+  const [rows, setRows] = useState<InboundRequest[]>(INBOUND_REQUESTS);
+  const [pending, setPending] = useState<InboundRequest | null>(null);
+
+  function approve(req: InboundRequest) {
+    setRows((rs) =>
+      rs.map((r) =>
+        r.id === req.id
+          ? { ...r, status: "routed", routedTo: "Priya (AE)" }
+          : r,
+      ),
+    );
+    setPending(null);
+  }
+
+  return (
+    <div>
+      <div className="opr-readout">
+        <span className="opr-readout-lead">today</span>
+        {TODAY_DIGEST.map((d) => (
+          <span className="opr-readout-stat" key={d.label}>
+            <span
+              className={`opr-readout-num${
+                d.tone === "good"
+                  ? " opr-digest-good"
+                  : d.tone === "warn"
+                    ? " opr-digest-warn"
+                    : ""
+              }`}
+            >
+              {d.value}
+            </span>
+            <span className="opr-readout-label">{d.label}</span>
+          </span>
+        ))}
+      </div>
+
+      {pending ? (
+        <ApprovalCard
+          integration="Slack"
+          title={`Route ${pending.company} to an AE in #ae-handoffs?`}
+          detail={`Fit ${pending.fitScore}/100, ${pending.reason}`}
+          onApprove={() => approve(pending)}
+          onSkip={() => setPending(null)}
+        />
+      ) : null}
+
+      {rows.length === 0 ? (
+        <EmptyState
+          glyph="◷"
+          title="No requests yet today"
+          hint="When a demo request comes in, it lands here, scored and routed automatically. Fire a test request to see it work."
+          actionLabel="Run on test data"
+        />
+      ) : (
+      <div className="opr-table-wrap">
+        <div className="opr-table-toolbar">
+          <Eyebrow>Incoming demo requests · today</Eyebrow>
+          <span className="opr-pill opr-pill-muted">{rows.length} requests</span>
+        </div>
+        <table className="opr-table">
+          <thead>
+            <tr>
+              <th>Company</th>
+              <th>Contact</th>
+              <th>Source</th>
+              <th>Fit</th>
+              <th>Status</th>
+              <th />
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((r) => (
+              <tr key={r.id}>
+                <td>
+                  <div className="opr-cell-primary">{r.company}</div>
+                  <div className="opr-cell-sub">{r.receivedAt}</div>
+                </td>
+                <td>
+                  <div>{r.contact}</div>
+                  <div className="opr-cell-sub">{r.email}</div>
+                </td>
+                <td className="opr-cell-sub">{r.source}</td>
+                <td>
+                  <ScorePill score={r.fitScore} />
+                </td>
+                <td>
+                  <RequestStatusPill status={r.status} />
+                  {r.routedTo ? (
+                    <div className="opr-cell-sub">assigned to {r.routedTo}</div>
+                  ) : null}
+                </td>
+                <td style={{ textAlign: "right" }}>
+                  {r.status === "scored" &&
+                  r.fitScore !== null &&
+                  r.fitScore >= 70 ? (
+                    <button
+                      type="button"
+                      className="opr-btn opr-btn-sm"
+                      onClick={() => setPending(r)}
+                    >
+                      Route
+                      <Send size={13} strokeWidth={1.9} aria-hidden />
+                    </button>
+                  ) : r.status === "needs-you" ? (
+                    <button type="button" className="opr-btn opr-btn-sm">
+                      <ArrowRight size={13} strokeWidth={1.9} aria-hidden />
+                      Review
+                    </button>
+                  ) : null}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      )}
+    </div>
+  );
+}
+
+// ── Workflow tab: the deterministic spec ────────────────────────────────
+
+const STEP_GLYPH: Record<WorkflowStep["kind"], string> = {
+  trigger: "TR",
+  enrich: "EN",
+  ai: "AI",
+  decision: "IF",
+  action: "DO",
+  branch: "EL",
+};
+
+function stepNodeClass(kind: WorkflowStep["kind"]): string {
+  return `opr-step-node opr-step-node-${kind}`;
+}
+
+function WorkflowTab({ tool }: { tool: InternalTool }) {
+  return (
+    <div className="opr-detail-cols">
+      <div>
+        <div className="opr-figure-label">FIG_003</div>
+        <Eyebrow>How it runs · every step is scripted</Eyebrow>
+        <div className="opr-flow" style={{ marginTop: "var(--space-3)" }}>
+          {tool.steps.map((step, i) => (
+            <div className="opr-step" key={step.id}>
+              <div className="opr-step-rail">
+                <div className={stepNodeClass(step.kind)} aria-hidden>
+                  {STEP_GLYPH[step.kind]}
+                </div>
+                {i < tool.steps.length - 1 ? (
+                  <div className="opr-step-line" />
+                ) : null}
+              </div>
+              <div className="opr-step-body">
+                <div className="opr-step-kind">{step.kind}</div>
+                <div className="opr-step-title">
+                  {step.title}
+                  {step.integration ? (
+                    <span className="opr-step-chip">{step.integration}</span>
+                  ) : null}
+                </div>
+                <div className="opr-step-detail">{step.detail}</div>
+                {step.gated ? (
+                  <div className="opr-step-gate">
+                    Approval required before it sends
+                  </div>
+                ) : null}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div>
+        <div className="opr-rail-card">
+          <Eyebrow>Recent runs</Eyebrow>
+          {tool.runs.length === 0 ? (
+            <div className="opr-step-detail" style={{ marginTop: 8 }}>
+              No runs yet.
+            </div>
+          ) : (
+            <div style={{ marginTop: "var(--space-2)" }}>
+              {tool.runs.map((run) => (
+                <div className="opr-run-row" key={run.id}>
+                  <span
+                    className={`opr-led ${
+                      run.outcome === "routed"
+                        ? "opr-led-live"
+                        : run.outcome === "needs-you"
+                          ? "opr-led-warn"
+                          : "opr-led-draft"
+                    }`}
+                    style={{ marginTop: 5 }}
+                  />
+                  <div style={{ flex: 1, minWidth: 0 }}>
+                    <div style={{ fontWeight: 550 }}>{run.trigger}</div>
+                    <div className="opr-cell-sub">{run.summary}</div>
+                  </div>
+                  <div className="opr-cell-sub">{run.ranAt}</div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+
+        <div className="opr-rail-card">
+          <Eyebrow>Version history</Eyebrow>
+          <div style={{ marginTop: "var(--space-2)" }}>
+            {tool.versions.map((v) => (
+              <div className="opr-version-row" key={v.version}>
+                <span className="opr-version-num">v{v.version}</span>
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <div style={{ fontWeight: 550 }}>{v.label}</div>
+                  <div className="opr-cell-sub">
+                    {v.author} · {v.at}
+                  </div>
+                  <div
+                    className="opr-step-detail"
+                    style={{ marginTop: 2, fontStyle: "italic" }}
+                  >
+                    {v.note}
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── Data tab: operator-owned typed tables ───────────────────────────────
+
+function DataTab({ tool }: { tool: InternalTool }) {
+  return (
+    <div>
+      <Eyebrow>requests · a typed table this tool owns</Eyebrow>
+      <div
+            className="opr-table-wrap"
+            style={{ marginTop: "var(--space-3)" }}
+          >
+        <div className="opr-table-toolbar">
+          <span className="opr-pill opr-pill-muted">
+            {INBOUND_REQUESTS.length} rows
+          </span>
+          <button type="button" className="opr-btn opr-btn-sm">
+            <Plus size={13} strokeWidth={1.9} aria-hidden />
+            Add column
+          </button>
+        </div>
+        <table className="opr-table">
+          <thead>
+            <tr>
+              {tool.dataColumns.map((c) => (
+                <th key={c.key}>
+                  {c.label}
+                  <span className="opr-schema-type">{c.type}</span>
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {INBOUND_REQUESTS.map((r) => (
+              <tr key={r.id}>
+                <td className="opr-cell-primary">{r.company}</td>
+                <td>{r.contact}</td>
+                <td className="opr-cell-sub">{r.email}</td>
+                <td className="opr-cell-sub">{r.source}</td>
+                <td>
+                  <ScorePill score={r.fitScore} />
+                </td>
+                <td>
+                  <RequestStatusPill status={r.status} />
+                </td>
+                <td className="opr-cell-sub">{r.receivedAt}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/web/src/operator/surfaces/InternalToolsSurface.tsx
+++ b/web/src/operator/surfaces/InternalToolsSurface.tsx
@@ -1,0 +1,170 @@
+// Internal Tools — the list surface. A live "hero" tool, then drafts and
+// AI-suggested tools. Selecting one opens InternalToolDetail (state in the
+// shell). Mock data only.
+
+import { ArrowRight, PhoneCall, Plus } from "lucide-react";
+
+import {
+  Eyebrow,
+  sigil,
+  SurfaceHeader,
+  ToolStatusBadge,
+} from "../components/primitives";
+import { type InternalTool, TOOLS } from "../mock/data";
+
+interface InternalToolsSurfaceProps {
+  onOpen: (toolId: string) => void;
+  onStartCall: () => void;
+  onBuild: () => void;
+}
+
+export function InternalToolsSurface({
+  onOpen,
+  onStartCall,
+  onBuild,
+}: InternalToolsSurfaceProps) {
+  const live = TOOLS.filter(
+    (t) => t.status === "enabled" || t.status === "disabled",
+  );
+  const drafts = TOOLS.filter((t) => t.status === "draft");
+  const suggested = TOOLS.filter((t) => t.status === "suggested");
+
+  return (
+    <div className="opr-surface-wide">
+      <SurfaceHeader
+        eyebrow="Internal tools"
+        title="Your tools"
+        lede="Each tool watches for something, decides what to do, and acts, exactly the way you taught it. Build a new one by describing it in chat, or talk it through on a call."
+        actions={
+          <div className="opr-header-actions">
+            <button
+              type="button"
+              className="opr-btn opr-btn-primary"
+              onClick={onBuild}
+            >
+              <Plus size={14} strokeWidth={1.9} aria-hidden />
+              Build a tool
+            </button>
+            <button
+              type="button"
+              className="opr-btn"
+              onClick={onStartCall}
+            >
+              <PhoneCall size={14} strokeWidth={1.9} aria-hidden />
+              Teach your workflow to Nex
+            </button>
+          </div>
+        }
+      />
+
+      {live.map((t) => (
+        <HeroToolCard key={t.id} tool={t} onOpen={() => onOpen(t.id)} />
+      ))}
+
+      {drafts.length > 0 ? (
+        <>
+          <div className="opr-section-label">
+            <Eyebrow>Drafts</Eyebrow>
+            <div className="opr-section-rule" />
+          </div>
+          <div className="opr-grid">
+            {drafts.map((t) => (
+              <ToolRow key={t.id} tool={t} onOpen={() => onOpen(t.id)} />
+            ))}
+          </div>
+        </>
+      ) : null}
+
+      {suggested.length > 0 ? (
+        <>
+          <div className="opr-section-label">
+            <Eyebrow>Suggested by your AI</Eyebrow>
+            <div className="opr-section-rule" />
+          </div>
+          <div className="opr-grid">
+            {suggested.map((t) => (
+              <ToolRow key={t.id} tool={t} onOpen={() => onOpen(t.id)} />
+            ))}
+          </div>
+        </>
+      ) : null}
+    </div>
+  );
+}
+
+function HeroToolCard({
+  tool,
+  onOpen,
+}: {
+  tool: InternalTool;
+  onOpen: () => void;
+}) {
+  return (
+    <div
+      className="opr-card opr-card-hero"
+      role="button"
+      tabIndex={0}
+      onClick={onOpen}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          onOpen();
+        }
+      }}
+      style={{ cursor: "pointer", marginBottom: "var(--space-2)" }}
+    >
+      <div className="opr-detail-head" style={{ marginBottom: 0 }}>
+        <span className="opr-tool-emoji" aria-hidden>
+          {sigil(tool.name)}
+        </span>
+        <div className="opr-detail-titles">
+          <div className="opr-tool-name">{tool.name}</div>
+          <p className="opr-tool-summary">{tool.summary}</p>
+          <div className="opr-tool-meta">
+            <ToolStatusBadge status={tool.status} />
+            <span className="opr-meta-dot">{tool.runsToday} runs today</span>
+            <span className="opr-meta-dot">last run {tool.lastRun}</span>
+          </div>
+        </div>
+        <button type="button" className="opr-btn opr-btn-sm">
+          Open
+          <ArrowRight size={13} strokeWidth={1.9} aria-hidden />
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function ToolRow({
+  tool,
+  onOpen,
+}: {
+  tool: InternalTool;
+  onOpen: () => void;
+}) {
+  return (
+    <div
+      className="opr-tool-row"
+      role="button"
+      tabIndex={0}
+      onClick={onOpen}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          onOpen();
+        }
+      }}
+    >
+      <span className="opr-tool-emoji" aria-hidden>
+        {sigil(tool.name)}
+      </span>
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div className="opr-tool-name" style={{ fontSize: "var(--text-md)" }}>
+          {tool.name}
+        </div>
+        <p className="opr-tool-summary">{tool.summary}</p>
+      </div>
+      <ToolStatusBadge status={tool.status} />
+    </div>
+  );
+}

--- a/web/src/operator/surfaces/KnowledgeSurface.tsx
+++ b/web/src/operator/surfaces/KnowledgeSurface.tsx
@@ -1,0 +1,208 @@
+// Knowledge — a Wikipedia-style reader over the company brain (gbrain). Every
+// claim that came from somewhere carries a citation. Hovering (or focusing) a
+// citation shows the source: what kind it is, where it came from, and the exact
+// snippet the fact was drawn from. An "Explain" button reveals why the brain
+// chose that source for this fact (e.g. why a specific chat backs an insight).
+// Mock data only.
+
+import { type ReactNode, useMemo, useState } from "react";
+import { Sparkles } from "lucide-react";
+
+import { Eyebrow } from "../components/primitives";
+import {
+  type KnowledgeRef,
+  type KnowledgeSourceKind,
+  KNOWLEDGE,
+} from "../mock/data";
+
+const KIND_LABEL: Record<KnowledgeSourceKind, string> = {
+  chat: "Chat",
+  document: "Document",
+  crm: "CRM",
+  decision: "Decision",
+  roster: "Roster",
+};
+
+// A single [n] citation with a hover/focus popover over its source.
+function Citation({ n, source }: { n: number; source?: KnowledgeRef }) {
+  const [explained, setExplained] = useState(false);
+
+  if (!source) {
+    return (
+      <sup className="opr-cite">
+        <a href={`#ref-${n}`}>[{n}]</a>
+      </sup>
+    );
+  }
+
+  return (
+    <sup className="opr-cite opr-cite-has-pop">
+      <a href={`#ref-${n}`} aria-label={`Source ${n}: ${source.title}`}>
+        [{n}]
+      </a>
+      <span className="opr-cite-pop" role="note">
+        <span className="opr-cite-pop-head">
+          <span className="opr-cite-pop-kind">{KIND_LABEL[source.kind]}</span>
+          <span className="opr-cite-pop-title">{source.title}</span>
+        </span>
+        <span className="opr-cite-pop-detail">{source.detail}</span>
+        <span className="opr-cite-pop-snippet">{source.snippet}</span>
+        {explained ? (
+          <span className="opr-cite-pop-why">
+            <span className="opr-cite-pop-why-label">
+              <Sparkles size={11} strokeWidth={2} aria-hidden /> Why this source
+            </span>
+            {source.why}
+          </span>
+        ) : (
+          <button
+            type="button"
+            className="opr-btn opr-btn-sm opr-cite-pop-explain"
+            onClick={() => setExplained(true)}
+          >
+            <Sparkles size={12} strokeWidth={2} aria-hidden />
+            Explain
+          </button>
+        )}
+      </span>
+    </sup>
+  );
+}
+
+// Turn "...routes it.[[1]]" prose into text + citation popovers.
+function renderProse(
+  text: string,
+  refByN: Map<number, KnowledgeRef>,
+): ReactNode[] {
+  return text.split(/(\[\[\d+\]\])/g).map((part, i) => {
+    const m = part.match(/^\[\[(\d+)\]\]$/);
+    if (m) {
+      const n = Number(m[1]);
+      return <Citation key={i} n={n} source={refByN.get(n)} />;
+    }
+    return <span key={i}>{part}</span>;
+  });
+}
+
+export function KnowledgeSurface() {
+  const [activeId, setActiveId] = useState(KNOWLEDGE[0]?.id ?? "");
+  const page = KNOWLEDGE.find((k) => k.id === activeId) ?? KNOWLEDGE[0];
+  const titleOf = (id: string) =>
+    KNOWLEDGE.find((k) => k.id === id)?.title ?? id;
+
+  const refByN = useMemo(
+    () => new Map((page?.references ?? []).map((r) => [r.n, r])),
+    [page],
+  );
+
+  return (
+    <div className="opr-surface-wide">
+      <div
+        className="opr-surface-head"
+        style={{ marginBottom: "var(--space-4)" }}
+      >
+        <div>
+          <Eyebrow>Knowledge</Eyebrow>
+          <h1 className="opr-surface-title">What your AI knows</h1>
+          <p className="opr-surface-lede">
+            The shared brain behind every tool. Each fact is cited back to where
+            it came from, so you can trust what the tools act on. Hover a citation
+            to see the source, and ask why it was chosen.
+          </p>
+        </div>
+        <button type="button" className="opr-btn opr-btn-sm">
+          New page
+        </button>
+      </div>
+
+      <div className="opr-wiki">
+        <nav className="opr-kn-list" aria-label="Knowledge pages">
+          <div className="opr-eyebrow" style={{ marginBottom: "var(--space-2)" }}>
+            Pages
+          </div>
+          {KNOWLEDGE.map((k) => (
+            <button
+              key={k.id}
+              type="button"
+              className={`opr-kn-item${k.id === activeId ? " is-active" : ""}`}
+              onClick={() => setActiveId(k.id)}
+            >
+              {k.title}
+            </button>
+          ))}
+        </nav>
+
+        {page ? (
+          <article className="opr-article">
+            <aside className="opr-article-infobox">
+              <div className="opr-infobox-title">{page.title}</div>
+              <dl>
+                {page.infobox.map((row) => (
+                  <div className="opr-infobox-row" key={row.label}>
+                    <dt>{row.label}</dt>
+                    <dd>{row.value}</dd>
+                  </div>
+                ))}
+              </dl>
+            </aside>
+
+            <h1>{page.title}</h1>
+            <div className="opr-article-meta">
+              From the company brain · {page.updatedAt}
+            </div>
+
+            <p className="opr-article-lead">{renderProse(page.lead, refByN)}</p>
+
+            {page.sections.map((section) => (
+              <section key={section.heading ?? "body"}>
+                {section.heading ? <h2>{section.heading}</h2> : null}
+                {section.paras.map((para, i) => (
+                  <p key={i}>{renderProse(para, refByN)}</p>
+                ))}
+              </section>
+            ))}
+
+            <h2>References</h2>
+            <ol className="opr-refs">
+              {page.references.map((ref) => (
+                <li id={`ref-${ref.n}`} key={ref.n}>
+                  <span className="opr-ref-kind">{KIND_LABEL[ref.kind]}</span>
+                  <span className="opr-ref-source">{ref.title}</span>
+                  <span className="opr-ref-detail"> · {ref.detail}</span>
+                </li>
+              ))}
+            </ol>
+
+            {page.seeAlso.length > 0 ? (
+              <>
+                <h2>See also</h2>
+                <ul className="opr-seealso">
+                  {page.seeAlso.map((id) => (
+                    <li key={id}>
+                      <button
+                        type="button"
+                        className="opr-wikilink"
+                        onClick={() => setActiveId(id)}
+                      >
+                        {titleOf(id)}
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              </>
+            ) : null}
+
+            <div className="opr-categories">
+              <span className="opr-cat-label">Categories</span>
+              {page.categories.map((c) => (
+                <span className="opr-cat" key={c}>
+                  {c}
+                </span>
+              ))}
+            </div>
+          </article>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/web/src/operator/surfaces/SettingsSurface.tsx
+++ b/web/src/operator/surfaces/SettingsSurface.tsx
@@ -1,0 +1,127 @@
+// Settings — kept deliberately small. Voice (the call) economics are the
+// load-bearing decision here: bring your own OpenAI Realtime key, or let Nex
+// host it; with no key the call is optional and chat-authoring is the floor.
+// Mock data; toggles flip local state only.
+
+import { useState } from "react";
+
+import { Eyebrow, SurfaceHeader } from "../components/primitives";
+
+export function SettingsSurface() {
+  const [nexHosted, setNexHosted] = useState(false);
+  const [digestOn, setDigestOn] = useState(true);
+  const [approvalsOn, setApprovalsOn] = useState(true);
+
+  return (
+    <div className="opr-surface-wide">
+      <SurfaceHeader
+        eyebrow="Settings"
+        title="Settings"
+        lede="Voice, notifications, and approvals. Everything else your AI handles."
+      />
+
+      <div className="opr-settings">
+        <div className="opr-set-group">
+          <Eyebrow>Voice · the call</Eyebrow>
+          <div className="opr-set-row">
+            <div>
+              <div className="opr-set-label">OpenAI Realtime key</div>
+              <div className="opr-set-help">
+                Powers the screen-share call where you build tools by talking.
+                Bring your own key, or let wuphf host it.
+              </div>
+            </div>
+            <input
+              className="opr-input"
+              type="password"
+              aria-label="OpenAI Realtime key"
+              placeholder="sk-..."
+              defaultValue=""
+              disabled={nexHosted}
+            />
+          </div>
+          <div className="opr-set-row">
+            <div>
+              <div className="opr-set-label">Let wuphf host voice for me</div>
+              <div className="opr-set-help">
+                Metered through wuphf cloud. With no key and this off, the call is
+                optional. You can still build everything from chat.
+              </div>
+            </div>
+            <button
+              type="button"
+              aria-pressed={nexHosted}
+              className={`opr-toggle${nexHosted ? " is-on" : ""}`}
+              onClick={() => setNexHosted((v) => !v)}
+            />
+          </div>
+        </div>
+
+        <div className="opr-set-group">
+          <Eyebrow>Notifications</Eyebrow>
+          <div className="opr-set-row">
+            <div>
+              <div className="opr-set-label">Daily digest</div>
+              <div className="opr-set-help">
+                A morning summary of what your tools did, and anything that
+                needs you, in Slack and email.
+              </div>
+            </div>
+            <button
+              type="button"
+              aria-pressed={digestOn}
+              className={`opr-toggle${digestOn ? " is-on" : ""}`}
+              onClick={() => setDigestOn((v) => !v)}
+            />
+          </div>
+          <div className="opr-set-row">
+            <div>
+              <div className="opr-set-label">Deliver to</div>
+              <div className="opr-set-help">Where digests and alerts go.</div>
+            </div>
+            <input
+              className="opr-input"
+              aria-label="Deliver digests and alerts to"
+              defaultValue="#revops · maya@company.com"
+            />
+          </div>
+        </div>
+
+        <div className="opr-set-group">
+          <Eyebrow>Approvals</Eyebrow>
+          <div className="opr-set-row">
+            <div>
+              <div className="opr-set-label">Ask before sending externally</div>
+              <div className="opr-set-help">
+                Your AI checks with you before any tool writes to an outside app
+                such as posting to Slack or updating the CRM. Recommended on.
+              </div>
+            </div>
+            <button
+              type="button"
+              aria-pressed={approvalsOn}
+              className={`opr-toggle${approvalsOn ? " is-on" : ""}`}
+              onClick={() => setApprovalsOn((v) => !v)}
+            />
+          </div>
+        </div>
+
+        <div className="opr-set-group">
+          <Eyebrow>Danger zone</Eyebrow>
+          <div className="opr-set-row">
+            <div>
+              <div className="opr-set-label opr-danger">Delete workspace</div>
+              <div className="opr-set-help">
+                Removes every tool, its data, and the connected apps. Cannot be
+                undone.
+              </div>
+            </div>
+            <button type="button" className="opr-btn opr-btn-sm opr-danger">
+              Delete
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/operator/surfaces/ToolEditChat.tsx
+++ b/web/src/operator/surfaces/ToolEditChat.tsx
@@ -1,0 +1,180 @@
+// Edit-with-AI — a chat docked beside a tool to change it in place, the way the
+// app builder builds-with-you. The operator describes a change; the AI proposes
+// the concrete edits and the operator applies them as a new version. Mock: the
+// AI replies with a canned proposal and "Apply" bumps the version locally.
+
+import { useEffect, useRef, useState } from "react";
+
+import type { InternalTool } from "../mock/data";
+
+interface Proposal {
+  summary: string[];
+  version: number;
+}
+
+interface EditMessage {
+  id: string;
+  from: "you" | "ai";
+  body: string;
+  proposal?: Proposal;
+  applied?: boolean;
+}
+
+interface ToolEditChatProps {
+  tool: InternalTool;
+  onClose: () => void;
+}
+
+// Read the operator's request and turn it into a concrete, named change list.
+// Keyword-driven so the mock feels like it understood, not a stock reply.
+function proposeFrom(text: string): string[] {
+  const t = text.toLowerCase();
+  const changes: string[] = [];
+  const threshold = t.match(/\b(\d{2,3})\b/);
+  if (t.includes("threshold") || (t.includes("score") && threshold)) {
+    changes.push(`Fit threshold becomes ${threshold ? threshold[1] : "70"}`);
+  }
+  if (t.includes("slack") || t.includes("message") || t.includes("notify")) {
+    changes.push("Update the Slack handoff message");
+  }
+  if (t.includes("industr") || t.includes("vertical")) {
+    changes.push("Adjust the industries used for scoring");
+  }
+  if (t.includes("nurtur")) {
+    changes.push("Change the nurture branch");
+  }
+  if (changes.length === 0) {
+    changes.push(`Apply: "${text.trim()}"`);
+  }
+  return changes;
+}
+
+export function ToolEditChat({ tool, onClose }: ToolEditChatProps) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const [draft, setDraft] = useState("");
+  const [version, setVersion] = useState(tool.version);
+  const [messages, setMessages] = useState<EditMessage[]>([
+    {
+      id: "seed-1",
+      from: "ai",
+      body: "I can edit this tool with you. Tell me what to change: the fit threshold, who gets routed, the Slack message, anything.",
+    },
+  ]);
+
+  useEffect(() => {
+    scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight });
+  }, [messages]);
+
+  function send() {
+    const text = draft.trim();
+    if (!text) return;
+    const nextVersion = version + 1;
+    setMessages((prev) => [
+      ...prev,
+      { id: `you-${prev.length}`, from: "you", body: text },
+      {
+        id: `ai-${prev.length}`,
+        from: "ai",
+        body: "Here's what I'll change. Want me to apply it and publish a new version?",
+        proposal: { summary: proposeFrom(text), version: nextVersion },
+      },
+    ]);
+    setDraft("");
+  }
+
+  function apply(msgId: string, v: number) {
+    setVersion(v);
+    setMessages((prev) =>
+      prev.map((m) => (m.id === msgId ? { ...m, applied: true } : m)),
+    );
+    setMessages((prev) => [
+      ...prev,
+      {
+        id: `done-${prev.length}`,
+        from: "ai",
+        body: `Done. Published v${v}. The change is live and shows in the version history.`,
+      },
+    ]);
+  }
+
+  return (
+    <aside className="opr-edit-panel" aria-label="Edit with AI">
+      <div className="opr-edit-head">
+        <div>
+          <div className="opr-eyebrow">Edit with AI</div>
+          <div className="opr-edit-tool">{tool.name}</div>
+        </div>
+        <button
+          type="button"
+          className="opr-btn opr-btn-ghost opr-btn-sm"
+          onClick={onClose}
+          aria-label="Close editor"
+        >
+          Close
+        </button>
+      </div>
+
+      <div className="opr-edit-scroll" ref={scrollRef}>
+        {messages.map((m) => (
+          <div key={m.id} className="opr-edit-msgwrap">
+            <div
+              className={`opr-msg ${
+                m.from === "ai" ? "opr-msg-ai" : "opr-msg-you"
+              }`}
+            >
+              {m.body}
+            </div>
+            {m.proposal ? (
+              <div className="opr-proposal">
+                <div className="opr-eyebrow">
+                  Proposed change · v{m.proposal.version}
+                </div>
+                <ul className="opr-proposal-list">
+                  {m.proposal.summary.map((s, i) => (
+                    <li key={i}>{s}</li>
+                  ))}
+                </ul>
+                {m.applied ? (
+                  <div className="opr-proposal-applied">Applied</div>
+                ) : (
+                  <div className="opr-proposal-actions">
+                    <button
+                      type="button"
+                      className="opr-btn opr-btn-primary opr-btn-sm"
+                      onClick={() => apply(m.id, m.proposal!.version)}
+                    >
+                      Apply &amp; publish
+                    </button>
+                    <button type="button" className="opr-btn opr-btn-sm">
+                      Not yet
+                    </button>
+                  </div>
+                )}
+              </div>
+            ) : null}
+          </div>
+        ))}
+      </div>
+
+      <div className="opr-composer">
+        <input
+          className="opr-composer-input"
+          aria-label="Describe a change to this tool"
+          placeholder="e.g. lower the threshold to 65, add finance"
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") send();
+          }}
+        />
+        <button
+          type="button"
+          className="opr-btn opr-btn-primary"
+          onClick={send}
+        >
+          Send
+        </button>
+      </div>
+    </aside>
+  );
+}

--- a/web/src/operator/surfaces/WorkflowBuilder.tsx
+++ b/web/src/operator/surfaces/WorkflowBuilder.tsx
@@ -1,0 +1,409 @@
+// WorkflowBuilder — the spine of the product: describe a workflow in plain
+// language and watch your AI build it out in front of you.
+//
+// Left: the conversation. Right: the workflow, which assembles step-by-step as
+// the AI understands the description, then refines one detail in place when the
+// AI asks its single clarifying question. On finish it hands off a draft tool.
+//
+// FRONTEND-FIRST RULE: all mock. The "understanding" is planWorkflow(); the
+// staged reveal and the clarify-and-refine loop are the shape to react to
+// before the agentic build phase exists.
+
+import { useEffect, useRef, useState } from "react";
+import { ArrowRight, Check, Send, X } from "lucide-react";
+
+import { Eyebrow, ToolStatusBadge } from "../components/primitives";
+import { buildPlanSmart } from "../builder/agentClient";
+import {
+  applyClarify,
+  type ClarifyQuestion,
+  type WorkflowPlan,
+} from "../builder/planWorkflow";
+import type { WorkflowStep } from "../mock/data";
+
+const STEP_GLYPH: Record<WorkflowStep["kind"], string> = {
+  trigger: "TR",
+  enrich: "EN",
+  ai: "AI",
+  decision: "IF",
+  action: "DO",
+  branch: "EL",
+};
+
+type Phase = "intro" | "thinking" | "assembling" | "refining" | "done";
+
+interface FinishCard {
+  name: string;
+  toolId: string;
+}
+
+interface BuilderMessage {
+  id: string;
+  from: "you" | "ai";
+  body: string;
+  finish?: FinishCard;
+}
+
+const STARTERS: readonly string[] = [
+  "When a demo request comes in, look up the company, score how good a fit they are, and send the strong ones to an AE in Slack. Nurture the rest.",
+  "When a support ticket is tagged urgent, classify its severity and page the on-call engineer for the worst ones.",
+  "When an expense over $5k comes in, check it against policy and route the exceptions to me to approve.",
+];
+
+const GREETING =
+  "Tell me what you want to automate. Walk me through how you would do it by hand, start to finish, and I will build the workflow as you talk.";
+
+interface WorkflowBuilderProps {
+  onClose: () => void;
+  onFinish: (toolId: string) => void;
+}
+
+export function WorkflowBuilder({ onClose, onFinish }: WorkflowBuilderProps) {
+  const [phase, setPhase] = useState<Phase>("intro");
+  const [draft, setDraft] = useState("");
+  const [messages, setMessages] = useState<BuilderMessage[]>([
+    { id: "greet", from: "ai", body: GREETING },
+  ]);
+  const [plan, setPlan] = useState<WorkflowPlan | null>(null);
+  const [targetSteps, setTargetSteps] = useState<WorkflowStep[]>([]);
+  const [revealCount, setRevealCount] = useState(0);
+  const [pendingClarify, setPendingClarify] = useState<ClarifyQuestion | null>(
+    null,
+  );
+  const [flashStepId, setFlashStepId] = useState<string | null>(null);
+
+  const timers = useRef<number[]>([]);
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const seq = useRef(0);
+
+  function track(id: number) {
+    timers.current.push(id);
+  }
+  useEffect(() => {
+    return () => {
+      timers.current.forEach((t) => clearTimeout(t));
+      timers.current = [];
+    };
+  }, []);
+
+  useEffect(() => {
+    scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight });
+  }, [messages, phase]);
+
+  function nextId(prefix: string) {
+    seq.current += 1;
+    return `${prefix}-${seq.current}`;
+  }
+  function pushAI(body: string, finish?: FinishCard) {
+    setMessages((prev) => [
+      ...prev,
+      { id: nextId("ai"), from: "ai", body, finish },
+    ]);
+  }
+  function pushYou(body: string) {
+    setMessages((prev) => [...prev, { id: nextId("you"), from: "you", body }]);
+  }
+
+  function presentFinish(p: WorkflowPlan) {
+    const t = window.setTimeout(() => {
+      pushAI(
+        `That is a complete workflow. I have saved it as a draft so nothing runs until you say so. Run it on a few real ones to see how it does, then publish.`,
+        { name: p.name, toolId: p.toolId },
+      );
+      setPhase("done");
+    }, 520);
+    track(t);
+  }
+
+  function runBuild(text: string) {
+    setRevealCount(0);
+    setPendingClarify(null);
+    setPhase("thinking");
+    // Real pi-mono engine when the agent service is reachable; deterministic mock
+    // otherwise (frontend-first graceful degrade). The thinking phase covers the
+    // round-trip; the staggered reveal below is unchanged.
+    void buildPlanSmart(text).then((built) => {
+    setPlan(built);
+    setTargetSteps(built.steps);
+
+    const start = window.setTimeout(() => {
+      pushAI(built.narration);
+      setPhase("assembling");
+      built.steps.forEach((_, i) => {
+        const reveal = window.setTimeout(
+          () => setRevealCount((c) => Math.max(c, i + 1)),
+          280 + i * 440,
+        );
+        track(reveal);
+      });
+      const done = window.setTimeout(
+        () => {
+          if (built.clarify) {
+            pushAI(built.clarify.prompt);
+            setPendingClarify(built.clarify);
+            setPhase("refining");
+          } else {
+            presentFinish(built);
+          }
+        },
+        280 + built.steps.length * 440 + 240,
+      );
+      track(done);
+    }, 720);
+    track(start);
+    });
+  }
+
+  function handleAnswer(text: string, clarify: ClarifyQuestion, p: WorkflowPlan) {
+    setPhase("thinking");
+    const t = window.setTimeout(() => {
+      const updated = applyClarify(targetSteps, clarify.field, text);
+      setTargetSteps(updated);
+      setFlashStepId(clarify.stepId);
+      const clearFlash = window.setTimeout(() => setFlashStepId(null), 1100);
+      track(clearFlash);
+      pushAI(
+        clarify.field === "threshold"
+          ? "Locked in. I updated the decision step to use that cutoff."
+          : "Got it. I pointed the handoff at that channel.",
+      );
+      setPendingClarify(null);
+      presentFinish(p);
+    }, 640);
+    track(t);
+  }
+
+  function send(raw?: string) {
+    const text = (raw ?? draft).trim();
+    if (!text || phase === "thinking" || phase === "assembling") return;
+    pushYou(text);
+    setDraft("");
+    if (pendingClarify && plan) {
+      handleAnswer(text, pendingClarify, plan);
+    } else {
+      runBuild(text);
+    }
+  }
+
+  const visibleSteps = targetSteps.slice(0, revealCount);
+  const canvasState =
+    phase === "thinking"
+      ? "Reading your description"
+      : phase === "assembling"
+        ? "Building the workflow"
+        : phase === "refining"
+          ? "One detail to confirm"
+          : phase === "done"
+            ? "Draft ready"
+            : "Waiting for your description";
+  const showGhost =
+    (phase === "thinking" || phase === "assembling") &&
+    revealCount < targetSteps.length;
+  const composerLocked = phase === "thinking" || phase === "assembling";
+
+  return (
+    <div className="opr-builder">
+      <div className="opr-builder-chat">
+        <header className="opr-builder-head">
+          <div>
+            <Eyebrow>Build a tool</Eyebrow>
+            <div className="opr-builder-title">Describe it, I will build it</div>
+          </div>
+          <button
+            type="button"
+            className="opr-btn opr-btn-ghost opr-btn-sm"
+            onClick={onClose}
+            aria-label="Close builder"
+          >
+            <X size={13} strokeWidth={1.9} aria-hidden />
+            Close
+          </button>
+        </header>
+
+        <div className="opr-builder-scroll" ref={scrollRef}>
+          {messages.map((m) => (
+            <div key={m.id} className="opr-edit-msgwrap">
+              <div
+                className={`opr-msg ${
+                  m.from === "ai" ? "opr-msg-ai" : "opr-msg-you"
+                }`}
+              >
+                {m.body}
+              </div>
+              {m.finish ? (
+                <div className="opr-finish-card">
+                  <div className="opr-finish-row">
+                    <span className="opr-finish-glyph" aria-hidden>
+                      <Check size={15} strokeWidth={2.2} />
+                    </span>
+                    <div style={{ flex: 1, minWidth: 0 }}>
+                      <div className="opr-finish-name">{m.finish.name}</div>
+                      <div className="opr-finish-sub">
+                        <ToolStatusBadge status="draft" />
+                        <span>{targetSteps.length}-step workflow</span>
+                      </div>
+                    </div>
+                  </div>
+                  <div className="opr-finish-actions">
+                    <button
+                      type="button"
+                      className="opr-btn opr-btn-primary opr-btn-sm"
+                      onClick={() => onFinish(m.finish!.toolId)}
+                    >
+                      Open the tool
+                      <ArrowRight size={13} strokeWidth={1.9} aria-hidden />
+                    </button>
+                    <button
+                      type="button"
+                      className="opr-btn opr-btn-sm"
+                      onClick={() => onFinish(m.finish!.toolId)}
+                    >
+                      Run on test data
+                    </button>
+                  </div>
+                </div>
+              ) : null}
+            </div>
+          ))}
+          {phase === "thinking" ? (
+            <div className="opr-msg opr-msg-ai opr-thinking" aria-live="polite">
+              <span className="opr-think-dot" />
+              <span className="opr-think-dot" />
+              <span className="opr-think-dot" />
+            </div>
+          ) : null}
+        </div>
+
+        {phase === "intro" ? (
+          <div className="opr-starters">
+            <div className="opr-starters-label">Or start from one of these</div>
+            {STARTERS.map((s) => (
+              <button
+                key={s}
+                type="button"
+                className="opr-starter-chip"
+                onClick={() => send(s)}
+              >
+                {s}
+              </button>
+            ))}
+          </div>
+        ) : null}
+
+        <div className="opr-composer">
+          <input
+            className="opr-composer-input"
+            aria-label="Describe the workflow you want to build"
+            placeholder={
+              pendingClarify
+                ? "Type your answer..."
+                : "Describe what should happen, step by step..."
+            }
+            value={draft}
+            disabled={composerLocked}
+            onChange={(e) => setDraft(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") send();
+            }}
+          />
+          <button
+            type="button"
+            className="opr-btn opr-btn-primary"
+            onClick={() => send()}
+            disabled={composerLocked}
+          >
+            <Send size={14} strokeWidth={1.9} aria-hidden />
+            Send
+          </button>
+        </div>
+      </div>
+
+      <aside className="opr-builder-canvas" aria-label="Workflow preview">
+        <div className="opr-figure-label opr-builder-figure-label">FIG_002</div>
+        <div className="opr-canvas-head">
+          <Eyebrow>{plan ? plan.name : "Your workflow"}</Eyebrow>
+          <span className="opr-canvas-state">
+            <span
+              className={`opr-led ${
+                phase === "done"
+                  ? "opr-led-live"
+                  : phase === "intro"
+                    ? "opr-led-draft"
+                    : "opr-led-suggested"
+              }`}
+            />
+            {canvasState}
+          </span>
+        </div>
+
+        {visibleSteps.length === 0 && !showGhost ? (
+          <div className="opr-canvas-empty">
+            <div className="opr-canvas-empty-glyph" aria-hidden>
+              ◇
+            </div>
+            <div className="opr-canvas-empty-title">
+              Your workflow takes shape here
+            </div>
+            <p className="opr-canvas-empty-hint">
+              As you describe what should happen, each step appears on this side,
+              wired up and scripted, so you can see exactly what your AI is
+              building.
+            </p>
+          </div>
+        ) : (
+          <div className="opr-flow opr-flow-building">
+            {visibleSteps.map((step, i) => (
+              <div
+                className={`opr-step opr-step-reveal${
+                  flashStepId === step.id ? " opr-step-flash" : ""
+                }`}
+                key={step.id}
+              >
+                <div className="opr-step-rail">
+                  <div
+                    className={`opr-step-node opr-step-node-${step.kind}`}
+                    aria-hidden
+                  >
+                    {STEP_GLYPH[step.kind]}
+                  </div>
+                  {i < visibleSteps.length - 1 || showGhost ? (
+                    <div className="opr-step-line" />
+                  ) : null}
+                </div>
+                <div className="opr-step-body">
+                  <div className="opr-step-kind">{step.kind}</div>
+                  <div className="opr-step-title">
+                    {step.title}
+                    {step.integration ? (
+                      <span className="opr-step-chip">{step.integration}</span>
+                    ) : null}
+                  </div>
+                  <div className="opr-step-detail">{step.detail}</div>
+                  {step.gated ? (
+                    <div className="opr-step-gate">
+                      Approval required before it sends
+                    </div>
+                  ) : null}
+                </div>
+              </div>
+            ))}
+            {showGhost ? (
+              <div className="opr-step opr-step-ghost">
+                <div className="opr-step-rail">
+                  <div className="opr-step-node opr-step-node-ghost" aria-hidden>
+                    <span className="opr-think-dot" />
+                    <span className="opr-think-dot" />
+                    <span className="opr-think-dot" />
+                  </div>
+                </div>
+                <div className="opr-step-body">
+                  <div className="opr-step-detail">working out the next step...</div>
+                </div>
+              </div>
+            ) : null}
+          </div>
+        )}
+      </aside>
+    </div>
+  );
+}

--- a/web/src/routes/RootRoute.tsx
+++ b/web/src/routes/RootRoute.tsx
@@ -190,6 +190,14 @@ const SkillDetailRoute = lazy(() =>
   })),
 );
 
+// Operator product shell. Mounted full-bleed at /#/operator, ahead of the office
+// Shell / onboarding / broker gates so the shape is always viewable regardless of
+// backend state. The clean-start product (web/src/operator) — talks to the pi-mono
+// agent service over HTTP/SSE, not the broker. See operator-harness-clean-start.md.
+const OperatorApp = lazy(() =>
+  import("../operator/OperatorApp").then((m) => ({ default: m.OperatorApp })),
+);
+
 function LazyPanelFallback() {
   return (
     <div
@@ -909,6 +917,20 @@ export default function RootRoute() {
   const [bootError, setBootError] = useState(false);
   const [bootAttempt, setBootAttempt] = useState(0);
 
+  // Operator shell mount. The product shell lives at /#/operator and is fully
+  // self-contained, so it short-circuits the office boot/onboarding/Shell. Read
+  // the hash directly (not useRouterState) so it also works where RootRoute
+  // renders without a RouterProvider (bootstrap-fallback tests).
+  const [hashPath, setHashPath] = useState<string>(() =>
+    typeof window !== "undefined" ? window.location.hash.replace(/^#/, "") : "",
+  );
+  useEffect(() => {
+    const onHash = () => setHashPath(window.location.hash.replace(/^#/, ""));
+    window.addEventListener("hashchange", onHash);
+    return () => window.removeEventListener("hashchange", onHash);
+  }, []);
+  const isOperatorRoute = hashPath.startsWith("/operator");
+
   // Manual SPA pageviews (autocapture is off). We subscribe to the router
   // singleton rather than useRouterState so this works even where RootRoute is
   // rendered without a RouterProvider (the bootstrap-fallback tests). Fires the
@@ -1100,7 +1122,15 @@ export default function RootRoute() {
   }, [bootError, bootAttempt]);
 
   let body: ReactNode;
-  if (bootError) {
+  if (isOperatorRoute) {
+    // Operator product shell — self-contained, full-bleed. Bypasses the office
+    // boot/onboarding/Shell so it renders regardless of backend state.
+    body = (
+      <Suspense fallback={<LazyPanelFallback />}>
+        <OperatorApp />
+      </Suspense>
+    );
+  } else if (bootError) {
     body = (
       <BrokerUnreachableScreen onRetry={() => setBootAttempt((a) => a + 1)} />
     );

--- a/web/src/styles/operator-shell.css
+++ b/web/src/styles/operator-shell.css
@@ -1,0 +1,2459 @@
+/* operator-shell.css - the operator-MLP product shell.
+ *
+ * Visual direction: dark technical manual. The shell keeps the locked dark
+ * operator spec, then borrows Making Software's visible language: cobalt figure
+ * ink, small mono figure labels, fine construction grids, hairline rules,
+ * compact reference tables, and sparse physical controls.
+ *
+ * The palette is self-contained and scoped to .opr-root, so the shell owns its
+ * look regardless of the surrounding app theme. Class prefix `opr-` (the
+ * `op-*` console stylesheet, operator.css, is unrelated, keep them separate).
+ *
+ * MOCK-DATA PROTOTYPE: styles the frontend-first shell at /operator.
+ */
+
+.opr-root {
+  /* Design system: shadcn `nex-dark` tokens, pinned dark for the operator
+     shell regardless of the app theme. Contrast is deliberately terminal-muted
+     (soft off-white on dark gray, never bright-white on pure-black) so long
+     sessions don't fatigue the eyes. */
+  --background: 210 6% 8%;
+  --foreground: 210 8% 82%;
+  --card: 210 5% 10%;
+  --secondary: 214 5% 14%;
+  --muted: 210 5% 15%;
+  --muted-foreground: 215 6% 60%;
+  --primary: 264.84 100% 53.7%;
+  --primary-foreground: 210 10% 10%;
+  --border: 210 6% 20%;
+  --destructive: 6 58% 60%;
+  --radius: 6px;
+
+  --ms-cobalt-950: oklch(21% 0.034 264.665);
+  --ms-cobalt-700: oklch(48.8% 0.243 264.376);
+  --ms-cobalt-600: oklch(50.58% 0.2886 264.84);
+  --ms-cobalt-500: oklch(63.79% 0.1899 269.89);
+  --ms-cobalt-400: oklch(76.12% 0.1218 272.4);
+  --ms-cobalt-300: oklch(83.76% 0.0774 273.32);
+  --ms-cobalt-100: oklch(94.22% 0.0275 274.66);
+  --ms-cobalt-50: oklch(97.05% 0.0054 274.97);
+
+  --t-paper: hsl(var(--background));
+  --t-surface: hsl(var(--card));
+  --t-surface-2: hsl(var(--secondary));
+  --t-elevated: hsl(214 5% 18%);
+  --t-ink: hsl(var(--foreground)); /* soft, not harsh white */
+  --t-dim: hsl(var(--muted-foreground));
+  --t-faint: hsl(215 6% 56%);
+  --t-line: hsl(var(--border));
+  --t-line-2: hsl(210 6% 25%);
+  --t-inv-fg: hsl(var(--primary-foreground));
+
+  --t-accent: hsl(var(--foreground)); /* soft-white — chrome / buttons (B&W) */
+  --t-accent-2: var(--ms-cobalt-600);
+  --t-accent-3: var(--ms-cobalt-400);
+  --t-figure-bg: hsl(210 6% 12%);
+  --t-figure-grid: color-mix(in srgb, var(--ms-cobalt-300) 9%, transparent);
+  --t-figure-grid-strong: color-mix(
+    in srgb,
+    var(--ms-cobalt-400) 15%,
+    transparent
+  );
+  --t-paper-speckle: color-mix(in srgb, var(--t-ink) 3%, transparent);
+  /* semantic status - softened so nothing glows on the muted surface */
+  --t-green: oklch(0.76 0.11 158); /* good / live / routed */
+  --t-cyan: var(--ms-cobalt-500); /* info / scored / trigger */
+  --t-blue: var(--ms-cobalt-600); /* enrich / links */
+  --t-yellow: oklch(0.79 0.1 85); /* attention / needs-you / decision */
+  --t-red: hsl(var(--destructive)); /* danger / recording */
+
+  --t-tint-accent: hsl(var(--foreground) / 0.08);
+  --t-tint-2: color-mix(in srgb, var(--t-accent-2) 12%, transparent);
+  --t-r: var(--radius);
+  --t-r-sm: 4px;
+
+  position: fixed;
+  inset: 0;
+  display: grid;
+  grid-template-columns: 240px 1fr;
+  background-color: var(--t-paper);
+  background-image:
+    radial-gradient(circle at 1px 1px, var(--t-paper-speckle) 1px, transparent 0),
+    linear-gradient(90deg, hsl(210 6% 13% / 0.34) 1px, transparent 1px),
+    linear-gradient(180deg, hsl(210 6% 13% / 0.34) 1px, transparent 1px);
+  background-size:
+    15px 15px,
+    56px 56px,
+    56px 56px;
+  color: var(--t-ink);
+  /* Interface is set in the UI sans; monospace is reserved for real data
+     (numbers, IDs, code, timestamps) via .opr-mono and the data classes below.
+     Terminal soul lives in the details, not a full-screen costume. */
+  font-family: var(--font-sans);
+  font-size: 14px;
+  line-height: 1.55;
+  overflow: hidden;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+
+.opr-root *,
+.opr-root *::before,
+.opr-root *::after {
+  box-sizing: border-box;
+}
+
+/* Monospace, strictly for data / code / identifiers. */
+.opr-mono,
+.opr-score,
+.opr-readout-num,
+.opr-readout-lead,
+.opr-version-num,
+.opr-schema-type,
+.opr-step-chip,
+.opr-step-node,
+.opr-figure-label,
+.opr-figure-title,
+.opr-tool-figure-chip,
+.opr-tool-figure-step-title,
+.opr-nav-count,
+.opr-tool-emoji,
+.opr-int-emoji,
+.opr-empty-glyph,
+.opr-brand-sub,
+.opr-brand-mark,
+.opr-cell-sub,
+.opr-msg-meta,
+.opr-call-line b,
+.opr-table thead th {
+  font-family: var(--font-mono);
+}
+
+.opr-main {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  overflow: hidden;
+  border-left: 1px solid var(--t-line);
+  background:
+    linear-gradient(180deg, hsl(210 5% 10% / 0.94), hsl(210 6% 8% / 0.98)),
+    var(--t-paper);
+}
+
+.opr-surface {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: var(--space-7) var(--space-8) var(--space-8);
+}
+
+.opr-surface-wide {
+  max-width: 1080px;
+  margin: 0 auto;
+  width: 100%;
+}
+
+/* blinking accent cursor (the one motion idea) */
+@keyframes opr-blink {
+  0%,
+  50% {
+    opacity: 1;
+  }
+  50.01%,
+  100% {
+    opacity: 0;
+  }
+}
+
+/* Keyboard focus — visible accent ring on every interactive element. Mouse
+   clicks stay clean (:focus-visible only fires for keyboard/AT navigation). */
+.opr-root :focus-visible {
+  outline: 2px solid var(--t-accent);
+  outline-offset: 2px;
+  border-radius: var(--t-r-sm);
+}
+.opr-root button:focus:not(:focus-visible) {
+  outline: none;
+}
+
+/* ───────────────────────────── Sidebar */
+
+.opr-sidebar {
+  display: flex;
+  flex-direction: column;
+  background:
+    linear-gradient(180deg, hsl(210 5% 11% / 0.96), hsl(210 6% 8% / 0.98)),
+    var(--t-paper);
+  padding: var(--space-4) var(--space-3);
+  gap: var(--space-1);
+}
+
+.opr-brand {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-1) var(--space-2) var(--space-4);
+}
+.opr-brand-mark {
+  width: 30px;
+  height: 30px;
+  border-radius: var(--t-r-sm);
+  display: block;
+  object-fit: contain;
+  image-rendering: pixelated; /* keep the pixel-art mark crisp */
+}
+.opr-brand-name {
+  font-family: var(--font-pixel, var(--font-mono));
+  font-weight: 400;
+  font-size: 15px;
+  letter-spacing: 0.08em;
+  color: var(--t-accent-3);
+  text-transform: uppercase;
+}
+.opr-brand-sub {
+  font-size: 9px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--t-faint);
+}
+
+.opr-nav {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.opr-nav-item {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-2-5);
+  border-radius: var(--t-r-sm);
+  color: var(--t-dim);
+  font-size: 13.5px;
+  cursor: pointer;
+  border: none;
+  background: transparent;
+  text-align: left;
+  width: 100%;
+  transition:
+    background var(--duration-fast) ease,
+    color var(--duration-fast) ease,
+    border-color var(--duration-fast) ease;
+}
+.opr-nav-item::before {
+  content: "";
+  width: 4px;
+  height: 16px;
+  border-left: 1px dotted transparent;
+  white-space: pre;
+  color: var(--t-accent);
+  flex-shrink: 0;
+}
+.opr-nav-item:hover {
+  color: var(--t-ink);
+  background: var(--t-surface-2);
+}
+.opr-nav-item.is-active {
+  color: var(--t-ink);
+  background: color-mix(in srgb, var(--t-accent-2) 9%, transparent);
+  font-weight: 700;
+}
+.opr-nav-item.is-active::before {
+  border-left-color: var(--t-accent-2);
+}
+.opr-nav-icon {
+  width: 16px;
+  display: inline-grid;
+  place-items: center;
+  flex-shrink: 0;
+  color: var(--t-faint);
+}
+.opr-nav-icon svg,
+.opr-btn svg {
+  flex-shrink: 0;
+}
+.opr-nav-item:hover .opr-nav-icon {
+  color: var(--t-ink);
+}
+.opr-nav-item.is-active .opr-nav-icon {
+  color: var(--t-accent);
+}
+.opr-nav-count {
+  margin-left: auto;
+  font-size: 11px;
+  color: var(--t-faint);
+}
+
+.opr-sidebar-spacer {
+  flex: 1;
+}
+
+.opr-call-cta {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  margin: var(--space-2) 0;
+  padding: var(--space-2-5) var(--space-3);
+  border: none;
+  border-radius: var(--t-r-sm);
+  background: var(--t-accent);
+  color: var(--t-inv-fg);
+  font-weight: 700;
+  font-size: 13px;
+  cursor: pointer;
+  width: 100%;
+  transition: filter var(--duration-fast) ease;
+}
+.opr-call-cta:hover {
+  filter: brightness(1.08);
+}
+.opr-call-cta .opr-led {
+  background: var(--t-inv-fg);
+  animation: opr-blink 1.1s steps(1) infinite;
+}
+
+.opr-user {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2-5);
+  padding: var(--space-2) var(--space-1);
+  border-top: 1px dotted var(--t-line-2);
+  margin-top: var(--space-2);
+}
+.opr-user-avatar {
+  width: 27px;
+  height: 27px;
+  border-radius: var(--t-r-sm);
+  border: 1px solid var(--t-accent-2);
+  color: var(--t-accent-2);
+  background: var(--t-tint-2);
+  display: grid;
+  place-items: center;
+  font-weight: 700;
+  font-size: 11px;
+}
+.opr-user-name {
+  font-size: 12.5px;
+  font-weight: 600;
+}
+.opr-user-role {
+  font-size: 11px;
+  color: var(--t-faint);
+}
+
+/* ───────────────────────────── Eyebrow + headers */
+
+.opr-eyebrow {
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--t-faint);
+}
+
+.opr-surface-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--space-4);
+  margin-bottom: var(--space-6);
+  padding-bottom: var(--space-4);
+  border-bottom: 1px dotted var(--t-line-2);
+}
+.opr-surface-title {
+  font-size: 25px;
+  font-weight: 800;
+  letter-spacing: 0;
+  margin: var(--space-2) 0;
+}
+.opr-surface-title::before {
+  content: "";
+  display: block;
+  width: 36px;
+  height: 1px;
+  margin: 0 0 var(--space-2);
+  background: var(--t-accent-2);
+}
+.opr-surface-lede {
+  color: var(--t-dim);
+  font-size: 13px;
+  max-width: 68ch;
+  line-height: 1.65;
+}
+
+/* ───────────────────────────── Buttons */
+
+.opr-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1-5);
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid var(--t-line-2);
+  border-radius: var(--t-r-sm);
+  background: color-mix(in srgb, var(--t-surface) 82%, var(--t-paper));
+  color: var(--t-ink);
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow:
+    inset 1px 1px 0 color-mix(in srgb, var(--t-ink) 9%, transparent),
+    inset -1px -1px 0 color-mix(in srgb, black 32%, transparent);
+  transition:
+    border-color var(--duration-fast) ease,
+    color var(--duration-fast) ease,
+    background var(--duration-fast) ease,
+    transform var(--duration-fast) ease;
+  white-space: nowrap;
+}
+.opr-btn:hover {
+  border-color: var(--t-accent);
+  color: var(--t-accent);
+  transform: translateY(-1px);
+}
+.opr-btn-primary {
+  background: var(--t-accent);
+  border-color: var(--t-accent);
+  color: var(--t-inv-fg);
+}
+.opr-btn-primary:hover {
+  filter: brightness(1.08);
+  color: var(--t-inv-fg);
+}
+.opr-btn:active {
+  transform: translateY(0);
+}
+.opr-btn-ghost {
+  border-color: transparent;
+  background: transparent;
+}
+.opr-btn-sm {
+  padding: var(--space-1) var(--space-2);
+  font-size: 11px;
+}
+.opr-btn:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+.opr-btn:disabled:hover {
+  border-color: var(--t-line-2);
+  color: var(--t-ink);
+}
+
+/* ───────────────────────────── Status LED + pills */
+
+.opr-led {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--t-faint);
+  flex-shrink: 0;
+}
+.opr-led-live {
+  background: var(--t-green);
+  animation: opr-blink 1.6s steps(1) infinite;
+}
+.opr-led-warn {
+  background: var(--t-accent);
+}
+.opr-led-draft {
+  background: transparent;
+  box-shadow: inset 0 0 0 1.5px var(--t-faint);
+}
+.opr-led-suggested {
+  background: transparent;
+  box-shadow: inset 0 0 0 1.5px var(--t-accent-2);
+}
+
+.opr-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1-5);
+  padding: 1px 0;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  color: var(--t-dim);
+}
+.opr-pill-good {
+  color: var(--t-green);
+}
+.opr-pill-info {
+  color: var(--t-cyan);
+}
+.opr-pill-muted {
+  color: var(--t-faint);
+}
+/* attention — amber, the one "look here" status */
+.opr-pill-warn {
+  background: color-mix(in srgb, var(--t-yellow) 15%, transparent);
+  color: var(--t-yellow);
+  border-radius: var(--t-r-sm);
+  padding: 1px 6px;
+}
+.opr-pill-warn::before,
+.opr-pill-warn::after {
+  color: var(--t-yellow);
+}
+
+/* Fit score — hierarchy by color */
+.opr-score {
+  display: inline-flex;
+  align-items: baseline;
+  justify-content: center;
+  font-weight: 700;
+  font-size: 13px;
+  padding: 1px 7px;
+  min-width: 34px;
+  border-radius: var(--t-r-sm);
+}
+.opr-score-hot {
+  background: color-mix(in srgb, var(--t-green) 18%, transparent);
+  color: var(--t-green);
+}
+.opr-score-mid {
+  background: color-mix(in srgb, var(--t-yellow) 16%, transparent);
+  color: var(--t-yellow);
+}
+.opr-score-low {
+  color: var(--t-faint);
+}
+.opr-score-unit {
+  display: none;
+}
+
+/* ───────────────────────────── Cards */
+
+.opr-card {
+  background: var(--t-surface);
+  border: 1px solid var(--t-line-2);
+  border-radius: var(--t-r);
+  padding: var(--space-4);
+}
+/* The live tool leads the page as an open block, set off by weight and space,
+   not a box. */
+.opr-card-hero {
+  border: none;
+  border-bottom: 1px dotted var(--t-line-2);
+  border-radius: 0;
+  background: transparent;
+  padding: var(--space-3) 0 var(--space-6);
+}
+.opr-hero-tool-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 0.9fr) minmax(360px, 1.1fr);
+  gap: var(--space-6);
+  align-items: stretch;
+}
+.opr-hero-tool-copy {
+  min-width: 0;
+}
+.opr-tool-figure {
+  position: relative;
+  min-height: 226px;
+  margin: 0;
+  padding: var(--space-5) var(--space-4) var(--space-4);
+  border: 1px solid var(--t-line-2);
+  border-radius: var(--t-r);
+  overflow: hidden;
+  background:
+    linear-gradient(var(--t-figure-grid) 1px, transparent 1px),
+    linear-gradient(90deg, var(--t-figure-grid) 1px, transparent 1px),
+    linear-gradient(
+      135deg,
+      color-mix(in srgb, var(--t-accent-2) 9%, transparent),
+      transparent 55%
+    ),
+    var(--t-figure-bg);
+  background-size:
+    10px 10px,
+    10px 10px,
+    100% 100%,
+    auto;
+}
+.opr-tool-figure::before,
+.opr-tool-figure::after {
+  content: "";
+  position: absolute;
+  width: 7px;
+  height: 7px;
+  border-color: var(--t-line-2);
+  pointer-events: none;
+}
+.opr-tool-figure::before {
+  top: 7px;
+  left: 7px;
+  border-top: 1px solid;
+  border-left: 1px solid;
+}
+.opr-tool-figure::after {
+  right: 7px;
+  bottom: 7px;
+  border-right: 1px solid;
+  border-bottom: 1px solid;
+}
+.opr-figure-label {
+  color: var(--t-accent-3);
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+.opr-figure-title {
+  color: var(--t-faint);
+  font-size: 10px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  margin-top: 2px;
+}
+.opr-tool-figure-rail {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: var(--space-4) var(--space-3);
+  margin-top: var(--space-5);
+}
+.opr-tool-figure-step {
+  position: relative;
+  min-height: 54px;
+  padding-left: var(--space-4);
+}
+.opr-tool-figure-dot {
+  position: absolute;
+  top: 5px;
+  left: 0;
+  width: 8px;
+  height: 8px;
+  border: 1px solid var(--t-accent-2);
+  background: var(--t-figure-bg);
+}
+.opr-step-dot-trigger,
+.opr-step-dot-enrich {
+  border-color: var(--t-accent-2);
+}
+.opr-step-dot-ai {
+  background: var(--t-accent-2);
+  border-color: var(--t-accent-2);
+}
+.opr-step-dot-decision {
+  border-color: var(--t-yellow);
+}
+.opr-step-dot-action {
+  border-color: var(--t-green);
+  background: color-mix(in srgb, var(--t-green) 20%, var(--t-figure-bg));
+}
+.opr-step-dot-branch {
+  border-color: var(--t-faint);
+}
+.opr-tool-figure-line {
+  position: absolute;
+  top: 8px;
+  left: 11px;
+  right: calc(var(--space-3) * -1);
+  border-top: 1px solid color-mix(in srgb, var(--t-accent-2) 38%, transparent);
+}
+.opr-tool-figure-step-title {
+  display: block;
+  color: var(--t-ink);
+  font-size: 10.5px;
+  line-height: 1.35;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.opr-tool-figure-chip {
+  display: inline-flex;
+  margin-top: var(--space-1);
+  color: var(--t-accent-3);
+  font-size: 9.5px;
+}
+.opr-tool-figure-chip::before {
+  content: "@";
+  color: var(--t-faint);
+}
+
+.opr-tool-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-3-5) var(--space-2);
+  margin: 0 calc(var(--space-2) * -1);
+  border-bottom: 1px dotted var(--t-line);
+  border-radius: var(--t-r-sm);
+  cursor: pointer;
+  transition: background var(--duration-fast) ease;
+}
+.opr-tool-row:hover {
+  background: color-mix(in srgb, var(--t-accent-2) 5%, var(--t-surface));
+}
+
+/* mono sigil box (replaces emoji) — purple */
+.opr-tool-emoji,
+.opr-int-emoji {
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  width: 38px;
+  height: 38px;
+  display: grid;
+  place-items: center;
+  border: 1px solid color-mix(in srgb, var(--t-accent-2) 70%, var(--t-line-2));
+  border-radius: var(--t-r-sm);
+  color: var(--t-accent-2);
+  background:
+    linear-gradient(var(--t-figure-grid) 1px, transparent 1px),
+    linear-gradient(90deg, var(--t-figure-grid) 1px, transparent 1px),
+    var(--t-tint-2);
+  background-size: 6px 6px;
+  flex-shrink: 0;
+}
+
+.opr-tool-name {
+  font-weight: 700;
+  font-size: 15.5px;
+  letter-spacing: -0.01em;
+}
+.opr-tool-summary {
+  color: var(--t-dim);
+  font-size: 12.5px;
+  line-height: 1.55;
+  margin-top: 3px;
+}
+.opr-tool-meta {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  margin-top: var(--space-2-5);
+  font-size: 11px;
+  color: var(--t-faint);
+}
+.opr-meta-dot::before {
+  content: "";
+  display: inline-block;
+  width: 3px;
+  height: 3px;
+  margin-right: var(--space-2);
+  border-radius: 50%;
+  background: var(--t-line-2);
+  vertical-align: middle;
+}
+
+.opr-grid {
+  display: grid;
+  gap: 0;
+}
+.opr-section-label {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  margin: var(--space-6) 0 var(--space-3);
+}
+.opr-section-label .opr-eyebrow {
+  white-space: nowrap;
+}
+.opr-section-rule {
+  height: 0;
+  border-top: 1px dotted var(--t-line-2);
+  flex: 1;
+}
+
+/* ───────────────────────────── Tool detail */
+
+.opr-detail-head {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-3-5);
+  margin-bottom: var(--space-4);
+  padding-bottom: var(--space-4);
+  border-bottom: 1px dotted var(--t-line-2);
+}
+.opr-detail-titles {
+  flex: 1;
+  min-width: 0;
+}
+.opr-detail-name {
+  font-size: 19px;
+  font-weight: 800;
+  letter-spacing: 0;
+  display: flex;
+  align-items: center;
+  gap: var(--space-2-5);
+}
+.opr-detail-actions {
+  display: flex;
+  gap: var(--space-2);
+  align-items: center;
+}
+
+.opr-back {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1-5);
+  color: var(--t-dim);
+  font-size: 12px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: var(--space-1) 0;
+  margin-bottom: var(--space-3);
+}
+.opr-back:hover {
+  color: var(--t-ink);
+}
+
+/* Tabs */
+.opr-tabs {
+  display: flex;
+  gap: 2px;
+  border-bottom: 1px dotted var(--t-line-2);
+  margin-bottom: var(--space-5);
+}
+.opr-tab {
+  position: relative;
+  padding: var(--space-2) var(--space-3);
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--t-dim);
+  background: none;
+  border: none;
+  cursor: pointer;
+  margin-bottom: -1px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  border: 1px solid transparent;
+  border-bottom: none;
+  border-radius: var(--t-r-sm) var(--t-r-sm) 0 0;
+}
+.opr-tab:hover {
+  color: var(--t-ink);
+}
+.opr-tab.is-active {
+  color: var(--t-accent-3);
+  background: color-mix(in srgb, var(--t-accent-2) 8%, var(--t-surface));
+  border-color: var(--t-line-2);
+  box-shadow: inset 0 -2px 0 var(--t-accent-2);
+}
+.opr-tab-hint {
+  font-size: 9px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--t-faint);
+  margin-left: auto;
+  align-self: center;
+  padding: 0 var(--space-1) var(--space-1);
+}
+
+/* ───────────────────────────── Data table */
+
+.opr-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+.opr-table thead th {
+  text-align: left;
+  font-size: 10px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--t-faint);
+  font-weight: 700;
+  padding: var(--space-2) var(--space-3);
+  border-bottom: 1px dotted var(--t-line-2);
+  white-space: nowrap;
+}
+.opr-table tbody td {
+  padding: var(--space-2-5) var(--space-3);
+  border-bottom: 1px dotted var(--t-line);
+  vertical-align: middle;
+}
+.opr-table tbody tr:hover {
+  background: color-mix(in srgb, var(--t-accent-2) 5%, var(--t-surface));
+}
+.opr-table tbody tr:last-child td {
+  border-bottom: none;
+}
+.opr-cell-primary {
+  font-weight: 700;
+}
+.opr-cell-sub {
+  color: var(--t-faint);
+  font-size: 11px;
+}
+
+/* No container box — the table is content, not a card. Cells run flush to the
+   column edges for an editorial, ledger-like read. */
+.opr-table-wrap {
+  margin-top: var(--space-2);
+  border-top: 1px solid var(--t-line-2);
+  border-bottom: 1px solid var(--t-line-2);
+  background:
+    linear-gradient(var(--t-figure-grid) 1px, transparent 1px),
+    linear-gradient(90deg, var(--t-figure-grid) 1px, transparent 1px);
+  background-size: 12px 12px;
+}
+.opr-table-toolbar {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  padding: var(--space-2-5) 0;
+  gap: var(--space-3);
+  border-bottom: 1px dotted var(--t-line-2);
+}
+.opr-table th:first-child,
+.opr-table td:first-child {
+  padding-left: 0;
+}
+.opr-table th:last-child,
+.opr-table td:last-child {
+  padding-right: 0;
+}
+.opr-schema-type {
+  font-size: 9px;
+  color: var(--t-cyan);
+  text-transform: lowercase;
+  letter-spacing: 0;
+  margin-left: var(--space-2);
+}
+.opr-schema-type::before {
+  content: "·";
+  margin-right: var(--space-2);
+  color: var(--t-faint);
+}
+
+/* ───────────────────────────── Workflow flow */
+
+.opr-flow {
+  display: flex;
+  flex-direction: column;
+  position: relative;
+}
+.opr-step {
+  display: flex;
+  gap: var(--space-3);
+}
+.opr-step-rail {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 32px;
+  flex-shrink: 0;
+}
+.opr-step-node {
+  width: 31px;
+  height: 31px;
+  border: 1px solid var(--t-line-2);
+  border-radius: var(--t-r-sm);
+  background:
+    linear-gradient(var(--t-figure-grid) 1px, transparent 1px),
+    linear-gradient(90deg, var(--t-figure-grid) 1px, transparent 1px),
+    var(--t-surface);
+  background-size: 6px 6px;
+  display: grid;
+  place-items: center;
+  font-size: 9.5px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  z-index: 1;
+}
+.opr-step-node-trigger {
+  border-color: var(--t-cyan);
+  color: var(--t-cyan);
+}
+.opr-step-node-enrich {
+  border-color: var(--t-blue);
+  color: var(--t-blue);
+}
+.opr-step-node-ai {
+  border-color: var(--t-accent);
+  background: var(--t-accent);
+  color: var(--t-inv-fg);
+}
+.opr-step-node-decision {
+  border-color: var(--t-yellow);
+  color: var(--t-yellow);
+  border-style: dashed;
+}
+.opr-step-node-action {
+  border-color: var(--t-green);
+  color: var(--t-green);
+}
+.opr-step-node-branch {
+  border-color: var(--t-faint);
+  color: var(--t-faint);
+}
+.opr-step-line {
+  width: 1px;
+  flex: 1;
+  background: repeating-linear-gradient(
+    to bottom,
+    var(--t-line-2),
+    var(--t-line-2) 3px,
+    transparent 3px,
+    transparent 6px
+  );
+  min-height: var(--space-4);
+}
+.opr-step-body {
+  padding-bottom: var(--space-4);
+  flex: 1;
+  min-width: 0;
+}
+.opr-step-kind {
+  font-size: 9px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--t-faint);
+}
+.opr-step-title {
+  font-weight: 700;
+  font-size: 13.5px;
+  margin: 2px 0 3px;
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+.opr-step-detail {
+  color: var(--t-dim);
+  font-size: 12px;
+  line-height: 1.55;
+}
+.opr-step-chip {
+  display: inline-flex;
+  align-items: center;
+  font-size: 10px;
+  border: 1px solid color-mix(in srgb, var(--t-accent-2) 45%, var(--t-line-2));
+  border-radius: var(--t-r-sm);
+  color: var(--t-cyan);
+  padding: 0 5px;
+}
+.opr-step-chip::before {
+  content: "@";
+  color: var(--t-faint);
+  margin-right: 2px;
+}
+.opr-step-gate {
+  margin-top: var(--space-2);
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1-5);
+  font-size: 10.5px;
+  font-weight: 700;
+  color: var(--t-yellow);
+  background: color-mix(in srgb, var(--t-yellow) 12%, transparent);
+  border: 1px solid color-mix(in srgb, var(--t-yellow) 30%, transparent);
+  border-radius: var(--t-r-sm);
+  padding: 1px 7px;
+}
+
+.opr-detail-cols {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 340px;
+  gap: var(--space-6);
+  align-items: start;
+}
+.opr-rail-card {
+  padding: var(--space-3);
+  margin-bottom: var(--space-6);
+  border: 1px solid var(--t-line-2);
+  border-radius: var(--t-r);
+  background: color-mix(in srgb, var(--t-surface) 80%, transparent);
+}
+.opr-rail-card > .opr-eyebrow {
+  display: block;
+  padding-bottom: var(--space-2);
+  margin-bottom: var(--space-1);
+  border-bottom: 1px dotted var(--t-line-2);
+}
+.opr-run-row {
+  display: flex;
+  gap: var(--space-2-5);
+  padding: var(--space-2-5) 0;
+  border-bottom: 1px dotted var(--t-line);
+  font-size: 11.5px;
+}
+.opr-run-row:last-child {
+  border-bottom: none;
+}
+.opr-version-row {
+  display: flex;
+  gap: var(--space-2-5);
+  padding: var(--space-2-5) 0;
+  border-bottom: 1px dotted var(--t-line);
+}
+.opr-version-row:last-child {
+  border-bottom: none;
+}
+.opr-version-num {
+  font-size: 10px;
+  font-weight: 700;
+  color: var(--t-accent-2);
+  border: 1px solid var(--t-accent-2);
+  border-radius: var(--t-r-sm);
+  padding: 0 5px;
+  height: fit-content;
+}
+
+/* ───────────────────────────── Digest strip */
+
+/* Run summary as a terminal status line, not a stat-tile row. Inline, baseline-
+   aligned, generous rhythm; the number carries meaning, the label recedes. */
+.opr-readout {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: var(--space-2) var(--space-6);
+  padding: var(--space-2) 0 var(--space-4);
+  margin-bottom: var(--space-5);
+  border-bottom: 1px dotted var(--t-line);
+}
+.opr-readout-lead {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--t-faint);
+  margin-right: var(--space-1);
+}
+.opr-readout-stat {
+  display: inline-flex;
+  align-items: baseline;
+  gap: var(--space-2);
+}
+.opr-readout-num {
+  font-size: 21px;
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  color: var(--t-ink);
+  font-variant-numeric: tabular-nums;
+}
+.opr-readout-label {
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  color: var(--t-faint);
+}
+.opr-digest-good {
+  color: var(--t-green);
+}
+.opr-digest-warn {
+  color: var(--t-yellow);
+}
+
+/* ───────────────────────────── Chats */
+
+.opr-chat-layout {
+  display: grid;
+  grid-template-columns: 282px 1fr;
+  height: 100%;
+  min-height: 0;
+}
+.opr-chat-list {
+  border-right: 1px dotted var(--t-line);
+  overflow-y: auto;
+  padding: var(--space-3);
+  background: color-mix(in srgb, var(--t-surface) 75%, var(--t-paper));
+}
+.opr-chat-list > .opr-eyebrow {
+  padding: 0 var(--space-3);
+}
+.opr-chat-listitem {
+  display: block;
+  width: 100%;
+  text-align: left;
+  border: none;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  padding: var(--space-2-5) var(--space-3);
+  cursor: pointer;
+  border-radius: var(--t-r-sm);
+  transition: background var(--duration-fast) ease;
+}
+.opr-chat-listitem:hover {
+  background: color-mix(in srgb, var(--t-accent-2) 6%, var(--t-surface));
+}
+.opr-chat-listitem.is-active {
+  background: color-mix(in srgb, var(--t-accent-2) 8%, var(--t-surface));
+}
+.opr-chat-listitem-title {
+  font-weight: 700;
+  font-size: 12.5px;
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+.opr-chat-listitem.is-active .opr-chat-listitem-title {
+  color: var(--t-accent-3);
+}
+.opr-chat-listitem-sub {
+  color: var(--t-faint);
+  font-size: 11px;
+  margin-top: 2px;
+}
+.opr-chat-main {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  min-height: 0;
+}
+.opr-chat-scroll {
+  flex: 1;
+  overflow-y: auto;
+  padding: var(--space-6) var(--space-7);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3-5);
+}
+.opr-msg {
+  max-width: 66%;
+  padding: var(--space-2-5) var(--space-3);
+  font-size: 13px;
+  line-height: 1.6;
+  border: 1px solid var(--t-line-2);
+  border-radius: var(--t-r-sm);
+}
+.opr-msg-ai {
+  align-self: flex-start;
+  background: color-mix(in srgb, var(--t-surface) 86%, transparent);
+}
+.opr-msg-ai::before {
+  content: "Nex";
+  display: block;
+  color: var(--t-accent-2);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  margin-bottom: 3px;
+}
+.opr-msg-you {
+  align-self: flex-end;
+  background: color-mix(in srgb, var(--t-accent-2) 9%, var(--t-surface));
+  border-color: color-mix(in srgb, var(--t-accent-2) 45%, var(--t-line-2));
+}
+.opr-msg-meta {
+  font-size: 10px;
+  color: var(--t-faint);
+  margin-top: 1px;
+}
+.opr-composer {
+  border-top: 1px dotted var(--t-line-2);
+  padding: var(--space-3) var(--space-4);
+  display: flex;
+  gap: var(--space-2);
+  align-items: center;
+  background: color-mix(in srgb, var(--t-surface) 78%, var(--t-paper));
+}
+.opr-composer-input {
+  flex: 1;
+  border: 1px solid var(--t-line-2);
+  border-radius: var(--t-r-sm);
+  padding: var(--space-2-5) var(--space-3);
+  font-size: 12.5px;
+  background: var(--t-paper);
+  color: var(--t-ink);
+}
+.opr-composer-input::placeholder {
+  color: var(--t-faint);
+}
+.opr-composer-input:focus {
+  outline: none;
+  border-color: var(--t-accent);
+  box-shadow: 0 0 0 3px var(--t-tint-accent);
+}
+
+/* ───────────────────────────── Call modal */
+
+.opr-modal-scrim {
+  position: fixed;
+  inset: 0;
+  background: hsl(210 12% 3% / 0.66);
+  backdrop-filter: blur(2px);
+  display: grid;
+  place-items: center;
+  z-index: var(--z-modal, 160);
+}
+.opr-call {
+  width: min(720px, 92vw);
+  background: var(--t-surface);
+  border: 1px solid var(--t-line-2);
+  border-radius: var(--t-r);
+  overflow: hidden;
+  box-shadow: 0 24px 80px -24px rgba(0, 0, 0, 0.7);
+}
+.opr-call-stage {
+  position: relative;
+  aspect-ratio: 16 / 9;
+  background:
+    linear-gradient(var(--t-figure-grid) 1px, transparent 1px),
+    linear-gradient(90deg, var(--t-figure-grid) 1px, transparent 1px),
+    hsl(210 12% 5%);
+  background-size: 12px 12px;
+  color: var(--t-ink);
+  display: grid;
+  place-items: center;
+  overflow: hidden;
+  border-bottom: 1px dotted var(--t-line-2);
+}
+.opr-call-rec {
+  position: absolute;
+  top: var(--space-3);
+  left: var(--space-3);
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--t-red);
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+.opr-call-rec .opr-led {
+  background: var(--t-red);
+  animation: opr-blink 1.1s steps(1) infinite;
+}
+.opr-call-screenshare {
+  text-align: center;
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  color: var(--t-faint);
+}
+.opr-call-wave {
+  position: absolute;
+  bottom: 56px;
+  left: 0;
+  right: 0;
+  text-align: center;
+  font-size: 18px;
+  letter-spacing: 2px;
+  color: var(--t-accent-3);
+  animation: opr-wave 1.4s steps(4) infinite;
+}
+@keyframes opr-wave {
+  0% {
+    opacity: 0.45;
+  }
+  50% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0.45;
+  }
+}
+.opr-call-caption {
+  position: absolute;
+  bottom: var(--space-3);
+  left: var(--space-3);
+  right: var(--space-3);
+  font-size: 12.5px;
+  line-height: 1.45;
+  color: var(--t-ink);
+}
+.opr-call-caption b {
+  color: var(--t-accent-2);
+  text-transform: uppercase;
+  font-size: 10px;
+  letter-spacing: 0.08em;
+}
+.opr-call-body {
+  padding: var(--space-4) var(--space-5) var(--space-5);
+}
+.opr-call-transcript {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2-5);
+  margin: var(--space-3) 0 var(--space-4);
+  max-height: 168px;
+  overflow-y: auto;
+}
+.opr-call-line {
+  font-size: 12.5px;
+  line-height: 1.5;
+}
+.opr-call-line b {
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--t-accent-2);
+  display: block;
+  margin-bottom: 1px;
+  font-weight: 700;
+}
+
+/* ───────────────────────────── Approval card */
+
+.opr-approval {
+  border: 1px solid color-mix(in srgb, var(--t-yellow) 45%, var(--t-line-2));
+  border-radius: var(--t-r-sm);
+  background: color-mix(in srgb, var(--t-yellow) 9%, transparent);
+  padding: var(--space-3-5) var(--space-4);
+  display: flex;
+  gap: var(--space-3);
+  align-items: flex-start;
+  margin: var(--space-4) 0;
+}
+.opr-approval-icon {
+  width: 22px;
+  height: 22px;
+  border-radius: var(--t-r-sm);
+  display: grid;
+  place-items: center;
+  background: var(--t-yellow);
+  color: var(--t-inv-fg);
+  font-weight: 700;
+  flex-shrink: 0;
+}
+.opr-approval-actions {
+  display: flex;
+  gap: var(--space-2);
+  margin-top: var(--space-2-5);
+}
+
+/* ───────────────────────────── Knowledge — Wikipedia-style reader */
+
+.opr-wiki {
+  display: grid;
+  grid-template-columns: 200px 1fr;
+  gap: var(--space-7);
+  align-items: start;
+}
+.opr-kn-list {
+  position: sticky;
+  top: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+.opr-kn-item {
+  padding: var(--space-1-5) var(--space-2);
+  cursor: pointer;
+  border: none;
+  background: none;
+  text-align: left;
+  width: 100%;
+  font-size: 13px;
+  color: var(--t-blue);
+  border-radius: var(--t-r-sm);
+}
+.opr-kn-item:hover {
+  background: var(--t-surface);
+  text-decoration: underline;
+}
+.opr-kn-item.is-active {
+  color: var(--t-ink);
+  font-weight: 600;
+  background: var(--t-surface);
+}
+
+.opr-article {
+  max-width: 72ch;
+  font-size: 14px;
+}
+.opr-article h1 {
+  font-size: 27px;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  margin: 0 0 var(--space-1);
+  padding-bottom: var(--space-2);
+  border-bottom: 1px dotted var(--t-line-2);
+}
+.opr-article-meta {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--t-faint);
+  margin-bottom: var(--space-4);
+}
+.opr-article h2 {
+  font-size: 18px;
+  font-weight: 650;
+  margin: var(--space-5) 0 var(--space-2);
+  padding-bottom: var(--space-1);
+  border-bottom: 1px dotted var(--t-line);
+}
+.opr-article p {
+  line-height: 1.75;
+  color: var(--t-dim);
+  margin: 0 0 var(--space-3);
+}
+.opr-article-lead {
+  color: var(--t-ink) !important;
+  font-size: 15px;
+}
+.opr-article section {
+  margin: 0;
+}
+
+/* Infobox — right-floated, Wikipedia's signature */
+.opr-article-infobox {
+  float: right;
+  width: 248px;
+  margin: var(--space-1) 0 var(--space-4) var(--space-5);
+  background: color-mix(in srgb, var(--t-surface) 86%, transparent);
+  border: 1px solid var(--t-line-2);
+  border-radius: var(--t-r);
+  padding: var(--space-3) var(--space-3-5);
+  font-size: 12.5px;
+}
+.opr-infobox-title {
+  font-weight: 700;
+  font-size: 13.5px;
+  text-align: center;
+  padding-bottom: var(--space-2);
+  margin-bottom: var(--space-2);
+  border-bottom: 1px dotted var(--t-line-2);
+}
+.opr-infobox-row {
+  display: grid;
+  grid-template-columns: 1fr 1.3fr;
+  gap: var(--space-2);
+  padding: var(--space-1) 0;
+  border-bottom: 1px dotted var(--t-line);
+}
+.opr-infobox-row:last-child {
+  border-bottom: none;
+}
+.opr-infobox-row dt {
+  color: var(--t-faint);
+  font-size: 11px;
+}
+.opr-infobox-row dd {
+  margin: 0;
+  color: var(--t-ink);
+}
+
+/* Inline citations */
+.opr-cite {
+  font-size: 0.7em;
+  line-height: 0;
+}
+.opr-cite a {
+  color: var(--t-blue);
+  text-decoration: none;
+}
+.opr-cite a:hover {
+  text-decoration: underline;
+}
+
+/* References list */
+.opr-refs {
+  margin: 0 0 var(--space-4);
+  padding-left: var(--space-5);
+  font-size: 12.5px;
+  color: var(--t-dim);
+  line-height: 1.7;
+}
+.opr-refs li {
+  scroll-margin-top: var(--space-6);
+}
+.opr-ref-source {
+  color: var(--t-ink);
+}
+.opr-ref-detail {
+  color: var(--t-faint);
+}
+
+.opr-seealso {
+  margin: 0 0 var(--space-4);
+  padding-left: var(--space-5);
+  font-size: 13.5px;
+}
+.opr-wikilink {
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  color: var(--t-blue);
+  font-size: inherit;
+}
+.opr-wikilink:hover {
+  text-decoration: underline;
+}
+
+.opr-categories {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-2);
+  margin-top: var(--space-5);
+  padding-top: var(--space-3);
+  border-top: 1px dotted var(--t-line-2);
+  font-size: 12px;
+}
+.opr-cat-label {
+  color: var(--t-faint);
+  margin-right: var(--space-1);
+}
+.opr-cat {
+  color: var(--t-blue);
+  padding: 1px 8px;
+  border: 1px solid var(--t-line-2);
+  border-radius: var(--radius-full, 999px);
+}
+
+/* ───────────────────────────── Integrations */
+
+.opr-int-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(294px, 1fr));
+  gap: var(--space-2);
+}
+.opr-int-card {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-3);
+  border: 1px solid var(--t-line-2);
+  border-radius: var(--t-r);
+  background: color-mix(in srgb, var(--t-surface) 84%, transparent);
+}
+
+/* ───────────────────────────── Settings */
+
+.opr-settings {
+  max-width: 660px;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+.opr-set-group {
+  border: 1px solid var(--t-line-2);
+  border-radius: var(--t-r);
+  background: color-mix(in srgb, var(--t-surface) 84%, transparent);
+  padding: var(--space-3) var(--space-4) var(--space-4);
+}
+.opr-set-group > .opr-eyebrow {
+  display: block;
+  padding-bottom: var(--space-2);
+  border-bottom: 1px dotted var(--t-line);
+  margin-bottom: var(--space-1);
+  color: var(--t-accent-2);
+}
+.opr-set-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-4);
+  padding: var(--space-3) 0;
+  border-bottom: 1px dotted var(--t-line);
+}
+.opr-set-row:last-child {
+  border-bottom: none;
+}
+.opr-set-label {
+  font-weight: 700;
+  font-size: 12.5px;
+}
+.opr-set-help {
+  color: var(--t-faint);
+  font-size: 11px;
+  margin-top: 3px;
+  max-width: 46ch;
+  line-height: 1.5;
+}
+.opr-input {
+  border: 1px solid var(--t-line-2);
+  border-radius: var(--t-r-sm);
+  padding: var(--space-2) var(--space-2-5);
+  font-size: 12px;
+  background: var(--t-paper);
+  color: var(--t-ink);
+  min-width: 250px;
+}
+.opr-input:focus {
+  outline: none;
+  border-color: var(--t-accent);
+  box-shadow: 0 0 0 3px var(--t-tint-accent);
+}
+.opr-input:disabled {
+  opacity: 0.45;
+}
+
+/* TUI switch */
+.opr-toggle {
+  width: 44px;
+  height: 23px;
+  border: 1px solid var(--t-line-2);
+  border-radius: var(--radius-full, 999px);
+  background: var(--t-paper);
+  position: relative;
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: background var(--duration-base) ease,
+    border-color var(--duration-base) ease;
+}
+.opr-toggle::after {
+  content: "";
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 17px;
+  height: 17px;
+  border-radius: 50%;
+  background: var(--t-faint);
+  transition: transform var(--duration-base) ease,
+    background var(--duration-base) ease;
+}
+.opr-toggle.is-on {
+  background: var(--t-green);
+  border-color: var(--t-green);
+}
+.opr-toggle.is-on::after {
+  background: var(--t-inv-fg);
+  transform: translateX(21px);
+}
+
+.opr-danger {
+  color: var(--t-red);
+}
+.opr-btn.opr-danger:hover {
+  border-color: var(--t-red);
+  color: var(--t-red);
+}
+
+/* ───────────────────────────── Empty / banner */
+
+/* Empty state — a feature, not a dead end: a glyph, a warm line, an action. */
+.opr-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: var(--space-2);
+  padding: var(--space-8) var(--space-4);
+  border: 1px dashed var(--t-line-2);
+  border-radius: var(--t-r);
+}
+.opr-empty-glyph {
+  width: 40px;
+  height: 40px;
+  display: grid;
+  place-items: center;
+  border: 1px solid var(--t-accent-2);
+  border-radius: var(--t-r-sm);
+  color: var(--t-accent-2);
+  background: var(--t-tint-2);
+  font-size: 18px;
+  margin-bottom: var(--space-1);
+}
+.opr-empty-title {
+  font-weight: 700;
+  font-size: 13.5px;
+  color: var(--t-ink);
+}
+.opr-empty-hint {
+  font-size: 12px;
+  color: var(--t-dim);
+  max-width: 44ch;
+  line-height: 1.55;
+}
+.opr-empty-actions {
+  margin-top: var(--space-2);
+}
+.opr-banner {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: 11px;
+  color: var(--t-dim);
+  letter-spacing: 0.04em;
+  padding: var(--space-2) var(--space-4);
+  background: color-mix(in srgb, var(--t-surface) 70%, var(--t-paper));
+  border-bottom: 1px solid var(--t-line-2);
+}
+
+/* ───────────────────────────── Responsive (adapt) */
+
+/* Coarse pointers (touch): enlarge tap targets to the 44px guideline. */
+@media (pointer: coarse) {
+  .opr-nav-item,
+  .opr-btn,
+  .opr-tab,
+  .opr-tool-row,
+  .opr-chat-listitem,
+  .opr-kn-item {
+    min-height: 44px;
+  }
+}
+
+/* Tablet and below: collapse the two-column surfaces to one column. */
+@media (max-width: 900px) {
+  .opr-surface {
+    padding: var(--space-5) var(--space-4) var(--space-7);
+  }
+  .opr-detail-cols,
+  .opr-wiki {
+    grid-template-columns: 1fr;
+    gap: var(--space-5);
+  }
+  .opr-article-infobox {
+    float: none;
+    width: auto;
+    margin: 0 0 var(--space-4);
+  }
+  .opr-kn-list {
+    position: static;
+    flex-direction: row;
+    flex-wrap: wrap;
+    gap: var(--space-1);
+    padding-bottom: var(--space-3);
+    border-bottom: 1px solid var(--t-line);
+  }
+  .opr-table-wrap {
+    overflow-x: auto;
+  }
+}
+
+/* Narrow: sidebar becomes a horizontal top bar; chat stacks. */
+@media (max-width: 680px) {
+  .opr-root {
+    grid-template-columns: 1fr;
+    grid-template-rows: auto 1fr;
+  }
+  .opr-sidebar {
+    flex-direction: row;
+    align-items: center;
+    gap: var(--space-1);
+    overflow-x: auto;
+    padding: var(--space-2) var(--space-3);
+    border-bottom: 1px solid var(--t-line);
+  }
+  .opr-sidebar .opr-nav {
+    flex-direction: row;
+  }
+  .opr-brand {
+    padding: 0 var(--space-2) 0 0;
+  }
+  .opr-sidebar-spacer,
+  .opr-call-cta,
+  .opr-user {
+    display: none;
+  }
+  .opr-nav-item {
+    white-space: nowrap;
+  }
+  .opr-main {
+    border-left: none;
+  }
+  .opr-chat-layout {
+    grid-template-columns: 1fr;
+    grid-template-rows: auto 1fr;
+  }
+  .opr-chat-list {
+    flex-direction: row;
+    overflow-x: auto;
+    gap: var(--space-2);
+    border-right: none;
+    border-bottom: 1px solid var(--t-line);
+  }
+  .opr-chat-listitem {
+    white-space: nowrap;
+  }
+  .opr-msg {
+    max-width: 88%;
+  }
+}
+
+/* ───────────────────────────── Edit-with-AI dock */
+
+.opr-detail-wrap.is-editing .opr-surface-wide {
+  max-width: none;
+  margin-right: 416px;
+}
+.opr-edit-panel {
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: min(400px, 92vw);
+  background: var(--t-surface);
+  border-left: 1px solid var(--t-line-2);
+  display: flex;
+  flex-direction: column;
+  z-index: 50;
+  box-shadow: -18px 0 48px -28px rgba(0, 0, 0, 0.7);
+  animation: opr-dock var(--duration-base) ease;
+}
+@keyframes opr-dock {
+  from {
+    transform: translateX(12px);
+    opacity: 0;
+  }
+  to {
+    transform: translateX(0);
+    opacity: 1;
+  }
+}
+.opr-edit-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-4);
+  border-bottom: 1px solid var(--t-line-2);
+}
+.opr-edit-tool {
+  font-weight: 650;
+  font-size: 14px;
+  margin-top: 2px;
+}
+.opr-edit-scroll {
+  flex: 1;
+  overflow-y: auto;
+  padding: var(--space-4);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3-5);
+}
+.opr-edit-msgwrap {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+.opr-edit-panel .opr-msg {
+  max-width: 100%;
+}
+.opr-proposal {
+  border: 1px solid var(--t-line-2);
+  border-radius: var(--t-r);
+  background: var(--t-paper);
+  padding: var(--space-3) var(--space-3-5);
+}
+.opr-proposal-list {
+  margin: var(--space-2) 0 0;
+  padding-left: var(--space-4);
+  font-size: 13px;
+  line-height: 1.7;
+  color: var(--t-ink);
+}
+.opr-proposal-list li::marker {
+  color: var(--t-accent-2);
+}
+.opr-proposal-actions {
+  display: flex;
+  gap: var(--space-2);
+  margin-top: var(--space-3);
+}
+.opr-proposal-applied {
+  margin-top: var(--space-2);
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--t-green);
+}
+.opr-proposal-applied::before {
+  content: "Applied: ";
+}
+.opr-edit-panel .opr-composer {
+  border-top: 1px solid var(--t-line-2);
+}
+
+@media (max-width: 900px) {
+  .opr-detail-wrap.is-editing .opr-surface-wide {
+    margin-right: 0;
+  }
+  .opr-edit-panel {
+    width: 100vw;
+  }
+}
+
+/* ───────────────────────────── Skin toggle (prototype A/B) */
+
+.opr-skin-toggle {
+  position: fixed;
+  top: var(--space-3);
+  right: var(--space-4);
+  z-index: 80;
+  display: inline-flex;
+  gap: 2px;
+  padding: 2px;
+  border: 1px solid var(--t-line-2);
+  border-radius: var(--t-r-sm);
+  background: var(--t-surface);
+}
+.opr-skin-toggle button {
+  border: none;
+  background: transparent;
+  color: var(--t-faint);
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  letter-spacing: 0.04em;
+  padding: var(--space-1-5) var(--space-2-5);
+  border-radius: calc(var(--t-r-sm) - 1px);
+  cursor: pointer;
+}
+.opr-skin-toggle button.is-active {
+  background: var(--t-accent);
+  color: var(--t-inv-fg);
+  font-weight: 700;
+}
+
+/* ───────────────────────────── Build-a-tool CTAs */
+
+.opr-build-cta {
+  width: 100%;
+  justify-content: center;
+  margin: var(--space-2) 0 0;
+}
+.opr-call-cta-secondary {
+  background: transparent;
+  color: var(--t-ink);
+  border: 1px solid var(--t-line-2);
+  font-weight: 600;
+}
+.opr-call-cta-secondary .opr-led {
+  background: var(--t-red);
+}
+.opr-call-cta-secondary:hover {
+  filter: none;
+  background: color-mix(in srgb, var(--t-accent-2) 6%, var(--t-surface));
+}
+.opr-header-actions {
+  display: flex;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+}
+
+/* ───────────────────────────── Chat-to-build authoring */
+
+.opr-builder {
+  flex: 1;
+  min-height: 0;
+  display: grid;
+  grid-template-columns: minmax(380px, 1fr) minmax(360px, 1.05fr);
+}
+.opr-builder-chat {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  min-height: 0;
+  border-right: 1px dotted var(--t-line);
+}
+.opr-builder-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--space-3);
+  padding: var(--space-4) var(--space-5);
+  border-bottom: 1px dotted var(--t-line-2);
+}
+.opr-builder-title {
+  font-weight: 700;
+  font-size: 15px;
+  margin-top: 3px;
+}
+.opr-builder-scroll {
+  flex: 1;
+  overflow-y: auto;
+  padding: var(--space-5) var(--space-5);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3-5);
+}
+.opr-builder-scroll .opr-msg {
+  max-width: 86%;
+}
+
+/* AI thinking indicator */
+.opr-thinking {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: var(--space-3) var(--space-3-5);
+}
+.opr-think-dot {
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: var(--t-accent-2);
+  opacity: 0.4;
+  animation: opr-think 1.1s ease-in-out infinite;
+}
+.opr-think-dot:nth-child(2) {
+  animation-delay: 0.16s;
+}
+.opr-think-dot:nth-child(3) {
+  animation-delay: 0.32s;
+}
+@keyframes opr-think {
+  0%,
+  100% {
+    opacity: 0.3;
+    transform: translateY(0);
+  }
+  40% {
+    opacity: 1;
+    transform: translateY(-2px);
+  }
+}
+
+/* Starter suggestions */
+.opr-starters {
+  padding: 0 var(--space-5) var(--space-3);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+.opr-starters-label {
+  font-size: 10px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--t-faint);
+  margin-bottom: 2px;
+}
+.opr-starter-chip {
+  text-align: left;
+  border: 1px solid var(--t-line-2);
+  border-radius: var(--t-r-sm);
+  background: color-mix(in srgb, var(--t-surface) 82%, transparent);
+  color: var(--t-dim);
+  padding: var(--space-2-5) var(--space-3);
+  font-size: 12px;
+  line-height: 1.5;
+  cursor: pointer;
+  transition:
+    border-color var(--duration-fast) ease,
+    color var(--duration-fast) ease;
+}
+.opr-starter-chip:hover {
+  border-color: var(--t-accent-2);
+  color: var(--t-ink);
+}
+
+/* Finish card — the draft tool handed off in the conversation */
+.opr-finish-card {
+  border: 1px solid color-mix(in srgb, var(--t-green) 40%, var(--t-line-2));
+  border-radius: var(--t-r-sm);
+  background: color-mix(in srgb, var(--t-green) 7%, var(--t-surface));
+  padding: var(--space-3) var(--space-3-5);
+}
+.opr-finish-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+}
+.opr-finish-glyph {
+  width: 26px;
+  height: 26px;
+  flex-shrink: 0;
+  display: grid;
+  place-items: center;
+  border-radius: var(--t-r-sm);
+  background: var(--t-green);
+  color: var(--t-inv-fg);
+  font-size: 14px;
+  font-weight: 700;
+}
+.opr-finish-name {
+  font-weight: 700;
+  font-size: 13.5px;
+}
+.opr-finish-sub {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  margin-top: 3px;
+  font-size: 11px;
+  color: var(--t-faint);
+}
+.opr-finish-actions {
+  display: flex;
+  gap: var(--space-2);
+  margin-top: var(--space-3);
+}
+
+/* Right pane — the live workflow canvas */
+.opr-builder-canvas {
+  position: relative;
+  min-width: 0;
+  min-height: 0;
+  overflow-y: auto;
+  padding: var(--space-5) var(--space-6) var(--space-7);
+  background:
+    linear-gradient(var(--t-figure-grid) 1px, transparent 1px),
+    linear-gradient(90deg, var(--t-figure-grid) 1px, transparent 1px),
+    radial-gradient(circle at 1px 1px, var(--t-paper-speckle) 1px, transparent 0),
+    color-mix(in srgb, var(--t-surface) 55%, var(--t-paper));
+  background-size:
+    12px 12px,
+    12px 12px,
+    18px 18px,
+    auto;
+}
+.opr-builder-canvas::before,
+.opr-builder-canvas::after {
+  content: "";
+  position: absolute;
+  width: 9px;
+  height: 9px;
+  border-color: var(--t-line-2);
+  pointer-events: none;
+}
+.opr-builder-canvas::before {
+  top: var(--space-4);
+  left: var(--space-4);
+  border-top: 1px solid;
+  border-left: 1px solid;
+}
+.opr-builder-canvas::after {
+  right: var(--space-4);
+  bottom: var(--space-4);
+  border-right: 1px solid;
+  border-bottom: 1px solid;
+}
+.opr-builder-figure-label {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  margin-bottom: var(--space-2);
+  width: fit-content;
+  background: color-mix(in srgb, var(--t-surface) 75%, var(--t-paper));
+  padding-right: var(--space-2);
+}
+.opr-canvas-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  padding-bottom: var(--space-4);
+  margin-bottom: var(--space-4);
+  border-bottom: 1px dotted var(--t-line-2);
+}
+.opr-canvas-state {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1-5);
+  font-size: 11px;
+  color: var(--t-faint);
+}
+.opr-flow-building {
+  padding-top: var(--space-1);
+}
+
+/* Empty canvas placeholder */
+.opr-canvas-empty {
+  max-width: 340px;
+  margin: var(--space-7) auto 0;
+  text-align: center;
+  border: 1px dotted var(--t-line-2);
+  border-radius: var(--t-r);
+  padding: var(--space-7) var(--space-4);
+  background: color-mix(in srgb, var(--t-surface) 42%, transparent);
+}
+.opr-canvas-empty-glyph {
+  font-family: var(--font-mono);
+  font-size: 30px;
+  color: var(--t-accent-2);
+  margin-bottom: var(--space-3);
+}
+.opr-canvas-empty-title {
+  font-weight: 700;
+  font-size: 14px;
+}
+.opr-canvas-empty-hint {
+  color: var(--t-faint);
+  font-size: 12px;
+  line-height: 1.6;
+  margin-top: var(--space-2);
+}
+
+/* Steps cascade in as the AI builds them */
+.opr-step-reveal {
+  animation: opr-step-in var(--duration-base) cubic-bezier(0.22, 1, 0.36, 1);
+}
+@keyframes opr-step-in {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+/* A step refined in place by a clarifying answer flashes its node */
+.opr-step-flash .opr-step-node {
+  animation: opr-node-flash 1.1s ease;
+}
+@keyframes opr-node-flash {
+  0% {
+    box-shadow: 0 0 0 0 var(--t-tint-2);
+  }
+  30% {
+    box-shadow: 0 0 0 4px var(--t-tint-2);
+  }
+  100% {
+    box-shadow: 0 0 0 0 transparent;
+  }
+}
+/* Ghost node = "more coming" while assembling */
+.opr-step-ghost .opr-step-body {
+  padding-top: 6px;
+}
+.opr-step-node-ghost {
+  border-style: dashed;
+  border-color: var(--t-line-2);
+  gap: 3px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .opr-step-reveal,
+  .opr-step-flash .opr-step-node,
+  .opr-think-dot {
+    animation: none;
+  }
+}
+
+@media (max-width: 900px) {
+  .opr-builder {
+    grid-template-columns: 1fr;
+    grid-template-rows: 1fr auto;
+  }
+  .opr-builder-chat {
+    border-right: none;
+    border-bottom: 1px dotted var(--t-line);
+  }
+  .opr-builder-canvas {
+    max-height: 42vh;
+  }
+}
+
+@media (max-width: 680px) {
+  .opr-sidebar .opr-build-cta,
+  .opr-sidebar .opr-call-cta-secondary {
+    display: none;
+  }
+}
+
+/* ───────────────────────────── Grids removed (founder, 2026-06-27)
+ * The terminal theme stays; the construction/graph-paper grids and paper
+ * speckle are stripped everywhere. Tokens are inherited, so zeroing them at the
+ * root makes every token-driven figure grid render transparent; the root's own
+ * hardcoded grid is cleared with background-image: none. End-of-file so it wins
+ * the cascade regardless of upstream edits. */
+.opr-root {
+  --t-figure-grid: transparent;
+  --t-figure-grid-strong: transparent;
+  --t-paper-speckle: transparent;
+  background-image: none;
+}
+
+/* ───────────────────────────── Lighter Making Software blue (founder, 2026-06-27)
+ * The cobalt-600 accent (oklch ~50% L) read too dark on the dark field. Lift the
+ * accent/link/figure blue to makingsoftware.com's vivid cobalt, brightened so it
+ * pops on dark (higher L, kept hue + chroma). End-of-file so it wins the cascade. */
+.opr-root {
+  --t-accent-2: oklch(0.72 0.18 264);
+  --t-blue: oklch(0.72 0.18 264);
+  --t-cyan: oklch(0.75 0.15 248);
+}
+
+/* ───────────────────────────── Citation source popover (Knowledge)
+ * Hover or keyboard-focus a [n] citation to see its source snippet; an Explain
+ * button reveals why the brain chose that source. Rendered in-DOM and shown via
+ * :hover / :focus-within so keyboard users get it too. */
+.opr-cite-has-pop {
+  position: relative;
+}
+.opr-cite-pop {
+  display: none;
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  margin-top: 8px;
+  z-index: 60;
+  width: min(300px, 76vw);
+  flex-direction: column;
+  gap: var(--space-2);
+  padding: var(--space-3) var(--space-3-5);
+  background: var(--t-elevated);
+  border: 1px solid var(--t-line-2);
+  border-radius: var(--t-r);
+  box-shadow: 0 18px 44px -22px rgba(0, 0, 0, 0.8);
+  font-size: 12.5px;
+  line-height: 1.55;
+  font-weight: 400;
+  color: var(--t-ink);
+  text-align: left;
+  cursor: default;
+  white-space: normal;
+}
+/* invisible bridge across the gap so the pointer keeps :hover on the citation */
+.opr-cite-pop::before {
+  content: "";
+  position: absolute;
+  top: -10px;
+  left: 0;
+  right: 0;
+  height: 10px;
+}
+.opr-cite-has-pop:hover .opr-cite-pop,
+.opr-cite-has-pop:focus-within .opr-cite-pop {
+  display: flex;
+}
+.opr-cite-pop-head {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-2);
+}
+.opr-cite-pop-kind {
+  font-family: var(--font-mono);
+  font-size: 9px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--t-accent-2);
+  border: 1px solid color-mix(in srgb, var(--t-accent-2) 40%, var(--t-line-2));
+  border-radius: var(--t-r-sm);
+  padding: 1px 5px;
+  flex-shrink: 0;
+  position: relative;
+  top: -1px;
+}
+.opr-cite-pop-title {
+  font-weight: 700;
+  font-size: 12.5px;
+  color: var(--t-ink);
+}
+.opr-cite-pop-detail {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  color: var(--t-faint);
+}
+.opr-cite-pop-snippet {
+  background: var(--t-surface);
+  border-radius: var(--t-r-sm);
+  padding: var(--space-2) var(--space-2-5);
+  font-size: 12px;
+  line-height: 1.55;
+  color: var(--t-dim);
+}
+.opr-cite-pop-snippet::before {
+  content: "\201C";
+}
+.opr-cite-pop-snippet::after {
+  content: "\201D";
+}
+.opr-cite-pop-explain {
+  align-self: flex-start;
+  gap: var(--space-1-5);
+}
+.opr-cite-pop-why {
+  display: block;
+  font-size: 12px;
+  line-height: 1.6;
+  color: var(--t-dim);
+  border-top: 1px solid var(--t-line-2);
+  padding-top: var(--space-2);
+}
+.opr-cite-pop-why-label {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1-5);
+  font-family: var(--font-mono);
+  font-size: 9.5px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--t-accent-2);
+  margin-bottom: 4px;
+}
+.opr-ref-kind {
+  font-family: var(--font-mono);
+  font-size: 9px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--t-accent-2);
+  margin-right: var(--space-2);
+}


### PR DESCRIPTION
## S5 — the operator FE on the real engine (stacked on #1139)

Imports the operator product FE (Slice 1 — the clean-start UI) and wires its chat-to-build flow to the **real pi-mono agent service**. The "commit Slice 1 as a checkpoint" step + the FE↔engine integration, in one slice.

- **`web/src/operator/**`** (17 files) + `operator-shell.css`: the operator shell (Chats · Internal Tools · Knowledge · Integrations · Settings), the `WorkflowBuilder` (chat→workflow), approval card (CQ1), call mock.
- **RootRoute mount:** `/#/operator` renders the self-contained shell ahead of the office boot/onboarding gates (additive; only deps are `react` + `lucide-react`, both present).
- **`builder/agentClient.ts`:** calls `/build/stream` (SSE) + `/run`, maps `WorkflowSpec → WorkflowPlan`. `buildPlanSmart()` uses the **real engine** when the service is up, else falls back to the deterministic mock (frontend-first graceful degrade — always clickable).
- **`WorkflowBuilder.runBuild`** now awaits `buildPlanSmart`, keeping the staggered-reveal UX.

### Verified
Web **typecheck clean (0 errors)**. End-to-end, **key-free**: with the service up, the FE client (`buildPlanSmart` — the exact browser code path) compiled a real `WorkflowSpec` via pi-mono → local Ollama over HTTP (enrich → score → **gated** Slack page → triage), no key/login. Service down → mock fallback.

The operator product now runs on the chosen engine over the thin HTTP/SSE API, not the broker.

### Remaining
A Playwright screenshot of the in-browser real-engine build, and a subscription model (operator `/login`) for top-quality specs (tiny Ollama under-populates fields). Branch convergence note: this imports a snapshot of the FE that also lives uncommitted on `pivot/operator-mlp` — that worktree's copy should now point here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)