### PR TITLE
feat(operator): browser execution as a workflow step (no integration → browser step)

### DIFF
--- a/docs/specs/operator-browser-step.md
+++ b/docs/specs/operator-browser-step.md
@@ -43,18 +43,31 @@ the `run_id` + stdin back-channel already built for the send-gate
 sends.
 
 ## Slices
-1. **Authoring (this slice):** the plan model + parser produce `browser` steps
-   when there is no integration (A + B). `kind:"browser"` is a first-class kind.
-2. **Bind tolerance:** `BindWorkflowPlan` passes a `browser` step through as a
-   non-Composio step (no `action_id`), so a frozen workflow can hold browser
-   steps.
-3. **Execution:** the run engine runs a `browser` step via the cua runner,
-   streaming its actions into the run + surfacing the permission/send-gate in the
-   app chat.
-4. **Retire the modal:** remove the standalone `BrowserRunModal` "Run" button;
-   browser runs happen only inside a workflow run.
-5. **FE:** render a `browser` step in the workflow view (its own glyph + "runs in
-   your browser" note) and the chat permission/approval affordance.
+1. **Authoring — DONE.** The plan model + parser produce `browser` steps when
+   there is no integration (A + B). `kind:"browser"` is a first-class kind.
+2. **Bind + engine tolerance — DONE.** The resolver binds a browser step
+   (`BoundStep{Type:"browser"}`, goal in the template); the Composio spec
+   validates a `browser` type; `executeWorkflowStep` emits a deterministic marker
+   (`{type:browser, goal, runs_in_browser}`) so a frozen run never breaks.
+3. **Execution — the architectural bridge (NEXT, do carefully).** Run a `browser`
+   step via the cua runner. The hard part: the deterministic workflow run
+   (`ExecuteWorkflow`) is **synchronous/batch**, while cua is **streaming +
+   interactive with a mid-run chat approval**. Options:
+   - **(a) injected step-executor hook** — the action package calls an injected
+     `browserStepRunner(ctx, goal)` (package-var, like `realtimeHTTPClient`); the
+     broker supplies a cua-backed, chat-gated implementation. Keeps the engine
+     agnostic; the runner blocks until cua finishes/approves.
+   - **(b) broker orchestration** — the broker runs the workflow itself, calling
+     `ExecuteWorkflow` for Composio steps and cua for browser steps, interleaved.
+     More control, but re-implements the step loop + scope/data flow.
+   Lean **(a)**. Either way the browser step pauses for the in-chat permission via
+   the existing `run_id`/stdin back-channel before it drives, and a gated send
+   inside it asks again.
+4. **Chat permission + send-gate** surfaced in `AppBuilderChat` (part of slice 3's
+   flow).
+5. **Retire the modal:** remove the standalone `BrowserRunModal` "Run" button.
+6. **FE:** render a `browser` step in the workflow view (its own glyph + "runs in
+   your browser") and the chat approval affordance.
 
 ## Reused, unchanged
 `runner/cua_exec.py` (execute/record/replay/heal + `needs_approval`), broker

--- a/docs/specs/operator-browser-step.md
+++ b/docs/specs/operator-browser-step.md
@@ -49,22 +49,21 @@ sends.
    (`BoundStep{Type:"browser"}`, goal in the template); the Composio spec
    validates a `browser` type; `executeWorkflowStep` emits a deterministic marker
    (`{type:browser, goal, runs_in_browser}`) so a frozen run never breaks.
-3. **Execution — the architectural bridge (NEXT, do carefully).** Run a `browser`
-   step via the cua runner. The hard part: the deterministic workflow run
-   (`ExecuteWorkflow`) is **synchronous/batch**, while cua is **streaming +
-   interactive with a mid-run chat approval**. Options:
-   - **(a) injected step-executor hook** — the action package calls an injected
-     `browserStepRunner(ctx, goal)` (package-var, like `realtimeHTTPClient`); the
-     broker supplies a cua-backed, chat-gated implementation. Keeps the engine
-     agnostic; the runner blocks until cua finishes/approves.
-   - **(b) broker orchestration** — the broker runs the workflow itself, calling
-     `ExecuteWorkflow` for Composio steps and cua for browser steps, interleaved.
-     More control, but re-implements the step loop + scope/data flow.
-   Lean **(a)**. Either way the browser step pauses for the in-chat permission via
-   the existing `run_id`/stdin back-channel before it drives, and a gated send
-   inside it asks again.
-4. **Chat permission + send-gate** surfaced in `AppBuilderChat` (part of slice 3's
-   flow).
+3. **Execution — DONE (3a).** The engine calls an injected `action.BrowserStepRunner`
+   (a package-var hook, so the action package never imports the broker/cua). The
+   broker wires a cua-backed impl (`runBrowserStepViaCua`, `broker_browser_step.go`)
+   that drives cua for the step's goal on a REAL run. A **dry** run previews (no
+   drive); an **unwired** host degrades to a marker; **sends are auto-denied**
+   (they need 3b's chat approval). Chosen option (a) over broker orchestration —
+   the engine stays agnostic.
+4. **Chat permission + send-gate (3b) — the resumable-run piece.** Asking the
+   browser-control permission (and per-send approval) *in the app chat and
+   waiting for the reply mid-run* means the deterministic run can no longer be a
+   single blocking request — it must **pause, post to `AppBuilderChat`, and
+   resume when the operator replies**. That needs run-state persistence + a
+   resume path (a real async-workflow change), so it is deliberately separated
+   from 3a. Interim: 3a auto-denies sends (safe) and drives non-send browser
+   steps after the operator hits "Run".
 5. **Retire the modal:** remove the standalone `BrowserRunModal` "Run" button.
 6. **FE:** render a `browser` step in the workflow view (its own glyph + "runs in
    your browser") and the chat approval affordance.

--- a/docs/specs/operator-browser-step.md
+++ b/docs/specs/operator-browser-step.md
@@ -1,0 +1,63 @@
+# Browser execution as a workflow step (not a Run button)
+
+**Status:** plan + slice 1. **Supersedes** the standalone `BrowserRunModal` "Run in
+browser" button. **Builds on** the cua execution engine (C1/C2/send-gating):
+`runner/cua_exec.py` + broker `/execute` · `/replay` · `/approve` · `/observe`.
+
+## Principle
+A workflow runs on APIs (Composio) when it can. **When there is no integration
+for what a step needs, that step becomes a `browser` step** — Nex drives the
+browser to do it. Browser execution is therefore a *step type*, invoked by the
+workflow engine when the run reaches it — never a standalone button/modal.
+**Permission (browser control) and the send-gate are asked in the app chat**,
+conversationally; the operator's reply resumes the paused run.
+
+## How a browser step is created — "no integration available → browser step"
+- **B (build/author time):** the plan-authoring model may emit `kind:"browser"`
+  for a step that must touch an external system the app has no integration for;
+  it describes the exact goal in `detail`.
+- **A (compile/bind time):** if the model names an integration the app does NOT
+  actually have on an action/send step, that step is converted to a `browser`
+  step instead of being silently dropped — the honest "there is no API for this,
+  so drive the browser" fallback.
+
+A browser step: `kind:"browser"`, `integration:""`, no `action_id`, `detail` =
+the natural-language sub-goal, `gated` carried through (a browser *send* still
+needs approval).
+
+## Execution (engine → cua)
+When the frozen workflow runs and reaches a `browser` step, the engine hands the
+step's `detail` sub-goal to the cua runner (the existing `/execute` machinery)
+instead of a Composio action. cua records + replays (C2), so repeat runs of a
+browser step stay deterministic; the model is invoked only to heal a changed
+page. A gated browser step routes through the same send-gate.
+
+## Permission + approval in chat (not a modal)
+The run **pauses** at a browser step and posts into the app chat:
+> "This step has no integration, so I'll do it in your browser: *<sub-goal>*. Let
+> me control your browser to run it?"
+
+The operator's chat reply (allow / not now) resumes or skips the step — reusing
+the `run_id` + stdin back-channel already built for the send-gate
+(`/execute/approve`). A gated send inside the step asks again, in chat, before it
+sends.
+
+## Slices
+1. **Authoring (this slice):** the plan model + parser produce `browser` steps
+   when there is no integration (A + B). `kind:"browser"` is a first-class kind.
+2. **Bind tolerance:** `BindWorkflowPlan` passes a `browser` step through as a
+   non-Composio step (no `action_id`), so a frozen workflow can hold browser
+   steps.
+3. **Execution:** the run engine runs a `browser` step via the cua runner,
+   streaming its actions into the run + surfacing the permission/send-gate in the
+   app chat.
+4. **Retire the modal:** remove the standalone `BrowserRunModal` "Run" button;
+   browser runs happen only inside a workflow run.
+5. **FE:** render a `browser` step in the workflow view (its own glyph + "runs in
+   your browser" note) and the chat permission/approval affordance.
+
+## Reused, unchanged
+`runner/cua_exec.py` (execute/record/replay/heal + `needs_approval`), broker
+`/execute` · `/replay` · `/approve` · `/observe`, the `run_id` stdin
+back-channel. Only the *surface* changes: from a modal button to a workflow step
++ chat approval.

--- a/internal/action/composio_workflows.go
+++ b/internal/action/composio_workflows.go
@@ -276,6 +276,12 @@ func (c *ComposioREST) decodeWorkflowDefinition(definition json.RawMessage) (com
 				return spec, fmt.Errorf("workflow step %q is missing query_template", spec.Steps[i].ID)
 			}
 		case "nex_insights":
+		case "browser":
+			// No Composio action — the browser step carries a natural-language
+			// goal (in template or description) that cua runs.
+			if strings.TrimSpace(spec.Steps[i].Template) == "" && strings.TrimSpace(spec.Steps[i].Description) == "" {
+				return spec, fmt.Errorf("workflow step %q (browser) is missing a goal", spec.Steps[i].ID)
+			}
 		default:
 			return spec, fmt.Errorf("unsupported workflow step type %q", spec.Steps[i].Type)
 		}
@@ -430,9 +436,24 @@ func (c *ComposioREST) executeWorkflowStep(ctx context.Context, step workflowSte
 		return executeWorkflowNexAskStep(step, scope)
 	case "nex_insights":
 		return executeWorkflowNexInsightsStep(step, scope)
+	case "browser":
+		return executeWorkflowBrowserStep(step)
 	default:
 		return nil, fmt.Errorf("unsupported workflow step type %q", step.Type)
 	}
+}
+
+// executeWorkflowBrowserStep records a browser step deterministically. The step
+// has NO Composio action — Nex drives the browser to accomplish its goal. Actual
+// cua execution + the in-chat permission are wired at the broker orchestration
+// layer (which can reach the cua runner); here we emit a stable marker so a
+// frozen run never breaks on a browser step and later steps can reference it.
+func executeWorkflowBrowserStep(step workflowStep) (map[string]any, error) {
+	goal := strings.TrimSpace(step.Template)
+	if goal == "" {
+		goal = strings.TrimSpace(step.Description)
+	}
+	return map[string]any{"type": "browser", "goal": goal, "runs_in_browser": true}, nil
 }
 
 func (c *ComposioREST) executeWorkflowActionStep(ctx context.Context, step workflowStep, scope map[string]any, workflowDryRun bool) (map[string]any, error) {

--- a/internal/action/composio_workflows.go
+++ b/internal/action/composio_workflows.go
@@ -437,23 +437,41 @@ func (c *ComposioREST) executeWorkflowStep(ctx context.Context, step workflowSte
 	case "nex_insights":
 		return executeWorkflowNexInsightsStep(step, scope)
 	case "browser":
-		return executeWorkflowBrowserStep(step)
+		return executeWorkflowBrowserStep(ctx, step, workflowDryRun)
 	default:
 		return nil, fmt.Errorf("unsupported workflow step type %q", step.Type)
 	}
 }
 
-// executeWorkflowBrowserStep records a browser step deterministically. The step
-// has NO Composio action — Nex drives the browser to accomplish its goal. Actual
-// cua execution + the in-chat permission are wired at the broker orchestration
-// layer (which can reach the cua runner); here we emit a stable marker so a
-// frozen run never breaks on a browser step and later steps can reference it.
-func executeWorkflowBrowserStep(step workflowStep) (map[string]any, error) {
+// BrowserStepRunner, when set by the broker, actually drives the browser (via
+// cua) to accomplish a browser step's goal and returns the outcome. It is a hook
+// (not a direct dependency) so the action package never imports the broker/cua;
+// the broker wires a cua-backed, chat-gated implementation in. Left nil in tests
+// and when unwired, so a browser step degrades to a deterministic marker.
+var BrowserStepRunner func(ctx context.Context, goal string) (map[string]any, error)
+
+// executeWorkflowBrowserStep runs a browser step. The step has NO Composio action
+// — its goal is driven in the browser by cua (via BrowserStepRunner). A DRY run
+// never drives (preview only) and an unwired runner degrades to a stable marker,
+// so a frozen run never breaks on a browser step and later steps can reference it.
+func executeWorkflowBrowserStep(ctx context.Context, step workflowStep, dryRun bool) (map[string]any, error) {
 	goal := strings.TrimSpace(step.Template)
 	if goal == "" {
 		goal = strings.TrimSpace(step.Description)
 	}
-	return map[string]any{"type": "browser", "goal": goal, "runs_in_browser": true}, nil
+	if dryRun || BrowserStepRunner == nil {
+		return map[string]any{"type": "browser", "goal": goal, "runs_in_browser": true, "dry_run": dryRun}, nil
+	}
+	res, err := BrowserStepRunner(ctx, goal)
+	if err != nil {
+		return nil, err
+	}
+	if res == nil {
+		res = map[string]any{}
+	}
+	res["type"] = "browser"
+	res["goal"] = goal
+	return res, nil
 }
 
 func (c *ComposioREST) executeWorkflowActionStep(ctx context.Context, step workflowStep, scope map[string]any, workflowDryRun bool) (map[string]any, error) {

--- a/internal/action/workflow_resolver.go
+++ b/internal/action/workflow_resolver.go
@@ -54,6 +54,16 @@ func (r *ComposioActionResolver) Resolve(ctx context.Context, plan Plan, step Pl
 	if kind == "trigger" {
 		return BoundStep{Skip: true}, nil
 	}
+	if kind == "browser" {
+		// No integration for this step → Nex drives the browser. The sub-goal
+		// rides in the template; the broker's browser-step executor runs it via
+		// cua (there is no Composio action to bind).
+		goal := strings.TrimSpace(step.Detail)
+		if goal == "" {
+			goal = stepLabel(step)
+		}
+		return BoundStep{Type: "browser", Template: goal}, nil
+	}
 
 	integration := strings.TrimSpace(step.Integration)
 	if integration == "" {

--- a/internal/action/workflow_resolver_test.go
+++ b/internal/action/workflow_resolver_test.go
@@ -40,6 +40,38 @@ func TestResolverBindsActionFromCandidate(t *testing.T) {
 	}
 }
 
+func TestResolverBrowserStep(t *testing.T) {
+	// A browser step (no integration) binds to a "browser" step carrying its goal
+	// — no Composio action, no search/LLM needed.
+	r := resolverWith(nil, nil)
+	step := PlanStep{
+		ID:     "portal",
+		Kind:   "browser",
+		Title:  "Submit in the vendor portal",
+		Detail: "Open the vendor portal and submit the refund",
+	}
+	bound, err := r.Resolve(context.Background(), Plan{Steps: []PlanStep{step}}, step)
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if bound.Type != "browser" {
+		t.Fatalf("browser step should bind to type browser, got %#v", bound)
+	}
+	if bound.Template != "Open the vendor portal and submit the refund" {
+		t.Fatalf("browser goal not carried in template: %q", bound.Template)
+	}
+}
+
+func TestExecuteWorkflowBrowserStepEmitsGoal(t *testing.T) {
+	out, err := executeWorkflowBrowserStep(workflowStep{Type: "browser", Template: "do the thing"})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if out["type"] != "browser" || out["goal"] != "do the thing" || out["runs_in_browser"] != true {
+		t.Fatalf("browser step output = %#v", out)
+	}
+}
+
 func TestResolverRejectsInventedActionAndFallsBack(t *testing.T) {
 	search := func(_ context.Context, _, _ string) ([]Action, error) { return slackCandidates(), nil }
 	// The model picks an action id that is NOT a candidate — must not be trusted.

--- a/internal/action/workflow_resolver_test.go
+++ b/internal/action/workflow_resolver_test.go
@@ -3,8 +3,50 @@ package action
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 )
+
+// TestBindAndRunBrowserStepE2E is the engine e2e for the browser-step foundation
+// (slices 1-2): a plan with a no-integration step binds into a real `browser`
+// step in the frozen workflow, that step carries its goal, and running it is
+// tolerated (a marker, never an error). Actual cua execution is slice 3.
+func TestBindAndRunBrowserStepE2E(t *testing.T) {
+	plan := Plan{
+		Name:   "Vendor Portal Poster",
+		ToolID: "app_x",
+		Steps: []PlanStep{
+			{ID: "t", Kind: "trigger", Title: "On a schedule"},
+			{ID: "portal", Kind: "browser", Title: "Submit in the vendor portal", Detail: "Open the vendor portal and submit the refund"},
+		},
+	}
+	// A browser step needs no search/LLM to bind.
+	def, err := BindWorkflowPlan(context.Background(), plan, NewComposioActionResolver(nil, nil))
+	if err != nil {
+		t.Fatalf("bind: %v", err)
+	}
+	var browser *workflowStep
+	for i := range def.Steps {
+		if def.Steps[i].Type == "browser" {
+			browser = &def.Steps[i]
+			break
+		}
+	}
+	if browser == nil {
+		t.Fatal("expected a browser step in the frozen definition")
+	}
+	if !strings.Contains(browser.Template, "submit the refund") {
+		t.Fatalf("browser step lost its goal: %q", browser.Template)
+	}
+	// A frozen run tolerates the browser step (marker, no error).
+	out, err := executeWorkflowBrowserStep(*browser)
+	if err != nil {
+		t.Fatalf("run browser step: %v", err)
+	}
+	if out["runs_in_browser"] != true || out["goal"] == "" {
+		t.Fatalf("browser step run output = %#v", out)
+	}
+}
 
 func slackCandidates() []Action {
 	return []Action{

--- a/internal/action/workflow_resolver_test.go
+++ b/internal/action/workflow_resolver_test.go
@@ -39,7 +39,7 @@ func TestBindAndRunBrowserStepE2E(t *testing.T) {
 		t.Fatalf("browser step lost its goal: %q", browser.Template)
 	}
 	// A frozen run tolerates the browser step (marker, no error).
-	out, err := executeWorkflowBrowserStep(*browser)
+	out, err := executeWorkflowBrowserStep(context.Background(), *browser, false)
 	if err != nil {
 		t.Fatalf("run browser step: %v", err)
 	}
@@ -105,12 +105,44 @@ func TestResolverBrowserStep(t *testing.T) {
 }
 
 func TestExecuteWorkflowBrowserStepEmitsGoal(t *testing.T) {
-	out, err := executeWorkflowBrowserStep(workflowStep{Type: "browser", Template: "do the thing"})
+	out, err := executeWorkflowBrowserStep(context.Background(), workflowStep{Type: "browser", Template: "do the thing"}, false)
 	if err != nil {
 		t.Fatalf("execute: %v", err)
 	}
 	if out["type"] != "browser" || out["goal"] != "do the thing" || out["runs_in_browser"] != true {
 		t.Fatalf("browser step output = %#v", out)
+	}
+}
+
+func TestExecuteWorkflowBrowserStepDrivesViaRunner(t *testing.T) {
+	prev := BrowserStepRunner
+	defer func() { BrowserStepRunner = prev }()
+
+	var gotGoal string
+	BrowserStepRunner = func(_ context.Context, goal string) (map[string]any, error) {
+		gotGoal = goal
+		return map[string]any{"actions_count": 2, "result": "did it"}, nil
+	}
+	// A REAL (non-dry) run drives the runner and merges its outcome.
+	out, err := executeWorkflowBrowserStep(context.Background(), workflowStep{Type: "browser", Template: "email the digest"}, false)
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if gotGoal != "email the digest" {
+		t.Fatalf("runner got goal %q", gotGoal)
+	}
+	if out["type"] != "browser" || out["goal"] != "email the digest" || out["result"] != "did it" || out["actions_count"] != 2 {
+		t.Fatalf("browser step output = %#v", out)
+	}
+
+	// A DRY run NEVER drives the browser (preview only).
+	gotGoal = ""
+	dryOut, _ := executeWorkflowBrowserStep(context.Background(), workflowStep{Type: "browser", Template: "x"}, true)
+	if gotGoal != "" {
+		t.Fatal("dry run must not drive the browser")
+	}
+	if dryOut["dry_run"] != true {
+		t.Fatalf("dry marker = %#v", dryOut)
 	}
 }
 

--- a/internal/team/broker_browser_step.go
+++ b/internal/team/broker_browser_step.go
@@ -1,0 +1,92 @@
+package team
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/nex-crm/wuphf/internal/action"
+	"github.com/nex-crm/wuphf/internal/config"
+)
+
+// broker_browser_step.go wires the workflow engine's browser-step hook
+// (action.BrowserStepRunner) to cua: when a frozen workflow reaches a `browser`
+// step on a REAL (non-dry) run, the broker drives the browser to accomplish the
+// step's goal via the cua runner.
+//
+// Slice 3a runs cua synchronously and AUTO-DENIES any external send — a send
+// inside a browser step needs the operator's in-chat approval, which is slice 3b
+// (the browser-control permission + send-approval asked in the app chat). With
+// no key/runner on the host it degrades to a "skipped" marker so the frozen run
+// still completes. See docs/specs/operator-browser-step.md.
+
+func init() {
+	action.BrowserStepRunner = runBrowserStepViaCua
+}
+
+func runBrowserStepViaCua(ctx context.Context, goal string) (map[string]any, error) {
+	goal = strings.TrimSpace(goal)
+	if goal == "" {
+		return map[string]any{"skipped": "empty goal"}, nil
+	}
+	key := strings.TrimSpace(config.ResolveOpenAIAPIKey())
+	runner := cuaRunnerPath("cua_exec.py", "WUPHF_CUA_RUNNER")
+	if key == "" || runner == "" {
+		// No key/runner on this host → tolerate; the frozen run still completes.
+		return map[string]any{"skipped": "browser execution unavailable on this host"}, nil
+	}
+
+	cmd := exec.CommandContext(ctx, cuaPython(), runner, "--goal", goal)
+	cmd.Env = append(os.Environ(), "OPENAI_API_KEY="+key)
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, err
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, err
+	}
+	cmd.Stderr = os.Stderr
+	if err := cmd.Start(); err != nil {
+		return nil, err
+	}
+
+	actions := []string{}
+	var result, errMsg string
+	scanner := bufio.NewScanner(stdout)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1<<20)
+	for scanner.Scan() {
+		var e map[string]any
+		if json.Unmarshal([]byte(strings.TrimSpace(scanner.Text())), &e) != nil {
+			continue
+		}
+		switch e["type"] {
+		case "approval_request":
+			// 3a: an external send inside a browser step is DENIED here — it needs
+			// the in-chat approval that 3b will wire.
+			_, _ = stdin.Write([]byte("deny\n"))
+		case "action":
+			if l, _ := e["label"].(string); l != "" {
+				actions = append(actions, l)
+			}
+		case "done":
+			result, _ = e["result"].(string)
+		case "error":
+			errMsg, _ = e["message"].(string)
+		}
+	}
+	_ = stdin.Close()
+	_ = cmd.Wait()
+
+	out := map[string]any{"actions": actions, "actions_count": len(actions)}
+	if result != "" {
+		out["result"] = result
+	}
+	if errMsg != "" {
+		out["error"] = errMsg
+	}
+	return out, nil
+}

--- a/internal/team/broker_operator_workflow.go
+++ b/internal/team/broker_operator_workflow.go
@@ -335,12 +335,13 @@ func (b *Broker) operatorWorkflowProvider(w http.ResponseWriter) (action.Provide
 const workflowAuthorSystemPrompt = `You design a DETERMINISTIC automation that runs an internal app on a schedule.
 Return ONLY a JSON object, no prose: {"steps":[{"id","kind","title","detail","integration","gated"}]}.
 Rules:
-- kind is one of: trigger, enrich, ai, decision, action, branch.
+- kind is one of: trigger, enrich, ai, decision, action, branch, browser.
 - The FIRST step is exactly one "trigger" (the schedule).
 - "enrich" reads data; "ai" summarizes/analyzes; "action" sends or writes to an external system; "decision"/"branch" gate on a condition.
 - integration is a lowercase platform slug (e.g. "gmail", "slack") ONLY for a step that calls that external system, else "".
 - gated is true for any step that SENDS or WRITES to an external system.
 - Use ONLY the data sources and integrations the app actually has (listed below). Do NOT invent capabilities.
+- kind "browser" — for a step that must use an external system the app has NO integration for: set integration to "" and put the exact goal in "detail". Nex drives the browser to do it. Set gated true if it sends/writes.
 - Tailor the steps to THIS app's specific purpose. Keep it tight: 3 to 7 steps.`
 
 // authoredAppWorkflowPlan asks the model to design a workflow for THIS app from
@@ -414,14 +415,20 @@ func parseAuthoredWorkflowPlan(raw string, app CustomApp, caps AppCapabilities) 
 			id = fmt.Sprintf("s%d", i)
 		}
 		integ := strings.ToLower(strings.TrimSpace(s.Integration))
-		// Clamp a hallucinated integration to nothing (it becomes a narration step
-		// rather than a call to a system the app does not actually use).
+		kind := normalizeAuthoredKind(s.Kind)
+		// No integration for what this step needs → drive the browser instead of
+		// pretending the API exists ("no integration available → browser step").
+		// Only convert steps that actually touch an external system (action/send);
+		// a stray integration on a read becomes a plain narration as before.
 		if integ != "" && !known[integ] {
+			if kind == "action" || s.Gated {
+				kind = "browser"
+			}
 			integ = ""
 		}
 		steps = append(steps, action.PlanStep{
 			ID:          id,
-			Kind:        normalizeAuthoredKind(s.Kind),
+			Kind:        kind,
 			Title:       strings.TrimSpace(s.Title),
 			Detail:      strings.TrimSpace(s.Detail),
 			Integration: integ,
@@ -443,7 +450,7 @@ func parseAuthoredWorkflowPlan(raw string, app CustomApp, caps AppCapabilities) 
 
 func normalizeAuthoredKind(raw string) string {
 	switch strings.ToLower(strings.TrimSpace(raw)) {
-	case "trigger", "enrich", "ai", "decision", "action", "branch":
+	case "trigger", "enrich", "ai", "decision", "action", "branch", "browser":
 		return strings.ToLower(strings.TrimSpace(raw))
 	case "read", "fetch", "load":
 		return "enrich"

--- a/internal/team/broker_operator_workflow_test.go
+++ b/internal/team/broker_operator_workflow_test.go
@@ -112,6 +112,36 @@ func TestParseAuthoredWorkflowPlan(t *testing.T) {
 	}
 }
 
+func TestParseAuthoredWorkflowPlanBrowserStep(t *testing.T) {
+	app := CustomApp{ID: "app_b", Name: "Portal Poster"}
+	caps := AppCapabilities{Integrations: []AppIntegrationUsage{{Platform: "slack"}}}
+	// A send step to a system the app has NO integration for → browser step
+	// ("no integration available → browser step"). An explicit kind:"browser"
+	// is kept as-is.
+	raw := `{"steps":[
+	  {"id":"t","kind":"trigger","title":"On a schedule"},
+	  {"id":"post","kind":"action","title":"Submit in the vendor portal","detail":"Open the vendor portal and submit the refund","integration":"vendorportal","gated":true},
+	  {"id":"nav","kind":"browser","title":"Update the tracker","detail":"Mark it done in the web tracker"}
+	]}`
+	plan, ok := parseAuthoredWorkflowPlan(raw, app, caps)
+	if !ok {
+		t.Fatal("expected a valid plan")
+	}
+	// Unavailable integration on a gated send → browser, integration cleared,
+	// gated preserved, goal kept in detail.
+	post := plan.Steps[1]
+	if post.Kind != "browser" || post.Integration != "" || !post.Gated {
+		t.Fatalf("post step should be a gated browser step, got %+v", post)
+	}
+	if post.Detail == "" {
+		t.Fatal("browser step must carry the goal in detail")
+	}
+	// An explicitly-authored browser step is preserved.
+	if plan.Steps[2].Kind != "browser" {
+		t.Fatalf("explicit browser step = %+v", plan.Steps[2])
+	}
+}
+
 func TestParseAuthoredWorkflowPlanRejectsJunk(t *testing.T) {
 	if _, ok := parseAuthoredWorkflowPlan("not json at all", CustomApp{}, AppCapabilities{}); ok {
 		t.Fatal("expected non-JSON to be rejected")


### PR DESCRIPTION
Reframes cua browser execution from a standalone "Run in browser" modal into a **workflow step**: the step a workflow takes when there's **no integration for what it needs**. Builds on the merged cua engine (C1/C5/C2/send-gating). This PR is slices 1–3a — a coherent, safe unit; the in-chat approval (3b), modal retirement (5), and FE rendering (6) follow.

## Principle
A workflow runs on APIs (Composio) when it can. **When there is no integration for a step, that step becomes a `browser` step** and Nex drives the browser to do it. Browser execution is a *step type*, invoked by the engine when the run reaches it — not a button.

## What's in this PR
- **Slice 1 — authoring ("no integration → browser step").** The plan model may author `kind:"browser"` for a step touching a system the app has no integration for (B); the parser converts a gated/action step that names an *unavailable* integration into a browser step instead of dropping it (A). Goal rides in `detail`, `gated` carried through.
- **Slice 2 — bind + engine tolerance.** The resolver binds a browser step (`BoundStep{Type:"browser"}`, goal in the template); the Composio spec validates a `browser` type; `executeWorkflowStep` emits a deterministic marker so a frozen run never breaks on one.
- **Slice 3a — execution via cua.** A REAL (non-dry) run drives the browser for a browser step, through an injected hook (`action.BrowserStepRunner`) so the action package never imports the broker/cua. The broker wires a cua-backed impl (`runBrowserStepViaCua`) that runs `runner/cua_exec.py --goal <step goal>`. A **dry run previews** (no drive); an **unwired host** degrades to a marker; **external sends inside a browser step are auto-denied** (they need the in-chat approval of 3b).

## Proven live
On a fresh broker, compiling real apps produced browser steps automatically — e.g. *Weekly Pipeline Summary* → *"Email the digest to the team"* became a `browser` step because the app has no email-send integration.

## Tests
Go: parser converts an unavailable send to a browser step (+ explicit browser kept); resolver binds a browser step + carries the goal; the executor drives an injected runner on a real run and never on dry; a bind→run engine e2e. Existing action + team workflow tests green; build/vet clean.

## Not in this PR (follow-ups)
- **3b** — browser-control permission + per-send approval asked in the app chat (needs a pausable/resumable run; the deterministic run can't stay a single blocking request). Interim: 3a auto-denies sends.
- **5** retire the standalone `BrowserRunModal` Run button · **6** render a browser step in the workflow view.

Spec: `docs/specs/operator-browser-step.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)