### PR TITLE
fix(apps): serve cached knowledge when gbrain is unreachable

### DIFF
--- a/internal/team/broker_apps_knowledge.go
+++ b/internal/team/broker_apps_knowledge.go
@@ -128,17 +128,37 @@ func (b *Broker) handleAppKnowledge(w http.ResponseWriter, r *http.Request, id s
 	// otherwise the per-app knowledge.json file.
 	if !refresh {
 		if gbBacked {
-			if pages, err := b.readAppKnowledgeFromGBrain(ctx, gbClient, id); err == nil && len(pages) > 0 {
+			pages, err := b.readAppKnowledgeFromGBrain(ctx, gbClient, id)
+			switch {
+			case err == nil && len(pages) > 0:
 				writeJSON(w, http.StatusOK, map[string]any{"pages": pages})
 				return
-			}
-			// A genuinely-empty synthesis leaves nothing to read back from gbrain,
-			// so its "already ran" record is the per-app file cache holding an
-			// empty page set (stamped on write below). Without this, every request
-			// for an empty app would re-run the full LLM synthesis.
-			if pages, ok, err := store.ReadAppKnowledge(id); err == nil && ok && len(pages) == 0 {
-				writeJSON(w, http.StatusOK, map[string]any{"pages": []appKnowledgePage{}})
-				return
+			case err != nil:
+				// The brain is UNREACHABLE (dead serve, lock contention, missing
+				// binary) — not empty. Serve the last good synthesis from the
+				// per-app file cache (stamped on every write below) instead of
+				// reporting "no knowledge yet" and burning an LLM pass whose
+				// result could not persist anyway. A reachable-but-empty brain
+				// deliberately skips this: pages deleted from the brain must not
+				// be resurrected from a stale cache.
+				fmt.Fprintf(os.Stderr, "broker: app knowledge gbrain read failed: %v\n", err)
+				if cached, ok, cerr := store.ReadAppKnowledge(id); cerr == nil && ok {
+					if cached == nil {
+						cached = []appKnowledgePage{}
+					}
+					writeJSON(w, http.StatusOK, map[string]any{"pages": cached})
+					return
+				}
+			default:
+				// A genuinely-empty synthesis leaves nothing to read back from
+				// gbrain, so its "already ran" record is the per-app file cache
+				// holding an empty page set (stamped on write below). Without
+				// this, every request for an empty app would re-run the full LLM
+				// synthesis.
+				if cached, ok, cerr := store.ReadAppKnowledge(id); cerr == nil && ok && len(cached) == 0 {
+					writeJSON(w, http.StatusOK, map[string]any{"pages": []appKnowledgePage{}})
+					return
+				}
 			}
 		} else if pages, ok, err := store.ReadAppKnowledge(id); err == nil && ok {
 			writeJSON(w, http.StatusOK, map[string]any{"pages": pages})

--- a/internal/team/broker_apps_knowledge_test.go
+++ b/internal/team/broker_apps_knowledge_test.go
@@ -297,10 +297,11 @@ const (
 // the rendered frontmatter (the same shape renderKnowledgePageForGBrain emits),
 // so ListPages-by-tag and GetPage behave like the real brain.
 type fakeBrain struct {
-	mu     sync.Mutex
-	pages  map[string]gbrain.Page
-	links  map[string][]gbrain.Link
-	putErr error // injected PutPage failure
+	mu      sync.Mutex
+	pages   map[string]gbrain.Page
+	links   map[string][]gbrain.Link
+	putErr  error // injected PutPage failure
+	listErr error // injected ListPages failure (unreachable brain)
 }
 
 func newFakeBrain() *fakeBrain {
@@ -335,6 +336,9 @@ func (f *fakeBrain) GetPage(_ context.Context, slug string) (gbrain.Page, error)
 func (f *fakeBrain) ListPages(_ context.Context, opts gbrain.ListOptions) ([]gbrain.PageMeta, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
 	var out []gbrain.PageMeta
 	for _, p := range f.pages {
 		if opts.Tag != "" && !slices.Contains(p.Tags, opts.Tag) {
@@ -485,5 +489,126 @@ func TestKnowledgeSharedPageRetagFailureSurfaces(t *testing.T) {
 	err = b.writeAppKnowledgeToGBrain(ctx, brain, testKnowledgeAppX, []appKnowledgePage{knowledgeTestPage("px", "Shared Topic")})
 	if err == nil {
 		t.Fatal("re-tag failure was swallowed, want error")
+	}
+}
+
+// TestAppKnowledgeGBrainReadFailureServesCache locks the fallback contract for
+// an UNREACHABLE brain (dead serve, PGLite lock contention, missing binary): a
+// prior synthesis whose gbrain write failed lives on in the per-app file cache
+// (stamped by the marker write), and the handler must serve it rather than tell
+// the user "no knowledge yet" and burn a fresh LLM pass whose result could not
+// persist anyway.
+func TestAppKnowledgeGBrainReadFailureServesCache(t *testing.T) {
+	t.Setenv("WUPHF_RUNTIME_HOME", t.TempDir())
+	b := newTestBroker(t)
+	brain := newFakeBrain()
+	b.knowledgeBrainOverride = brain
+	var synthCalls atomic.Int32
+	withFakeAppsLLM(t, func(context.Context, string, string) (string, error) {
+		synthCalls.Add(1)
+		return `{"pages": []}`, nil
+	})
+	if err := b.StartOnPort(0); err != nil {
+		t.Fatalf("start broker: %v", err)
+	}
+	defer b.Stop()
+	base := fmt.Sprintf("http://%s", b.Addr())
+
+	regBody, _ := json.Marshal(map[string]any{
+		"name": "Cached App", "description": "An app with a cached operating guide.",
+		"html": validAppHTML,
+	})
+	created := postAppsAsAgent(t, base+"/apps", b.Token(), appBuilderSlug, regBody)
+	app, _ := created["app"].(map[string]any)
+	id, _ := app["id"].(string)
+	if id == "" {
+		t.Fatalf("no app id: %v", created)
+	}
+	if err := b.appStore().WriteAppKnowledge(id, []appKnowledgePage{knowledgeTestPage("p1", "Operating Guide")}); err != nil {
+		t.Fatalf("seed cache: %v", err)
+	}
+
+	brain.mu.Lock()
+	brain.listErr = fmt.Errorf("connect gbrain mcp: context deadline exceeded")
+	brain.mu.Unlock()
+
+	status, out := getAppsJSON(t, base+"/apps/"+id+"/knowledge", b.Token())
+	if status != http.StatusOK {
+		t.Fatalf("GET knowledge: %d", status)
+	}
+	pages, _ := out["pages"].([]any)
+	if len(pages) != 1 {
+		t.Fatalf("pages = %v, want the one cached page", out["pages"])
+	}
+	first, _ := pages[0].(map[string]any)
+	if got, _ := first["title"].(string); got != "Operating Guide" {
+		t.Fatalf("title = %q, want cached \"Operating Guide\"", got)
+	}
+	if errStr, _ := out["error"].(string); errStr != "" {
+		t.Fatalf("error = %q, want none (a cache serve is a good response)", errStr)
+	}
+	if got := synthCalls.Load(); got != 0 {
+		t.Fatalf("synthesis ran %d times, want 0 (the cache must satisfy the read)", got)
+	}
+
+	// The empty MARKER also survives an unreachable brain: an app whose last
+	// synthesis was genuinely empty serves empty without a fresh LLM pass.
+	if err := b.appStore().WriteAppKnowledge(id, nil); err != nil {
+		t.Fatalf("seed empty marker: %v", err)
+	}
+	status, out = getAppsJSON(t, base+"/apps/"+id+"/knowledge", b.Token())
+	if status != http.StatusOK {
+		t.Fatalf("GET knowledge (empty marker): %d", status)
+	}
+	if pages, _ := out["pages"].([]any); len(pages) != 0 {
+		t.Fatalf("pages = %v, want empty from the marker", out["pages"])
+	}
+	if got := synthCalls.Load(); got != 0 {
+		t.Fatalf("synthesis ran %d times, want 0 (the empty marker must satisfy the read)", got)
+	}
+}
+
+// TestAppKnowledgeGBrainEmptyStaysAuthoritative locks the OTHER side of the
+// fallback boundary: when the brain is REACHABLE and simply holds no pages, a
+// stale non-empty file cache must NOT be served — pages deleted from the brain
+// stay deleted, and the handler re-synthesizes instead.
+func TestAppKnowledgeGBrainEmptyStaysAuthoritative(t *testing.T) {
+	t.Setenv("WUPHF_RUNTIME_HOME", t.TempDir())
+	b := newTestBroker(t)
+	b.knowledgeBrainOverride = newFakeBrain()
+	var synthCalls atomic.Int32
+	withFakeAppsLLM(t, func(context.Context, string, string) (string, error) {
+		synthCalls.Add(1)
+		return `{"pages": []}`, nil
+	})
+	if err := b.StartOnPort(0); err != nil {
+		t.Fatalf("start broker: %v", err)
+	}
+	defer b.Stop()
+	base := fmt.Sprintf("http://%s", b.Addr())
+
+	regBody, _ := json.Marshal(map[string]any{
+		"name": "Stale Cache App", "description": "An app whose brain pages were deleted.",
+		"html": validAppHTML,
+	})
+	created := postAppsAsAgent(t, base+"/apps", b.Token(), appBuilderSlug, regBody)
+	app, _ := created["app"].(map[string]any)
+	id, _ := app["id"].(string)
+	if id == "" {
+		t.Fatalf("no app id: %v", created)
+	}
+	if err := b.appStore().WriteAppKnowledge(id, []appKnowledgePage{knowledgeTestPage("p1", "Stale Page")}); err != nil {
+		t.Fatalf("seed stale cache: %v", err)
+	}
+
+	status, out := getAppsJSON(t, base+"/apps/"+id+"/knowledge", b.Token())
+	if status != http.StatusOK {
+		t.Fatalf("GET knowledge: %d", status)
+	}
+	if pages, _ := out["pages"].([]any); len(pages) != 0 {
+		t.Fatalf("pages = %v, want empty (stale cache must not mask a reachable brain)", out["pages"])
+	}
+	if got := synthCalls.Load(); got != 1 {
+		t.Fatalf("synthesis ran %d times, want 1 (reachable-but-empty brain re-synthesizes)", got)
 	}
 }


### PR DESCRIPTION
## What

The app Knowledge tab's gbrain-backed read path only honored the per-app `knowledge.json` cache as an *empty* "synthesis already ran" marker. When the brain was **unreachable** (dead serve, PGLite lock contention, missing binary) the handler ignored cached pages, burned a fresh LLM synthesis that could not persist either, and the tab told the user **"No knowledge yet"** despite holding a good copy on disk.

Now the handler falls back to the file cache **only when the brain read fails**. A reachable-but-empty brain keeps the old behavior on purpose: pages deleted from the brain must not be resurrected from a stale cache.

## How it was found

Live repro on the eval broker: a foreground `gbrain serve` held the `~/.gbrain` PGLite lock, the broker's spawned serve timed out (`connect gbrain mcp: context deadline exceeded`), and the Knowledge tab rendered empty for an app whose operating guide had just synthesized successfully into the local cache.

## Tests

- `TestAppKnowledgeGBrainReadFailureServesCache` — regression test, **fails pre-fix**: unreachable brain + cached page ⇒ serve the page, zero synthesis calls; also locks that the empty marker survives an unreachable brain.
- `TestAppKnowledgeGBrainEmptyStaysAuthoritative` — locks the other side of the boundary: reachable-but-empty brain re-synthesizes instead of serving a stale non-empty cache.

## Test plan

- [x] `go test ./internal/team -run 'TestAppKnowledge|TestKnowledge'` green
- [x] `gofmt` / `go vet` clean
- [x] Full `bash scripts/test-go.sh ./internal/team`: only `TestOnboardingCompleteMaterializesWiki` and `TestConfigEndpointAndHealth` fail locally, and both fail identically on clean `origin/main` (host-env leakage: user config has `memory_backend=gbrain`; git history quirk under /private/tmp) — CI's clean env is the oracle
- [ ] CI green

Backend-only change; no web/ delta, so no screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved app knowledge retrieval when the primary source is unavailable, so existing cached knowledge is now shown instead of failing over to repeated regeneration.
  * Ensured truly empty knowledge remains authoritative, preventing stale cached content from being shown and reducing unnecessary reprocessing.
* **Tests**
  * Added coverage for cache fallback behavior during read failures and for empty-result handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->