### PR TITLE
feat(operator): UI tab owns the app + artifacts, Composio onboarding gate, demo call builds the real agent

### DIFF
--- a/web/e2e/screenshots/composio-gate.mjs
+++ b/web/e2e/screenshots/composio-gate.mjs
@@ -1,0 +1,50 @@
+// Capture the Composio onboarding gate (PR #1159): the operator Integrations
+// tab with no Composio key connected renders the shipped ComposioOnboarding
+// (sign-in primary, key-paste fallback) instead of an empty catalog. The
+// /api/config response is mocked to force the first-run state.
+
+import process from "node:process";
+
+import { installCommonMocks, launchBrowser, shotPage } from "./lib.mjs";
+
+const BASE = process.env.BASE_URL ?? "http://localhost:5273";
+
+const OUT = process.env.WUPHF_SCREENSHOTS_OUT;
+if (!OUT) {
+  console.error("WUPHF_SCREENSHOTS_OUT is not set; run via publish.sh / driver");
+  process.exit(2);
+}
+
+const { browser, context, page } = await launchBrowser({
+  viewport: { width: 1440, height: 900 },
+});
+
+try {
+  await installCommonMocks(context);
+  // Force the no-key state regardless of the workspace's real config.
+  await context.route("**/api/config", (r) => {
+    if (r.request().method() !== "GET") return r.fallback();
+    r.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({ composio_key_set: false }),
+    });
+  });
+
+  await page.goto(`${BASE}/#/operator`, { waitUntil: "domcontentloaded" });
+  await page.waitForTimeout(1200);
+
+  // Open a mock agent's detail and its Integrations tab.
+  await page.getByText("Support escalation triage").first().click();
+  await page.getByRole("tab", { name: "Integrations" }).waitFor({ timeout: 45_000 });
+  await page.getByRole("tab", { name: "Integrations" }).click();
+  await page
+    .getByText("Add integrations to your office")
+    .waitFor({ timeout: 15_000 });
+  await page.waitForTimeout(400);
+  await shotPage(page, OUT, "01-composio-onboarding-gate");
+
+  console.log("captured 1 state");
+} finally {
+  await context.close();
+  await browser.close();
+}

--- a/web/e2e/screenshots/ui-tab-artifacts.mjs
+++ b/web/e2e/screenshots/ui-tab-artifacts.mjs
@@ -1,0 +1,139 @@
+// Capture the UI-tab reframe (PR #1159): the agent's ONE live app IS the UI
+// tab again, with the artifacts its runs produced (md/html/pdf) collected in a
+// strip below the app — the app is no longer an artifact chip. All /api/* and
+// /agent/* traffic is mocked so the shots are reproducible without a broker or
+// agent service.
+
+import process from "node:process";
+
+import { installCommonMocks, launchBrowser, shotPage } from "./lib.mjs";
+
+const BASE = process.env.BASE_URL ?? "http://localhost:5273";
+
+const OUT = process.env.WUPHF_SCREENSHOTS_OUT;
+if (!OUT) {
+  console.error("WUPHF_SCREENSHOTS_OUT is not set; run via publish.sh / driver");
+  process.exit(2);
+}
+
+// Fixed clock so `at` values are stable across runs.
+const NOW = Date.parse("2026-07-01T09:00:00Z");
+const hrsAgo = (h) => new Date(NOW - h * 3_600_000).toISOString();
+
+const AGENT_ID = "app_c0ffee0badc0ffee";
+
+const AGENT = {
+  id: AGENT_ID,
+  slug: "pipeline-agent",
+  name: "Pipeline Agent",
+  icon: "📈",
+  summary:
+    "Keeps the sales pipeline honest: scores and routes inbound leads, posts a Monday recap of stage moves, and drafts follow-ups for stalled deals.",
+  entry: "index.html",
+  version: 3,
+  status: "ready",
+  createdBy: "nex",
+  createdAt: hrsAgo(240),
+  updatedAt: hrsAgo(2),
+  contentHash: "c0ffee",
+};
+
+const APP_HTML = `<!doctype html><html><body style="font-family:system-ui;background:#101014;color:#d8d8de;margin:0;padding:28px">
+<h2 style="margin:0 0 6px;font-size:16px">Pipeline overview</h2>
+<p style="margin:0 0 18px;color:#8b8b95;font-size:12px">Live view produced by this agent's one app.</p>
+<table style="border-collapse:collapse;font-size:13px;width:100%">
+<tr style="text-align:left;color:#8b8b95"><th style="padding:6px 12px 6px 0">Deal</th><th style="padding:6px 12px 6px 0">Stage</th><th style="padding:6px 0">Owner</th></tr>
+<tr><td style="padding:6px 12px 6px 0">Acme</td><td style="padding:6px 12px 6px 0">Evaluation</td><td style="padding:6px 0">Priya</td></tr>
+<tr><td style="padding:6px 12px 6px 0">Globex</td><td style="padding:6px 12px 6px 0">Negotiation</td><td style="padding:6px 0">Sam</td></tr>
+<tr><td style="padding:6px 12px 6px 0">Umbrella</td><td style="padding:6px 12px 6px 0">Stalled</td><td style="padding:6px 0">Priya</td></tr>
+</table></body></html>`;
+
+const ARTIFACTS = [
+  {
+    id: "art_run01",
+    type: "md",
+    title: "monday-pipeline-recap-run-4.md",
+    producedBy: "Monday pipeline recap",
+    at: hrsAgo(2),
+    content:
+      "# Monday pipeline recap — run 4\n\n**Stage moves (3):** Globex → Negotiation, Acme → Evaluation, Initech → Discovery.\n\n**New leads (2):** Hooli, Stark Industries.\n\n**Stalled:** Umbrella — 21 days, owner Priya, last touch was the pricing call.",
+    size: "1.2 KB",
+  },
+  {
+    id: "art_run02",
+    type: "pdf",
+    title: "q3-pipeline-brief.pdf",
+    producedBy: "Monday pipeline recap",
+    at: hrsAgo(26),
+    size: "182 KB",
+  },
+];
+
+async function installAgentMocks(context) {
+  // /api/* — the broker side: the agents list and this agent's detail. Order
+  // matters: register the more specific routes AFTER the generic ones so they
+  // win.
+  await context.route("**/api/apps", (r) =>
+    r.fulfill({ contentType: "application/json", body: JSON.stringify({ apps: [AGENT] }) }),
+  );
+  await context.route(`**/api/apps/${AGENT_ID}*`, (r) =>
+    r.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({ app: AGENT, html: APP_HTML }),
+    }),
+  );
+
+  // /agent/* — the agent service's persistence endpoints. Tools/sessions stay
+  // empty; only the artifacts matter for these shots.
+  await context.route("**/agent/tools?*", (r) =>
+    r.fulfill({ contentType: "application/json", body: JSON.stringify({ tools: [] }) }),
+  );
+  await context.route("**/agent/artifacts?*", (r) =>
+    r.fulfill({ contentType: "application/json", body: JSON.stringify({ artifacts: ARTIFACTS }) }),
+  );
+}
+
+const { browser, context, page } = await launchBrowser({
+  viewport: { width: 1440, height: 900 },
+});
+
+try {
+  await installCommonMocks(context);
+  await installAgentMocks(context);
+
+  await page.goto(`${BASE}/#/operator`, { waitUntil: "domcontentloaded" });
+  await page.getByText("Pipeline Agent").first().waitFor({ timeout: 30_000 });
+  await page.waitForTimeout(800);
+
+  // Open the agent detail. The detail chunk is lazy — the first dev-mode
+  // compile can take a while, so give the tab strip a generous deadline.
+  await page.getByText("Pipeline Agent").first().click();
+  await page.getByRole("tab", { name: "UI" }).waitFor({ timeout: 45_000 });
+
+  // 1. UI tab (the landing tab) — the one live app on top, the artifacts its
+  //    runs produced collected in the strip below. The first artifact's viewer
+  //    (the md run outcome) opens by default.
+  await page
+    .getByText("monday-pipeline-recap-run-4.md")
+    .filter({ visible: true })
+    .first()
+    .waitFor({ timeout: 10_000 });
+  await page.waitForTimeout(800);
+  await shotPage(page, OUT, "01-ui-tab-app-with-artifacts");
+
+  // 2. A file-ish artifact opened in place — the pdf shows its download card
+  //    under the strip; the app stays mounted above.
+  await page
+    .getByText("q3-pipeline-brief.pdf")
+    .filter({ visible: true })
+    .first()
+    .click();
+  await page.getByText("Download").filter({ visible: true }).first().waitFor({ timeout: 10_000 });
+  await page.waitForTimeout(400);
+  await shotPage(page, OUT, "02-ui-tab-pdf-artifact");
+
+  console.log("captured 2 states");
+} finally {
+  await context.close();
+  await browser.close();
+}

--- a/web/src/operator/OperatorApp.tsx
+++ b/web/src/operator/OperatorApp.tsx
@@ -10,7 +10,7 @@ import { useState } from "react";
 import "../styles/operator-shell.css";
 
 import { useAgentNames } from "./agents/agentNames";
-import { capturePromptSeed } from "./apps/demoCapture";
+import { capturePromptSeed, type DemoCapture } from "./apps/demoCapture";
 import {
   appBuildState,
   isRealAppId,
@@ -75,9 +75,11 @@ export function OperatorApp() {
   // working on the demonstrated change.
   const [detailNonce, setDetailNonce] = useState(0);
   // Seeds handed to the build engine by a "Demo workflow to Nex" call so the AI
-  // starts working from the captured context: buildSeed feeds a fresh workflow
-  // build; demoSeed feeds the chat scoped to the tool being modified.
+  // starts working from the captured context: demoBuild feeds a fresh AGENT
+  // build (the real app-builder, plus the captured routine/tools); demoSeed
+  // feeds the chat scoped to the tool being modified.
   const [buildSeed, setBuildSeed] = useState<string | null>(null);
+  const [demoBuild, setDemoBuild] = useState<DemoCapture | null>(null);
   const [demoSeed, setDemoSeed] = useState<string | null>(null);
 
   // The sidebar's collapsible Agents rail: every agent (real + mock), renames
@@ -105,6 +107,7 @@ export function OperatorApp() {
     setBuiltDraft(null);
     setOpenOnWorkflowTab(false);
     setBuildSeed(null);
+    setDemoBuild(null);
     setDemoSeed(null);
   }
 
@@ -201,6 +204,7 @@ export function OperatorApp() {
       <main className="opr-main">
         {appBuilding ? (
           <OperatorBuildExperience
+            demo={demoBuild ?? undefined}
             onClose={() => setAppBuilding(false)}
             onFinish={finishApp}
           />
@@ -236,8 +240,9 @@ export function OperatorApp() {
                 onBuild={(capture) => {
                   // The call captured everything; hand it to the AI, which starts
                   // working at once. A modify call reopens the tool with its chat
-                  // already reworking the demonstrated change; a build call opens the
-                  // workflow builder, already assembling the new tool.
+                  // already reworking the demonstrated change; a build call opens
+                  // the REAL agent build (the app-builder engine), which also sets
+                  // up the captured routine and tools on the new agent.
                   const seed = capturePromptSeed(capture);
                   resetSubState();
                   setCall(null);
@@ -247,8 +252,8 @@ export function OperatorApp() {
                     setSurface("tools");
                     setDetailNonce((n) => n + 1);
                   } else {
-                    setBuildSeed(seed);
-                    setBuilding(true);
+                    setDemoBuild(capture);
+                    setAppBuilding(true);
                     setSurface("tools");
                   }
                 }}

--- a/web/src/operator/OperatorApp.tsx
+++ b/web/src/operator/OperatorApp.tsx
@@ -172,7 +172,7 @@ export function OperatorApp() {
               toolName: selectedTool.name,
             })
           }
-          initialTab={openOnWorkflowTab ? "workflow" : "artifacts"}
+          initialTab={openOnWorkflowTab ? "workflow" : "ui"}
           demoSeed={demoSeed ?? undefined}
         />
       );

--- a/web/src/operator/apps/demoCapture.test.ts
+++ b/web/src/operator/apps/demoCapture.test.ts
@@ -163,3 +163,62 @@ describe("demoCaptureFromDraft (real-call converter)", () => {
     expect(capture.transcript).toHaveLength(1);
   });
 });
+
+describe("demo intent (kind / routine / tools)", () => {
+  it("coerces the drafted kind, routine, and tools with safe defaults", () => {
+    const capture = demoCaptureFromDraft(
+      {
+        goal: "Recap the pipeline every Monday.",
+        kind: "ROUTINE",
+        routine: { prompt: "Summarize last week's pipeline." },
+        tools: [
+          { name: "summarizePipeline", purpose: "Read deals and recap moves." },
+          { name: "", purpose: "dropped — no name" },
+        ],
+      },
+      { mode: "build", transcript: [] },
+    );
+    expect(capture.kind).toBe("routine");
+    // Name and schedule default; the prompt is what makes a routine runnable.
+    expect(capture.routine).toEqual({
+      name: "Scheduled routine",
+      prompt: "Summarize last week's pipeline.",
+      schedule: "daily",
+    });
+    expect(capture.tools).toEqual([
+      { name: "summarizePipeline", purpose: "Read deals and recap moves." },
+    ]);
+  });
+
+  it("defaults to an app build and drops a promptless routine", () => {
+    const capture = demoCaptureFromDraft(
+      { goal: "A screen to review refunds.", routine: { name: "no prompt" } },
+      { mode: "build", transcript: [] },
+    );
+    expect(capture.kind).toBe("app");
+    expect(capture.routine).toBeUndefined();
+    expect(capture.tools).toEqual([]);
+  });
+
+  it("seeds the build with the intent, the routine, and the needed tools", () => {
+    const capture = demoCaptureFromDraft(
+      {
+        goal: "Recap the pipeline every Monday.",
+        kind: "both",
+        routine: {
+          name: "Monday recap",
+          prompt: "Summarize last week's pipeline.",
+          schedule: "0 9 * * 1",
+        },
+        tools: [
+          { name: "summarizePipeline", purpose: "Read deals and recap moves." },
+        ],
+      },
+      { mode: "build", transcript: [] },
+    );
+    const seed = capturePromptSeed(capture);
+    expect(seed).toMatch(/What to build: .*BOTH/);
+    expect(seed).toContain('"Monday recap" — runs 0 9 * * 1');
+    expect(seed).toContain("summarizePipeline (Read deals and recap moves.)");
+  });
+});

--- a/web/src/operator/apps/demoCapture.ts
+++ b/web/src/operator/apps/demoCapture.ts
@@ -60,11 +60,36 @@ export interface DemoCaptureLine {
   text: string;
 }
 
+// What the demonstrated work calls for: an app UI the team works in, a
+// scheduled routine the agent runs itself, or both.
+export type DemoKind = "app" | "routine" | "both";
+
+// A routine the call captured: the scheduled job the built agent should run.
+export interface CapturedRoutine {
+  name: string;
+  prompt: string;
+  /** Cron expression or broker shorthand (daily, hourly, Nh, "0 9 * * 1"). */
+  schedule: string;
+}
+
+// A callable tool the call identified the agent will need.
+export interface CapturedTool {
+  name: string;
+  purpose: string;
+}
+
 export interface DemoCapture {
   mode: "build" | "modify";
   // Present in modify mode: the tool the change was demonstrated on.
   toolId?: string;
   toolName?: string;
+  // What to build from the demo: an app UI, a routine, or both. The agent
+  // always gets built; this decides what gets set up on it.
+  kind: DemoKind;
+  // Present when kind is routine/both: the scheduled job to create.
+  routine?: CapturedRoutine;
+  // The tools the agent will need for this work (created after the build).
+  tools: CapturedTool[];
   // The narrated goal, as a clean instruction the build engine can plan from.
   goal: string;
   // The AI's reflect-back at the end of the call (the drafted tool or change).
@@ -185,6 +210,8 @@ export function assembleDemoCapture(args: {
       mode,
       toolId: tool.id,
       toolName: tool.name,
+      kind: "app",
+      tools: [],
       goal:
         "When a lead scores below 40, archive it instead of adding it to the " +
         "nurture sequence. Leave every other branch unchanged.",
@@ -219,6 +246,18 @@ export function assembleDemoCapture(args: {
 
   return {
     mode: "build",
+    kind: "app",
+    tools: [
+      {
+        name: "scoreAndRouteLead",
+        purpose:
+          "Look the company up in HubSpot, score fit 0-100 from size and industry, and route 70+ to an AE.",
+      },
+      {
+        name: "postHandoffToSlack",
+        purpose: "Post the lead, score, and reason to #ae-handoffs.",
+      },
+    ],
     goal: BUILD_GOAL,
     summary,
     transcript,
@@ -239,6 +278,27 @@ export function capturePromptSeed(capture: DemoCapture): string {
 
   if (capture.summary) {
     lines.push("", `What Nex drafted on the call: ${capture.summary}`);
+  }
+
+  // What the demo calls for, so the build plans an agent, not just a screen.
+  const kindLine =
+    capture.kind === "routine"
+      ? "This work runs on a SCHEDULE (a routine) — the agent does it itself; the app UI is for reviewing outcomes."
+      : capture.kind === "both"
+        ? "This work needs BOTH: an app UI the team works in AND a scheduled routine the agent runs itself."
+        : "This work needs an APP UI the team works in.";
+  lines.push("", `What to build: ${kindLine}`);
+  if (capture.routine) {
+    lines.push(
+      `Routine captured on the call: "${capture.routine.name}" — runs ${capture.routine.schedule} — prompt: ${capture.routine.prompt}`,
+    );
+  }
+  if (capture.tools.length > 0) {
+    lines.push(
+      `Tools the agent will need: ${capture.tools
+        .map((t) => `${t.name} (${t.purpose})`)
+        .join("; ")}`,
+    );
   }
 
   const details: string[] = [];
@@ -317,6 +377,9 @@ export function capturePromptSeed(capture: DemoCapture): string {
 export interface DraftWorkflowArgs {
   goal: string;
   summary?: string;
+  kind?: string;
+  routine?: { name?: string; prompt?: string; schedule?: string };
+  tools?: Array<{ name?: string; purpose?: string }>;
   screens?: Array<{ label?: string; url?: string; dom?: string }>;
   selectors?: Array<{
     label?: string;
@@ -377,10 +440,30 @@ export function demoCaptureFromDraft(
     observed?: ObservedScreen[];
   },
 ): DemoCapture {
+  const kind = (args.kind ?? "").toLowerCase();
+  const routine = args.routine;
+  const routinePrompt = (routine?.prompt ?? "").trim();
   return {
     mode: opts.mode,
     toolId: opts.tool?.id,
     toolName: opts.tool?.name,
+    kind: kind === "routine" || kind === "both" ? kind : "app",
+    // A routine needs a prompt to run; name and schedule get safe defaults.
+    ...(routinePrompt
+      ? {
+          routine: {
+            name: (routine?.name ?? "").trim() || "Scheduled routine",
+            prompt: routinePrompt,
+            schedule: (routine?.schedule ?? "").trim() || "daily",
+          },
+        }
+      : {}),
+    tools: (args.tools ?? [])
+      .filter((t) => (t.name ?? "").trim() && (t.purpose ?? "").trim())
+      .map((t) => ({
+        name: (t.name ?? "").trim(),
+        purpose: (t.purpose ?? "").trim(),
+      })),
     goal: (args.goal ?? "").trim(),
     summary: (args.summary ?? "").trim(),
     transcript: opts.transcript,

--- a/web/src/operator/apps/realtimeClient.ts
+++ b/web/src/operator/apps/realtimeClient.ts
@@ -89,9 +89,9 @@ const DRAFT_TOOL = {
   type: "function" as const,
   name: "draft_workflow",
   description:
-    "Call this once the operator has said yes to building the app. It does NOT " +
-    "end the call — it shows the operator a summary with a 'Build the app' " +
-    "button they tap to confirm and start the build, so they keep final " +
+    "Call this once the operator has said yes to building the agent. It does " +
+    "NOT end the call — it shows the operator a summary with a 'Build the " +
+    "agent' button they tap to confirm and start the build, so they keep final " +
     "control. Never call it on a pause, silence, or your own judgment. Capture " +
     "everything you observed for the build.",
   parameters: {
@@ -100,7 +100,56 @@ const DRAFT_TOOL = {
       goal: {
         type: "string",
         description:
-          "One clean imperative sentence: the workflow to build, or the change to make.",
+          "One clean imperative sentence: what the agent should do, or the change to make.",
+      },
+      kind: {
+        type: "string",
+        enum: ["app", "routine", "both"],
+        description:
+          "What the demo calls for: 'app' when the team needs a screen to work " +
+          "in, 'routine' when the work should run on a schedule without anyone " +
+          "at a screen, 'both' when it needs both.",
+      },
+      routine: {
+        type: "object",
+        description:
+          "Present when kind is routine/both: the scheduled job the agent runs.",
+        properties: {
+          name: { type: "string", description: "Short routine name." },
+          prompt: {
+            type: "string",
+            description:
+              "The instruction the agent runs on each fire, self-contained.",
+          },
+          schedule: {
+            type: "string",
+            description:
+              "5-field cron ('0 9 * * 1') or the shorthands daily / hourly / Nh.",
+          },
+        },
+        required: ["name", "prompt", "schedule"],
+      },
+      tools: {
+        type: "array",
+        description:
+          "The callable tools the agent will need for this work — one per " +
+          "distinct capability you saw demonstrated (look something up, score " +
+          "something, post somewhere).",
+        items: {
+          type: "object",
+          properties: {
+            name: {
+              type: "string",
+              description: "camelCase tool name, e.g. scoreAndRouteLead.",
+            },
+            purpose: {
+              type: "string",
+              description:
+                "One sentence: what the tool does, concrete enough to build from.",
+            },
+          },
+          required: ["name", "purpose"],
+        },
       },
       summary: {
         type: "string",
@@ -166,29 +215,34 @@ const DRAFT_TOOL = {
 
 function instructionsFor(opts: StartRealtimeOptions): string {
   const base =
-    "You are Nex. The operator demonstrates a WORKFLOW on their shared screen, and from that workflow you will build them an APP " +
-    "(a small internal tool). Always say you are building the APP from the workflow they show you — never call it 'building the workflow'. " +
+    "You are Nex. The operator demonstrates a WORKFLOW on their shared screen, and from that workflow you will build them an AGENT " +
+    "— a coworker that takes this work over. An agent has three parts, and part of your job on the call is figuring out which ones this " +
+    "work needs: an APP UI (a screen the team works in — needed when a person reviews, approves, or browses), ROUTINES (the agent runs " +
+    "the work itself on a schedule — needed when they say 'every Monday', 'daily', 'whenever a lead comes in'), and TOOLS (the concrete " +
+    "capabilities the work needs: look a company up, score a lead, post to a channel — the agent builds these for itself). " +
+    "Always say you are building them an AGENT that does this work — never call it 'building the workflow', and don't reduce it to 'an app'. " +
     "OPEN THE CALL by warmly greeting them in one short sentence and saying you are ready to watch them work and learn their workflow — for example: " +
-    "\"Hey, I'm ready when you are. Walk me through what you do, and I'll watch your screen and learn it, then build you an app from it.\" " +
+    "\"Hey, I'm ready when you are. Walk me through what you do, and I'll watch your screen and learn it, then build you an agent that does it.\" " +
     "\n\nAs they work, WATCH THE SCREEN CLOSELY and NARRATE WHAT YOU SEE. When a meaningful step happens — they open an app, search a record, " +
     "copy a value, click a button, send a message — briefly confirm it out loud in one short sentence so they know you caught it " +
     '(e.g., "Got it, you looked up the company in HubSpot," or "Okay, you posted that to #ae-handoffs"). Keep confirmations short and ' +
     "natural, not a play-by-play of every pixel.\n\n" +
-    "BE GENUINELY CURIOUS. Ask sharp questions to capture what the app will need when you build it: what triggers this? what decides one " +
-    "path versus another (thresholds, fields, conditions)? what happens to the cases that do not qualify? which app or channel does each " +
-    "step touch, and what gets written where? what should happen when something is missing or ambiguous? Ask one question at a time and " +
-    "keep it conversational.\n\n" +
-    "Track everything you learn: the trigger, each app/integration and the API calls you can see, the decision logic and its branches, the " +
-    "actions and where they write.\n\n" +
+    "BE GENUINELY CURIOUS. Ask sharp questions to capture what the agent will need when you build it: what triggers this — does it run on a " +
+    "SCHEDULE (a routine) or does someone work a SCREEN (an app UI)? what decides one path versus another (thresholds, fields, conditions)? " +
+    "what happens to the cases that do not qualify? which app or channel does each step touch, and what gets written where? what should " +
+    "happen when something is missing or ambiguous? Ask one question at a time and keep it conversational.\n\n" +
+    "Track everything you learn: the trigger and its cadence, each app/integration and the API calls you can see, the decision logic and its " +
+    "branches, the actions and where they write — and the distinct capabilities you'd make into tools.\n\n" +
     "NEVER DECIDE BY YOURSELF THAT YOU ARE DONE. When you think you have the whole flow, or the operator pauses, ASK FOR EXPLICIT CONFIRMATION " +
-    '— for example: "I think I\'ve got the whole flow. Are you ready for me to build the app from this, or is there more you want to show me?" ' +
+    '— for example: "I think I\'ve got the whole flow. Are you ready for me to build the agent from this, or is there more you want to show me?" ' +
     'Then WAIT and listen for their spoken answer. ONLY when the operator gives a CLEAR yes to building it (e.g., "yes", "build it", "go ahead", ' +
-    '"that\'s it") do you call the draft_workflow tool with everything you captured, and say one short line like "Great — I\'ve put it together, ' +
-    'tap Build when you\'re ready." Calling draft_workflow does NOT cut the call: it shows the operator a summary with a "Build the app" button ' +
-    "they tap to confirm, so THEY have the final say. Do NOT call it on a pause, an ambiguous comment, silence, mid-sentence, or your own judgment. " +
-    "If they say no, not yet, wait, or keep going, do not call it — stay on the call and keep learning.";
+    "\"that's it\") do you call the draft_workflow tool with everything you captured — including kind (app / routine / both), the routine's " +
+    "name + prompt + schedule when the work is scheduled, and the tools the agent will need — and say one short line like \"Great — I've put it " +
+    'together, tap Build when you\'re ready." Calling draft_workflow does NOT cut the call: it shows the operator a summary with a "Build the ' +
+    'agent" button they tap to confirm, so THEY have the final say. Do NOT call it on a pause, an ambiguous comment, silence, mid-sentence, or ' +
+    "your own judgment. If they say no, not yet, wait, or keep going, do not call it — stay on the call and keep learning.";
   if (opts.mode === "modify" && opts.tool) {
-    return `${base} The operator is CHANGING an existing app named "${opts.tool.name}". Open by saying you're ready to see the change, narrate the change as they show it, ask what should stay the same, and the same rule applies: only call draft_workflow after they clearly say yes — and it still just shows them the Build button to tap.`;
+    return `${base} The operator is CHANGING an existing agent named "${opts.tool.name}". Open by saying you're ready to see the change, narrate the change as they show it, ask what should stay the same, and the same rule applies: only call draft_workflow after they clearly say yes — and it still just shows them the Build button to tap.`;
   }
   return base;
 }

--- a/web/src/operator/artifacts/ArtifactsTab.test.tsx
+++ b/web/src/operator/artifacts/ArtifactsTab.test.tsx
@@ -6,13 +6,6 @@ import type { Artifact } from "./artifacts";
 
 const ARTIFACTS: Artifact[] = [
   {
-    id: "app",
-    type: "app",
-    title: "Pipeline Agent",
-    producedBy: "built by Nex",
-    at: "v3",
-  },
-  {
     id: "m1",
     type: "md",
     title: "weekly-summary.md",
@@ -31,34 +24,24 @@ const ARTIFACTS: Artifact[] = [
 ];
 
 describe("ArtifactsTab", () => {
-  it("lists every artifact and renders the app first via renderApp", () => {
-    const { getByText, getByTestId } = render(
-      <ArtifactsTab
-        agentName="Pipeline Agent"
-        artifacts={ARTIFACTS}
-        renderApp={() => <div data-testid="live-app" />}
-      />,
+  it("lists every artifact and opens the first one's viewer", () => {
+    const { getByText } = render(
+      <ArtifactsTab agentName="Pipeline Agent" artifacts={ARTIFACTS} />,
     );
-    // All artifacts appear as chips (app + md + pdf).
+    // All artifacts appear as chips (md + pdf).
     expect(getByText("weekly-summary.md")).toBeTruthy();
     expect(getByText("brief.pdf")).toBeTruthy();
-    // The first artifact (the app) is selected and rendered via the host slot.
-    expect(getByTestId("live-app")).toBeTruthy();
+    // The first artifact is selected and its viewer is rendered.
+    expect(getByText(/6 deals moved/)).toBeTruthy();
   });
 
   it("switches viewer when another artifact is selected", () => {
-    const { getByText, queryByTestId } = render(
-      <ArtifactsTab
-        agentName="Pipeline Agent"
-        artifacts={ARTIFACTS}
-        renderApp={() => <div data-testid="live-app" />}
-      />,
+    const { getByText, queryByText } = render(
+      <ArtifactsTab agentName="Pipeline Agent" artifacts={ARTIFACTS} />,
     );
-    fireEvent.click(getByText("weekly-summary.md"));
-    expect(queryByTestId("live-app")).toBeNull();
-    expect(getByText(/6 deals moved/)).toBeTruthy();
     // The pdf artifact shows the file card with a download affordance.
     fireEvent.click(getByText("brief.pdf"));
+    expect(queryByText(/6 deals moved/)).toBeNull();
     expect(getByText("Download")).toBeTruthy();
     expect(getByText(/182 KB/)).toBeTruthy();
   });

--- a/web/src/operator/artifacts/ArtifactsTab.tsx
+++ b/web/src/operator/artifacts/ArtifactsTab.tsx
@@ -1,10 +1,9 @@
-// ArtifactsTab — the agent's outcomes, plural. A chip strip of everything the
-// agent produced (its app, PDFs, HTML pages, markdown docs) with a viewer per
-// type below. The app is one artifact among many, rendered by the host detail
-// via `renderApp` (the real detail mounts the live sandboxed app; the mock detail
-// mounts its request table). See web/src/operator/artifacts/artifacts.ts.
+// ArtifactsTab — the file-ish outcomes the agent produced (PDFs, HTML pages,
+// markdown docs) as a chip strip with a viewer per type below. It lives INSIDE
+// the UI tab, under the agent's one live app — the app itself is the tab, not
+// an artifact. See web/src/operator/artifacts/artifacts.ts.
 
-import { type ReactNode, useState } from "react";
+import { useState } from "react";
 import { Download, FileText } from "lucide-react";
 
 import { ARTIFACT_BADGE, type Artifact } from "./artifacts";
@@ -12,15 +11,9 @@ import { ARTIFACT_BADGE, type Artifact } from "./artifacts";
 interface ArtifactsTabProps {
   agentName: string;
   artifacts: Artifact[];
-  /** Render the live app for an `app`-type artifact (host-owned). */
-  renderApp?: (artifact: Artifact) => ReactNode;
 }
 
-export function ArtifactsTab({
-  agentName,
-  artifacts,
-  renderApp,
-}: ArtifactsTabProps) {
+export function ArtifactsTab({ agentName, artifacts }: ArtifactsTabProps) {
   const [selectedId, setSelectedId] = useState<string | null>(
     artifacts[0]?.id ?? null,
   );
@@ -67,31 +60,15 @@ export function ArtifactsTab({
 
       {selected ? (
         <div className="opr-artifact-viewer">
-          <ArtifactViewer artifact={selected} renderApp={renderApp} />
+          <ArtifactViewer artifact={selected} />
         </div>
       ) : null}
     </div>
   );
 }
 
-function ArtifactViewer({
-  artifact,
-  renderApp,
-}: {
-  artifact: Artifact;
-  renderApp?: (artifact: Artifact) => ReactNode;
-}) {
+function ArtifactViewer({ artifact }: { artifact: Artifact }) {
   switch (artifact.type) {
-    case "app":
-      return (
-        <>
-          {renderApp?.(artifact) ?? (
-            <div className="opr-empty-hint">
-              This app has no live preview here.
-            </div>
-          )}
-        </>
-      );
     case "md":
       return (
         <pre className="opr-artifact-md">

--- a/web/src/operator/artifacts/artifacts.ts
+++ b/web/src/operator/artifacts/artifacts.ts
@@ -1,13 +1,12 @@
-// Artifacts — what an AGENT produces. The old "UI" tab showed exactly one built
-// mini-app; the Artifacts tab holds EVERY outcome the agent's work yields: the
-// app itself, PDFs, HTML pages, markdown docs — whatever a run produced. The app
-// is just the first artifact type, not the tab.
+// Artifacts — the file-ish outcomes an AGENT's runs produce: PDFs, HTML pages,
+// markdown docs. The agent's ONE built app is not an artifact — it IS the UI
+// tab; artifacts collect below it as the outputs of routines and tool runs.
 //
-// FE-first: the shapes are real, the non-app seeds are mock (used by the mock
-// agent detail to show the range; a real agent starts with its app artifact and
-// collects more as tools/runs produce them).
+// FE-first: the shapes are real, the seeds are mock (used by the mock agent
+// detail to show the range; a real agent starts empty and collects artifacts as
+// tools/runs produce them).
 
-export type ArtifactType = "app" | "pdf" | "html" | "md";
+export type ArtifactType = "pdf" | "html" | "md";
 
 export interface Artifact {
   id: string;
@@ -17,7 +16,7 @@ export interface Artifact {
   /** What produced it, e.g. "weeklyPipelineSummary" or "built by Nex". */
   producedBy: string;
   at: string;
-  /** Inline content for md/html; absent for app (rendered live) and pdf (mock). */
+  /** Inline content for md/html; absent for pdf (file-ish, download only). */
   content?: string;
   /** Download URL for file-ish artifacts; absent until the file is exported. */
   url?: string;
@@ -27,7 +26,6 @@ export interface Artifact {
 
 /** Short uppercase badge per artifact type. */
 export const ARTIFACT_BADGE: Record<ArtifactType, string> = {
-  app: "APP",
   pdf: "PDF",
   html: "HTML",
   md: "MD",

--- a/web/src/operator/surfaces/AppBuilderChat.test.tsx
+++ b/web/src/operator/surfaces/AppBuilderChat.test.tsx
@@ -1,0 +1,119 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { DemoCapture } from "../apps/demoCapture";
+import { AppBuilderChat } from "./AppBuilderChat";
+
+// A "Demo workflow to Nex" handoff must start the REAL agent build at once
+// from the captured context, and set up the captured routine + tools on the
+// new agent the moment its id resolves — that is the contract this covers.
+
+const listAppsMock = vi.fn();
+vi.mock("../../api/apps", () => ({
+  listApps: () => listAppsMock(),
+  submitAppEdit: vi.fn(),
+}));
+
+const buildMutateMock = vi.fn(
+  async (_input: { name: string; description: string }) => ({}),
+);
+vi.mock("../apps/useOperatorApps", () => ({
+  useBuildApp: () => ({ mutateAsync: buildMutateMock }),
+  deriveAppName: () => "Pipeline Agent",
+  resolveNewAppId: (before: ReadonlySet<string>, apps: { id: string }[]) =>
+    apps.find((a) => !before.has(a.id))?.id ?? null,
+  appBuildState: (app: { status?: string }) =>
+    app.status === "building" ? "building" : "ready",
+}));
+
+const createRoutineMock = vi.fn(async (_input: unknown) => ({ id: "job_1" }));
+vi.mock("../agents/agentStateClient", () => ({
+  tryCreateRoutine: (input: unknown) => createRoutineMock(input),
+}));
+
+const buildToolMock = vi.fn(async (_instruction: string, _agent: string) => ({
+  tool: {},
+  offline: false,
+}));
+vi.mock("../tools/toolAgentClient", () => ({
+  buildToolFromChat: (instruction: string, agent: string) =>
+    buildToolMock(instruction, agent),
+}));
+
+vi.mock("../../components/apps/AppActivity", () => ({
+  AppActivity: () => null,
+}));
+
+const DEMO: DemoCapture = {
+  mode: "build",
+  kind: "both",
+  routine: {
+    name: "Monday recap",
+    prompt: "Summarize last week's pipeline.",
+    schedule: "0 9 * * 1",
+  },
+  tools: [
+    { name: "summarizePipeline", purpose: "Read deals and recap moves." },
+  ],
+  goal: "Recap the pipeline every Monday.",
+  summary: "",
+  transcript: [],
+  screens: [],
+  selectors: [],
+  apiCalls: [],
+  entities: [],
+};
+
+function renderChat() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <AppBuilderChat demo={DEMO} onClose={() => {}} onFinish={() => {}} />
+    </QueryClientProvider>,
+  );
+}
+
+describe("AppBuilderChat demo handoff", () => {
+  beforeEach(() => {
+    listAppsMock.mockReset();
+    buildMutateMock.mockClear();
+    createRoutineMock.mockClear();
+    buildToolMock.mockClear();
+    // Baseline snapshot (send) sees no apps; every poll after sees the
+    // pre-scaffolded building agent.
+    listAppsMock
+      .mockResolvedValueOnce([])
+      .mockResolvedValue([{ id: "app_new1", status: "building", version: 0 }]);
+  });
+
+  it("starts the build from the capture and shows the goal, not the raw seed", async () => {
+    const { getByText, queryByText } = renderChat();
+    await waitFor(() => expect(buildMutateMock).toHaveBeenCalledTimes(1));
+    // The build engine gets the FULL capture (intent + routine + tools)…
+    const description = buildMutateMock.mock.calls[0]?.[0]?.description ?? "";
+    expect(description).toContain("What to build:");
+    expect(description).toContain("Monday recap");
+    // …while the transcript shows the narrated goal as the operator's message.
+    expect(getByText("Recap the pipeline every Monday.")).toBeTruthy();
+    expect(queryByText(/What to build:/)).toBeNull();
+  });
+
+  it("creates the captured routine and tools once the agent id resolves", async () => {
+    renderChat();
+    await waitFor(() => expect(createRoutineMock).toHaveBeenCalledTimes(1));
+    expect(createRoutineMock).toHaveBeenCalledWith({
+      agent: "app_new1",
+      name: "Monday recap",
+      prompt: "Summarize last week's pipeline.",
+      schedule: "0 9 * * 1",
+    });
+    await waitFor(() => expect(buildToolMock).toHaveBeenCalledTimes(1));
+    expect(buildToolMock).toHaveBeenCalledWith(
+      "summarizePipeline — Read deals and recap moves.",
+      "app_new1",
+    );
+  });
+});

--- a/web/src/operator/surfaces/AppBuilderChat.tsx
+++ b/web/src/operator/surfaces/AppBuilderChat.tsx
@@ -11,6 +11,8 @@ import { ArrowRight, Check, Send, X } from "lucide-react";
 
 import { type CustomApp, listApps, submitAppEdit } from "../../api/apps";
 import { AppActivity } from "../../components/apps/AppActivity";
+import { tryCreateRoutine } from "../agents/agentStateClient";
+import { capturePromptSeed, type DemoCapture } from "../apps/demoCapture";
 import {
   appBuildState,
   deriveAppName,
@@ -18,6 +20,7 @@ import {
   useBuildApp,
 } from "../apps/useOperatorApps";
 import { Eyebrow } from "../components/primitives";
+import { buildToolFromChat } from "../tools/toolAgentClient";
 
 const BUILD_POLL_MS = 3000;
 // How long a terminal-on-first-sight candidate must STAY terminal before we
@@ -66,6 +69,13 @@ interface AppBuilderChatProps {
    * Ask-AI bar provides the title + close/resize controls instead).
    */
   panelMode?: boolean;
+  /**
+   * A "Demo workflow to Nex" call's capture. The build starts from it at once
+   * (the full capture is the build description; the goal is what the transcript
+   * shows), and the captured routine + tools are created on the new agent the
+   * moment its id resolves.
+   */
+  demo?: DemoCapture;
 }
 
 export function AppBuilderChat({
@@ -74,6 +84,7 @@ export function AppBuilderChat({
   onBuildingApp,
   editApp,
   panelMode,
+  demo,
 }: AppBuilderChatProps) {
   const [phase, setPhase] = useState<Phase>("intro");
   const [draft, setDraft] = useState("");
@@ -88,7 +99,9 @@ export function AppBuilderChat({
         from: "ai",
         body: editApp
           ? `Tell me what to change about “${editApp.name}”. I will apply it and publish a new version.`
-          : "Tell me what this agent should do. I will build it, and it will appear under Agents the moment it is ready.",
+          : demo
+            ? "I caught everything on the call — building your agent from the demo now."
+            : "Tell me what this agent should do. I will build it, and it will appear under Agents the moment it is ready.",
       },
     ];
   });
@@ -159,10 +172,13 @@ export function AppBuilderChat({
     setBuildingAppId(candidate.id);
 
     // Tell the host the app exists the moment it is resolved (even building), so
-    // it can show the live preview beside the chat. New builds only.
+    // it can show the live preview beside the chat. New builds only. A demo-call
+    // build also sets up the captured routine + tools now — both are keyed by
+    // the agent id and do not need the app published.
     if (!refineId && reportedBuildingRef.current !== candidate.id) {
       reportedBuildingRef.current = candidate.id;
       onBuildingApp?.(candidate.id);
+      void setupDemoExtras(candidate.id);
     }
 
     const state = appBuildState(candidate);
@@ -222,9 +238,84 @@ export function AppBuilderChat({
     if (id) appChatHistory.set(id, messages);
   }, [messages, editApp, newAppId]);
 
-  async function send(text?: string): Promise<void> {
+  // A demo-call handoff starts the build at once: the FULL capture is the build
+  // description, the narrated goal is what the transcript shows. One-shot.
+  const demoStartedRef = useRef(false);
+  // biome-ignore lint/correctness/useExhaustiveDependencies: fire the demo start once
+  useEffect(() => {
+    if (!demo || editApp || demoStartedRef.current) return;
+    demoStartedRef.current = true;
+    void send(capturePromptSeed(demo), { display: demo.goal });
+  }, []);
+
+  // ── Demo-call extras: the captured routine + tools, created on the new agent ──
+
+  // Fires once per chat, the moment the new agent's id resolves. Failures are
+  // reported honestly in the chat but never block the app build itself.
+  const demoSetupRef = useRef(false);
+  function say(body: string) {
+    setMessages((prev) => [
+      ...prev,
+      { id: `ai-${seqRef.current++}`, from: "ai", body },
+    ]);
+  }
+  async function setupDemoExtras(agentId: string): Promise<void> {
+    if (!demo || demoSetupRef.current) return;
+    const routine = demo.routine;
+    const tools = demo.tools;
+    if (!routine && tools.length === 0) return;
+    demoSetupRef.current = true;
+
+    const planned = [
+      routine ? `the “${routine.name}” routine` : null,
+      tools.length > 0
+        ? `${tools.length} tool${tools.length === 1 ? "" : "s"} (${tools
+            .map((t) => t.name)
+            .join(", ")})`
+        : null,
+    ].filter(Boolean);
+    say(`While it builds, I am also setting up ${planned.join(" and ")}.`);
+
+    const done: string[] = [];
+    const failed: string[] = [];
+    if (routine) {
+      const created = await tryCreateRoutine({
+        agent: agentId,
+        name: routine.name,
+        prompt: routine.prompt,
+        schedule: routine.schedule,
+      });
+      (created ? done : failed).push(`“${routine.name}” (${routine.schedule})`);
+    }
+    for (const tool of tools) {
+      try {
+        await buildToolFromChat(`${tool.name} — ${tool.purpose}`, agentId);
+        done.push(tool.name);
+      } catch {
+        failed.push(tool.name);
+      }
+    }
+    if (done.length > 0) {
+      say(
+        `In place: ${done.join(", ")}. You will find them on the agent's Routines and Tools tabs.`,
+      );
+    }
+    if (failed.length > 0) {
+      say(
+        `I could not set up ${failed.join(", ")} — the workspace may be offline. Ask me again from the agent's chat.`,
+      );
+    }
+  }
+
+  async function send(
+    text?: string,
+    opts?: { display?: string },
+  ): Promise<void> {
     const description = (text ?? draft).trim();
     if (!description || phase === "building") return;
+    // What the transcript shows as the operator's message. A demo-call start
+    // shows the narrated goal, not the full multi-line capture it builds from.
+    const display = opts?.display?.trim() || description;
     setDraft("");
     // Once this chat has produced an app (or it opened to edit one), every
     // follow-up REFINES that app instead of starting a brand-new build — so a
@@ -243,7 +334,7 @@ export function AppBuilderChat({
     setAppName(name);
     setMessages((prev) => [
       ...prev,
-      { id: `you-${seqRef.current++}`, from: "you", body: description },
+      { id: `you-${seqRef.current++}`, from: "you", body: display },
       {
         id: `ai-${seqRef.current++}`,
         from: "ai",

--- a/web/src/operator/surfaces/InternalToolDetail.tsx
+++ b/web/src/operator/surfaces/InternalToolDetail.tsx
@@ -60,7 +60,7 @@ import { KnowledgeSurface } from "./KnowledgeSurface";
 import { ToolIntegrations } from "./ToolIntegrations";
 
 type ToolTab =
-  | "artifacts"
+  | "ui"
   | "workflow"
   | "tools"
   | "data"
@@ -68,7 +68,7 @@ type ToolTab =
   | "knowledge";
 
 const TABS: readonly TabDef<ToolTab>[] = [
-  { id: "artifacts", label: "Artifacts" },
+  { id: "ui", label: "UI" },
   { id: "workflow", label: "Routines" },
   // Tools Nex builds from taught workflows; the app's chat calls them. Additive.
   { id: "tools", label: "Tools" },
@@ -81,7 +81,7 @@ interface InternalToolDetailProps {
   tool: InternalTool;
   onBack: () => void;
   onStartCall: () => void;
-  // Which tab to land on. "Run on test data" hands off to the Workflow tab
+  // Which tab to land on. "Run on test data" hands off to the Routines tab
   // (where run history lives); a plain open stays on the UI tab.
   initialTab?: ToolTab;
   // When set, a "Demo workflow to Nex" call just finished on this tool: open the
@@ -94,7 +94,7 @@ export function InternalToolDetail({
   tool,
   onBack,
   onStartCall,
-  initialTab = "artifacts",
+  initialTab = "ui",
   demoSeed,
 }: InternalToolDetailProps) {
   const [tab, setTab] = useState<ToolTab>(initialTab);
@@ -206,33 +206,28 @@ export function InternalToolDetail({
             id={`opr-panel-${tab}`}
             aria-labelledby={`opr-tab-${tab}`}
           >
-            {tab === "artifacts" && (
-              <ArtifactsTab
-                agentName={tool.name}
-                artifacts={[
-                  {
-                    id: "app",
-                    type: "app",
-                    title: tool.name,
-                    producedBy: "built by Nex",
-                    at: `v${version}`,
-                  },
-                  ...seedArtifacts(),
-                ]}
-                renderApp={() =>
-                  isInbound ? (
-                    <UITab rows={inboundRows} onApprove={approveInbound} />
-                  ) : (
-                    <EmptyState
-                      glyph="◧"
-                      title="No screen built yet"
-                      hint="Build the screen your team will use to run this agent. Demo it to Nex on a call and your AI assembles it."
-                      actionLabel="Demo workflow to Nex"
-                      onAction={onStartCall}
-                    />
-                  )
-                }
-              />
+            {tab === "ui" && (
+              <>
+                {isInbound ? (
+                  <UITab rows={inboundRows} onApprove={approveInbound} />
+                ) : (
+                  <EmptyState
+                    glyph="◧"
+                    title="No screen built yet"
+                    hint="Build the screen your team will use to run this agent. Demo it to Nex on a call and your AI assembles it."
+                    actionLabel="Demo workflow to Nex"
+                    onAction={onStartCall}
+                  />
+                )}
+                {/* The artifacts this agent's runs produced, under its one app. */}
+                <div className="opr-ui-artifacts">
+                  <Eyebrow>Artifacts</Eyebrow>
+                  <ArtifactsTab
+                    agentName={tool.name}
+                    artifacts={seedArtifacts()}
+                  />
+                </div>
+              </>
             )}
             {tab === "workflow" && (
               <RoutinesTab

--- a/web/src/operator/surfaces/OperatorAppDetail.test.tsx
+++ b/web/src/operator/surfaces/OperatorAppDetail.test.tsx
@@ -140,7 +140,7 @@ describe("OperatorAppDetail", () => {
     expect(queryByRole("button", { name: /ask agent/i })).toBeNull();
   });
 
-  it("appends the agent service's artifacts after the live app artifact", async () => {
+  it("collects the agent service's artifacts under the live app on the UI tab", async () => {
     useOperatorAppMock.mockReturnValue({
       data: detail({ status: "ready" }, "<html>hi</html>"),
       isError: false,
@@ -167,16 +167,34 @@ describe("OperatorAppDetail", () => {
       return { ok: false, status: 404, json: async () => ({}) };
     });
     vi.stubGlobal("fetch", fetchMock);
-    const { container, findByText } = render(
+    const { container, findByText, getByTestId, getByText } = render(
       <OperatorAppDetail appId="app_abc" onBack={() => {}} />,
     );
-    // The persisted artifact renders in the strip…
+    // The persisted artifact renders in the strip under the app…
     expect(await findByText("weekly-recap.md")).toBeTruthy();
-    // …AFTER the live app artifact.
+    expect(getByText("Artifacts")).toBeTruthy();
+    // …while the app itself stays THE UI (rendered once, not an artifact chip).
+    expect(getByTestId("app-frame")).toBeTruthy();
     const chips = container.querySelectorAll(".opr-artifact-chip");
-    expect(chips.length).toBe(2);
-    expect(chips[0].textContent).toContain("Open Tasks");
-    expect(chips[1].textContent).toContain("weekly-recap.md");
+    expect(chips.length).toBe(1);
+    expect(chips[0].textContent).toContain("weekly-recap.md");
+  });
+
+  it("shows no artifacts section when the agent has produced nothing", () => {
+    useOperatorAppMock.mockReturnValue({
+      data: detail({ status: "ready" }, "<html>hi</html>"),
+      isError: false,
+    });
+    // The agent service is unreachable: the UI tab is just the app.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({ ok: false, status: 404, json: async () => ({}) })),
+    );
+    const { getByTestId, queryByText } = render(
+      <OperatorAppDetail appId="app_abc" onBack={() => {}} />,
+    );
+    expect(getByTestId("app-frame")).toBeTruthy();
+    expect(queryByText("Artifacts")).toBeNull();
   });
 
   it("opens Ask AI as a docked drawer (not full screen) when clicked", () => {

--- a/web/src/operator/surfaces/OperatorAppDetail.tsx
+++ b/web/src/operator/surfaces/OperatorAppDetail.tsx
@@ -1,8 +1,8 @@
 // OperatorAppDetail — the detail view for a REAL built app (id `app_…`). It
-// keeps the operator App's tab model (UI / Workflow / Data / Integrations /
-// Knowledge); the UI tab renders the live, persisted app inside the shipped
-// hardened sandbox (CustomAppFrame + Bridge v2). The other tabs are honest
-// empty states for this slice — the workflow/data/knowledge wiring lands next.
+// keeps the operator App's tab model (UI / Routines / Tools / Data / Knowledge /
+// Integrations); the UI tab renders the agent's ONE live app inside the shipped
+// hardened sandbox (CustomAppFrame + Bridge v2), with the artifacts its runs
+// produced (md/html/pdf) collected below the app.
 
 import { useEffect, useRef, useState } from "react";
 import type { UseQueryResult } from "@tanstack/react-query";
@@ -33,7 +33,7 @@ import {
 import { ArtifactsTab } from "../artifacts/ArtifactsTab";
 import type { Artifact } from "../artifacts/artifacts";
 import { EmptyState } from "../components/EmptyState";
-import { type TabDef, Tabs } from "../components/primitives";
+import { Eyebrow, type TabDef, Tabs } from "../components/primitives";
 import { RoutinesTab } from "../routines/RoutinesTab";
 import { ToolsProvider } from "../tools/toolsContext";
 import { AppDataTab } from "./AppDataTab";
@@ -44,7 +44,7 @@ import { ToolIntegrations } from "./ToolIntegrations";
 type PanelSize = "dock" | "wide" | "modal";
 
 type AppTab =
-  | "artifacts"
+  | "ui"
   | "workflow"
   | "tools"
   | "data"
@@ -52,7 +52,7 @@ type AppTab =
   | "knowledge";
 
 const TABS: readonly TabDef<AppTab>[] = [
-  { id: "artifacts", label: "Artifacts" },
+  { id: "ui", label: "UI" },
   { id: "workflow", label: "Routines" },
   // Tools: the callable tools Nex builds from taught workflows; the app's chat
   // calls them. Additive — the Workflow tab is unchanged.
@@ -78,7 +78,7 @@ export function OperatorAppDetail({
   onBack,
   buildWalk,
 }: OperatorAppDetailProps) {
-  const [tab, setTab] = useState<AppTab>("artifacts");
+  const [tab, setTab] = useState<AppTab>("ui");
   const [chatOpen, setChatOpen] = useState(false);
   // A routine's "Open its chat" jumps the Ask Agent dock to that session.
   const [requestedSession, setRequestedSession] = useState<string | null>(null);
@@ -93,12 +93,12 @@ export function OperatorAppDetail({
   const ready = state === "ready" && !!detail?.html;
 
   // The agent's persisted artifacts (routine outcomes) from the agent service,
-  // appended after the live app artifact. Refreshed each time the Artifacts tab
+  // collected below the live app on the UI tab. Refreshed each time the UI tab
   // becomes active; stays empty when the service is unreachable.
   const [remoteArtifacts, setRemoteArtifacts] = useState<Artifact[]>([]);
   const agentId = app?.id;
   useEffect(() => {
-    if (tab !== "artifacts" || !agentId) return;
+    if (tab !== "ui" || !agentId) return;
     let cancelled = false;
     void tryListArtifacts(agentId).then((wire) => {
       if (cancelled || !wire) return;
@@ -130,7 +130,7 @@ export function OperatorAppDetail({
       window.setTimeout(() => setTab("workflow"), 900),
       window.setTimeout(() => setTab("data"), 3200),
       window.setTimeout(() => setTab("knowledge"), 5500),
-      window.setTimeout(() => setTab("artifacts"), 8000),
+      window.setTimeout(() => setTab("ui"), 8000),
     ];
     return () => timers.forEach((t) => window.clearTimeout(t));
   }, [buildWalk, ready]);
@@ -227,34 +227,29 @@ export function OperatorAppDetail({
             id={`opr-panel-${tab}`}
             aria-labelledby={`opr-tab-${tab}`}
           >
-            {/* The Artifacts tab (hosting the live app frame) stays MOUNTED
-                across tab switches — hidden, not unmounted — so returning to it
-                does NOT reload the iframe and re-run the app every time. The
-                other tabs mount only while active. */}
-            <div style={tab === "artifacts" ? undefined : { display: "none" }}>
-              <ArtifactsTab
-                agentName={app?.name ?? "This agent"}
-                artifacts={[
-                  {
-                    id: "app",
-                    type: "app",
-                    title: app?.name ?? "App",
-                    producedBy: "built by Nex",
-                    at: app ? `v${app.version}` : "",
-                  },
-                  ...remoteArtifacts,
-                ]}
-                renderApp={() => (
-                  <UiTab
-                    query={query}
-                    failed={failed}
-                    onRemove={removeAndBack}
-                    removing={remove.isPending}
-                  />
-                )}
+            {/* The UI tab (hosting the live app frame) stays MOUNTED across
+                tab switches — hidden, not unmounted — so returning to it does
+                NOT reload the iframe and re-run the app every time. The other
+                tabs mount only while active. */}
+            <div style={tab === "ui" ? undefined : { display: "none" }}>
+              <UiTab
+                query={query}
+                failed={failed}
+                onRemove={removeAndBack}
+                removing={remove.isPending}
               />
+              {/* The artifacts the agent's runs produced, under its one app. */}
+              {remoteArtifacts.length > 0 ? (
+                <div className="opr-ui-artifacts">
+                  <Eyebrow>Artifacts</Eyebrow>
+                  <ArtifactsTab
+                    agentName={app?.name ?? "This agent"}
+                    artifacts={remoteArtifacts}
+                  />
+                </div>
+              ) : null}
             </div>
-            {tab !== "artifacts" ? (
+            {tab !== "ui" ? (
               <TabBody
                 tab={tab}
                 query={query}

--- a/web/src/operator/surfaces/OperatorBuildExperience.tsx
+++ b/web/src/operator/surfaces/OperatorBuildExperience.tsx
@@ -9,17 +9,25 @@
 import { useState } from "react";
 import { Sparkles, X } from "lucide-react";
 
+import type { DemoCapture } from "../apps/demoCapture";
 import { AppBuilderChat } from "./AppBuilderChat";
 import { OperatorAppDetail } from "./OperatorAppDetail";
 
 interface OperatorBuildExperienceProps {
   onClose: () => void;
   onFinish: (appId: string) => void;
+  /**
+   * A "Demo workflow to Nex" call's capture: the build starts from it at once
+   * (no describe step), and the captured routine + tools get set up on the new
+   * agent as it builds.
+   */
+  demo?: DemoCapture;
 }
 
 export function OperatorBuildExperience({
   onClose,
   onFinish,
+  demo,
 }: OperatorBuildExperienceProps) {
   // Set the instant the build scaffolds; flips the layout from a centered
   // describe chat to "live preview + docked chat".
@@ -44,7 +52,7 @@ export function OperatorBuildExperience({
           <div className="opr-ask-bar">
             <span className="opr-ask-bar-title">
               <Sparkles size={13} strokeWidth={2} aria-hidden={true} />
-              Building your app
+              Building your agent
             </span>
             <button
               type="button"
@@ -60,6 +68,7 @@ export function OperatorBuildExperience({
         <div className={live ? "opr-ask-body" : "opr-build-exp-chat-full"}>
           <AppBuilderChat
             panelMode={live}
+            demo={demo}
             onClose={onClose}
             onBuildingApp={setBuildingAppId}
             onFinish={onFinish}

--- a/web/src/operator/surfaces/ToolIntegrations.test.tsx
+++ b/web/src/operator/surfaces/ToolIntegrations.test.tsx
@@ -1,0 +1,80 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ToolIntegrations } from "./ToolIntegrations";
+
+// The catalog cannot exist without a Composio key, so the tab must fall back
+// to the shipped ComposioOnboarding (sign-in / key paste) on first run.
+
+const getConfigMock = vi.fn();
+vi.mock("../../api/client", () => ({
+  getConfig: () => getConfigMock(),
+}));
+
+// ConnectIntegrationCard (reused unmocked) pulls the connect/signin helpers
+// from the same module; they only fire on interaction, so inert stubs suffice.
+const listIntegrationsMock = vi.fn();
+vi.mock("../../api/integrations", () => ({
+  listIntegrations: (opts: unknown) => listIntegrationsMock(opts),
+  getComposioSigninStatus: vi.fn(),
+  getIntegrationConnectStatus: vi.fn(),
+  startComposioSignin: vi.fn(),
+  startIntegrationConnection: vi.fn(),
+}));
+
+// Unit scope: the onboarding flow itself is covered by its own tests.
+vi.mock("../../components/apps/integrations/ComposioOnboarding", () => ({
+  ComposioOnboarding: () => <div data-testid="composio-onboarding" />,
+}));
+
+function renderTab() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <ToolIntegrations usedNames={[]} />
+    </QueryClientProvider>,
+  );
+}
+
+describe("ToolIntegrations", () => {
+  beforeEach(() => {
+    getConfigMock.mockReset();
+    listIntegrationsMock.mockReset();
+  });
+
+  it("shows Composio onboarding when no key is connected yet", async () => {
+    getConfigMock.mockResolvedValue({ composio_key_set: false });
+    const { findByTestId } = renderTab();
+    expect(await findByTestId("composio-onboarding")).toBeTruthy();
+    // Without a key there is no catalog to fetch.
+    expect(listIntegrationsMock).not.toHaveBeenCalled();
+  });
+
+  it("shows the catalog once a Composio key is connected", async () => {
+    getConfigMock.mockResolvedValue({ composio_key_set: true });
+    listIntegrationsMock.mockResolvedValue({
+      items: [
+        {
+          platform: "slack",
+          name: "Slack",
+          state: "connected",
+          can_connect: true,
+        },
+        {
+          platform: "github",
+          name: "GitHub",
+          state: "available",
+          can_connect: true,
+        },
+      ],
+    });
+    const { findByText, getByText, queryByTestId } = renderTab();
+    expect(await findByText("Slack")).toBeTruthy();
+    expect(getByText("GitHub")).toBeTruthy();
+    expect(getByText("Connect")).toBeTruthy();
+    expect(queryByTestId("composio-onboarding")).toBeNull();
+  });
+});

--- a/web/src/operator/surfaces/ToolIntegrations.tsx
+++ b/web/src/operator/surfaces/ToolIntegrations.tsx
@@ -3,15 +3,20 @@
 // and the human-interview ConnectIntegrationCard), but render them with operator
 // tokens and operator copy — no main-app chrome, no "agents"/"channels"
 // vocabulary. Connected once for the workspace; shown scoped under each tool.
+//
+// First run: the whole catalog is powered by Composio, so when no Composio key
+// is connected yet there is nothing to browse — the shipped ComposioOnboarding
+// (broker-driven CLI sign-in, manual key-paste fallback) renders instead.
 
 import { useMemo, useState } from "react";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 
-import type { AgentRequest } from "../../api/client";
+import { type AgentRequest, getConfig } from "../../api/client";
 import {
   type IntegrationCatalogItem,
   listIntegrations,
 } from "../../api/integrations";
+import { ComposioOnboarding } from "../../components/apps/integrations/ComposioOnboarding";
 import {
   GenericIntegrationLogo,
   ToolkitBrandLogo,
@@ -27,11 +32,23 @@ interface ToolIntegrationsProps {
 export function ToolIntegrations({ usedNames }: ToolIntegrationsProps) {
   const [search, setSearch] = useState("");
   const [connecting, setConnecting] = useState<string | null>(null);
+  const queryClient = useQueryClient();
+
+  // Whether a Composio key is connected for this workspace. Without one the
+  // catalog cannot exist, so the onboarding gate below takes over.
+  const cfgQuery = useQuery({
+    queryKey: ["config"],
+    queryFn: getConfig,
+    staleTime: 30_000,
+  });
+  const composioKeySet = cfgQuery.data?.composio_key_set ?? false;
 
   const query = useQuery({
     queryKey: ["operator-integrations"],
     queryFn: () => listIntegrations({ limit: 100 }),
     staleTime: 30_000,
+    // No key → the catalog request can only fail or come back empty.
+    enabled: composioKeySet,
   });
 
   const items = query.data?.items ?? [];
@@ -47,6 +64,23 @@ export function ToolIntegrations({ usedNames }: ToolIntegrationsProps) {
 
   const connected = filtered.filter((i) => i.state === "connected");
   const available = filtered.filter((i) => i.state !== "connected");
+
+  // First run: connect Composio itself (sign-in or key paste), then the
+  // catalog loads in place.
+  if (cfgQuery.isSuccess && !composioKeySet) {
+    return (
+      <div className="opr-tool-scoped">
+        <ComposioOnboarding
+          onConnected={() => {
+            void cfgQuery.refetch();
+            void queryClient.invalidateQueries({
+              queryKey: ["operator-integrations"],
+            });
+          }}
+        />
+      </div>
+    );
+  }
 
   return (
     <div className="opr-tool-scoped">
@@ -80,7 +114,7 @@ export function ToolIntegrations({ usedNames }: ToolIntegrationsProps) {
         onChange={(e) => setSearch(e.target.value)}
       />
 
-      {query.isLoading ? (
+      {cfgQuery.isLoading || query.isLoading ? (
         <p className="opr-scoped-note">Loading your integrations…</p>
       ) : query.isError ? (
         <p className="opr-scoped-note">

--- a/web/src/styles/operator-shell.css
+++ b/web/src/styles/operator-shell.css
@@ -4285,9 +4285,15 @@
   color: var(--t-faint);
 }
 
-/* ── Artifacts tab: everything the agent produced (app, pdf, html, md) ──────── */
-/* A chip strip of outcomes + a viewer per type. The app is one artifact among
-   many. Tokens only. See web/src/operator/artifacts/. */
+/* ── Artifacts: the outputs the agent produced (pdf, html, md) ─────────────── */
+/* A chip strip of outcomes + a viewer per type, living on the UI tab under the
+   agent's one live app. Tokens only. See web/src/operator/artifacts/. */
+.opr-ui-artifacts {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  margin-top: var(--space-5);
+}
 .opr-artifacts {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## What

Three operator-surface changes from the same testing session, per founder direction.

### 1. Artifacts move back into the UI tab — one app UI
The agent detail's first tab is **UI** again: the agent has exactly ONE app UI, and it IS the tab — not an artifact chip among its outputs.
- The UI tab renders the live app directly (sealed `CustomAppFrame` when ready, `AppLivePreview` while building), staying mounted across tab switches.
- The artifacts the agent's runs produce (md/html/pdf routine outcomes) collect in an `Artifacts` strip **below the app**; the section only renders when at least one exists.
- The synthetic `app`-type artifact and the `renderApp` slot are removed (the wire never carried `app`). Same restructure in the mock detail.

### 2. Composio onboarding gate on the Integrations tab
Without a Composio key there is no catalog to browse. When `composio_key_set` is false, the operator Integrations tab renders the shipped `ComposioOnboarding` (broker-driven CLI sign-in, manual key-paste fallback); the catalog query only runs once a key exists.

### 3. Demo-workflow-to-Nex builds the real AGENT
- The realtime call's instructions now frame the work as building an **agent** with three parts — app UI, routines, tools — and `draft_workflow` captures which the demo calls for (`kind: app/routine/both`), the routine's name + prompt + schedule, and the tools the agent will need.
- The build handoff routes to the **real agent build** (app-builder engine) instead of the legacy mock workflow builder — so when the build finishes, "Open the agent" lands on the app inside the agent's UI tab.
- As the new agent's id resolves, the captured routine is created on the broker scheduler and each captured tool is authored through the agent service, with honest progress messages in the build chat.

## Test plan

- [x] `bash scripts/test-web.sh` — full suite green (2346 passed)
- [x] `bunx tsc --noEmit` clean; `bunx biome check --write` on changed files (no new findings beyond repo baseline)
- [x] New/updated tests: UI tab app+artifacts composition; empty-artifacts state; ArtifactsTab outputs-only; ToolIntegrations onboarding gate (no key → onboarding, no catalog fetch); demoCapture kind/routine/tools coercion + seed; AppBuilderChat demo auto-start + routine/tool creation
- [x] Visual check: Composio onboarding renders inside the operator shell (mocked `composio_key_set: false`)
- [x] Screenshots (below)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
## Screenshots

![01-ui-tab-app-with-artifacts](https://github.com/nex-crm/wuphf/raw/screenshots/pr-1159/01-ui-tab-app-with-artifacts.png)

![02-ui-tab-pdf-artifact](https://github.com/nex-crm/wuphf/raw/screenshots/pr-1159/02-ui-tab-pdf-artifact.png)





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated **UI** tab in the operator view, keeping the live app visible while showing related outputs below it.
  * Introduced a clearer **build your agent** flow with support for app, routine, or combined demo setups.
  * Added onboarding for Composio-connected integrations, including a clearer connect state before the catalog loads.

* **Bug Fixes**
  * Improved artifact browsing so markdown, HTML, and PDF outputs switch more reliably.
  * Updated screenshots and tests to cover the new UI and onboarding states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->