### PR TITLE
fix(operator): QA fixes for v0.232.0 — honest outcomes, resilient store, session and integration corrections

### DIFF
--- a/agent/src/capabilities.test.ts
+++ b/agent/src/capabilities.test.ts
@@ -63,6 +63,36 @@ test("GATED_CAPABILITIES lists every mutating capability the send-gate must hold
 	expect(GATED_CAPABILITIES.has("nex.browser")).toBe(true);
 });
 
+// --- simulated fallbacks (empty input honesty) ----------------------------------
+
+test("simulated nex.run with a blank input is honest, not 'Ran on  (simulated).'", async () => {
+	// QA HIGH-1: a routine ran a generic tool with no bound input, so nex.run("")
+	// interpolated an empty string -> "Ran on  (simulated)." (double space, zero
+	// information). The digest must not carry that string and must say WHY nothing
+	// ran (no model/broker connected).
+	const tree = buildCapabilities({});
+	const out = String(await cap(tree, "nex.run")(""));
+	expect(out).not.toContain("Ran on  (simulated)."); // the double-space bug
+	expect(out).not.toMatch(/on\s{2,}/); // no empty interpolation anywhere
+	expect(out.toLowerCase()).toContain("simulated");
+	expect(out).toContain("no model"); // honest about why
+});
+
+test("simulated nex.run names the input it would have acted on", async () => {
+	const tree = buildCapabilities({});
+	const out = String(await cap(tree, "nex.run")("Summarize the open office tasks"));
+	expect(out).toContain("Summarize the open office tasks");
+	expect(out.toLowerCase()).toContain("simulated");
+});
+
+test("labelOf-backed sims never leave a blank hole for an empty argument", async () => {
+	const tree = buildCapabilities({});
+	// nex.send / nex.ai.write route their arg through labelOf; a blank must render
+	// the neutral marker, not a double space.
+	expect(String(await cap(tree, "nex.send")(""))).not.toMatch(/\s{2,}/);
+	expect(String(await cap(tree, "nex.ai.write")(""))).not.toMatch(/Drafted\s{2,}/);
+});
+
 // --- real nex.ai (stubbed complete) ---------------------------------------------
 
 test("real nex.ai.score parses the model's integer and clamps it", async () => {

--- a/agent/src/capabilities.ts
+++ b/agent/src/capabilities.ts
@@ -66,7 +66,10 @@ const DEFAULT_CAP_TIMEOUT_MS = 60_000;
 
 function labelOf(v: unknown): string {
 	if (v == null) return "…";
-	if (typeof v === "string") return v;
+	// A blank/whitespace-only string must NOT interpolate as "" — that produced
+	// digests like "Ran on  (simulated)." (double space, zero information) when a
+	// routine ran a tool with no bound input. Fall back to the neutral marker.
+	if (typeof v === "string") return v.trim() ? v : "…";
 	if (typeof v === "object") {
 		const o = v as Record<string, unknown>;
 		if (typeof o.name === "string") return o.name;
@@ -106,6 +109,22 @@ function simSummarize(items: unknown): string {
 	return `${list.length} item${list.length === 1 ? "" : "s"} — ${names || "nothing notable"} (simulated recap)`;
 }
 
+/** The generic fallback capability (nex.run) has no domain shape to imitate, so a
+ * simulated run must be HONEST about why nothing happened rather than emit a
+ * hollow "Ran on X" line. It names the input it would have acted on and points at
+ * the two knobs that make it real. One line — it is the routine's digest/artifact. */
+function simRun(input: unknown): string {
+	let subject = "";
+	if (typeof input === "string") {
+		const trimmed = input.replace(/\s+/g, " ").trim();
+		subject = trimmed.length > 80 ? `${trimmed.slice(0, 77)}…` : trimmed;
+	} else if (input != null) {
+		subject = preview(input);
+	}
+	const on = subject ? ` of "${subject}"` : "";
+	return `Simulated run${on}: no model or integrations are connected on this host, so nothing actually ran — set TOOL_RUNTIME_MODEL=1 or connect the broker (WUPHF_BROKER_URL/WUPHF_BROKER_TOKEN) to run it for real.`;
+}
+
 /** The all-simulated runtime: deterministic, no network, no model. */
 export function simulatedCapabilities(): CapabilityTree {
 	return {
@@ -115,7 +134,7 @@ export function simulatedCapabilities(): CapabilityTree {
 				summarize: (items: unknown) => simSummarize(items),
 				write: (kind: unknown) => `Drafted ${labelOf(kind)} — warm, brief, ready to review (simulated).`,
 			},
-			run: (input: unknown) => `Ran on ${labelOf(input)} (simulated).`,
+			run: (input: unknown) => simRun(input),
 			send: (target: unknown) => `Sent to ${labelOf(target)} (simulated).`,
 			browser: (goal: unknown) => `Would drive the browser: ${labelOf(goal)} (browser engine not configured).`,
 		},

--- a/agent/src/routineRunner.ts
+++ b/agent/src/routineRunner.ts
@@ -112,7 +112,11 @@ export async function runRoutine(agent: string, routine: RoutineRunRequest, deps
 		const execute = deps.execute ?? runTool;
 		const capabilities = deps.capabilities ?? buildCapabilities(capabilityConfigFromEnv());
 		const timeoutMs = Number(process.env.TOOL_CALL_TIMEOUT_MS) || undefined;
-		const r = await execute(tool, {}, { approved: false, capabilities, timeoutMs });
+		// Give the tool the routine's prompt as `input`. A synthesized fallback tool
+		// takes a single `input` param (tools.ts authorTool) — without this it ran on
+		// "" and the digest read "Ran on  (simulated).". Tools with named params
+		// (lead, deal, …) ignore it, so this only enriches the generic case.
+		const r = await execute(tool, { input: routine.prompt }, { approved: false, capabilities, timeoutMs });
 		status = r.status;
 		outcome = outcomeText(r);
 	} else {

--- a/agent/src/serviceRoutines.test.ts
+++ b/agent/src/serviceRoutines.test.ts
@@ -7,7 +7,7 @@
 // the broker's scheduler registry, so there is no routine CRUD here.
 
 import { afterAll, beforeAll, expect, test } from "bun:test";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createServer } from "./service.js";
@@ -23,12 +23,13 @@ async function* fakeBuild() {
 }
 
 let tmp: string;
+let dataDir: string;
 let server: ReturnType<typeof createServer>;
 let base: string;
 beforeAll(() => {
 	tmp = mkdtempSync(join(tmpdir(), "wuphf-agent-svc-"));
-	const data = join(tmp, "data");
-	server = createServer({ port: 0, buildStream: fakeBuild, store: new AgentStore(data), sessions: new PiSessions(data) });
+	dataDir = join(tmp, "data");
+	server = createServer({ port: 0, buildStream: fakeBuild, store: new AgentStore(dataDir), sessions: new PiSessions(dataDir) });
 	base = server.url.toString().replace(/\/$/, "");
 });
 afterAll(() => {
@@ -141,6 +142,26 @@ test("validation ladder: bad JSON, bad shape, schema mismatch, missing agent", a
 	for (const path of ["/tools", "/sessions", "/artifacts", "/tools?agent=..", "/sessions?agent=%20"]) {
 		expect((await fetch(`${base}${path}`)).status).toBe(400);
 	}
+});
+
+test("POST /tools/build recovers from a corrupt app file instead of 500ing (HIGH-2)", async () => {
+	// QA repro: a torn/corrupt per-agent store file made the store throw, so
+	// /tools/build 500'd and the FE (buildToolFromChat) fell back to offline.
+	// Pre-fix this is 500; post-fix the corrupt file is quarantined and the build
+	// succeeds. Message mirrors the reported one ("<name> — <instruction>").
+	mkdirSync(dataDir, { recursive: true });
+	writeFileSync(join(dataDir, "app_torn.json"), "{ corrupt, not json");
+	const res = await post("/tools/build", {
+		schema_version: 1,
+		message: "postHandoffToSlack — Post the lead, score, and reason to #ae-handoffs.",
+		app: "app_torn",
+	});
+	expect(res.status).toBe(200);
+	const body = (await res.json()) as { tool: StoredTool };
+	expect(body.tool.name).toBeTruthy();
+	expect(body.tool.version).toBe(1); // fresh file after quarantine
+	const listed = (await (await fetch(`${base}/tools?agent=app_torn`)).json()) as { tools: StoredTool[] };
+	expect(listed.tools).toHaveLength(1);
 });
 
 test("GET routes read empty for an unknown agent (no 500s from a missing file)", async () => {

--- a/agent/src/store.test.ts
+++ b/agent/src/store.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, expect, test } from "bun:test";
-import { existsSync, mkdtempSync, readdirSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { AgentStore, defaultDataDir, sanitizeAgentId } from "./store.js";
@@ -90,4 +90,27 @@ test("data survives a fresh store instance over the same dir (atomic file write)
 	expect(reopened.listArtifacts("a1")).toHaveLength(1);
 	// No stray tmp file left behind.
 	expect(readdirSync(dir).filter((f) => f.endsWith(".tmp"))).toEqual([]);
+});
+
+test("a corrupt data file is quarantined and read as empty — authoring recovers, not a 500", () => {
+	// Repro of the QA HIGH-2 symptom: a torn/corrupt per-agent file made load()
+	// throw, so every /tools/build for that app 500'd and the FE fell back to
+	// offline. Pre-fix this test throws on listTools; post-fix it recovers.
+	const { store, dir } = tmpStore();
+	mkdirSync(dir, { recursive: true });
+	const file = join(dir, "app_x.json");
+	writeFileSync(file, "{ torn write, not valid json");
+
+	// Reads recover to empty instead of throwing.
+	expect(store.listTools("app_x")).toEqual([]);
+	// The corrupt bytes are preserved under a quarantine name, not clobbered.
+	const quarantined = readdirSync(dir).filter((f) => f.startsWith("app_x.json.corrupt-"));
+	expect(quarantined).toHaveLength(1);
+	expect(readFileSync(join(dir, quarantined[0]), "utf8")).toBe("{ torn write, not valid json");
+
+	// Authoring now succeeds and writes a fresh, valid file.
+	store.upsertTool("app_x", TOOL);
+	expect(store.listTools("app_x")).toHaveLength(1);
+	// The recovered agent is not double-counted, and quarantine files are not agents.
+	expect(store.agents()).toEqual(["app_x"]);
 });

--- a/agent/src/store.ts
+++ b/agent/src/store.ts
@@ -5,11 +5,17 @@
 //
 //   - Data dir: WUPHF_AGENT_DATA_DIR, default agent/.wuphf-agent-data/ relative
 //     to this package. Created lazily on first save.
-//   - Writes are atomic-ish: write <file>.tmp, then rename over the target.
+//   - Writes are atomic-ish: write a UNIQUE <file>.<pid>.<rand>.tmp, then rename
+//     over the target. The temp name is per-write so two concurrent writers (e.g.
+//     two service instances sharing WUPHF_AGENT_DATA_DIR) never scribble over one
+//     shared temp and rename a torn file into place.
 //   - Agent ids are sanitized into safe filenames (path separators and other
 //     unsafe characters normalize to "_"; empty / dot-only ids are rejected).
-//   - A missing file reads as the empty shape; a CORRUPT file throws (loading
-//     it as empty would clobber the operator's data on the next save).
+//   - A missing file reads as the empty shape. A CORRUPT file is QUARANTINED
+//     (renamed to <file>.corrupt-<ts>) and read as empty: the operator's tool
+//     authoring recovers instead of dead-ending in an opaque 500 (which the FE
+//     shows as "offline"), and the unparseable bytes are preserved for recovery
+//     rather than clobbered on the next save.
 
 import { mkdirSync, readdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
@@ -67,14 +73,25 @@ export class AgentStore {
 	}
 
 	load(agent: string): AgentData {
+		const file = this.fileFor(agent);
 		let raw: string;
 		try {
-			raw = readFileSync(this.fileFor(agent), "utf8");
+			raw = readFileSync(file, "utf8");
 		} catch (e) {
 			if (isEnoent(e)) return emptyData();
-			throw e;
+			throw e; // a transient read error (EACCES etc.) must NOT quarantine good data
 		}
-		const parsed = JSON.parse(raw) as Partial<AgentData>;
+		let parsed: Partial<AgentData>;
+		try {
+			parsed = JSON.parse(raw) as Partial<AgentData>;
+		} catch {
+			// Corrupt JSON (e.g. a torn write from a pre-fix concurrent writer): move
+			// it aside so this agent's authoring recovers on the next save instead of
+			// every store-backed request 500ing. The bytes survive under the quarantine
+			// name for manual recovery — we never clobber them in place.
+			this.quarantine(file);
+			return emptyData();
+		}
 		// Tolerate older/partial files: missing sections read as empty (a file
 		// from the pre-rework store may also carry routines/sessions keys —
 		// ignored here; the broker and pi sessions own those now).
@@ -84,10 +101,23 @@ export class AgentStore {
 		};
 	}
 
+	/** Rename an unparseable data file aside so it stops wedging reads, keeping the
+	 * bytes for recovery. Best-effort: a failure here must not mask the original. */
+	private quarantine(file: string): void {
+		try {
+			renameSync(file, `${file}.corrupt-${Date.now()}`);
+		} catch {
+			// If we cannot move it aside, fall through — the next save overwrites the
+			// target, which is still better than a permanently 500ing agent.
+		}
+	}
+
 	save(agent: string, data: AgentData): void {
 		mkdirSync(this.dir, { recursive: true }); // lazy dir creation
 		const file = this.fileFor(agent);
-		const tmp = `${file}.tmp`;
+		// Unique temp per write: concurrent writers each own their temp, so a rename
+		// only ever publishes a fully-written file — no torn bytes reach the target.
+		const tmp = `${file}.${process.pid}.${crypto.randomUUID().slice(0, 8)}.tmp`;
 		writeFileSync(tmp, JSON.stringify(data, null, 2));
 		renameSync(tmp, file); // atomic-ish: readers never see a half-written file
 	}

--- a/agent/src/tools.test.ts
+++ b/agent/src/tools.test.ts
@@ -39,6 +39,17 @@ test("authorTool synthesizes a name + plain title for an unknown workflow", () =
 	expect(t.inputs.map((i) => i.name)).toEqual(["input"]);
 });
 
+test("authorTool title cuts at a natural boundary, not mid-clause (LOW-9)", () => {
+	// QA LOW-9: this exact instruction produced "Count the open tasks and tell" —
+	// truncated mid-clause after a dangling "and". The title must end before the
+	// coordinating conjunction instead.
+	const t = authorTool("When I ask, count the open tasks and tell me the number.");
+	expect(t.title).toBe("Count the open tasks");
+	expect(t.title).not.toContain("and tell");
+	// A short instruction (<= budget) is still kept whole.
+	expect(authorTool("When it fires, archive the stale records").title).toBe("Archive the stale records");
+});
+
 test("authorTool synthesizes a valid identifier from a digit-leading workflow", () => {
 	// "2026" leads after stopword filtering — bare camelCasing would emit
 	// `async function 2026RenewalSync(...)`, which is not legal JS.

--- a/agent/src/tools.test.ts
+++ b/agent/src/tools.test.ts
@@ -31,6 +31,31 @@ test("authorTool matches a known workflow shape", () => {
 	expect(t.code).toContain("async function scoreAndRouteLead(lead)");
 });
 
+test("authorTool honors an explicit leading name over a keyword-hijacked shape", () => {
+	// QA HIGH-2 (clean-workspace rerun): this exact demo-handoff instruction
+	// returned the scoreAndRouteLead TEMPLATE — "lead"/"score" in the purpose
+	// matched shape 1 and the explicitly requested tool silently never existed.
+	const t = authorTool("postHandoffToSlack — Post the lead, score, and reason to #ae-handoffs.");
+	expect(t.name).toBe("postHandoffToSlack");
+	expect(t.code).toContain("async function postHandoffToSlack(input)");
+	// The purpose/title come from the text AFTER the name, not the name itself.
+	expect(t.purpose).toBe("Post the lead, score, and reason to #ae-handoffs.");
+	expect(t.title.toLowerCase()).not.toContain("posthandofftoslack");
+});
+
+test("authorTool still uses a shape when the explicit name AGREES with it", () => {
+	const t = authorTool("scoreAndRouteLead — Score a lead's fit and route hot ones to the right AE.");
+	expect(t.name).toBe("scoreAndRouteLead");
+	expect(t.title).toBe("Score & route a lead");
+	expect(t.code).toContain("nex.ai.score");
+});
+
+test("authorTool does not read prose with a dash as an explicit name", () => {
+	// No interior capital → not camelCase → not a name; shape matching applies.
+	const t = authorTool("okay — score its fit and route hot leads to the AE");
+	expect(t.name).toBe("scoreAndRouteLead");
+});
+
 test("authorTool synthesizes a name + plain title for an unknown workflow", () => {
 	const t = authorTool("When an invoice arrives, archive old records nightly");
 	// Trigger clause dropped for the title; stopwords dropped + camelCased for name.

--- a/agent/src/tools.ts
+++ b/agent/src/tools.ts
@@ -91,12 +91,45 @@ function camel(words: string[]): string {
 	return words.map((w, i) => (i === 0 ? w : w[0].toUpperCase() + w.slice(1))).join("");
 }
 
+// Coordinating conjunctions where a long instruction can be cut without leaving a
+// dangling fragment: "count the open tasks AND tell me the number" -> stop before
+// "and". Kept to coordinators (not "to"/"if") so short imperatives are not clipped.
+const CLAUSE_BREAK = new Set(["and", "or", "then", "but", "so", "plus", "also", "nor"]);
+const TITLE_MAX_WORDS = 6;
+const TITLE_MIN_WORDS = 3;
+
+function bareWord(w: string): string {
+	return w.toLowerCase().replace(/[^a-z0-9]/g, "");
+}
+
+/** Trim a lead phrase to a title-length budget WITHOUT cutting mid-clause. When
+ * the phrase is longer than the budget, end it at the last natural boundary inside
+ * the kept window — before a coordinating conjunction, or after a comma — so we
+ * never emit "… and tell". Short phrases pass through whole. */
+function naturalTitle(lead: string): string {
+	const words = lead.split(/\s+/).filter(Boolean);
+	if (words.length <= TITLE_MAX_WORDS) return words.join(" ");
+	const window = words.slice(0, TITLE_MAX_WORDS);
+	let cut = window.length;
+	for (let i = window.length - 1; i >= TITLE_MIN_WORDS; i--) {
+		if (CLAUSE_BREAK.has(bareWord(window[i]))) {
+			cut = i; // drop the conjunction and everything the truncation orphaned after it
+			break;
+		}
+		if (/[,;]$/.test(window[i])) {
+			cut = i + 1; // a clause that ends on this word is complete — keep through it
+			break;
+		}
+	}
+	return window.slice(0, cut).join(" ");
+}
+
 /** Human title from a described workflow: drop a leading "When ... ," trigger,
- * sentence-case the rest. Shared by the stub author and the model path (when the
- * model omits a title). */
+ * cut to a title length at a natural clause boundary, sentence-case the rest.
+ * Shared by the stub author and the model path (when the model omits a title). */
 function humanTitle(description: string, fallback: string): string {
 	const lead = description.trim().replace(/^when\b[^,]*,\s*/i, "");
-	const titleWords = lead.split(/\s+/).slice(0, 6).join(" ");
+	const titleWords = naturalTitle(lead);
 	return (titleWords ? titleWords[0].toUpperCase() + titleWords.slice(1) : fallback).replace(/[.,;:]+$/, "");
 }
 

--- a/agent/src/tools.ts
+++ b/agent/src/tools.ts
@@ -133,30 +133,47 @@ function humanTitle(description: string, fallback: string): string {
 	return (titleWords ? titleWords[0].toUpperCase() + titleWords.slice(1) : fallback).replace(/[.,;:]+$/, "");
 }
 
+// An instruction can LEAD with an explicit camelCase tool name — the demo-call
+// handoff always sends "postHandoffToSlack — Post the lead, score, …". Strict
+// camelCase (an interior capital) so prose with a dash ("ok — do this") never
+// reads as a name.
+const EXPLICIT_NAME = /^\s*([a-z][a-z0-9]*[A-Z][A-Za-z0-9]*)\s*[—–:-]\s+(.+)$/s;
+
 /** Derive a create_tool spec from a described workflow — a known shape, else a
- * synthesized camelCase name + plain-language title. Deterministic. */
+ * synthesized camelCase name + plain-language title. Deterministic.
+ *
+ * An explicit leading name is an ORDER, not a hint: a keyword shape applies only
+ * when it AGREES on the name. Without this, purpose words like "lead"/"score" in
+ * "postHandoffToSlack — Post the lead, score, …" hijacked the request into the
+ * scoreAndRouteLead template — the service returned 200 with the WRONG tool and
+ * the requested one silently never existed. */
 export function authorTool(description: string): Tool {
 	const desc = description.trim();
-	const shape = SHAPES.find((s) => s.test.test(desc));
+	const explicit = EXPLICIT_NAME.exec(desc);
+	const requested = explicit?.[1];
+	// What the tool is ABOUT: the purpose after an explicit name, else the whole
+	// instruction. Titles, purposes, and the code comment derive from this.
+	const about = explicit?.[2].trim() || desc;
+	const shape = SHAPES.find((s) => s.test.test(desc) && (!requested || s.name === requested));
 	if (shape) {
 		return { name: shape.name, title: shape.title, purpose: shape.purpose, inputs: toInputs(shape.inputs), code: shape.code };
 	}
-	const words = desc
+	const words = about
 		.toLowerCase()
 		.replace(/[^a-z0-9\s]/g, " ")
 		.split(/\s+/)
 		.filter((w) => w && !STOPWORDS.has(w));
-	const rawName = words.length ? camel(words.slice(0, 3)) : "runWorkflow";
+	const rawName = requested ?? (words.length ? camel(words.slice(0, 3)) : "runWorkflow");
 	// A digit-leading word would yield `async function 2026RenewalSync` — not a
 	// legal identifier. Prefix "run" (keeping the camelCase tail) when needed.
 	const name = /^[A-Za-z_$]/.test(rawName) ? rawName : `run${rawName[0].toUpperCase()}${rawName.slice(1)}`;
 	// The description is interpolated into a `//` line comment: a newline in it
 	// would terminate the comment and spill raw text into the function body.
-	const commentDesc = desc.replace(/\s+/g, " ");
+	const commentDesc = about.replace(/\s+/g, " ");
 	return {
 		name,
-		title: humanTitle(desc, name),
-		purpose: desc ? desc[0].toUpperCase() + desc.slice(1) : name,
+		title: humanTitle(about, name),
+		purpose: about ? about[0].toUpperCase() + about.slice(1) : name,
 		inputs: [{ name: "input", type: "string" }],
 		code: `async function ${name}(input) {\n  // Nex scripted this from: "${commentDesc}"\n  return nex.run(input);\n}`,
 	};

--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -194,16 +194,21 @@ type Broker struct {
 	// knowledgeBrainOverride substitutes the Knowledge surface's brain in tests
 	// (set before Start; nil in production).
 	knowledgeBrainOverride knowledgeBrain
-	inboxCursorMu          sync.RWMutex
-	userInboxCursors       map[string]InboxCursor
-	factLog                *FactLog
-	readLog                *ReadLog
-	entityGraph            *EntityGraph
-	entitySynthesizer      *EntitySynthesizer
-	wikiCompressor         *WikiCompressor
-	teamLearningLog        *LearningLog
-	playbookSynthesizer    *PlaybookSynthesizer
-	pamDispatcher          *PamDispatcher
+	// legacyKnowledge holds the previous product's wiki articles + notebook
+	// notes preserved as Knowledge pages, loaded once per broker from the
+	// legacy wiki tree (broker_apps_knowledge_legacy.go).
+	legacyKnowledgeOnce sync.Once
+	legacyKnowledge     []appKnowledgePage
+	inboxCursorMu       sync.RWMutex
+	userInboxCursors    map[string]InboxCursor
+	factLog             *FactLog
+	readLog             *ReadLog
+	entityGraph         *EntityGraph
+	entitySynthesizer   *EntitySynthesizer
+	wikiCompressor      *WikiCompressor
+	teamLearningLog     *LearningLog
+	playbookSynthesizer *PlaybookSynthesizer
+	pamDispatcher       *PamDispatcher
 	// sourceCaptureDispatcher drains S2 source-capture jobs off-lock (see
 	// source_capture.go). Held as an atomic pointer so captureSource can read
 	// it WITHOUT b.mu — capture hooks fire while b.mu is held, so the read

--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -728,6 +728,9 @@ func (b *Broker) StartOnPort(port int) error {
 	mux.HandleFunc("/apps/integrations/call", b.requireAuth(b.handleAppsIntegrationsCall))
 	mux.HandleFunc("/apps/integrations/catalog", b.requireAuth(b.handleAppsIntegrationsCatalog))
 	mux.HandleFunc("/apps/ai", b.requireAuth(b.handleAppsAI))
+	// Preserved visual artifacts (HTML briefs / PDFs) from the previous
+	// product's wiki, attached to legacy Knowledge pages.
+	mux.HandleFunc(legacyArtifactURLPrefix, b.requireAuth(b.handleLegacyKnowledgeArtifact))
 	mux.HandleFunc("/apps/", b.requireAuth(b.handleAppByID))
 	b.registerKnowledgeRoutes(mux)
 	mux.HandleFunc("/interview", b.requireAuth(b.handleInterview))

--- a/internal/team/broker_apps_knowledge.go
+++ b/internal/team/broker_apps_knowledge.go
@@ -107,6 +107,20 @@ type knowledgeSource struct {
 
 // ── HTTP ─────────────────────────────────────────────────────────────────────
 
+// writeAppKnowledge serves a knowledge payload with the previous product's
+// preserved wiki/notebook pages appended (broker_apps_knowledge_legacy.go).
+// Legacy pages ride along on EVERY outcome — cache hit, fresh synthesis, and
+// the rate-limited/unavailable states — because they exist independent of the
+// AI provider; a workspace without a legacy tree appends nothing.
+func (b *Broker) writeAppKnowledge(w http.ResponseWriter, pages []appKnowledgePage, errCode string) {
+	all := append(append([]appKnowledgePage{}, pages...), b.legacyKnowledgePages()...)
+	resp := map[string]any{"pages": all}
+	if errCode != "" {
+		resp["error"] = errCode
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
 func (b *Broker) handleAppKnowledge(w http.ResponseWriter, r *http.Request, id string) {
 	if r.Method != http.MethodGet {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
@@ -131,7 +145,7 @@ func (b *Broker) handleAppKnowledge(w http.ResponseWriter, r *http.Request, id s
 			pages, err := b.readAppKnowledgeFromGBrain(ctx, gbClient, id)
 			switch {
 			case err == nil && len(pages) > 0:
-				writeJSON(w, http.StatusOK, map[string]any{"pages": pages})
+				b.writeAppKnowledge(w, pages, "")
 				return
 			case err != nil:
 				// The brain is UNREACHABLE (dead serve, lock contention, missing
@@ -143,10 +157,7 @@ func (b *Broker) handleAppKnowledge(w http.ResponseWriter, r *http.Request, id s
 				// be resurrected from a stale cache.
 				fmt.Fprintf(os.Stderr, "broker: app knowledge gbrain read failed: %v\n", err)
 				if cached, ok, cerr := store.ReadAppKnowledge(id); cerr == nil && ok {
-					if cached == nil {
-						cached = []appKnowledgePage{}
-					}
-					writeJSON(w, http.StatusOK, map[string]any{"pages": cached})
+					b.writeAppKnowledge(w, cached, "")
 					return
 				}
 			default:
@@ -156,19 +167,19 @@ func (b *Broker) handleAppKnowledge(w http.ResponseWriter, r *http.Request, id s
 				// this, every request for an empty app would re-run the full LLM
 				// synthesis.
 				if cached, ok, cerr := store.ReadAppKnowledge(id); cerr == nil && ok && len(cached) == 0 {
-					writeJSON(w, http.StatusOK, map[string]any{"pages": []appKnowledgePage{}})
+					b.writeAppKnowledge(w, nil, "")
 					return
 				}
 			}
 		} else if pages, ok, err := store.ReadAppKnowledge(id); err == nil && ok {
-			writeJSON(w, http.StatusOK, map[string]any{"pages": pages})
+			b.writeAppKnowledge(w, pages, "")
 			return
 		}
 	}
 
 	// Budget the synthesis per-app like ai() — it is an LLM completion.
 	if _, limited := b.consumeAppAIBudget(appBudgetKey(id, r)); limited {
-		writeJSON(w, http.StatusOK, map[string]any{"pages": []appKnowledgePage{}, "error": "rate_limited"})
+		b.writeAppKnowledge(w, nil, "rate_limited")
 		return
 	}
 
@@ -177,7 +188,7 @@ func (b *Broker) handleAppKnowledge(w http.ResponseWriter, r *http.Request, id s
 		fmt.Fprintf(os.Stderr, "broker: app knowledge synth failed: %v\n", err)
 		// Expected product state (no provider / empty brain): let the FE render a
 		// graceful "no knowledge yet" rather than an error toast.
-		writeJSON(w, http.StatusOK, map[string]any{"pages": []appKnowledgePage{}, "error": "ai_unavailable"})
+		b.writeAppKnowledge(w, nil, "ai_unavailable")
 		return
 	}
 
@@ -199,7 +210,7 @@ func (b *Broker) handleAppKnowledge(w http.ResponseWriter, r *http.Request, id s
 	} else if err := store.WriteAppKnowledge(id, pages); err != nil {
 		fmt.Fprintf(os.Stderr, "broker: app knowledge cache write failed: %v\n", err)
 	}
-	writeJSON(w, http.StatusOK, map[string]any{"pages": pages})
+	b.writeAppKnowledge(w, pages, "")
 }
 
 // ── gbrain-backed store: knowledge pages live in the shared brain ─────────────

--- a/internal/team/broker_apps_knowledge.go
+++ b/internal/team/broker_apps_knowledge.go
@@ -87,6 +87,19 @@ type appKnowledgePage struct {
 	// Computed at read time from the page's app-scope tags — not stored in the
 	// page body — so a page shared across apps shows "Also in: <app>" in each.
 	AlsoIn []appKnowledgeAppRef `json:"alsoIn,omitempty"`
+	// Artifacts are file-ish views attached to this page — today the previous
+	// product's visual artifacts (sanitized HTML briefs, PDFs) preserved with
+	// their legacy pages (broker_apps_knowledge_legacy.go). URL is a broker
+	// route the FE fetches with auth and renders sandboxed.
+	Artifacts []appKnowledgeArtifact `json:"artifacts,omitempty"`
+}
+
+// appKnowledgeArtifact is one attached file-ish view of a knowledge page.
+type appKnowledgeArtifact struct {
+	Title string `json:"title"`
+	// Kind is the render hint: "html" (sandboxed inline view) or "pdf" (download).
+	Kind string `json:"kind"`
+	URL  string `json:"url"`
 }
 
 // appKnowledgeAppRef names another app a shared page belongs to.

--- a/internal/team/broker_apps_knowledge_legacy.go
+++ b/internal/team/broker_apps_knowledge_legacy.go
@@ -48,10 +48,13 @@ func loadLegacyKnowledgePages(root string) []appKnowledgePage {
 
 	// Team wiki articles: team/<category>/**.md (the category is the first
 	// folder under team/; root-level files read as plain "Team wiki").
+	// A walk error (missing tree, unreadable entry) ends the walk; whatever was
+	// collected up to that point is still preserved — this is best-effort
+	// archaeology, not a transaction.
 	teamRoot := filepath.Join(root, "team")
-	_ = filepath.Walk(teamRoot, func(path string, info os.FileInfo, err error) error {
-		if err != nil {
-			return nil // unreadable subtree — preserve what we can
+	_ = filepath.Walk(teamRoot, func(path string, info os.FileInfo, werr error) error {
+		if werr != nil {
+			return werr
 		}
 		if info.IsDir() {
 			// Editor/system dirs (.obsidian, .git) are not articles.
@@ -60,10 +63,9 @@ func loadLegacyKnowledgePages(root string) []appKnowledgePage {
 			}
 			return nil
 		}
-		rel, relErr := filepath.Rel(teamRoot, path)
-		if relErr != nil {
-			return nil
-		}
+		// Walk only yields paths under teamRoot, so a prefix trim IS the
+		// relative path — no error case to swallow.
+		rel := strings.TrimPrefix(path, teamRoot+string(filepath.Separator))
 		category := "Team wiki"
 		if dir := filepath.Dir(rel); dir != "." {
 			category = "Team wiki · " + strings.SplitN(filepath.ToSlash(dir), "/", 2)[0]

--- a/internal/team/broker_apps_knowledge_legacy.go
+++ b/internal/team/broker_apps_knowledge_legacy.go
@@ -1,9 +1,12 @@
 package team
 
 import (
+	"encoding/json"
 	"fmt"
+	"net/http"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 
@@ -45,6 +48,9 @@ func (b *Broker) legacyKnowledgePages() []appKnowledgePage {
 // wiki root. A missing root, or one with no markdown, yields nil.
 func loadLegacyKnowledgePages(root string) []appKnowledgePage {
 	var pages []appKnowledgePage
+	// Root-relative source path (e.g. "team/research/brief.md") → index into
+	// pages, so visual artifacts can attach to the pages they belong to.
+	byRel := map[string]int{}
 
 	// Team wiki articles: team/<category>/**.md (the category is the first
 	// folder under team/; root-level files read as plain "Team wiki").
@@ -71,6 +77,7 @@ func loadLegacyKnowledgePages(root string) []appKnowledgePage {
 			category = "Team wiki · " + strings.SplitN(filepath.ToSlash(dir), "/", 2)[0]
 		}
 		if page, ok := legacyPageFromFile(path, "legacy-wiki-"+slugifyKnowledgeID(filepath.ToSlash(rel)), category); ok {
+			byRel["team/"+filepath.ToSlash(rel)] = len(pages)
 			pages = append(pages, page)
 		}
 		return nil
@@ -92,10 +99,13 @@ func loadLegacyKnowledgePages(root string) []appKnowledgePage {
 			path := filepath.Join(root, "agents", agent, "notebook", note.Name())
 			id := "legacy-notebook-" + slugifyKnowledgeID(agent+"-"+note.Name())
 			if page, ok := legacyPageFromFile(path, id, "Notebook · "+agent); ok {
+				byRel["agents/"+agent+"/notebook/"+note.Name()] = len(pages)
 				pages = append(pages, page)
 			}
 		}
 	}
+
+	attachLegacyArtifacts(root, pages, byRel)
 
 	// Stable order: wiki articles first (the reviewed, promoted knowledge), then
 	// notebooks (draft scratch); alphabetical within.
@@ -119,6 +129,126 @@ func loadLegacyKnowledgePages(root string) []appKnowledgePage {
 		pages = pages[:legacyKnowledgeMaxPages]
 	}
 	return pages
+}
+
+// ── Visual artifacts: the previous product's HTML briefs and PDFs ─────────────
+
+// legacyArtifactSidecar is the metadata file the previous product wrote next to
+// each visual artifact (wiki/visual-artifacts/ra_*.json). The two path fields
+// name exactly which pages the artifact belongs to.
+type legacyArtifactSidecar struct {
+	Title              string `json:"title"`
+	HTMLPath           string `json:"htmlPath"`
+	PDFPath            string `json:"pdfPath"`
+	SourceMarkdownPath string `json:"sourceMarkdownPath"`
+	PromotedWikiPath   string `json:"promotedWikiPath"`
+}
+
+// legacyArtifactsRelDir is where the previous product kept visual artifacts,
+// relative to the legacy wiki root.
+const legacyArtifactsRelDir = "wiki/visual-artifacts"
+
+// legacyArtifactURLPrefix is the broker route serving preserved artifact files
+// (handleLegacyKnowledgeArtifact). The FE fetches these with auth and renders
+// HTML sandboxed / PDFs as downloads.
+const legacyArtifactURLPrefix = "/apps/knowledge/legacy-artifacts/"
+
+// attachLegacyArtifacts reads every artifact sidecar and attaches the artifact
+// to the pages its metadata names (the source notebook note and the promoted
+// wiki article). Artifacts without a parseable sidecar, or whose files are
+// gone, attach nowhere — a page never links a view that cannot be served.
+func attachLegacyArtifacts(root string, pages []appKnowledgePage, byRel map[string]int) {
+	dir := filepath.Join(root, legacyArtifactsRelDir)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return
+	}
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.EqualFold(filepath.Ext(entry.Name()), ".json") {
+			continue
+		}
+		raw, readErr := os.ReadFile(filepath.Join(dir, entry.Name()))
+		if readErr != nil {
+			continue
+		}
+		var side legacyArtifactSidecar
+		if json.Unmarshal(raw, &side) != nil {
+			continue
+		}
+		for _, rel := range []string{side.HTMLPath, side.PDFPath} {
+			file := filepath.Base(strings.TrimSpace(rel))
+			if file == "." || file == "" || !legacyArtifactNameRe.MatchString(file) {
+				continue
+			}
+			if _, statErr := os.Stat(filepath.Join(dir, file)); statErr != nil {
+				continue
+			}
+			kind := strings.TrimPrefix(strings.ToLower(filepath.Ext(file)), ".")
+			if kind != "html" && kind != "pdf" {
+				continue
+			}
+			title := side.Title
+			if title == "" {
+				title = humanizeLegacyName(strings.TrimSuffix(file, filepath.Ext(file)))
+			}
+			art := appKnowledgeArtifact{Title: title, Kind: kind, URL: legacyArtifactURLPrefix + file}
+			for _, owner := range []string{side.SourceMarkdownPath, side.PromotedWikiPath} {
+				idx, ok := byRel[strings.TrimSpace(owner)]
+				if !ok {
+					continue
+				}
+				if hasLegacyArtifact(pages[idx].Artifacts, art.URL) {
+					continue
+				}
+				pages[idx].Artifacts = append(pages[idx].Artifacts, art)
+			}
+		}
+	}
+}
+
+func hasLegacyArtifact(list []appKnowledgeArtifact, url string) bool {
+	for _, a := range list {
+		if a.URL == url {
+			return true
+		}
+	}
+	return false
+}
+
+// legacyArtifactNameRe is the whole trust boundary for the artifact file route:
+// a bare filename, no separators, no leading dot — path traversal cannot be
+// expressed in this alphabet.
+var legacyArtifactNameRe = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]*$`)
+
+// handleLegacyKnowledgeArtifact serves one preserved visual-artifact file. The
+// HTML was sanitized by the previous product, but we do not lean on that: the
+// response carries `CSP: sandbox` and the FE additionally renders it inside a
+// fully sandboxed iframe (no scripts, no navigation, no same-origin).
+func (b *Broker) handleLegacyKnowledgeArtifact(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	name := strings.TrimPrefix(r.URL.Path, legacyArtifactURLPrefix)
+	ext := strings.ToLower(filepath.Ext(name))
+	if !legacyArtifactNameRe.MatchString(name) || (ext != ".html" && ext != ".pdf") {
+		http.Error(w, "not found", http.StatusNotFound)
+		return
+	}
+	path := filepath.Join(config.RuntimeHomeDir(), ".wuphf", "wiki", legacyArtifactsRelDir, name)
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		http.Error(w, "not found", http.StatusNotFound)
+		return
+	}
+	if ext == ".pdf" {
+		w.Header().Set("Content-Type", "application/pdf")
+	} else {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	}
+	w.Header().Set("Content-Security-Policy", "sandbox")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	_, _ = w.Write(raw)
 }
 
 // legacyPageFromFile turns one legacy markdown file into a verbatim Knowledge

--- a/internal/team/broker_apps_knowledge_legacy.go
+++ b/internal/team/broker_apps_knowledge_legacy.go
@@ -1,0 +1,237 @@
+package team
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/nex-crm/wuphf/internal/config"
+)
+
+// broker_apps_knowledge_legacy.go — preserve the previous product's wiki
+// articles and per-agent notebook notes as Knowledge pages.
+//
+// The office-era wuphf kept a files-on-disk knowledge base under
+// <runtime home>/.wuphf/wiki: team articles in team/<category>/*.md and each
+// agent's draft notes in agents/<agent>/notebook/*.md. The operator product
+// synthesizes cited pages instead — but an upgrading workspace must not lose
+// what it already wrote. Every knowledge response therefore appends the legacy
+// pages, preserved VERBATIM (no synthesis, no fabricated citations), under
+// "Team wiki · <category>" / "Notebook · <agent>" categories. A workspace
+// without a legacy tree contributes nothing.
+
+// legacyKnowledgeMaxPages bounds the payload for enormous legacy trees. The cap
+// is logged when hit — never a silent truncation.
+const legacyKnowledgeMaxPages = 200
+
+const legacyKnowledgeCategoryTag = "Imported from your previous workspace"
+
+// legacyKnowledgePages loads the legacy tree once per broker; the previous
+// product no longer writes to it, so it is immutable for this process's life.
+func (b *Broker) legacyKnowledgePages() []appKnowledgePage {
+	b.legacyKnowledgeOnce.Do(func() {
+		root := filepath.Join(config.RuntimeHomeDir(), ".wuphf", "wiki")
+		b.legacyKnowledge = loadLegacyKnowledgePages(root)
+		if n := len(b.legacyKnowledge); n > 0 {
+			fmt.Fprintf(os.Stderr, "broker: preserved %d legacy wiki/notebook page(s) into Knowledge\n", n)
+		}
+	})
+	return b.legacyKnowledge
+}
+
+// loadLegacyKnowledgePages reads team articles and notebook notes from a legacy
+// wiki root. A missing root, or one with no markdown, yields nil.
+func loadLegacyKnowledgePages(root string) []appKnowledgePage {
+	var pages []appKnowledgePage
+
+	// Team wiki articles: team/<category>/**.md (the category is the first
+	// folder under team/; root-level files read as plain "Team wiki").
+	teamRoot := filepath.Join(root, "team")
+	_ = filepath.Walk(teamRoot, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return nil // unreadable subtree — preserve what we can
+		}
+		if info.IsDir() {
+			// Editor/system dirs (.obsidian, .git) are not articles.
+			if strings.HasPrefix(info.Name(), ".") && path != teamRoot {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		rel, relErr := filepath.Rel(teamRoot, path)
+		if relErr != nil {
+			return nil
+		}
+		category := "Team wiki"
+		if dir := filepath.Dir(rel); dir != "." {
+			category = "Team wiki · " + strings.SplitN(filepath.ToSlash(dir), "/", 2)[0]
+		}
+		if page, ok := legacyPageFromFile(path, "legacy-wiki-"+slugifyKnowledgeID(filepath.ToSlash(rel)), category); ok {
+			pages = append(pages, page)
+		}
+		return nil
+	})
+
+	// Notebook notes: agents/<agent>/notebook/*.md — each old office agent's
+	// draft notes, kept under that agent's name.
+	agentDirs, _ := os.ReadDir(filepath.Join(root, "agents"))
+	for _, agentDir := range agentDirs {
+		if !agentDir.IsDir() || strings.HasPrefix(agentDir.Name(), ".") {
+			continue
+		}
+		agent := agentDir.Name()
+		notes, _ := os.ReadDir(filepath.Join(root, "agents", agent, "notebook"))
+		for _, note := range notes {
+			if note.IsDir() {
+				continue
+			}
+			path := filepath.Join(root, "agents", agent, "notebook", note.Name())
+			id := "legacy-notebook-" + slugifyKnowledgeID(agent+"-"+note.Name())
+			if page, ok := legacyPageFromFile(path, id, "Notebook · "+agent); ok {
+				pages = append(pages, page)
+			}
+		}
+	}
+
+	// Stable order: wiki articles first (the reviewed, promoted knowledge), then
+	// notebooks (draft scratch); alphabetical within.
+	rank := func(p appKnowledgePage) int {
+		if strings.HasPrefix(p.Category, "Team wiki") {
+			return 0
+		}
+		return 1
+	}
+	sort.Slice(pages, func(i, j int) bool {
+		if r1, r2 := rank(pages[i]), rank(pages[j]); r1 != r2 {
+			return r1 < r2
+		}
+		if pages[i].Category != pages[j].Category {
+			return pages[i].Category < pages[j].Category
+		}
+		return pages[i].Title < pages[j].Title
+	})
+	if len(pages) > legacyKnowledgeMaxPages {
+		fmt.Fprintf(os.Stderr, "broker: legacy knowledge capped at %d of %d pages\n", legacyKnowledgeMaxPages, len(pages))
+		pages = pages[:legacyKnowledgeMaxPages]
+	}
+	return pages
+}
+
+// legacyPageFromFile turns one legacy markdown file into a verbatim Knowledge
+// page. Non-markdown, placeholder, and empty files report ok=false.
+func legacyPageFromFile(path, id, category string) (appKnowledgePage, bool) {
+	base := filepath.Base(path)
+	if strings.HasPrefix(base, ".") || !strings.EqualFold(filepath.Ext(base), ".md") {
+		return appKnowledgePage{}, false
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return appKnowledgePage{}, false
+	}
+	title, lead, sections := parseLegacyMarkdown(string(raw))
+	if title == "" {
+		title = humanizeLegacyName(strings.TrimSuffix(base, filepath.Ext(base)))
+	}
+	if lead == "" && len(sections) == 0 {
+		return appKnowledgePage{}, false // .gitkeep-grade emptiness
+	}
+	updated := ""
+	if info, statErr := os.Stat(path); statErr == nil {
+		updated = "Preserved from your previous workspace · " + info.ModTime().Format("Jan 2, 2006")
+	}
+	summary := lead
+	if summary == "" && len(sections) > 0 && len(sections[0].Paras) > 0 {
+		summary = sections[0].Paras[0]
+	}
+	if len(summary) > 240 {
+		summary = summary[:237] + "…"
+	}
+	return appKnowledgePage{
+		ID:         id,
+		Title:      title,
+		Category:   category,
+		UpdatedAt:  updated,
+		Summary:    summary,
+		Infobox:    []appKnowledgeInfoRow{},
+		Lead:       lead,
+		Sections:   sections,
+		References: []appKnowledgeRef{},
+		Categories: []string{legacyKnowledgeCategoryTag},
+		SeeAlso:    []string{},
+	}, true
+}
+
+// parseLegacyMarkdown splits a legacy article into the page shape the reader
+// renders: an optional YAML frontmatter title, the text before the first "## "
+// as the lead, and one section per "## " heading. Content is preserved verbatim
+// as paragraphs — no rewriting, no citations.
+func parseLegacyMarkdown(raw string) (title, lead string, sections []appKnowledgeSection) {
+	body := strings.ReplaceAll(raw, "\r\n", "\n")
+
+	// YAML frontmatter: keep only a title, drop the rest of the block.
+	if strings.HasPrefix(body, "---\n") {
+		if end := strings.Index(body[4:], "\n---"); end >= 0 {
+			front := body[4 : 4+end]
+			for _, line := range strings.Split(front, "\n") {
+				if t, ok := strings.CutPrefix(strings.TrimSpace(line), "title:"); ok {
+					title = strings.Trim(strings.TrimSpace(t), `"'`)
+				}
+			}
+			rest := body[4+end+4:]
+			body = strings.TrimPrefix(rest, "\n")
+		}
+	}
+
+	current := appKnowledgeSection{}
+	flush := func() {
+		if current.Heading == "" && len(current.Paras) == 0 {
+			return
+		}
+		if current.Heading == "" {
+			lead = strings.Join(current.Paras, "\n\n")
+		} else {
+			sections = append(sections, current)
+		}
+		current = appKnowledgeSection{}
+	}
+
+	var para []string
+	endPara := func() {
+		if len(para) == 0 {
+			return
+		}
+		current.Paras = append(current.Paras, strings.Join(para, "\n"))
+		para = nil
+	}
+
+	for _, line := range strings.Split(body, "\n") {
+		trimmed := strings.TrimSpace(line)
+		switch {
+		case strings.HasPrefix(trimmed, "# ") && title == "" && current.Heading == "" && len(current.Paras) == 0 && len(para) == 0:
+			title = strings.TrimSpace(trimmed[2:])
+		case strings.HasPrefix(trimmed, "## "):
+			endPara()
+			flush()
+			current.Heading = strings.TrimSpace(trimmed[3:])
+		case trimmed == "":
+			endPara()
+		default:
+			para = append(para, line)
+		}
+	}
+	endPara()
+	flush()
+	return title, lead, sections
+}
+
+// humanizeLegacyName turns a kebab/snake filename into a readable title.
+func humanizeLegacyName(name string) string {
+	words := strings.FieldsFunc(name, func(r rune) bool { return r == '-' || r == '_' })
+	if len(words) == 0 {
+		return name
+	}
+	words[0] = strings.ToUpper(words[0][:1]) + words[0][1:]
+	return strings.Join(words, " ")
+}

--- a/internal/team/broker_apps_knowledge_legacy_test.go
+++ b/internal/team/broker_apps_knowledge_legacy_test.go
@@ -1,0 +1,167 @@
+package team
+
+// Legacy knowledge preservation: a workspace upgrading from the office-era
+// product keeps its wiki articles (wiki/team/**.md) and per-agent notebook
+// notes (wiki/agents/<agent>/notebook/*.md) as Knowledge pages, verbatim,
+// appended to every knowledge response.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// seedLegacyWiki writes a small office-era wiki tree under home/.wuphf/wiki.
+func seedLegacyWiki(t *testing.T, home string) {
+	t.Helper()
+	write := func(rel, content string) {
+		t.Helper()
+		path := filepath.Join(home, ".wuphf", "wiki", rel)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", rel, err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatalf("write %s: %v", rel, err)
+		}
+	}
+	write("team/research/rag-brief.md", strings.Join([]string{
+		"---",
+		`title: "RAG retrieval quality brief"`,
+		"owner: rag-engineer",
+		"---",
+		"",
+		"Hybrid search beats pure semantic retrieval in our benchmarks.",
+		"",
+		"## Findings",
+		"",
+		"BM25 plus embeddings fused with RRF improved recall by 18%.",
+		"",
+		"Rank-sensitive metrics matter more than hit rate.",
+		"",
+		"## Next steps",
+		"",
+		"Wire the reranker into slice 2.",
+	}, "\n"))
+	write("team/decisions/OFFICE-59.md", "# Adopt RRF fusion\n\nDecision: fuse BM25 and semantic scores with RRF.\n")
+	write("team/.obsidian/app.json", "{}")
+	write("agents/rag-engineer/notebook/papers-survey.md", "# RAG papers survey\n\nNotes on 2024-2025 retrieval techniques.\n")
+	write("agents/rag-engineer/notebook/.gitkeep", "")
+	write("agents/outbound/notebook/empty-note.md", "\n\n")
+}
+
+func TestLoadLegacyKnowledgePages(t *testing.T) {
+	home := t.TempDir()
+	seedLegacyWiki(t, home)
+	pages := loadLegacyKnowledgePages(filepath.Join(home, ".wuphf", "wiki"))
+
+	if len(pages) != 3 {
+		titles := make([]string, 0, len(pages))
+		for _, p := range pages {
+			titles = append(titles, p.Category+" / "+p.Title)
+		}
+		t.Fatalf("pages = %d (%v), want 3 (2 wiki + 1 notebook; .obsidian, .gitkeep, empty skipped)", len(pages), titles)
+	}
+
+	byID := map[string]appKnowledgePage{}
+	for _, p := range pages {
+		byID[p.ID] = p
+	}
+
+	brief, ok := byID["legacy-wiki-"+slugifyKnowledgeID("research/rag-brief.md")]
+	if !ok {
+		t.Fatalf("missing wiki brief page; got %v", byID)
+	}
+	// Frontmatter title wins; the folder is the category; content is verbatim.
+	if brief.Title != "RAG retrieval quality brief" {
+		t.Fatalf("brief title = %q", brief.Title)
+	}
+	if brief.Category != "Team wiki · research" {
+		t.Fatalf("brief category = %q", brief.Category)
+	}
+	if !strings.Contains(brief.Lead, "Hybrid search beats pure semantic") {
+		t.Fatalf("brief lead = %q", brief.Lead)
+	}
+	if len(brief.Sections) != 2 || brief.Sections[0].Heading != "Findings" || len(brief.Sections[0].Paras) != 2 {
+		t.Fatalf("brief sections = %+v", brief.Sections)
+	}
+	if brief.Summary == "" || brief.References == nil || brief.Infobox == nil {
+		t.Fatalf("brief must have a summary and non-nil slices: %+v", brief)
+	}
+	if len(brief.Categories) == 0 || brief.Categories[0] != legacyKnowledgeCategoryTag {
+		t.Fatalf("brief categories = %v", brief.Categories)
+	}
+
+	decision, ok := byID["legacy-wiki-"+slugifyKnowledgeID("decisions/OFFICE-59.md")]
+	if !ok || decision.Title != "Adopt RRF fusion" {
+		t.Fatalf("decision page = %+v ok=%v (H1 must become the title)", decision, ok)
+	}
+
+	note, ok := byID["legacy-notebook-"+slugifyKnowledgeID("rag-engineer-papers-survey.md")]
+	if !ok || note.Category != "Notebook · rag-engineer" || note.Title != "RAG papers survey" {
+		t.Fatalf("notebook page = %+v ok=%v", note, ok)
+	}
+}
+
+func TestLoadLegacyKnowledgePagesMissingTree(t *testing.T) {
+	if pages := loadLegacyKnowledgePages(filepath.Join(t.TempDir(), "nope")); len(pages) != 0 {
+		t.Fatalf("missing tree must yield no pages, got %d", len(pages))
+	}
+}
+
+// TestAppKnowledgeIncludesLegacyPages locks the endpoint contract: the
+// preserved pages append to the response even when synthesis is unavailable —
+// an upgrading user sees their old wiki/notebooks the moment they open the
+// Knowledge tab, provider or no provider.
+func TestAppKnowledgeIncludesLegacyPages(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("WUPHF_RUNTIME_HOME", home)
+	seedLegacyWiki(t, home)
+
+	b := newTestBroker(t)
+	b.knowledgeBrainOverride = newFakeBrain()
+	// No provider: synthesis fails, but the legacy pages must still serve.
+	withFakeAppsLLM(t, func(context.Context, string, string) (string, error) {
+		return "", fmt.Errorf("no provider on this host")
+	})
+	if err := b.StartOnPort(0); err != nil {
+		t.Fatalf("start broker: %v", err)
+	}
+	defer b.Stop()
+	base := fmt.Sprintf("http://%s", b.Addr())
+
+	regBody, _ := json.Marshal(map[string]any{
+		"name": "Upgraded App", "description": "Lives in a workspace with a legacy wiki.",
+		"html": validAppHTML,
+	})
+	created := postAppsAsAgent(t, base+"/apps", b.Token(), appBuilderSlug, regBody)
+	app, _ := created["app"].(map[string]any)
+	id, _ := app["id"].(string)
+	if id == "" {
+		t.Fatalf("no app id: %v", created)
+	}
+
+	status, out := getAppsJSON(t, base+"/apps/"+id+"/knowledge", b.Token())
+	if status != http.StatusOK {
+		t.Fatalf("GET knowledge: %d", status)
+	}
+	pages, _ := out["pages"].([]any)
+	if len(pages) != 3 {
+		t.Fatalf("pages = %d, want the 3 preserved legacy pages", len(pages))
+	}
+	titles := make([]string, 0, len(pages))
+	for _, raw := range pages {
+		p, _ := raw.(map[string]any)
+		titles = append(titles, fmt.Sprint(p["title"]))
+	}
+	joined := strings.Join(titles, " | ")
+	for _, want := range []string{"RAG retrieval quality brief", "Adopt RRF fusion", "RAG papers survey"} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("legacy page %q missing from response: %s", want, joined)
+		}
+	}
+}

--- a/internal/team/broker_apps_knowledge_legacy_test.go
+++ b/internal/team/broker_apps_knowledge_legacy_test.go
@@ -52,6 +52,21 @@ func seedLegacyWiki(t *testing.T, home string) {
 	write("agents/rag-engineer/notebook/papers-survey.md", "# RAG papers survey\n\nNotes on 2024-2025 retrieval techniques.\n")
 	write("agents/rag-engineer/notebook/.gitkeep", "")
 	write("agents/outbound/notebook/empty-note.md", "\n\n")
+	// A visual artifact: the sanitized HTML view of the survey note, promoted
+	// into the research brief — its sidecar names both owner pages.
+	write("wiki/visual-artifacts/ra_abc123.html", "<h1>Survey figure</h1>")
+	write("wiki/visual-artifacts/ra_abc123.json", `{
+		"title": "RAG survey figure",
+		"htmlPath": "wiki/visual-artifacts/ra_abc123.html",
+		"sourceMarkdownPath": "agents/rag-engineer/notebook/papers-survey.md",
+		"promotedWikiPath": "team/research/rag-brief.md"
+	}`)
+	// A sidecar whose file is GONE must attach nowhere.
+	write("wiki/visual-artifacts/ra_gone.json", `{
+		"title": "Deleted view",
+		"htmlPath": "wiki/visual-artifacts/ra_gone.html",
+		"sourceMarkdownPath": "agents/rag-engineer/notebook/papers-survey.md"
+	}`)
 }
 
 func TestLoadLegacyKnowledgePages(t *testing.T) {
@@ -104,6 +119,74 @@ func TestLoadLegacyKnowledgePages(t *testing.T) {
 	note, ok := byID["legacy-notebook-"+slugifyKnowledgeID("rag-engineer-papers-survey.md")]
 	if !ok || note.Category != "Notebook · rag-engineer" || note.Title != "RAG papers survey" {
 		t.Fatalf("notebook page = %+v ok=%v", note, ok)
+	}
+
+	// The visual artifact attaches to BOTH owner pages its sidecar names —
+	// the source notebook note and the promoted wiki article.
+	wantURL := legacyArtifactURLPrefix + "ra_abc123.html"
+	for _, p := range []appKnowledgePage{brief, note} {
+		if len(p.Artifacts) != 1 || p.Artifacts[0].URL != wantURL {
+			t.Fatalf("%s artifacts = %+v, want the ra_abc123 html view", p.ID, p.Artifacts)
+		}
+		if p.Artifacts[0].Kind != "html" || p.Artifacts[0].Title != "RAG survey figure" {
+			t.Fatalf("%s artifact meta = %+v", p.ID, p.Artifacts[0])
+		}
+	}
+	// A sidecar whose file is gone attaches nowhere (note would have had 2).
+	if decision.Artifacts != nil {
+		t.Fatalf("decision page must carry no artifacts, got %+v", decision.Artifacts)
+	}
+}
+
+// TestLegacyKnowledgeArtifactEndpoint locks the artifact route's contract: the
+// file serves sandboxed with the right content type, and the filename alphabet
+// is the whole trust boundary — traversal and non-artifact extensions 404.
+func TestLegacyKnowledgeArtifactEndpoint(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("WUPHF_RUNTIME_HOME", home)
+	seedLegacyWiki(t, home)
+
+	b := newTestBroker(t)
+	if err := b.StartOnPort(0); err != nil {
+		t.Fatalf("start broker: %v", err)
+	}
+	defer b.Stop()
+	base := fmt.Sprintf("http://%s", b.Addr())
+
+	get := func(path string, auth bool) *http.Response {
+		t.Helper()
+		req, _ := http.NewRequest(http.MethodGet, base+path, nil)
+		if auth {
+			req.Header.Set("Authorization", "Bearer "+b.Token())
+		}
+		res, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("GET %s: %v", path, err)
+		}
+		t.Cleanup(func() { _ = res.Body.Close() })
+		return res
+	}
+
+	res := get(legacyArtifactURLPrefix+"ra_abc123.html", true)
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("artifact GET = %d", res.StatusCode)
+	}
+	if ct := res.Header.Get("Content-Type"); !strings.HasPrefix(ct, "text/html") {
+		t.Fatalf("content-type = %q", ct)
+	}
+	// Defense in depth: the response document is sandboxed even when opened
+	// directly, independent of the FE iframe sandbox. Never loosen silently.
+	if csp := res.Header.Get("Content-Security-Policy"); csp != "sandbox" {
+		t.Fatalf("CSP = %q, want sandbox", csp)
+	}
+
+	if res := get(legacyArtifactURLPrefix+"ra_abc123.html", false); res.StatusCode == http.StatusOK {
+		t.Fatalf("unauthenticated artifact GET must not serve, got %d", res.StatusCode)
+	}
+	for _, bad := range []string{"..%2f..%2fconfig.json", ".hidden.html", "ra_abc123.json", "nope.html"} {
+		if res := get(legacyArtifactURLPrefix+bad, true); res.StatusCode != http.StatusNotFound {
+			t.Fatalf("GET %q = %d, want 404", bad, res.StatusCode)
+		}
 	}
 }
 

--- a/web/e2e/screenshots/qa-fix-batch.mjs
+++ b/web/e2e/screenshots/qa-fix-batch.mjs
@@ -1,0 +1,62 @@
+// Capture the QA-fix batch (PR #1160) against the LIVE local stack — these
+// states depend on real broker/agent-service data (a routine with a recorded
+// run, real integrations, persisted artifacts), so unlike the other specs this
+// one does not mock routes. Requires the dev stack: broker :7890/:7891, agent
+// service :8824, vite :5273 with an agent named "Reporting Agent" that has a
+// run routine (see the v0.232.0 QA session).
+
+import process from "node:process";
+
+import { launchBrowser, shotPage } from "./lib.mjs";
+
+const BASE = process.env.BASE_URL ?? "http://localhost:5273";
+
+const OUT = process.env.WUPHF_SCREENSHOTS_OUT;
+if (!OUT) {
+  console.error("WUPHF_SCREENSHOTS_OUT is not set; run via publish.sh / driver");
+  process.exit(2);
+}
+
+// The live web token, fetched from the broker (not a secret beyond this host).
+const tokenRes = await fetch("http://127.0.0.1:7890/web-token");
+const { token } = await tokenRes.json();
+
+const { browser, context, page } = await launchBrowser({
+  viewport: { width: 1440, height: 900 },
+});
+
+try {
+  await page.goto(`${BASE}/?token=${token}#/operator`, {
+    waitUntil: "domcontentloaded",
+  });
+  await page.waitForTimeout(2500);
+  await page.getByText("Reporting Agent").first().click();
+  await page.getByRole("tab", { name: "Routines" }).waitFor({ timeout: 45_000 });
+
+  // 1. Routines — the lazy "Recent runs" disclosure over the broker's run ring.
+  await page.getByRole("tab", { name: "Routines" }).click();
+  await page.waitForTimeout(1500);
+  await page.getByText(/recent runs/i).first().click();
+  await page.waitForTimeout(2000);
+  await shotPage(page, OUT, "01-routine-recent-runs");
+
+  // 2. Integrations — chips reframed as workspace-connected, not "used by".
+  await page.getByRole("tab", { name: "Integrations" }).click();
+  await page.waitForTimeout(5000);
+  await shotPage(page, OUT, "02-integrations-reframed");
+
+  // 3. UI tab — artifacts strip with humanized stamps.
+  await page.getByRole("tab", { name: "UI" }).click();
+  await page.waitForTimeout(2500);
+  await shotPage(page, OUT, "03-artifacts-human-stamps");
+
+  // 4. Ask Agent — defaults to a manual chat, never the routine's transcript.
+  await page.getByRole("button", { name: /^ask agent$/i }).first().click();
+  await page.waitForTimeout(2500);
+  await shotPage(page, OUT, "04-ask-agent-manual-default");
+
+  console.log("captured 4 states");
+} finally {
+  await context.close();
+  await browser.close();
+}

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -308,6 +308,27 @@ export async function getText(
   return r.text();
 }
 
+/** Authenticated binary GET — for file-ish payloads (PDFs) that a plain <a>
+ * cannot fetch because the auth header does not travel with link navigation. */
+export async function getBlob(
+  path: string,
+  options?: GetOptions,
+): Promise<Blob> {
+  let r: Response;
+  try {
+    r = await fetch(baseURL() + path, {
+      headers: authHeaders(),
+      signal: getRequestSignal(options),
+    });
+  } catch (err) {
+    throw describeGetError(err) ?? err;
+  }
+  if (!r.ok) {
+    throw await apiErrorFromResponse(r);
+  }
+  return r.blob();
+}
+
 export async function post<T = unknown>(
   path: string,
   body?: unknown,

--- a/web/src/operator/agents/AgentSessions.test.tsx
+++ b/web/src/operator/agents/AgentSessions.test.tsx
@@ -107,8 +107,15 @@ describe("AgentSessions", () => {
 
   it("hydrates sessions + the persisted transcript from the service", async () => {
     vi.stubGlobal("fetch", serviceFetch());
+    // Explicitly open the routine session (as "Open its chat" would): the
+    // DEFAULT now lands on a manual session, so request s1 to exercise routine
+    // transcript hydration.
     const { findByText, getByTestId, queryByText } = render(
-      <AgentSessions agentName="Pipeline Agent" agentId="app_x" />,
+      <AgentSessions
+        agentName="Pipeline Agent"
+        agentId="app_x"
+        requestedSessionId="s1"
+      />,
     );
     expect(await findByText("Weekly recap run")).toBeTruthy();
     // The seeds were replaced by the service's sessions.
@@ -125,7 +132,11 @@ describe("AgentSessions", () => {
     const fetchMock = serviceFetch();
     vi.stubGlobal("fetch", fetchMock);
     const { findByText, getByTestId, getByText } = render(
-      <AgentSessions agentName="Pipeline Agent" agentId="app_x" />,
+      <AgentSessions
+        agentName="Pipeline Agent"
+        agentId="app_x"
+        requestedSessionId="s1"
+      />,
     );
     // Wait for the HYDRATED pane (the seeded pane has no mirroring hook).
     await findByText("Weekly recap run");
@@ -195,5 +206,104 @@ describe("AgentSessions", () => {
     await waitFor(() => expect(requested?.className).toContain("is-active"));
     const first = (await findByText("Weekly recap run")).closest("button");
     expect(first?.className).not.toContain("is-active");
+  });
+
+  it("defaults to a fresh manual chat when the service has only routine sessions (regression)", async () => {
+    // A real agent whose sessions are all ROUTINE runs used to open the routine
+    // session by default, so manual chatting polluted its run transcript. The
+    // default must be a MANUAL chat instead.
+    const routineOnly = [
+      {
+        id: "s1",
+        agent: "app_x",
+        title: "Weekly recap run",
+        kind: "routine",
+        at: "Monday 9:02",
+        routine: "routine-recap",
+      },
+    ];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string) => {
+        if (url === "/agent/sessions?agent=app_x") {
+          return ok({ sessions: routineOnly });
+        }
+        throw new Error(`unexpected fetch ${url}`);
+      }),
+    );
+    const { findByText, getByText } = render(
+      <AgentSessions agentName="Pipeline Agent" agentId="app_x" />,
+    );
+    // The routine session still shows in the strip…
+    expect(await findByText("Weekly recap run")).toBeTruthy();
+    // …but the ACTIVE default is a fresh manual chat, not the routine's run.
+    const manual = getByText("Chat with your agent").closest("button");
+    await waitFor(() => expect(manual?.className).toContain("is-active"));
+    const routine = getByText("Weekly recap run").closest("button");
+    expect(routine?.className).not.toContain("is-active");
+  });
+
+  it("creates the draft manual session on the first sent turn (not before)", async () => {
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      if (url === "/agent/sessions?agent=app_x") {
+        return ok({
+          sessions: [
+            {
+              id: "s1",
+              agent: "app_x",
+              title: "Weekly recap run",
+              kind: "routine",
+              at: "Monday 9:02",
+            },
+          ],
+        });
+      }
+      if (url === "/agent/sessions" && init?.method === "POST") {
+        return ok({
+          session: {
+            id: "s9",
+            agent: "app_x",
+            title: "Chat with your agent",
+            kind: "manual",
+            at: "just now",
+          },
+        });
+      }
+      if (url.endsWith("/message") && init?.method === "POST") {
+        return ok({ ok: true });
+      }
+      throw new Error(`unexpected fetch ${init?.method ?? "GET"} ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const { findByText, getByText } = render(
+      <AgentSessions agentName="Pipeline Agent" agentId="app_x" />,
+    );
+    await findByText("Chat with your agent");
+    // No session was created just to have a default (no POST /sessions yet).
+    expect(
+      fetchMock.mock.calls.some(
+        ([url, init]) => url === "/agent/sessions" && init?.method === "POST",
+      ),
+    ).toBe(false);
+    // The first turn persists the session, then mirrors both messages to it.
+    fireEvent.click(getByText("emit turn"));
+    await waitFor(() => {
+      const mirrored = fetchMock.mock.calls.filter(
+        ([url]) => typeof url === "string" && url.endsWith("/message"),
+      );
+      expect(mirrored).toHaveLength(2);
+    });
+    const created = fetchMock.mock.calls.filter(
+      ([url, init]) => url === "/agent/sessions" && init?.method === "POST",
+    );
+    expect(created).toHaveLength(1);
+    const mirroredUrls = fetchMock.mock.calls
+      .filter(([url]) => typeof url === "string" && url.endsWith("/message"))
+      .map(([url]) => url);
+    // Both turns mirror to the SAME newly-created session id.
+    expect(mirroredUrls).toEqual([
+      "/agent/sessions/s9/message",
+      "/agent/sessions/s9/message",
+    ]);
   });
 });

--- a/web/src/operator/agents/AgentSessions.tsx
+++ b/web/src/operator/agents/AgentSessions.tsx
@@ -89,6 +89,16 @@ export function AgentSessions({
   // "Open its chat"). The list hydration below resolves LATER and must not
   // clobber it back to the first session.
   const pickedRef = useRef<string | null>(null);
+  // The synthesized default manual chat used when the service has ONLY routine
+  // sessions: it never opens a routine's run transcript by default (manual
+  // chatting would pollute the run history). It stays LOCAL and is created on
+  // the service only when the operator first sends a message. draftServiceRef
+  // memoizes that one-time create so both turns of the first exchange land in
+  // the same real session.
+  const draftManualIdRef = useRef<string | null>(null);
+  const draftServiceRef = useRef<Map<string, Promise<string | null>>>(
+    new Map(),
+  );
 
   useEffect(() => {
     if (!realId) return;
@@ -96,23 +106,36 @@ export function AgentSessions({
     void tryListSessions(realId).then(async (remote) => {
       if (cancelled || !remote) return; // unreachable — keep the seeded state
       const picked = pickedRef.current;
+      // Default to a MANUAL session, never a routine's run transcript — manual
+      // chatting/teaching in a routine session would pollute its run history.
+      // An explicitly requested session (a routine's "Open its chat") wins.
       const target =
-        (picked && remote.find((s) => s.id === picked)) || remote[0];
+        (picked && remote.find((s) => s.id === picked)) ||
+        remote.find((s) => s.kind === "manual") ||
+        null;
       // Fetch the target session's transcript BEFORE mounting its pane: a pane
       // reads its initialTranscript only at mount.
       const detail = target ? await tryGetSession(target.id, realId) : null;
       if (cancelled) return;
       setLive(true);
-      setSessions(remote.map(toMeta));
       if (target) {
+        setSessions(remote.map(toMeta));
         setTranscripts({
           [target.id]: detail ? toTranscript(detail.messages) : null,
         });
         setActiveId(target.id);
         setMounted([target.id]);
       } else {
-        setActiveId("");
-        setMounted([]);
+        // Only routine sessions exist (or none): present a fresh local manual
+        // chat as the default so the operator lands in a clean chat instead of
+        // a routine's run transcript. It persists to the service only on the
+        // first sent message (see turnHandlerFor).
+        const draft = newSession("Chat with your agent", "manual");
+        draftManualIdRef.current = draft.id;
+        setSessions([draft, ...remote.map(toMeta)]);
+        setTranscripts({ [draft.id]: [] });
+        setActiveId(draft.id);
+        setMounted([draft.id]);
       }
     });
     return () => {
@@ -172,6 +195,32 @@ export function AgentSessions({
     openNew(newSession(title, "manual"));
   }
 
+  // Where a chat turn's live mirror goes. A normal session mirrors each turn to
+  // the service fire-and-forget. The synthesized default manual chat is LOCAL
+  // until its first turn: it then creates the real session once and mirrors this
+  // and every later turn to it, so an unused default never litters the service.
+  function turnHandlerFor(
+    s: ChatSessionMeta,
+  ): ((from: "you" | "nex", body: string) => void) | undefined {
+    if (!(live && realId)) return undefined;
+    const agent = realId;
+    if (s.id !== draftManualIdRef.current) {
+      return (from, body) => trySendSessionMessage(s.id, { agent, from, body });
+    }
+    return (from, body) => {
+      let created = draftServiceRef.current.get(s.id);
+      if (!created) {
+        created = tryCreateSession(agent, s.title).then((c) =>
+          c ? c.id : null,
+        );
+        draftServiceRef.current.set(s.id, created);
+      }
+      void created.then((sid) => {
+        if (sid) trySendSessionMessage(sid, { agent, from, body });
+      });
+    };
+  }
+
   // What a pane starts from: the persisted transcript when the service has
   // one, the mock routine transcript for offline routine sessions, else the
   // chat's own greeting.
@@ -228,16 +277,7 @@ export function AgentSessions({
                     : undefined
                 }
                 initialTranscript={initialTranscriptFor(s)}
-                onTurn={
-                  live && realId
-                    ? (from, body) =>
-                        trySendSessionMessage(s.id, {
-                          agent: realId,
-                          from,
-                          body,
-                        })
-                    : undefined
-                }
+                onTurn={turnHandlerFor(s)}
               />
             </div>
           ))}

--- a/web/src/operator/apps/knowledgeClient.ts
+++ b/web/src/operator/apps/knowledgeClient.ts
@@ -3,7 +3,7 @@
 // roster) and synthesizes cited Wikipedia-style pages grounded in them; the tab
 // renders them exactly like the mock. Cached server-side after first synthesis.
 
-import { get } from "../../api/client";
+import { get, getText } from "../../api/client";
 import type { KnowledgePage } from "../mock/data";
 
 export interface AppKnowledgeResult {
@@ -39,4 +39,14 @@ export async function getAppKnowledge(
     { timeoutMs: KNOWLEDGE_SYNTH_TIMEOUT_MS },
   );
   return { pages: res.pages ?? [], error: res.error };
+}
+
+/**
+ * getKnowledgeArtifactHTML fetches a page artifact's HTML through the authed
+ * client (an iframe src cannot carry the auth header). The caller renders it in
+ * a FULLY sandboxed iframe via srcDoc — never as live DOM; the broker also
+ * serves it with `CSP: sandbox` as defense in depth.
+ */
+export function getKnowledgeArtifactHTML(url: string): Promise<string> {
+  return getText(url);
 }

--- a/web/src/operator/apps/knowledgeClient.ts
+++ b/web/src/operator/apps/knowledgeClient.ts
@@ -12,9 +12,21 @@ export interface AppKnowledgeResult {
   error?: string;
 }
 
+// First open triggers a grounded LLM synthesis of several cited pages. The
+// broker bounds one synthesis at 90s server-side (knowledgeSynthTimeout in
+// internal/team/broker_apps_knowledge.go) and, because its context derives from
+// the HTTP request, cancels synthesis the instant the client disconnects. The
+// default 20s GET timeout therefore aborted every first read mid-synthesis — no
+// single request ever survived long enough to warm the cache, and the abort
+// surfaced as a spurious "provider unreachable" error. A patient window that
+// outlasts the server bound (plus headroom for the proxy) lets one read finish
+// and cache, so every later read is instant. KnowledgeSurface pairs this with a
+// poll so a rare miss still recovers.
+export const KNOWLEDGE_SYNTH_TIMEOUT_MS = 120_000;
+
 /**
  * getAppKnowledge fetches the app's cited knowledge pages. First open triggers a
- * grounded synthesis (a few seconds); it is cached after, so later reads are
+ * grounded synthesis (up to ~90s); it is cached after, so later reads are
  * instant. Pass refresh to force a re-synthesis.
  */
 export async function getAppKnowledge(
@@ -23,6 +35,8 @@ export async function getAppKnowledge(
 ): Promise<AppKnowledgeResult> {
   const res = await get<{ pages?: KnowledgePage[]; error?: string }>(
     `/apps/${encodeURIComponent(appId)}/knowledge${refresh ? "?refresh=1" : ""}`,
+    undefined,
+    { timeoutMs: KNOWLEDGE_SYNTH_TIMEOUT_MS },
   );
   return { pages: res.pages ?? [], error: res.error };
 }

--- a/web/src/operator/apps/useOperatorApps.test.ts
+++ b/web/src/operator/apps/useOperatorApps.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import type { CustomApp } from "../../api/apps";
+import { assembleDemoCapture, capturePromptSeed } from "./demoCapture";
 import {
   APP_ID_PREFIX,
   appBuildState,
@@ -95,6 +96,30 @@ describe("deriveAppName", () => {
     expect(deriveAppName("a weekly pipeline summary I can glance at")).toBe(
       "Pipeline Agent",
     );
+  });
+
+  it("names a lead-scoring/routing demo for its role, not CRM hygiene", () => {
+    // The narrated goal for the inbound demo-request scenario. Scoring and
+    // routing is the job; a CRM is merely one of the systems it touches.
+    const goal =
+      "When a demo request comes in, look up the company in HubSpot, score " +
+      "fit 0 to 100 from company size and industry, route 70 and up to an AE " +
+      "in Slack #ae-handoffs with the reason, and nurture the rest.";
+    expect(deriveAppName(goal)).not.toBe("CRM Hygiene Agent");
+    expect(deriveAppName(goal)).toBe("Lead Routing Agent");
+  });
+
+  it("does not read a CRM API endpoint in the build seed as a hygiene job", () => {
+    // The demo handoff derives the name from the FULL capture seed, which
+    // embeds the observed HubSpot endpoint /crm/v3/objects/companies/search.
+    // A bare "crm" mention means the workflow USES a CRM, not that it cleans
+    // one — the name must follow the actual work (lead scoring + routing).
+    const seed = capturePromptSeed(
+      assembleDemoCapture({ mode: "build", transcript: [] }),
+    );
+    expect(seed).toContain("/crm/v3/objects/companies/search");
+    expect(deriveAppName(seed)).not.toBe("CRM Hygiene Agent");
+    expect(deriveAppName(seed)).toBe("Lead Routing Agent");
   });
 
   it("synthesizes <lead words> Agent for an unknown domain", () => {

--- a/web/src/operator/apps/useOperatorApps.ts
+++ b/web/src/operator/apps/useOperatorApps.ts
@@ -163,7 +163,10 @@ export function resolveNewAppId(
 // operator jobs; anything else becomes "<Lead words> Agent".
 const AGENT_ROLES: ReadonlyArray<[RegExp, string]> = [
   [
-    /\b(crm|hygiene|dedupe|duplicate|clean[- ]?up|data quality)\b/i,
+    // NOT "crm": a bare CRM mention (or a HubSpot/Salesforce endpoint like
+    // /crm/v3/... in the captured build seed) means the workflow USES a CRM,
+    // not that it cleans one. Hygiene is signalled by dedupe/cleanup terms.
+    /\b(hygiene|dedupe|duplicate|clean[- ]?up|data quality)\b/i,
     "CRM Hygiene Agent",
   ],
   [

--- a/web/src/operator/artifacts/ArtifactsTab.test.tsx
+++ b/web/src/operator/artifacts/ArtifactsTab.test.tsx
@@ -88,6 +88,30 @@ describe("ArtifactsTab", () => {
     expect(anchor?.getAttribute("href")).toBe("/artifacts/brief.pdf");
   });
 
+  it("humanizes ISO artifact timestamps and passes non-date stamps through", () => {
+    const iso: Artifact = {
+      id: "i1",
+      type: "md",
+      title: "recap.md",
+      producedBy: "weeklyPipelineSummary",
+      at: "2026-07-03T01:08:04.821Z",
+      content: "# hi",
+    };
+    const { container, getByText } = render(
+      <ArtifactsTab
+        agentName="Pipeline Agent"
+        artifacts={[iso, ...ARTIFACTS]}
+      />,
+    );
+    const meta = container.querySelector(".opr-artifact-meta");
+    // The raw ISO stamp never reaches the UI…
+    expect(meta?.textContent).not.toContain("2026-07-03T01:08:04.821Z");
+    // …it renders as a short local "Mon D" date.
+    expect(meta?.textContent).toMatch(/[A-Z][a-z]{2}\s+\d{1,2}/);
+    // A non-date stamp (a seeded label) is left untouched.
+    expect(getByText(/weeklyPipelineSummary · Monday/)).toBeTruthy();
+  });
+
   it("shows the honest empty state when nothing was produced yet", () => {
     const { getByText } = render(
       <ArtifactsTab agentName="Pipeline Agent" artifacts={[]} />,

--- a/web/src/operator/artifacts/ArtifactsTab.tsx
+++ b/web/src/operator/artifacts/ArtifactsTab.tsx
@@ -6,6 +6,7 @@
 import { useState } from "react";
 import { Download, FileText } from "lucide-react";
 
+import { formatStamp } from "../routines/routines";
 import { ARTIFACT_BADGE, type Artifact } from "./artifacts";
 
 interface ArtifactsTabProps {
@@ -51,7 +52,7 @@ export function ArtifactsTab({ agentName, artifacts }: ArtifactsTabProps) {
             <span className="opr-artifact-chip-body">
               <span className="opr-artifact-title">{a.title}</span>
               <span className="opr-artifact-meta">
-                {a.producedBy} · {a.at}
+                {a.producedBy} · {formatStamp(a.at)}
               </span>
             </span>
           </button>
@@ -94,7 +95,8 @@ function ArtifactViewer({ artifact }: { artifact: Artifact }) {
           <div className="opr-artifact-file-body">
             <div className="opr-artifact-title">{artifact.title}</div>
             <div className="opr-artifact-meta">
-              {artifact.size ?? "PDF"} · {artifact.producedBy} · {artifact.at}
+              {artifact.size ?? "PDF"} · {artifact.producedBy} ·{" "}
+              {formatStamp(artifact.at)}
             </div>
           </div>
           {artifact.url ? (

--- a/web/src/operator/mock/data.ts
+++ b/web/src/operator/mock/data.ts
@@ -568,6 +568,15 @@ export interface KnowledgePage {
   seeAlso: string[]; // page ids
   /** Other apps this page also belongs to (cross-app share). */
   alsoIn?: { appId: string; name: string }[];
+  /** File-ish views attached to this page (preserved legacy HTML briefs /
+   * PDFs). The url is a broker route fetched with auth, rendered sandboxed. */
+  artifacts?: KnowledgeArtifact[];
+}
+
+export interface KnowledgeArtifact {
+  title: string;
+  kind: "html" | "pdf";
+  url: string;
 }
 
 export const KNOWLEDGE: KnowledgePage[] = [

--- a/web/src/operator/routines/RoutinesTab.test.tsx
+++ b/web/src/operator/routines/RoutinesTab.test.tsx
@@ -95,6 +95,7 @@ describe("RoutinesTab (live broker scheduler)", () => {
     onPatch?: () => unknown;
     onCreate?: () => unknown;
     jobs?: () => unknown[];
+    runs?: () => unknown[];
   }) {
     return vi.fn(async (url: string, init?: RequestInit) => {
       if (init?.method === "PATCH") {
@@ -107,7 +108,14 @@ describe("RoutinesTab (live broker scheduler)", () => {
         return ok({ job: job() });
       }
       if (url.endsWith("/revisions")) {
-        return ok({ revisions: [{ version: 2, created_at: "", label: "Live recap", enabled: true }] });
+        return ok({
+          revisions: [
+            { version: 2, created_at: "", label: "Live recap", enabled: true },
+          ],
+        });
+      }
+      if (url.endsWith("/runs")) {
+        return ok({ runs: overrides.runs?.() ?? [] });
       }
       return ok({ jobs: overrides.jobs?.() ?? [job()] });
     });
@@ -200,7 +208,11 @@ describe("RoutinesTab (live broker scheduler)", () => {
   it("Add routine registers a scheduler routine (purpose + cron + owner)", async () => {
     const fetchMock = brokerFetch({
       onCreate: () =>
-        job({ slug: "routine-chase-legal", label: "Chase legal", payload: "Email me anything stuck in legal" }),
+        job({
+          slug: "routine-chase-legal",
+          label: "Chase legal",
+          payload: "Email me anything stuck in legal",
+        }),
     });
     vi.stubGlobal("fetch", fetchMock);
     const { findByText, getByLabelText, getByText } = render(
@@ -223,5 +235,35 @@ describe("RoutinesTab (live broker scheduler)", () => {
       owner: "app_x",
       created_by: "operator",
     });
+  });
+
+  it("expands Recent runs and lists the routine's run history (first line only)", async () => {
+    const fetchMock = brokerFetch({
+      runs: () => [
+        {
+          slug: "routine-live-recap",
+          started_at: "2026-07-02T09:02:00Z",
+          status: "ok",
+          output_summary: "Recap saved to Artifacts.\nFull detail below.",
+        },
+      ],
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const { findByText, getByText, queryByText } = render(
+      <RoutinesTab agentName="Pipeline Agent" agentId="app_x" />,
+    );
+    await findByText("Live recap");
+    // Runs load lazily: nothing fetched until the disclosure is expanded.
+    expect(
+      fetchMock.mock.calls.some(([url]) => String(url).endsWith("/runs")),
+    ).toBe(false);
+    fireEvent.click(getByText("Recent runs"));
+    expect(await findByText("Recap saved to Artifacts.")).toBeTruthy();
+    // Only the first summary line is shown, not the whole thing.
+    expect(queryByText("Full detail below.")).toBeNull();
+    const runsCall = fetchMock.mock.calls.find(([url]) =>
+      String(url).endsWith("/runs"),
+    );
+    expect(runsCall?.[0]).toBe("/api/scheduler/routine-live-recap/runs");
   });
 });

--- a/web/src/operator/routines/RoutinesTab.tsx
+++ b/web/src/operator/routines/RoutinesTab.tsx
@@ -16,6 +16,7 @@ import { useEffect, useState } from "react";
 import {
   CalendarClock,
   CheckCircle2,
+  ChevronRight,
   MessageSquareText,
   Play,
   Plus,
@@ -24,15 +25,18 @@ import {
 
 import {
   tryCreateRoutine,
+  tryListRoutineRuns,
   tryListRoutines,
   tryPatchRoutine,
   tryRunRoutineNow,
   type WireRoutine,
+  type WireRoutineRun,
 } from "../agents/agentStateClient";
 import { isRealAppId } from "../apps/useOperatorApps";
 import { Eyebrow } from "../components/primitives";
 import {
   formatLastRun,
+  formatStamp,
   humanSchedule,
   newRoutine,
   type Routine,
@@ -40,6 +44,27 @@ import {
   SCHEDULE_PRESETS,
   seedRoutines,
 } from "./routines";
+
+// A run's status maps to a colored dot: succeeded → green, failed → red,
+// anything mid-flight or unknown → the muted default.
+function runStatusClass(status: string): string {
+  const s = status.toLowerCase();
+  if (s === "ok" || s === "success" || s === "succeeded" || s === "done") {
+    return "is-ok";
+  }
+  if (s === "failed" || s === "error" || s === "errored") return "is-bad";
+  return "is-pending";
+}
+
+// The first non-empty line of a run summary — the glanceable outcome.
+function firstLine(text: string): string {
+  return (
+    text
+      .split("\n")
+      .map((line) => line.trim())
+      .find((line) => line.length > 0) ?? ""
+  );
+}
 
 interface RoutinesTabProps {
   agentName: string;
@@ -79,6 +104,12 @@ export function RoutinesTab({
   // Run-now feedback: which routine is mid-queue, and which just queued/ran.
   const [runningId, setRunningId] = useState<string | null>(null);
   const [ranJustNowId, setRanJustNowId] = useState<string | null>(null);
+  // Recent-runs disclosure: which routine cards are expanded, and their loaded
+  // run history (undefined = not fetched yet, null = fetched but unavailable).
+  const [expandedRuns, setExpandedRuns] = useState<Set<string>>(new Set());
+  const [runsById, setRunsById] = useState<
+    Record<string, WireRoutineRun[] | null>
+  >({});
 
   const realId = isRealAppId(agentId) ? agentId : undefined;
 
@@ -97,6 +128,24 @@ export function RoutinesTab({
 
   function patch(id: string, up: (r: Routine) => Routine) {
     setRoutines((prev) => prev.map((r) => (r.id === id ? up(r) : r)));
+  }
+
+  // Expand/collapse a routine's run history; load it lazily on first expand
+  // (the broker keeps a per-slug run ring). Offline/mock agents just resolve
+  // null and the card shows the honest empty note.
+  function toggleRuns(r: Routine) {
+    const wasOpen = expandedRuns.has(r.id);
+    setExpandedRuns((prev) => {
+      const next = new Set(prev);
+      if (next.has(r.id)) next.delete(r.id);
+      else next.add(r.id);
+      return next;
+    });
+    if (!(wasOpen || r.id in runsById)) {
+      void tryListRoutineRuns(r.id).then((runs) => {
+        setRunsById((prev) => ({ ...prev, [r.id]: runs }));
+      });
+    }
   }
 
   function toggleEnabled(r: Routine) {
@@ -281,6 +330,23 @@ export function RoutinesTab({
                 Open its chat
               </button>
             </div>
+
+            <div className="opr-routine-runs">
+              <button
+                type="button"
+                className={`opr-routine-runs-toggle${
+                  expandedRuns.has(r.id) ? " is-open" : ""
+                }`}
+                aria-expanded={expandedRuns.has(r.id)}
+                onClick={() => toggleRuns(r)}
+              >
+                <ChevronRight size={11} strokeWidth={2} aria-hidden={true} />
+                Recent runs
+              </button>
+              {expandedRuns.has(r.id) ? (
+                <RecentRuns runs={runsById[r.id]} />
+              ) : null}
+            </div>
           </div>
         ))}
       </div>
@@ -333,5 +399,35 @@ export function RoutinesTab({
         </div>
       </div>
     </div>
+  );
+}
+
+// The routine's recent runs from the broker's per-slug run ring: status dot,
+// when it ran (humanized), and the first line of its outcome. `undefined` while
+// loading; `null`/empty shows the honest empty note.
+function RecentRuns({ runs }: { runs: WireRoutineRun[] | null | undefined }) {
+  if (runs === undefined) {
+    return <p className="opr-scoped-note">Loading recent runs…</p>;
+  }
+  if (!runs || runs.length === 0) {
+    return <p className="opr-scoped-note">No runs recorded yet.</p>;
+  }
+  return (
+    <ul className="opr-routine-runs-list">
+      {runs.slice(0, 5).map((run, i) => (
+        <li className="opr-routine-run" key={`${run.started_at}-${i}`}>
+          <span
+            className={`opr-run-led ${runStatusClass(run.status)}`}
+            aria-hidden={true}
+          />
+          <span className="opr-routine-run-when">
+            {formatStamp(run.started_at)}
+          </span>
+          <span className="opr-routine-run-summary">
+            {firstLine(run.output_summary || run.message || "") || run.status}
+          </span>
+        </li>
+      ))}
+    </ul>
   );
 }

--- a/web/src/operator/routines/routines.ts
+++ b/web/src/operator/routines/routines.ts
@@ -54,9 +54,11 @@ export function humanSchedule(schedule: string): string {
   return preset ? preset.label : schedule;
 }
 
-/** Render a last-run stamp: broker RFC3339 becomes a short local time; a
- * seeded human label ("12 minutes ago") renders as-is. */
-export function formatLastRun(value: string): string {
+/** Humanize a timestamp: an ISO/RFC3339 string becomes a short local
+ * "Mon D, HH:MM"; a value that isn't a date (a seeded label like "12 minutes
+ * ago", or "v3") passes through untouched. Shared by routine run-stamps and
+ * artifact chips so both humanize the same way. */
+export function formatStamp(value: string): string {
   const t = Date.parse(value);
   if (Number.isNaN(t)) return value;
   return new Date(t).toLocaleString(undefined, {
@@ -65,6 +67,12 @@ export function formatLastRun(value: string): string {
     hour: "2-digit",
     minute: "2-digit",
   });
+}
+
+/** Render a last-run stamp: broker RFC3339 becomes a short local time; a
+ * seeded human label ("12 minutes ago") renders as-is. */
+export function formatLastRun(value: string): string {
+  return formatStamp(value);
 }
 
 let seq = 0;

--- a/web/src/operator/surfaces/AppBuilderChat.test.tsx
+++ b/web/src/operator/surfaces/AppBuilderChat.test.tsx
@@ -116,4 +116,17 @@ describe("AppBuilderChat demo handoff", () => {
       "app_new1",
     );
   });
+
+  it("does not claim an offline (never-persisted) tool is in place", async () => {
+    // buildToolFromChat returns offline:true when the agent service was
+    // unreachable and only a local mock was made — the tool exists in memory
+    // and was NEVER persisted on the agent. The chat must report it as failed,
+    // not "In place".
+    buildToolMock.mockResolvedValueOnce({ tool: {}, offline: true });
+    const { findByText, queryByText } = renderChat();
+    // The honest failure names the tool that only built offline.
+    await findByText(/could not set up[\s\S]*summarizePipeline/);
+    // …and it must never be claimed as persisted.
+    expect(queryByText(/In place:[\s\S]*summarizePipeline/)).toBeNull();
+  });
 });

--- a/web/src/operator/surfaces/AppBuilderChat.test.tsx
+++ b/web/src/operator/surfaces/AppBuilderChat.test.tsx
@@ -32,8 +32,9 @@ vi.mock("../agents/agentStateClient", () => ({
   tryCreateRoutine: (input: unknown) => createRoutineMock(input),
 }));
 
-const buildToolMock = vi.fn(async (_instruction: string, _agent: string) => ({
-  tool: {},
+// Happy path: the service persists the REQUESTED tool (name echoed back).
+const buildToolMock = vi.fn(async (instruction: string, _agent: string) => ({
+  tool: { name: instruction.split(" — ")[0] },
   offline: false,
 }));
 vi.mock("../tools/toolAgentClient", () => ({
@@ -117,12 +118,28 @@ describe("AppBuilderChat demo handoff", () => {
     );
   });
 
+  it("does not claim a tool the service swapped for a different one", async () => {
+    // QA HIGH-2 (clean rerun): the service can answer 200 with the WRONG tool
+    // (a keyword template hijacking the request). A name mismatch means the
+    // requested tool does not exist — it must be reported, never "In place".
+    buildToolMock.mockResolvedValueOnce({
+      tool: { name: "scoreAndRouteLead" },
+      offline: false,
+    });
+    const { findByText, queryByText } = renderChat();
+    await findByText(/could not set up[\s\S]*summarizePipeline/);
+    expect(queryByText(/In place:[\s\S]*summarizePipeline/)).toBeNull();
+  });
+
   it("does not claim an offline (never-persisted) tool is in place", async () => {
     // buildToolFromChat returns offline:true when the agent service was
     // unreachable and only a local mock was made — the tool exists in memory
     // and was NEVER persisted on the agent. The chat must report it as failed,
     // not "In place".
-    buildToolMock.mockResolvedValueOnce({ tool: {}, offline: true });
+    buildToolMock.mockResolvedValueOnce({
+      tool: { name: "summarizePipeline" },
+      offline: true,
+    });
     const { findByText, queryByText } = renderChat();
     // The honest failure names the tool that only built offline.
     await findByText(/could not set up[\s\S]*summarizePipeline/);

--- a/web/src/operator/surfaces/AppBuilderChat.tsx
+++ b/web/src/operator/surfaces/AppBuilderChat.tsx
@@ -289,8 +289,14 @@ export function AppBuilderChat({
     }
     for (const tool of tools) {
       try {
-        await buildToolFromChat(`${tool.name} — ${tool.purpose}`, agentId);
-        done.push(tool.name);
+        const built = await buildToolFromChat(
+          `${tool.name} — ${tool.purpose}`,
+          agentId,
+        );
+        // offline:true means the agent service was unreachable and only a local
+        // mock was authored — the tool was NEVER persisted on the agent. Report
+        // it honestly as failed, not "In place".
+        (built.offline ? failed : done).push(tool.name);
       } catch {
         failed.push(tool.name);
       }
@@ -484,8 +490,8 @@ export function AppBuilderChat({
         <div className="opr-composer">
           <input
             className="opr-composer-input"
-            aria-label="Describe the app you want to build"
-            placeholder="Describe what this app should do..."
+            aria-label="Describe what this agent should do"
+            placeholder="Describe what this agent should do…"
             value={draft}
             disabled={phase === "building"}
             onChange={(e) => setDraft(e.target.value)}

--- a/web/src/operator/surfaces/AppBuilderChat.tsx
+++ b/web/src/operator/surfaces/AppBuilderChat.tsx
@@ -293,10 +293,13 @@ export function AppBuilderChat({
           `${tool.name} — ${tool.purpose}`,
           agentId,
         );
-        // offline:true means the agent service was unreachable and only a local
-        // mock was authored — the tool was NEVER persisted on the agent. Report
-        // it honestly as failed, not "In place".
-        (built.offline ? failed : done).push(tool.name);
+        // Two ways a "success" is not the tool we promised: offline:true (the
+        // agent service was unreachable — only a local mock exists, nothing
+        // persisted) and a NAME MISMATCH (the service authored/returned a
+        // different tool than the one requested). Both report as failed, never
+        // "In place".
+        const isRequested = built.tool?.name === tool.name;
+        (built.offline || !isRequested ? failed : done).push(tool.name);
       } catch {
         failed.push(tool.name);
       }

--- a/web/src/operator/surfaces/KnowledgeSurface.test.tsx
+++ b/web/src/operator/surfaces/KnowledgeSurface.test.tsx
@@ -10,8 +10,12 @@ import { KnowledgeSurface } from "./KnowledgeSurface";
 // hoisted too or the factory hits the TDZ. KnowledgeSurface reads through
 // getAppKnowledge, which calls this get() — mocking it exercises the real
 // client (including the patient-timeout option it passes).
-const { get } = vi.hoisted(() => ({ get: vi.fn() }));
-vi.mock("../../api/client", () => ({ get }));
+const { get, getText, getBlob } = vi.hoisted(() => ({
+  get: vi.fn(),
+  getText: vi.fn(),
+  getBlob: vi.fn(),
+}));
+vi.mock("../../api/client", () => ({ get, getText, getBlob }));
 
 function wrap(node: ReactNode) {
   const qc = new QueryClient({
@@ -39,6 +43,8 @@ function samplePage(): KnowledgePage {
 describe("KnowledgeSurface", () => {
   beforeEach(() => {
     get.mockReset();
+    getText.mockReset();
+    getBlob.mockReset();
   });
 
   it("requests knowledge with a patient timeout that outlasts the broker's 90s synthesis bound", async () => {
@@ -101,5 +107,51 @@ describe("KnowledgeSurface", () => {
     get.mockResolvedValue({ pages: [], error: "rate_limited" });
     const { getByText } = wrap(<KnowledgeSurface appId="app_abc" />);
     await waitFor(() => expect(getByText(/Knowledge is busy/i)).toBeTruthy());
+  });
+
+  it("renders a page's preserved artifacts and views html in a locked-down sandbox", async () => {
+    const page = {
+      ...samplePage(),
+      artifacts: [
+        {
+          title: "RAG survey figure",
+          kind: "html" as const,
+          url: "/apps/knowledge/legacy-artifacts/ra_abc.html",
+        },
+      ],
+    };
+    get.mockResolvedValue({ pages: [page] });
+    getText.mockResolvedValue("<h1>Survey figure</h1>");
+    const { container, getByText, findByText } = wrap(
+      <KnowledgeSurface appId="app_abc" />,
+    );
+    await findByText("Artifacts");
+    // The artifact fetches through the AUTHED client (an iframe src cannot
+    // carry the auth header) only when opened.
+    expect(getText).not.toHaveBeenCalled();
+    getByText(/RAG survey figure/).click();
+    await waitFor(() =>
+      expect(getText).toHaveBeenCalledWith(
+        "/apps/knowledge/legacy-artifacts/ra_abc.html",
+      ),
+    );
+    await waitFor(() => {
+      const iframe = container.querySelector("iframe.opr-artifact-html");
+      expect(iframe).toBeTruthy();
+      // The EMPTY sandbox attribute is the security boundary for preserved
+      // HTML: no scripts, no navigation, no same-origin. Never loosen it.
+      expect(iframe?.getAttribute("sandbox")).toBe("");
+    });
+  });
+
+  it("shows no References heading when a page has none", async () => {
+    get.mockResolvedValue({ pages: [samplePage()] });
+    const { queryByText, getAllByText } = wrap(
+      <KnowledgeSurface appId="app_abc" />,
+    );
+    await waitFor(() =>
+      expect(getAllByText("Ideal customer profile").length).toBeGreaterThan(0),
+    );
+    expect(queryByText("References")).toBeNull();
   });
 });

--- a/web/src/operator/surfaces/KnowledgeSurface.test.tsx
+++ b/web/src/operator/surfaces/KnowledgeSurface.test.tsx
@@ -1,0 +1,105 @@
+import type { ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { KnowledgePage } from "../mock/data";
+import { KnowledgeSurface } from "./KnowledgeSurface";
+
+// vi.mock is hoisted above the const declarations, so the mock handle must be
+// hoisted too or the factory hits the TDZ. KnowledgeSurface reads through
+// getAppKnowledge, which calls this get() — mocking it exercises the real
+// client (including the patient-timeout option it passes).
+const { get } = vi.hoisted(() => ({ get: vi.fn() }));
+vi.mock("../../api/client", () => ({ get }));
+
+function wrap(node: ReactNode) {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(<QueryClientProvider client={qc}>{node}</QueryClientProvider>);
+}
+
+function samplePage(): KnowledgePage {
+  return {
+    id: "icp",
+    title: "Ideal customer profile",
+    category: "Sales",
+    updatedAt: "Last edited yesterday by your AI",
+    summary: "Who buys.",
+    infobox: [{ label: "Segment", value: "Mid-market" }],
+    lead: "The company most likely to buy.",
+    sections: [{ heading: "Fit", paras: ["Named use case."] }],
+    references: [],
+    categories: ["Sales"],
+    seeAlso: [],
+  };
+}
+
+describe("KnowledgeSurface", () => {
+  beforeEach(() => {
+    get.mockReset();
+  });
+
+  it("requests knowledge with a patient timeout that outlasts the broker's 90s synthesis bound", async () => {
+    get.mockResolvedValue({ pages: [samplePage()] });
+    wrap(<KnowledgeSurface appId="app_abc" />);
+    await waitFor(() =>
+      expect(get).toHaveBeenCalledWith(
+        "/apps/app_abc/knowledge",
+        undefined,
+        expect.objectContaining({ timeoutMs: expect.any(Number) }),
+      ),
+    );
+    // The client must not abort mid-synthesis: the window has to exceed the
+    // broker's 90s server-side synthesis bound (the default 20s GET timeout was
+    // the bug).
+    const opts = get.mock.calls[0]?.[2] as { timeoutMs: number };
+    expect(opts.timeoutMs).toBeGreaterThan(90_000);
+  });
+
+  it("renders the synthesized pages once a slow first read resolves, never the provider error", async () => {
+    get.mockResolvedValue({ pages: [samplePage()] });
+    const { getAllByText, queryByText } = wrap(
+      <KnowledgeSurface appId="app_abc" />,
+    );
+    await waitFor(() =>
+      // The title renders in the nav, infobox, and article heading.
+      expect(getAllByText("Ideal customer profile").length).toBeGreaterThan(0),
+    );
+    expect(queryByText(/not reachable or not configured/i)).toBeNull();
+  });
+
+  it("shows 'taking longer', not the provider error, when a slow synthesis times out", async () => {
+    // A client timeout/abort surfaces as a thrown transport error with NO
+    // response body — the pre-fix code mislabeled this "your AI provider is not
+    // reachable". It must read as "still working" instead.
+    get.mockRejectedValue(
+      new Error("Broker not responding — request timed out."),
+    );
+    const { getByText, queryByText } = wrap(
+      <KnowledgeSurface appId="app_abc" />,
+    );
+    await waitFor(() =>
+      expect(getByText(/taking longer than usual/i)).toBeTruthy(),
+    );
+    expect(queryByText(/not reachable or not configured/i)).toBeNull();
+    expect(queryByText(/Knowledge is unavailable right now/i)).toBeNull();
+  });
+
+  it("shows the provider-unreachable message only on a real provider verdict", async () => {
+    // A genuine provider outage comes back as HTTP 200 with an error body.
+    get.mockResolvedValue({ pages: [], error: "ai_unavailable" });
+    const { getByText } = wrap(<KnowledgeSurface appId="app_abc" />);
+    await waitFor(() =>
+      expect(getByText(/Knowledge is unavailable right now/i)).toBeTruthy(),
+    );
+    expect(getByText(/not reachable or not configured/i)).toBeTruthy();
+  });
+
+  it("shows the busy message on a rate-limit verdict", async () => {
+    get.mockResolvedValue({ pages: [], error: "rate_limited" });
+    const { getByText } = wrap(<KnowledgeSurface appId="app_abc" />);
+    await waitFor(() => expect(getByText(/Knowledge is busy/i)).toBeTruthy());
+  });
+});

--- a/web/src/operator/surfaces/KnowledgeSurface.tsx
+++ b/web/src/operator/surfaces/KnowledgeSurface.tsx
@@ -156,6 +156,20 @@ export function KnowledgeSurface({ appId }: KnowledgeSurfaceProps) {
     queryFn: () => getAppKnowledge(appId ?? ""),
     enabled: Boolean(appId),
     staleTime: 5 * 60_000,
+    // A first synthesis is slow (getAppKnowledge waits patiently for it) but can
+    // still miss — a transient blip, or the very first read losing the race to
+    // warm the cache. Keep polling while there are no pages AND the broker has
+    // returned no real verdict; the synthesis warms the cache server-side, so a
+    // later poll lands on ready pages. Stop once pages arrive or the broker
+    // reports a real provider/rate-limit verdict (data.error). This is the
+    // "keep working" backstop; automatic retry is inherited from the client.
+    refetchInterval: (q) => {
+      if (!appId) return false;
+      const data = q.state.data;
+      if (data?.pages?.length) return false;
+      if (data?.error) return false;
+      return q.state.status === "error" ? 6_000 : false;
+    },
   });
 
   const pages: KnowledgePage[] = appId ? (query.data?.pages ?? []) : KNOWLEDGE;
@@ -168,22 +182,38 @@ export function KnowledgeSurface({ appId }: KnowledgeSurfaceProps) {
     [page],
   );
 
-  // Real synthesis takes a few seconds on first open (cached after).
-  const synthesizing = Boolean(appId) && query.isLoading;
-  // Synthesis failures are NOT an empty brain: the broker reports them as
-  // { error: "ai_unavailable" | "rate_limited" }, and a transport failure
-  // surfaces as query.isError. Render those honestly, distinct from "no
-  // knowledge yet". If cached pages arrived alongside an error, the pages win.
-  const backendError = appId ? query.data?.error : undefined;
-  const knowledgeFailed =
+  // A first synthesis is slow (up to ~90s server-side, cached after). While the
+  // query is loading OR re-fetching a slow/failed attempt with nothing to show
+  // yet, we are still working — never flip to an error mid-flight.
+  const working =
     Boolean(appId) &&
-    !query.isLoading &&
     pages.length === 0 &&
-    (query.isError || Boolean(backendError));
+    (query.isLoading || query.isFetching);
+
+  // Error taxonomy. A REAL provider verdict comes back in the RESPONSE BODY
+  // ({ error: "ai_unavailable" | "rate_limited" }) with HTTP 200 — that is the
+  // ONLY signal that the AI provider is down or throttled. A timeout, abort, or
+  // transport failure is query.isError with NO body: that means "the synthesis
+  // did not finish in time", which is a "still working" state, never a provider
+  // verdict. Keeping the two apart is the fix for a slow first synthesis being
+  // mislabeled "your AI provider is not reachable".
+  const backendError = appId ? query.data?.error : undefined;
+  const providerUnavailable =
+    Boolean(appId) && pages.length === 0 && backendError === "ai_unavailable";
+  const rateLimited =
+    Boolean(appId) && pages.length === 0 && backendError === "rate_limited";
+  const stillWorking =
+    Boolean(appId) &&
+    !working &&
+    pages.length === 0 &&
+    !backendError &&
+    query.isError;
   const emptyBrain =
     Boolean(appId) &&
-    !query.isLoading &&
-    !knowledgeFailed &&
+    !working &&
+    !stillWorking &&
+    !providerUnavailable &&
+    !rateLimited &&
     pages.length === 0;
 
   return (
@@ -208,37 +238,41 @@ export function KnowledgeSurface({ appId }: KnowledgeSurfaceProps) {
         )}
       </div>
 
-      {synthesizing ? (
+      {working || stillWorking ? (
         <div className="opr-app-building" role="status">
           <span className="opr-work-dots" aria-hidden={true}>
             <span />
             <span />
             <span />
           </span>
-          <div className="opr-empty-title">Reading what your AI knows…</div>
+          <div className="opr-empty-title">
+            {stillWorking
+              ? "Still reading what your AI knows…"
+              : "Reading what your AI knows…"}
+          </div>
           <div className="opr-empty-hint">
-            Synthesizing cited pages from this app's real sources.
+            {stillWorking
+              ? "This is taking longer than usual. Hang tight — it keeps trying, and the cited pages appear the moment they are ready."
+              : "Synthesizing cited pages from everything your AI has learned."}
           </div>
         </div>
-      ) : knowledgeFailed ? (
-        backendError === "rate_limited" ? (
-          <EmptyState
-            glyph="⚠"
-            title="Knowledge is busy — try again in a minute."
-            hint="Your AI hit a rate limit while synthesizing this app's pages. Nothing is lost — reopen this tab shortly."
-          />
-        ) : (
-          <EmptyState
-            glyph="⚠"
-            title="Knowledge is unavailable right now."
-            hint="Your AI provider is not reachable or not configured, so cited pages could not be synthesized. Once it is back, they appear here."
-          />
-        )
+      ) : rateLimited ? (
+        <EmptyState
+          glyph="⚠"
+          title="Knowledge is busy — try again in a minute."
+          hint="Your AI hit a rate limit while synthesizing these pages. Nothing is lost — reopen this tab shortly."
+        />
+      ) : providerUnavailable ? (
+        <EmptyState
+          glyph="⚠"
+          title="Knowledge is unavailable right now."
+          hint="Your AI provider is not reachable or not configured, so cited pages could not be synthesized. Once it is back, they appear here."
+        />
       ) : emptyBrain ? (
         <EmptyState
           glyph="📖"
           title="No knowledge yet"
-          hint="Your AI has not written any cited pages about this app yet. As it learns from the app and your workspace, they appear here."
+          hint="Your AI has not written any cited pages yet. As it learns from your workspace, they appear here."
         />
       ) : (
         <div className="opr-wiki">

--- a/web/src/operator/surfaces/KnowledgeSurface.tsx
+++ b/web/src/operator/surfaces/KnowledgeSurface.tsx
@@ -12,11 +12,16 @@ import { type ReactNode, useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { Sparkles } from "lucide-react";
 
-import { getAppKnowledge } from "../apps/knowledgeClient";
+import { getBlob } from "../../api/client";
+import {
+  getAppKnowledge,
+  getKnowledgeArtifactHTML,
+} from "../apps/knowledgeClient";
 import { EmptyState } from "../components/EmptyState";
 import { Eyebrow } from "../components/primitives";
 import {
   KNOWLEDGE,
+  type KnowledgeArtifact,
   type KnowledgePage,
   type KnowledgeRef,
   type KnowledgeSourceKind,
@@ -35,6 +40,82 @@ const KIND_LABEL: Record<KnowledgeSourceKind, string> = {
 // unmount the hash-routed shell, so we scroll to the target imperatively.
 function jumpToRef(n: number) {
   document.getElementById(`ref-${n}`)?.scrollIntoView({ block: "start" });
+}
+
+// ── Page artifacts: preserved file-ish views (legacy HTML briefs / PDFs) ──────
+
+// One attached artifact. HTML opens inline in a FULLY sandboxed iframe (the
+// content is fetched through the authed client and rendered via srcDoc — no
+// scripts, no navigation, no same-origin); a PDF downloads through the authed
+// client (a plain <a href> cannot carry the auth header).
+function ArtifactItem({ artifact }: { artifact: KnowledgeArtifact }) {
+  const [open, setOpen] = useState(false);
+  const [html, setHtml] = useState<string | null>(null);
+  const [failed, setFailed] = useState(false);
+
+  async function view() {
+    if (open) {
+      setOpen(false);
+      return;
+    }
+    setOpen(true);
+    if (artifact.kind === "html" && html === null) {
+      try {
+        setHtml(await getKnowledgeArtifactHTML(artifact.url));
+      } catch {
+        setFailed(true);
+      }
+    }
+  }
+
+  async function download() {
+    try {
+      const blob = await getBlob(artifact.url);
+      const href = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = href;
+      a.download = `${artifact.title}.pdf`;
+      a.click();
+      URL.revokeObjectURL(href);
+    } catch {
+      setFailed(true);
+    }
+  }
+
+  return (
+    <div className="opr-page-artifact">
+      <button
+        type="button"
+        className="opr-btn opr-btn-sm"
+        onClick={() => void (artifact.kind === "pdf" ? download() : view())}
+      >
+        <span className={`opr-artifact-badge is-${artifact.kind}`}>
+          {artifact.kind.toUpperCase()}
+        </span>
+        {artifact.title}
+        {artifact.kind === "html" ? (open ? " · hide" : " · view") : ""}
+      </button>
+      {failed ? (
+        <p className="opr-scoped-note">
+          Could not load this artifact right now.
+        </p>
+      ) : null}
+      {open && artifact.kind === "html" ? (
+        html === null ? (
+          <p className="opr-scoped-note">Loading…</p>
+        ) : (
+          // The EMPTY sandbox attribute is the security boundary for preserved
+          // HTML: no scripts, no navigation, no same-origin. Never loosen it.
+          <iframe
+            className="opr-artifact-html"
+            title={artifact.title}
+            sandbox=""
+            srcDoc={html}
+          />
+        )
+      ) : null}
+    </div>
+  );
 }
 
 // A single [n] citation with a hover/focus popover over its source.
@@ -338,15 +419,31 @@ export function KnowledgeSurface({ appId }: KnowledgeSurfaceProps) {
                 </section>
               ))}
 
-              <h2>References</h2>
-              <ol className="opr-refs">
-                {page.references.map((ref) => (
-                  // Key by page identity + n: ref numbers reset per page, so a
-                  // bare ref.n would reuse instances (and leak open state)
-                  // across page switches.
-                  <ReferenceItem key={`${page.id}-${ref.n}`} source={ref} />
-                ))}
-              </ol>
+              {page.artifacts && page.artifacts.length > 0 ? (
+                <>
+                  <h2>Artifacts</h2>
+                  {page.artifacts.map((artifact) => (
+                    <ArtifactItem
+                      key={`${page.id}-${artifact.url}`}
+                      artifact={artifact}
+                    />
+                  ))}
+                </>
+              ) : null}
+
+              {page.references.length > 0 ? (
+                <>
+                  <h2>References</h2>
+                  <ol className="opr-refs">
+                    {page.references.map((ref) => (
+                      // Key by page identity + n: ref numbers reset per page,
+                      // so a bare ref.n would reuse instances (and leak open
+                      // state) across page switches.
+                      <ReferenceItem key={`${page.id}-${ref.n}`} source={ref} />
+                    ))}
+                  </ol>
+                </>
+              ) : null}
 
               {page.seeAlso.length > 0 ? (
                 <>

--- a/web/src/operator/surfaces/OperatorAppDetail.tsx
+++ b/web/src/operator/surfaces/OperatorAppDetail.tsx
@@ -432,11 +432,12 @@ function TabBody({
   }
 }
 
-// The broker's app-scoped integration catalog: the CONNECTED platforms an app
-// (and the agent behind it) can call. Mirrors appIntegrationCatalogResponse in
-// internal/team/broker_apps_integrations.go. Passing the connected names into
-// ToolIntegrations stops the tab from falsely claiming "does not use any
-// integrations"; a fetch failure degrades to the previous empty state.
+// The broker's app-scoped integration catalog: the workspace's CONNECTED
+// platforms this app (and the agent behind it) can call. Mirrors
+// appIntegrationCatalogResponse in internal/team/broker_apps_integrations.go.
+// These are the workspace's connected integrations the agent CAN use — not
+// integrations "used by this tool" — so the tab is framed honestly below. A
+// fetch failure degrades to the previous empty state.
 interface AppIntegrationCatalogItem {
   platform: string;
   name: string;
@@ -465,7 +466,13 @@ function AppIntegrationsTab() {
       cancelled = true;
     };
   }, []);
-  return <ToolIntegrations usedNames={connectedNames} />;
+  return (
+    <ToolIntegrations
+      usedNames={connectedNames}
+      usedHeading="Connected for your workspace"
+      usedEmptyNote="No integrations connected yet. Connect from your catalog below and this agent can use them."
+    />
+  );
 }
 
 function UiTab({

--- a/web/src/operator/surfaces/ToolIntegrations.test.tsx
+++ b/web/src/operator/surfaces/ToolIntegrations.test.tsx
@@ -28,13 +28,18 @@ vi.mock("../../components/apps/integrations/ComposioOnboarding", () => ({
   ComposioOnboarding: () => <div data-testid="composio-onboarding" />,
 }));
 
-function renderTab() {
+function renderTab(
+  props: Partial<{ usedNames: string[]; usedHeading: string }> = {},
+) {
   const client = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });
   return render(
     <QueryClientProvider client={client}>
-      <ToolIntegrations usedNames={[]} />
+      <ToolIntegrations
+        usedNames={props.usedNames ?? []}
+        usedHeading={props.usedHeading}
+      />
     </QueryClientProvider>,
   );
 }
@@ -76,5 +81,19 @@ describe("ToolIntegrations", () => {
     expect(getByText("GitHub")).toBeTruthy();
     expect(getByText("Connect")).toBeTruthy();
     expect(queryByTestId("composio-onboarding")).toBeNull();
+  });
+
+  it("frames the scoped chips under the caller's heading (not always 'Used by this tool')", async () => {
+    getConfigMock.mockResolvedValue({ composio_key_set: true });
+    listIntegrationsMock.mockResolvedValue({ items: [] });
+    const { findByText, queryByText } = renderTab({
+      usedNames: ["GitHub"],
+      usedHeading: "Connected for your workspace",
+    });
+    // The agent-app path relabels the chips honestly.
+    expect(await findByText("Connected for your workspace")).toBeTruthy();
+    expect(await findByText("GitHub")).toBeTruthy();
+    // …and drops the misleading "Used by this tool" framing.
+    expect(queryByText("Used by this tool")).toBeNull();
   });
 });

--- a/web/src/operator/surfaces/ToolIntegrations.tsx
+++ b/web/src/operator/surfaces/ToolIntegrations.tsx
@@ -25,11 +25,23 @@ import { ConnectIntegrationCard } from "../../components/messages/ConnectIntegra
 import { Eyebrow } from "../components/primitives";
 
 interface ToolIntegrationsProps {
-  /** Integration names the tool's workflow references (from its steps). */
+  /** Integration names shown as scoped chips above the full catalog. For a tool
+   * these are the integrations its workflow steps reference; for an agent app
+   * they are the workspace's connected integrations the agent can use. */
   usedNames: string[];
+  /** Heading over the scoped chips. Defaults to the tool framing; the agent-app
+   * path passes an honest workspace-connected framing instead (the chips are
+   * NOT "used by this tool" — they are what the agent CAN use). */
+  usedHeading?: string;
+  /** Note shown in place of the chips when there are no scoped names. */
+  usedEmptyNote?: string;
 }
 
-export function ToolIntegrations({ usedNames }: ToolIntegrationsProps) {
+export function ToolIntegrations({
+  usedNames,
+  usedHeading = "Used by this tool",
+  usedEmptyNote = "This tool does not use any integrations yet.",
+}: ToolIntegrationsProps) {
   const [search, setSearch] = useState("");
   const [connecting, setConnecting] = useState<string | null>(null);
   const queryClient = useQueryClient();
@@ -86,7 +98,7 @@ export function ToolIntegrations({ usedNames }: ToolIntegrationsProps) {
     <div className="opr-tool-scoped">
       {usedNames.length > 0 ? (
         <>
-          <Eyebrow>Used by this tool</Eyebrow>
+          <Eyebrow>{usedHeading}</Eyebrow>
           <ul className="opr-scoped-chips">
             {usedNames.map((name) => (
               <li key={name} className="opr-scoped-chip">
@@ -96,9 +108,7 @@ export function ToolIntegrations({ usedNames }: ToolIntegrationsProps) {
           </ul>
         </>
       ) : (
-        <p className="opr-scoped-note">
-          This tool does not use any integrations yet.
-        </p>
+        <p className="opr-scoped-note">{usedEmptyNote}</p>
       )}
       <p className="opr-scoped-note">
         Connected once for your workspace and reused across tools. Search and

--- a/web/src/styles/operator-shell.css
+++ b/web/src/styles/operator-shell.css
@@ -4605,6 +4605,70 @@
   gap: var(--space-2);
   margin-top: var(--space-2);
 }
+
+/* Recent-runs disclosure: a per-routine collapsible list of run history. */
+.opr-routine-runs {
+  margin-top: var(--space-2-5);
+}
+.opr-routine-runs-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1-5);
+  padding: 0;
+  border: 0;
+  background: none;
+  cursor: pointer;
+  font-size: 11px;
+  color: var(--t-dim);
+}
+.opr-routine-runs-toggle:hover {
+  color: var(--t-ink);
+}
+.opr-routine-runs-toggle svg {
+  transition: transform 120ms ease;
+}
+.opr-routine-runs-toggle.is-open svg {
+  transform: rotate(90deg);
+}
+.opr-routine-runs-list {
+  list-style: none;
+  margin: var(--space-2) 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1-5);
+}
+.opr-routine-run {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: 11.5px;
+  color: var(--t-dim);
+}
+.opr-run-led {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  background: var(--t-faint);
+}
+.opr-run-led.is-ok {
+  background: var(--t-green);
+}
+.opr-run-led.is-bad {
+  background: var(--t-red);
+}
+.opr-routine-run-when {
+  color: var(--t-faint);
+  font-variant-numeric: tabular-nums;
+  flex-shrink: 0;
+}
+.opr-routine-run-summary {
+  color: var(--t-ink);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
 .opr-routine-new {
   border-top: 1px solid var(--t-line-2);
   padding-top: var(--space-3);

--- a/web/src/styles/operator-shell.css
+++ b/web/src/styles/operator-shell.css
@@ -4285,6 +4285,17 @@
   color: var(--t-faint);
 }
 
+/* A knowledge page's attached artifacts (preserved legacy HTML briefs/PDFs). */
+.opr-page-artifact {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  margin: var(--space-2) 0;
+}
+.opr-page-artifact > .opr-btn {
+  align-self: flex-start;
+}
+
 /* ── Artifacts: the outputs the agent produced (pdf, html, md) ─────────────── */
 /* A chip strip of outcomes + a viewer per type, living on the UI tab under the
    agent's one live app. Tokens only. See web/src/operator/artifacts/. */


### PR DESCRIPTION
## What

Fixes for the 12-issue QA report on v0.232.0 (full E2E QA of the operator surface, three ICP examples + feature sweep). Four batches, each with regression tests that failed pre-fix.

### HIGH
- **Simulated routine outcomes were meaningless** (`Ran on  (simulated).` as chat reply, digest, and artifact): a simulated `nex.run` now names the input and says nothing ran because no model/broker is connected (pointing at `TOOL_RUNTIME_MODEL=1` / `WUPHF_BROKER_URL`+`TOKEN`); the routine's prompt feeds the generic tool's input; blank inputs no longer interpolate empty. (`agent/src/capabilities.ts`, `routineRunner.ts`)
- **Demo-call tools claimed "In place" without persisting**: (a) FE — `offline: true` results from `buildToolFromChat` now land in the honest failure message, never "In place"; (b) root cause — the agent store's `save()` used one shared `<file>.tmp`, so concurrent writers (e.g. two instances sharing the data dir) could tear the store; every later read then 500'd and the FE fell back to "offline". Writes now use unique temp names, and a corrupt store file is quarantined (`<file>.corrupt-<ts>`, bytes preserved) and read as empty instead of wedging every store-backed route. Proven by curl pre/post fix. **Clean-workspace rerun found a second cause:** authorTool keyword shapes fired on purpose words and returned the scoreAndRouteLead template for the postHandoffToSlack request - a 200 with the WRONG tool. An explicit leading camelCase name now wins (shapes apply only when they agree on the name), and the FE treats a returned-name mismatch as not-set-up. Verified live: both demo tools persist on a clean workspace. (`AppBuilderChat.tsx`, `agent/src/store.ts`)
- **Knowledge first-load misreported "provider not reachable"**: the client's default 20s GET timeout aborted every first synthesis (broker bounds it at 90s and cancels on client disconnect), so the cache never warmed. The knowledge read now waits out the synthesis (120s) with a poll backstop, and the provider message is reserved for a real broker verdict — timeouts show still-working copy. (`knowledgeClient.ts`, `KnowledgeSurface.tsx`)

### MED
- **Ask Agent defaulted into a routine's run transcript**: with only routine sessions, the dock now presents a local manual chat, persisted to the service on the first sent message; explicit "Open its chat" still wins. (`AgentSessions.tsx`)
- **"USED BY THIS TOOL" chips were wrong**: the agent path now frames them honestly as the workspace's connected integrations the agent can use (`ToolIntegrations` grows `usedHeading`/`usedEmptyNote`; the mock tool path keeps its true used-by framing). (`ToolIntegrations.tsx`, `OperatorAppDetail.tsx`)
- **Demo name misfire** ("CRM Hygiene Agent" for lead routing): the capture seed's `/crm/v3/…` endpoint tripped the hygiene role's bare `crm` trigger — removed; hygiene is signalled by dedupe/cleanup/data-quality terms. Pinned to "Lead Routing Agent" by tests on the goal AND the full seed. (`useOperatorApps.ts`)

### LOW
- Build composer speaks agent, not app; knowledge copy likewise.
- Artifact stamps humanize via the shared `formatStamp` (raw ISO never reaches the UI; non-date labels pass through).
- Each routine card gains a lazy **Recent runs** disclosure over the broker's run ring (status dot, when, first line).
- Derived tool titles cut at clause boundaries ("Count the open tasks", not "…and tell").

### Skipped / deferred (from the QA report)
- **LOW-10 (502 console noise during builds)**: SKIPPED this round — the noise originates from the dev-preview iframe/proxy while the app dev server boots; a quiet probe needs care in the SHARED `AppLivePreview` and wasn't worth rushing. Follow-up candidate.
- **LOW-12 (Settings notifications mock)**: DEFERRED — audit confirmed the Voice section is wired (config query + mutation) but Notifications/Approvals are local-state mock with a hardcoded `#revops · maya@company.com` default. Needs a product decision on wiring digest delivery.

### Feature: legacy knowledge preservation
A workspace upgrading from the office-era product keeps its **wiki articles** (`wiki/team/**.md` → `Team wiki · <category>` pages) and **notebook notes** (`wiki/agents/<agent>/notebook/*.md` → `Notebook · <agent>` pages) in the Knowledge tab — verbatim, no synthesis, no fabricated citations, marked "Preserved from your previous workspace". They append to every knowledge response including the provider-down states. Verified live against a copy of a real legacy tree (50 pages served + rendered). Unit + endpoint tests cover parsing, categories, skips, and the provider-down contract. **Visual artifacts too:** the previous product’s sanitized HTML briefs and PDFs (wiki/visual-artifacts + JSON sidecars) attach to their owner pages; a name-validated broker route serves them (auth + CSP sandbox + nosniff), and the reader renders an Artifacts block — HTML inline in a fully sandboxed iframe fetched through the authed client, PDFs as authed blob downloads. Verified live (9 pages carrying artifacts; brief renders inline).

## Test plan
- [x] Full web suite: 259 files, **2359 passed** (was 2346 — new regression tests, each failing pre-fix)
- [x] Agent suite: **106 passed**
- [x] `bunx tsc --noEmit` clean (web + agent)
- [x] biome on changed web files (agent/ is not biome-governed; tabs preserved)
- [x] Screenshots (below)

QA report with evidence: session scratchpad `qa/QA-REPORT-v0.232.0.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Screenshots

![01-routine-recent-runs](https://github.com/nex-crm/wuphf/raw/screenshots/pr-1160/01-routine-recent-runs.png)

![02-integrations-reframed](https://github.com/nex-crm/wuphf/raw/screenshots/pr-1160/02-integrations-reframed.png)

![03-artifacts-human-stamps](https://github.com/nex-crm/wuphf/raw/screenshots/pr-1160/03-artifacts-human-stamps.png)

![04-ask-agent-manual-default](https://github.com/nex-crm/wuphf/raw/screenshots/pr-1160/04-ask-agent-manual-default.png)






<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Recent runs” expansion for routines with status indicators and short summaries.
  * Knowledge pages can include preserved legacy pages and legacy artifacts (HTML/PDF), rendered in a sandboxed viewer.
  * Tool integrations now support custom headings and empty-state text; artifact timestamps display as human-friendly dates.
* **Bug Fixes**
  * Improved honesty for simulated runs/tools and fixed empty-input spacing to avoid misleading blank output.
  * Better recovery from corrupted saved data, clearer knowledge loading/polling, and more reliable default chat-session + demo tool-setup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
