### PR TITLE
feat(website): rewrite wuphf.team — nex.ai hero + content shape, app-theme styling

### DIFF
--- a/website/download.html
+++ b/website/download.html
@@ -4,10 +4,10 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Download WUPHF Desktop — macOS &amp; Windows</title>
-<meta name="description" content="Download the WUPHF desktop app for macOS and Windows. Your whole office of AI employees in a native window — no browser tab, no terminal.">
+<meta name="description" content="Download the WUPHF desktop app for macOS and Windows. Your hired agents in a native window — no browser tab, no terminal.">
 <link rel="canonical" href="https://wuphf.team/download.html">
 <meta property="og:title" content="Download WUPHF Desktop">
-<meta property="og:description" content="The WUPHF office of AI employees as a native desktop app for macOS and Windows.">
+<meta property="og:description" content="WUPHF — hire agents, not automations — as a native desktop app for macOS and Windows.">
 <meta property="og:type" content="website">
 <meta property="og:url" content="https://wuphf.team/download.html">
 <meta property="og:image" content="https://wuphf.team/og-image.png">
@@ -118,7 +118,7 @@
 <main>
   <section class="hero">
     <h1>WUPHF <span class="accent">Desktop</span></h1>
-    <p class="lead">Your whole office of AI employees in a native window — no browser tab, no terminal. Same office as the CLI, just a real app.</p>
+    <p class="lead">Your hired agents in a native window — no browser tab, no terminal. Same workspace as the CLI, just a real app.</p>
     <a class="btn-primary" id="primaryDownload" href="https://github.com/nex-crm/wuphf/releases" target="_blank" rel="noopener">Download</a>
     <span class="btn-sub" id="primarySub">Pick your platform below</span>
   </section>
@@ -132,7 +132,7 @@
       <ol class="steps">
         <li>Open the downloaded <code>WUPHF-mac.dmg</code>.</li>
         <li>Drag <strong>WUPHF</strong> into your <strong>Applications</strong> folder.</li>
-        <li>Launch it from Applications or Spotlight — your office opens in the app.</li>
+        <li>Launch it from Applications or Spotlight — your workspace opens in the app.</li>
       </ol>
       <div class="callout" style="border-left-color: var(--yellow)">
         <span class="ct" style="color: var(--yellow)">No scary warnings</span>
@@ -166,12 +166,12 @@
 
   <section class="alt">
     <h3>Prefer the terminal? Or on Linux?</h3>
-    <p class="muted">The desktop app and the CLI are the same office — use whichever you like. The CLI runs everywhere, including Linux:</p>
+    <p class="muted">The desktop app and the CLI are the same workspace — use whichever you like. The CLI runs everywhere, including Linux:</p>
     <div class="cmd">
       <code>npx wuphf@latest</code>
       <button type="button" data-copy="npx wuphf@latest" aria-label="Copy command">COPY</button>
     </div>
-    <p class="muted">A native Linux desktop build is on the roadmap; for now Linux runs via the CLI above (your office opens at <code>localhost:7891</code>).</p>
+    <p class="muted">A native Linux desktop build is on the roadmap; for now Linux runs via the CLI above (your workspace opens at <code>localhost:7891</code>).</p>
   </section>
 </main>
 

--- a/website/index.html
+++ b/website/index.html
@@ -3,11 +3,11 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>WUPHF — Describe a job once. Hire an agent that does it.</title>
-<meta name="description" content="Describe a job in one sentence, or demo it once on a call. WUPHF builds an agent with its own app, schedule, tools, and memory. Runs 24x7 on your machine. Nothing sent without your tap.">
+<title>WUPHF — Turn your manual workflows into AI agents</title>
+<meta name="description" content="AI agents that can connect to 100+ integrations and automate manual tasks you couldn't automate before. Describe the job or demo it once — it runs 24x7 on your machine.">
 <link rel="canonical" href="https://wuphf.team">
-<meta property="og:title" content="WUPHF — You do not build automations. You hire agents.">
-<meta property="og:description" content="Describe a job once, or demo it on a call while WUPHF watches. Get an agent with its own app, schedule, tools, and memory — 24x7, on your machine.">
+<meta property="og:title" content="WUPHF — Turn your manual workflows into AI agents">
+<meta property="og:description" content="AI agents that can connect to 100+ integrations and automate manual tasks you couldn't automate before. Runs local, source-available, nothing sent without your approval.">
 <meta property="og:type" content="website">
 <meta property="og:url" content="https://wuphf.team">
 <meta property="og:site_name" content="WUPHF">
@@ -15,19 +15,19 @@
 <meta property="og:image" content="https://wuphf.team/og-image.png">
 <meta property="og:image:width" content="1280">
 <meta property="og:image:height" content="720">
-<meta property="og:image:alt" content="WUPHF — hire agents, not automations. Source-available, local-first agents with pixel-art charm.">
+<meta property="og:image:alt" content="WUPHF — turn your manual workflows into AI agents.">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="WUPHF — You do not build automations. You hire agents.">
-<meta name="twitter:description" content="Describe a job once, or demo it on a call while WUPHF watches. Get an agent with its own app, schedule, tools, and memory — 24x7, on your machine.">
+<meta name="twitter:title" content="WUPHF — Turn your manual workflows into AI agents">
+<meta name="twitter:description" content="AI agents that can connect to 100+ integrations and automate manual tasks you couldn't automate before.">
 <meta name="twitter:image" content="https://wuphf.team/og-image.png">
-<meta name="twitter:image:alt" content="WUPHF — hire agents, not automations. Source-available, local-first agents with pixel-art charm.">
-<meta name="theme-color" content="#1b0d2a">
+<meta name="twitter:image:alt" content="WUPHF — turn your manual workflows into AI agents.">
+<meta name="theme-color" content="#131416">
 <link rel="icon" type="image/svg+xml" href="favicon.svg">
 <link rel="icon" type="image/png" sizes="32x32" href="favicon-32.png">
 <link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon.png">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&family=VT323:wght@400&family=DM+Mono:wght@400;500&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700&family=Geist+Mono:wght@400;500&display=swap" rel="stylesheet">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -63,7 +63,7 @@
       "url": "https://wuphf.team",
       "applicationCategory": "DeveloperApplication",
       "operatingSystem": "macOS, Linux, Windows",
-      "description": "Describe a job in one sentence, or demo it once on a screen-share call. WUPHF builds an agent that does it: its own app UI, scheduled routines, self-authored tools, and cited knowledge. Local-first, source-available, with a human approval gate on everything it sends.",
+      "description": "AI agents that can connect to 100+ integrations and automate manual tasks you couldn't automate before. Describe the job or demo it once; the agent runs it 24x7 on your machine with a human approval gate on everything it sends.",
       "license": "https://github.com/nex-crm/wuphf/blob/main/LICENSE",
       "downloadUrl": "https://github.com/nex-crm/wuphf",
       "offers": {
@@ -79,1163 +79,369 @@
 <style>
   *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
+  /* ── Tokens: mirrors the app's nex-shell theme (web/public/themes/nex-shell.css
+     + operator-shell.css). Paper-dark surfaces, soft ink, cobalt = meaning. ── */
   :root {
-    --bg: #1b0d2a;
-    --surface: #24123a;
-    --surface-high: #2e1647;
-    --border: #612a92;
-    --yellow: #cf72d9;
-    --yellow-dark: #9f4dbf;
-    --yellow-glow: rgba(207,114,217,0.12);
-    --green: #D4DB18;
-    --blue: #ffb3e6;
-    --text: #ffebfc;
-    --text-muted: #a580c0;
-    --bg2: var(--surface);
-    --bg3: var(--surface-high);
-    --yellow-dim: var(--yellow-glow);
-    --accent-lime: var(--green);
-    --text-dim: var(--text-muted);
-    --font-display: 'Press Start 2P', monospace;
-    --font-vt: 'VT323', monospace;
-    --font-mono: 'DM Mono', monospace;
+    --bg: hsl(210 6% 8%);
+    --bg-subtle: hsl(210 6% 6%);
+    --bg-card: hsl(210 5% 10%);
+    --bg-elevated: hsl(214 5% 14%);
+    --text: hsl(210 8% 82%);
+    --text-2: hsl(215 6% 60%);
+    --text-3: hsl(215 6% 46%);
+    --line: hsl(210 6% 20%);
+    --line-soft: hsl(210 6% 16%);
+    --line-strong: hsl(210 6% 32%);
+    --accent: oklch(63.79% 0.1899 269.89);   /* cobalt — links, focus, meaning */
+    --accent-soft: oklch(76.12% 0.1218 272.4);
+    --accent-bg: color-mix(in srgb, oklch(50.58% 0.2886 264.84) 16%, transparent);
+    --green: oklch(0.76 0.11 158);           /* status: good / savings */
+    --amber: hsl(38 45% 62%);
+    --inv: hsl(210 8% 88%);                  /* B&W button fill */
+    --inv-fg: hsl(210 6% 10%);
+    --font-sans: "Geist", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    --font-mono: "Geist Mono", "SFMono-Regular", Menlo, Monaco, Consolas, monospace;
+    --radius-sm: 4px;
+    --radius-md: 8px;
+    --radius-lg: 12px;
+    --speckle: color-mix(in srgb, hsl(210 8% 82%) 3%, transparent);
   }
 
   html { scroll-behavior: smooth; }
 
   body {
     background: var(--bg);
+    background-image: radial-gradient(var(--speckle) 1px, transparent 1px);
+    background-size: 22px 22px;
     color: var(--text);
-    font-family: var(--font-mono);
+    font-family: var(--font-sans);
     line-height: 1.6;
     min-height: 100vh;
     overflow-x: hidden;
+    -webkit-font-smoothing: antialiased;
   }
 
-  /* ── NAV ─────────────────────────────────────────────── */
-  nav {
-    position: fixed; top: 0; left: 0; right: 0; z-index: 100;
-    height: 44px;
-    background: var(--bg);
-    border-bottom: 2px solid var(--yellow);
-    display: flex; align-items: center;
-    padding: 0 24px;
-    gap: 24px;
-  }
-  .nav-logo {
-    font-family: var(--font-display);
-    font-size: 11px;
-    color: var(--yellow);
-    letter-spacing: 0.05em;
-    text-decoration: none;
-  }
-  .nav-by {
+  ::selection { background: var(--accent-bg); }
+  a { color: var(--accent-soft); }
+  a:focus-visible, button:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+  code {
     font-family: var(--font-mono);
-    font-size: 9px;
-    color: var(--text-dim);
-    letter-spacing: 0.04em;
-    font-weight: 400;
-  }
-  .nav-links { display: flex; gap: 4px; margin-left: auto; }
-  .nav-links a {
-    font-family: var(--font-mono);
-    font-size: 11px;
-    color: var(--text-dim);
-    text-decoration: none;
-    letter-spacing: 0.04em;
-    display: flex; align-items: center;
-    min-height: 44px; padding: 0 12px;
-  }
-  .nav-links a:hover { color: var(--yellow); }
-  .nav-social {
-    display: flex; align-items: center; gap: 4px;
-  }
-  .nav-social-link {
-    display: flex; align-items: center; gap: 5px;
-    font-family: var(--font-mono);
-    font-size: 11px;
-    color: var(--text-dim);
-    text-decoration: none;
-    letter-spacing: 0.04em;
-    transition: color 0.15s;
-    min-width: 44px; min-height: 44px; padding: 0 10px;
-    justify-content: center;
-  }
-  .nav-social-link:hover { color: var(--yellow); }
-  .nav-social-link svg { flex-shrink: 0; }
-  .nav-star-count { font-size: 10px; }
-  .nav-badge {
-    font-family: var(--font-display);
-    font-size: 8px;
-    color: var(--bg);
-    background: var(--yellow);
-    padding: 0 12px;
-    min-height: 44px;
-    border: none;
-    cursor: pointer;
-    white-space: nowrap;
-    display: inline-flex;
-    align-items: center;
-    text-decoration: none;
-  }
-
-  /* ── HERO ─────────────────────────────────────────── */
-  .hero {
-    padding-top: 88px;
-    min-height: 100vh;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    position: relative;
-    overflow: hidden;
-  }
-
-  .hero::before {
-    content: '';
-    position: absolute; inset: 0;
-    background:
-      radial-gradient(ellipse 700px 400px at 50% 48%, rgba(207,114,217,0.07) 0%, transparent 70%),
-      repeating-linear-gradient(
-        0deg,
-        transparent,
-        transparent 3px,
-        rgba(0,0,0,0.09) 3px,
-        rgba(0,0,0,0.09) 4px
-      );
-    pointer-events: none; z-index: 1;
-  }
-
-  .hero-inner {
-    position: relative; z-index: 2;
-    display: flex; flex-direction: column;
-    align-items: center;
-    text-align: center;
-    padding: 0 24px;
-    max-width: 900px;
-    width: 100%;
-  }
-
-  .hero-sprites {
-    display: flex; gap: 32px; margin-bottom: 48px;
-    align-items: flex-end;
-    height: 80px;
-  }
-
-  .sprite {
-    display: flex; flex-direction: column; align-items: center; gap: 4px;
-    animation: sprite-bob 0.5s steps(1, end) infinite;
-  }
-  .sprite:nth-child(2) { animation-delay: 0.125s; }
-  .sprite:nth-child(3) { animation-delay: 0.25s; }
-
-  @keyframes sprite-bob {
-    0%, 100% { transform: translateY(0); }
-    50% { transform: translateY(-4px); }
-  }
-
-  .sprite-name {
-    font-family: var(--font-vt);
-    font-size: 14px;
-    color: var(--text-dim);
-    letter-spacing: 0.04em;
-  }
-
-  .label-tag {
-    font-family: var(--font-display);
-    font-size: 6px;
-    color: var(--bg);
-    background: var(--yellow);
-    padding: 3px 6px;
-  }
-
-  .hero-eyebrow {
-    font-family: var(--font-display);
-    font-size: 9px;
-    color: var(--yellow);
-    letter-spacing: 0.12em;
-    margin-bottom: 24px;
-    display: flex; align-items: center; gap: 8px;
-  }
-  .blink {
-    width: 8px; height: 12px;
-    background: var(--accent-lime);
-    display: inline-block;
-    animation: blink-cursor 1s steps(1, end) infinite;
-  }
-  @keyframes blink-cursor {
-    0%, 50% { opacity: 1; }
-    51%, 100% { opacity: 0; }
-  }
-
-  .hero-title {
-    font-family: var(--font-display);
-    font-size: clamp(40px, 8vw, 72px);
-    color: var(--yellow);
-    line-height: 1.1;
-    letter-spacing: 0.04em;
-    margin-left: -8px;
-    margin-bottom: 16px;
-    text-shadow: 6px 6px 0 var(--yellow-dark);
+    font-size: 0.92em;
+    background: var(--bg-elevated);
+    border: 1px solid var(--line-soft);
+    border-radius: var(--radius-sm);
+    padding: 1px 5px;
   }
   .visually-hidden {
-    position: absolute !important;
-    width: 1px; height: 1px;
-    padding: 0; margin: -1px;
-    overflow: hidden;
-    clip: rect(0, 0, 0, 0);
-    white-space: nowrap;
-    border: 0;
+    position: absolute; width: 1px; height: 1px;
+    clip: rect(0 0 0 0); clip-path: inset(50%); overflow: hidden; white-space: nowrap;
   }
+
+  /* ── NAV ── */
+  nav {
+    position: fixed; top: 0; left: 0; right: 0; z-index: 100;
+    height: 52px;
+    background: color-mix(in srgb, var(--bg) 88%, transparent);
+    backdrop-filter: blur(8px);
+    border-bottom: 1px solid var(--line-soft);
+    display: flex; align-items: center; gap: 20px;
+    padding: 0 20px;
+  }
+  .nav-logo {
+    font-family: var(--font-mono);
+    font-weight: 500; font-size: 15px; letter-spacing: 0.08em;
+    color: var(--text);
+  }
+  .nav-by { font-size: 11px; color: var(--text-3); letter-spacing: 0.02em; margin-left: 6px; }
+  .nav-links { display: flex; gap: 2px; margin-left: auto; }
+  .nav-links a {
+    font-family: var(--font-mono); font-size: 12px;
+    color: var(--text-2); text-decoration: none;
+    padding: 6px 10px; border-radius: var(--radius-sm);
+  }
+  .nav-links a:hover { color: var(--text); background: var(--bg-elevated); }
+  .nav-social { display: flex; align-items: center; gap: 10px; }
+  .nav-social-link { color: var(--text-2); display: inline-flex; align-items: center; gap: 6px; text-decoration: none; }
+  .nav-social-link:hover { color: var(--text); }
+  .nav-star-count { font-family: var(--font-mono); font-size: 12px; }
+  .nav-badge {
+    font-family: var(--font-mono); font-size: 11px; font-weight: 500;
+    letter-spacing: 0.08em; text-decoration: none;
+    background: var(--inv); color: var(--inv-fg);
+    padding: 7px 14px; border-radius: var(--radius-sm);
+  }
+  .nav-badge:hover { background: hsl(210 8% 96%); }
+
+  /* ── HERO ── */
+  .hero {
+    min-height: 92vh;
+    display: flex; align-items: center; justify-content: center;
+    padding: 110px 20px 60px;
+    text-align: center;
+    position: relative;
+  }
+  .hero-inner { max-width: 780px; display: flex; flex-direction: column; align-items: center; }
+  .hero-eyebrow {
+    font-family: var(--font-mono); font-size: 12px; letter-spacing: 0.14em;
+    text-transform: uppercase; color: var(--text-2);
+    display: inline-flex; align-items: center; gap: 8px;
+    border: 1px solid var(--line); border-radius: 999px;
+    padding: 6px 14px; margin-bottom: 28px;
+    background: var(--bg-card);
+  }
+  .led {
+    width: 7px; height: 7px; border-radius: 50%;
+    background: var(--green);
+    box-shadow: 0 0 6px color-mix(in srgb, var(--green) 60%, transparent);
+  }
+  .hero-title {
+    font-size: clamp(38px, 6vw, 64px);
+    font-weight: 700; line-height: 1.08; letter-spacing: -0.02em;
+    color: var(--text);
+  }
+  .hero-title em { font-style: normal; color: var(--accent-soft); }
   .hero-by {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 8px;
-    color: var(--text-dim);
-    font-family: var(--font-mono);
-    font-size: clamp(11px, 1.4vw, 14px);
-    letter-spacing: 0.08em;
-    font-weight: 400;
-    text-shadow: none;
-    margin-top: 8px;
-    margin-bottom: 16px;
-    text-decoration: none;
-    transition: color 0.15s;
-    min-height: 44px;
+    display: inline-flex; align-items: center; gap: 8px;
+    color: var(--text-3); text-decoration: none;
+    font-size: 13px; margin-top: 18px;
   }
-  .hero-by:hover { color: var(--text); }
-  .hero-nex-logo {
-    height: 16px;
-    width: auto;
-    color: var(--text-dim);
-    vertical-align: middle;
-  }
-
-  /* ── BACKED BY Y COMBINATOR (official badge) ───────── */
-  .yc-badge {
-    display: inline-flex;
-    line-height: 0;
-    margin: 4px 0 28px;
-    border-radius: 10px;
-    transition: opacity 0.15s, transform 0.15s;
-  }
-  .yc-badge img {
-    height: 44px;
-    width: auto;
-    display: block;
-  }
-  .yc-badge:hover { opacity: 0.92; transform: translateY(-1px); }
-  .yc-badge:focus-visible {
-    outline: 2px solid #fb651e;
-    outline-offset: 3px;
-  }
-  @media (prefers-reduced-motion: reduce) {
-    .yc-badge { transition: opacity 0.15s; }
-    .yc-badge:hover { transform: none; }
-  }
-
+  .hero-by:hover { color: var(--text-2); }
+  .hero-nex-logo { height: 16px; width: auto; }
+  .yc-badge { margin-top: 14px; display: inline-block; }
+  .yc-badge img { height: 26px; width: auto; display: block; }
   .hero-tagline {
-    font-family: var(--font-mono);
-    font-size: clamp(14px, 1.8vw, 17px);
-    color: var(--text);
-    line-height: 1.7;
-    max-width: 600px;
-    margin-bottom: 40px;
+    margin-top: 26px;
+    font-size: 18px; line-height: 1.65;
+    color: var(--text-2);
+    max-width: 620px;
   }
 
-  .hero-tagline em {
-    font-style: normal;
-    color: var(--yellow);
-    font-weight: 500;
-  }
-
-  .install-wrap {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 0;
-    margin-bottom: 40px;
-    width: 100%;
-    max-width: 560px;
-    scroll-margin-top: 60px;
-  }
-
-  .install-tabs {
-    display: flex;
-    width: 100%;
-  }
+  /* ── INSTALL ── */
+  .install-wrap { margin-top: 36px; width: 100%; max-width: 560px; }
+  .install-tabs { display: flex; gap: 6px; justify-content: center; margin-bottom: 10px; }
   .install-tab {
-    flex: 1;
-    min-height: 44px;
-    padding: 10px 12px;
-    font-family: var(--font-display);
-    font-size: 8px;
-    letter-spacing: 0.08em;
-    color: var(--text-dim);
-    background: var(--bg);
-    border: 2px solid var(--yellow-dark);
-    border-bottom: 2px solid var(--yellow);
-    cursor: pointer;
-    text-align: center;
-    transition: color 0.15s, background 0.15s;
+    font-family: var(--font-mono); font-size: 11px; letter-spacing: 0.1em;
+    background: none; border: 1px solid var(--line); border-radius: 999px;
+    color: var(--text-2); padding: 5px 14px; cursor: pointer;
   }
-  .install-tab.active {
-    color: var(--yellow);
-    background: var(--bg3);
-    border: 2px solid var(--yellow);
-    border-bottom: 2px solid var(--bg3);
-  }
-
-  .install-block {
-    width: 100%;
-    background: var(--bg3);
-    border: 2px solid var(--yellow);
-    border-top: none;
-    box-shadow: 4px 4px 0 var(--yellow-dark);
-    display: none;
-    flex-direction: column;
-    gap: 6px;
-    padding: 14px 20px;
-  }
-  .install-block.active { display: flex; }
-
+  .install-tab.active { color: var(--text); border-color: var(--line-strong); background: var(--bg-elevated); }
+  .install-block { display: none; }
+  .install-block.active { display: block; }
   .install-line {
-    display: flex;
-    align-items: center;
-    gap: 12px;
     width: 100%;
-    min-height: 44px;
-    padding: 0;
-    color: inherit;
-    background: transparent;
-    border: 0;
-    cursor: pointer;
-    text-align: left;
-  }
-  .install-line:hover,
-  .install-line:focus-visible {
-    background: var(--bg2);
-  }
-
-  .install-prompt {
-    font-family: var(--font-mono);
-    font-size: 14px;
-    color: var(--accent-lime);
-    flex-shrink: 0;
-  }
-  .install-cmd {
-    font-family: var(--font-mono);
-    font-size: 14px;
-    color: var(--text);
-    flex: 1;
-    text-align: left;
-  }
-  .install-copy {
-    font-family: var(--font-display);
-    font-size: 8px;
-    color: var(--text-dim);
-    flex-shrink: 0;
-    letter-spacing: 0.08em;
-  }
-  .install-copy.copied { color: var(--accent-lime); }
-
-  .install-note {
-    font-family: var(--font-mono);
-    font-size: 11px;
-    color: var(--text-dim);
-    margin-top: 16px;
-  }
-
-  .hero-ctas {
-    display: flex; gap: 16px; align-items: center; flex-wrap: wrap; justify-content: center;
-  }
-  .hero-cloud-cta {
-    font-family: var(--font-mono);
-    font-size: 12px;
-    color: var(--text-dim);
-    margin: 16px 0 0;
-    text-align: center;
-  }
-  .cloud-cta-link {
-    color: var(--yellow);
-    text-decoration: none;
-  }
-  .cloud-cta-link:hover {
-    text-decoration: underline;
-  }
-
-  .btn-primary {
-    font-family: var(--font-display);
-    font-size: 10px;
-    color: var(--bg);
-    display: inline-flex !important;
-    align-items: center;
-    gap: 8px;
-    background: var(--yellow);
-    border: none;
-    padding: 14px 24px;
-    cursor: pointer;
-    box-shadow: 4px 4px 0 var(--yellow-dark);
-    text-decoration: none;
-    display: inline-block;
-    letter-spacing: 0.06em;
-  }
-  .btn-primary:hover { transform: translate(-1px, -1px); box-shadow: 5px 5px 0 var(--yellow-dark); }
-  .btn-primary:active { transform: translate(2px, 2px); box-shadow: 2px 2px 0 var(--yellow-dark); }
-
-  .btn-ghost {
-    font-family: var(--font-display);
-    font-size: 10px;
-    color: var(--yellow);
-    background: transparent;
-    border: 2px solid var(--yellow);
-    padding: 12px 22px;
-    cursor: pointer;
-    box-shadow: 3px 3px 0 var(--yellow-dark);
-    text-decoration: none;
-    display: inline-block;
-    letter-spacing: 0.06em;
-  }
-  .btn-ghost:hover { background: var(--yellow-dim); }
-
-  .scroll-hint {
-    position: absolute; bottom: 24px; left: 50%; transform: translateX(-50%);
-    z-index: 2;
-    display: flex; flex-direction: column; align-items: center; gap: 8px;
-  }
-  .scroll-arrow {
-    width: 12px; height: 12px;
-    border-right: 3px solid var(--yellow);
-    border-bottom: 3px solid var(--yellow);
-    transform: rotate(45deg);
-    animation: arrow-bounce 0.8s steps(1, end) infinite;
-  }
-  .scroll-arrow:nth-child(2) {
-    animation-delay: 0.2s; margin-top: -8px; opacity: 0.5;
-    border-right-color: var(--accent-lime);
-    border-bottom-color: var(--accent-lime);
-  }
-  @keyframes arrow-bounce {
-    0%, 50% { opacity: 1; }
-    51%, 100% { opacity: 0.2; }
-  }
-
-  /* ── AMBIENT STRIP ────────────────────────────────── */
-  .ambient-strip {
-    background: var(--yellow);
-    padding: 12px 0;
-    overflow: hidden;
-    white-space: nowrap;
-    border-top: 2px solid var(--yellow-dark);
-    border-bottom: 2px solid var(--yellow-dark);
-  }
-  .ambient-scroll {
-    display: inline-flex; gap: 64px;
-    animation: marquee 120s steps(240, end) infinite;
-    will-change: transform;
-  }
-  .is-page-hidden .ambient-scroll { animation-play-state: paused; }
-  @keyframes marquee {
-    from { transform: translateX(0); }
-    to { transform: translateX(-50%); }
-  }
-  .ambient-item {
-    font-family: var(--font-vt);
-    font-size: 22px;
-    color: var(--bg);
-    letter-spacing: 0.06em;
-    flex-shrink: 0;
-  }
-
-  /* ── VIDEO SECTION ───────────────────────────────── */
-  .video-section {
-    padding: 72px 24px 40px;
-    max-width: 800px;
-    margin: 0 auto;
-    text-align: center;
-  }
-  .video-prompt {
-    font-family: var(--font-vt);
-    font-size: 32px;
-    color: var(--text);
-    letter-spacing: 0.06em;
-    margin: 0 0 28px;
-  }
-  .video-wrap {
-    position: relative;
-    border: 2px solid var(--yellow-dark);
-    line-height: 0;
-    margin: 24px auto 0;
-    max-width: 720px;
-  }
-  .video-wrap video {
-    width: 100%;
-    height: auto;
-    display: block;
-    background: #000;
-  }
-  .video-wrap::before {
-    content: '';
-    position: absolute;
-    inset: -2px;
-    box-shadow: inset 0 0 0 2px var(--yellow-dark);
-    pointer-events: none;
-  }
-
-  /* ── SECTIONS ─────────────────────────────────────── */
-  section { padding: 80px 24px; max-width: 1000px; margin: 0 auto; }
-
-  .office-section,
-  #open-source,
-  footer {
-    content-visibility: auto;
-    contain-intrinsic-size: auto 640px;
-  }
-
-  .section-eyebrow {
-    font-family: var(--font-display);
-    font-size: 8px;
-    color: var(--yellow);
-    letter-spacing: 0.14em;
-    margin-bottom: 16px;
     display: flex; align-items: center; gap: 12px;
-  }
-  .section-eyebrow::after {
-    content: '';
-    flex: 1;
-    height: 2px;
-    background: var(--yellow-dark);
-  }
-  .section-eyebrow::before {
-    content: '';
-    width: 8px; height: 8px;
-    background: var(--accent-lime);
-    flex-shrink: 0;
-  }
-
-  .section-title {
-    font-family: var(--font-display);
-    font-size: clamp(22px, 3.5vw, 36px);
+    font-family: var(--font-mono); font-size: 14px;
+    background: var(--bg-card);
+    border: 1px solid var(--line); border-radius: var(--radius-md);
     color: var(--text);
-    line-height: 1.4;
-    margin-bottom: 20px;
+    padding: 14px 16px; margin-bottom: 8px;
+    cursor: pointer; text-align: left;
   }
+  .install-line:hover { border-color: var(--line-strong); }
+  .install-prompt { color: var(--accent-soft); user-select: none; }
+  .install-cmd { flex: 1; overflow-x: auto; white-space: nowrap; }
+  .install-copy {
+    font-size: 10px; letter-spacing: 0.12em; color: var(--text-3);
+    border: 1px solid var(--line); border-radius: var(--radius-sm);
+    padding: 3px 8px; user-select: none;
+  }
+  .install-line:hover .install-copy { color: var(--text); border-color: var(--line-strong); }
+  .install-note { margin-top: 12px; font-size: 13px; color: var(--text-3); }
 
-  .section-body {
-    font-family: var(--font-mono);
-    font-size: 16px;
-    color: var(--text);
-    line-height: 1.8;
-    max-width: 640px;
-    margin-bottom: 48px;
-  }
-
-  /* ── HOW IT WORKS ─────────────────────────────────── */
-  .steps-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-    gap: 2px;
-    background: var(--yellow-dark);
-    border: 2px solid var(--yellow-dark);
-  }
-
-  .step-card {
-    background: var(--bg2);
-    padding: 28px 24px;
-  }
-
-  .step-num {
-    font-family: var(--font-display);
-    font-size: 9px;
-    color: var(--accent-lime);
-    margin-bottom: 16px;
-    letter-spacing: 0.1em;
-  }
-
-  .step-icon {
-    font-size: 32px;
-    margin-bottom: 12px;
-    display: block;
-  }
-
-  .step-title {
-    font-family: var(--font-display);
-    font-size: 12px;
-    color: var(--text);
-    line-height: 1.6;
-    margin-bottom: 8px;
-    letter-spacing: 0.04em;
-  }
-
-  .step-body {
-    font-family: var(--font-mono);
-    font-size: 14px;
-    color: var(--text-dim);
-    line-height: 1.7;
-  }
-
-  /* ── AGENT CARDS ──────────────────────────────────── */
-  .agents-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-    gap: 16px;
-  }
-
-  .agent-card {
-    background: var(--bg2);
-    border: 2px solid var(--yellow-dark);
-    padding: 24px;
-  }
-  .agent-card:hover {
-    border-color: var(--yellow);
-    box-shadow: 4px 4px 0 var(--yellow-dark);
-    transform: translate(-2px, -2px);
-  }
-
-  .agent-badge {
-    font-family: var(--font-display);
-    font-size: 8px;
-    color: var(--bg);
-    background: var(--yellow);
-    padding: 4px 10px;
-    display: inline-block;
-    margin-bottom: 16px;
-    letter-spacing: 0.08em;
-  }
-
-  .agent-title {
-    font-family: var(--font-display);
-    font-size: 14px;
-    color: var(--text);
-    line-height: 1.5;
-    margin-bottom: 12px;
-    letter-spacing: 0.04em;
-  }
-
-  .agent-desc {
-    font-family: var(--font-mono);
-    font-size: 14px;
-    color: var(--text-dim);
-    line-height: 1.7;
-    margin-bottom: 16px;
-  }
-
-  .agent-quote {
-    font-family: var(--font-vt);
-    font-size: 22px;
-    color: var(--yellow);
-    line-height: 1.4;
-    opacity: 0.85;
-  }
-  .agent-quote::before {
-    content: '▸ ';
-    font-size: 14px;
-  }
-
-  /* ── CODE DEMO ────────────────────────────────────── */
-  .code-demo {
-    background: var(--bg3);
-    border: 2px solid var(--yellow);
-    box-shadow: 6px 6px 0 var(--yellow-dark);
-    overflow: hidden;
-    max-width: 700px;
-  }
-
-  .code-titlebar {
-    background: var(--yellow);
-    padding: 8px 16px;
-    display: flex; align-items: center; gap: 8px;
-  }
-
-  .code-dot {
-    width: 8px; height: 8px;
-    background: var(--bg);
-    display: inline-block;
-  }
-
-  .code-label {
-    font-family: var(--font-display);
-    font-size: 8px;
-    color: var(--bg);
-    margin-left: 8px;
-    letter-spacing: 0.06em;
-  }
-
-  pre {
-    padding: 20px 24px;
-    font-family: var(--font-mono);
-    font-size: 15px;
-    color: var(--text);
-    line-height: 1.8;
-    overflow-x: auto;
-  }
-
-  .tok-kw { color: var(--yellow); }
-  .tok-str { color: var(--accent-lime); }
-  .tok-cmt { color: var(--text-dim); font-style: italic; }
-  .tok-fn { color: var(--blue); }
-
-  /* ── THREAD DEMO ──────────────────────────────────── */
-  .thread-demo {
-    display: flex; flex-direction: column;
-    max-width: 560px; gap: 0;
-  }
-
-  .thread-root {
-    display: flex; gap: 12px; align-items: flex-start;
-    padding: 16px;
-    background: var(--bg3);
-    border: 2px solid var(--yellow);
-  }
-
-  .thread-root-avatar {
-    width: 32px; height: 32px;
-    background: var(--yellow);
-    display: flex; align-items: center; justify-content: center;
-    flex-shrink: 0;
-    font-family: var(--font-display);
-    font-size: 8px; color: var(--bg);
-  }
-
-  .thread-root-body { flex: 1; }
-
-  .thread-root-channel {
-    font-family: var(--font-mono); font-size: 11px;
-    color: var(--yellow); opacity: 0.7; margin-bottom: 8px;
-  }
-
-  .thread-root-text {
-    font-family: var(--font-vt); font-size: 22px;
-    color: var(--yellow); line-height: 1.4;
-  }
-
-  .thread-root-replies {
-    font-family: var(--font-mono); font-size: 11px;
-    color: var(--text-dim); margin-top: 10px;
-    display: flex; align-items: center; gap: 8px;
-  }
-  .thread-root-replies::before {
-    content: ''; width: 2px; height: 14px;
-    background: var(--yellow); display: inline-block;
-  }
-
-  .thread-replies-wrap {
-    display: flex; flex-direction: column; gap: 10px;
-    padding: 12px;
-    border: 2px solid var(--yellow-dark);
-    margin-left: 16px;
-  }
-
-  .thread-reply {
-    display: flex; gap: 12px; align-items: flex-start;
-  }
-
-  .thread-reply-avatar {
-    width: 32px; height: 32px;
-    background: var(--bg3);
-    border: 2px solid var(--yellow-dark);
-    display: flex; align-items: center; justify-content: center;
-    flex-shrink: 0;
-    font-family: var(--font-display); font-size: 8px; color: var(--yellow);
-  }
-  .thread-reply-avatar.you {
-    background: var(--yellow); border-color: var(--yellow); color: var(--bg);
-  }
-
-  .thread-reply-bubble {
-    background: var(--bg3);
-    border: 2px solid var(--yellow-dark);
-    padding: 10px 14px;
-    font-family: var(--font-vt); font-size: 20px;
-    color: var(--text); line-height: 1.4;
-  }
-  .thread-reply.you .thread-reply-bubble {
-    background: var(--yellow-dim);
-    border-color: var(--yellow); color: var(--yellow);
-  }
-
-  .thread-mention {
-    color: var(--yellow);
-    background: var(--yellow-dim);
-    padding: 0 3px;
-    font-family: var(--font-display);
-    font-size: 0.7em;
-    letter-spacing: 0.04em;
-  }
-
-  /* ── CODE-LINE COPY BUTTONS ───────────────────────── */
-  .code-block {
-    padding: 20px 24px;
-    font-family: var(--font-mono);
-    font-size: 15px;
-    color: var(--text);
-    line-height: 1.8;
-    overflow-x: auto;
-  }
-
-  .code-line {
-    display: flex; align-items: center;
-    justify-content: space-between;
-    min-height: 1.8em; white-space: pre;
-    position: relative;
-  }
-  .code-line-empty { min-height: 0.9em; }
-  .line-content { flex: 1; }
-
-  .line-copy {
-    opacity: 0; background: var(--yellow-dark);
-    border: 1px solid var(--yellow-dark);
-    color: var(--yellow);
-    font-family: var(--font-mono); font-size: 11px;
-    cursor: pointer; padding: 6px 9px;
-    min-width: 44px;
-    min-height: 44px;
-    flex-shrink: 0; margin-left: 12px;
-    letter-spacing: 0.04em;
-  }
-  .code-line:hover .line-copy,
-  .code-line:active .line-copy,
-  .line-copy:focus-visible { opacity: 1; }
-  .line-copy:hover { background: var(--yellow); color: var(--bg); border-color: var(--yellow); }
-  @media (hover: none), (pointer: coarse) {
-    .line-copy { opacity: 1; }
-  }
-
-  /* ── ISOMETRIC OFFICE SECTION ─────────────────────── */
-  .office-section {
-    background: var(--bg2);
-    border-top: 3px solid var(--yellow-dark);
-    border-bottom: 3px solid var(--yellow-dark);
-    padding: 32px 0 0;
-    overflow: hidden;
-  }
-
-  .office-section-header {
-    text-align: center;
-    padding: 0 24px 16px;
-  }
-
-  .office-section-eyebrow {
-    font-family: var(--font-display);
-    font-size: 8px;
-    color: var(--yellow);
-    letter-spacing: 0.14em;
-    margin-bottom: 12px;
-  }
-
-  .office-section-title {
-    font-family: var(--font-display);
-    font-size: clamp(18px, 2.5vw, 28px);
-    color: var(--text);
-    line-height: 1.5;
-    margin-bottom: 8px;
-  }
-
-  .office-section-sub {
-    font-family: var(--font-vt);
-    font-size: 22px;
-    color: var(--text-dim);
-    letter-spacing: 0.04em;
-  }
-
-  #officeCanvas {
-    display: block;
-    image-rendering: pixelated;
-    width: 100%;
-  }
-
-  /* ── LICENSE SECTION ─────────────────────────────── */
-  .mit-block {
-    background: var(--bg3);
-    border: 2px solid var(--yellow-dark);
-    padding: 40px;
-    display: grid;
-    grid-template-columns: auto 1fr auto;
-    align-items: center;
-    gap: 40px;
-  }
-  @media (max-width: 768px) {
-    .mit-block { grid-template-columns: 1fr; }
-  }
-
-  .mit-badge {
-    font-family: var(--font-display);
-    font-size: 11px;
-    color: var(--yellow);
-    background: var(--bg);
-    border: 3px solid var(--yellow);
-    padding: 16px 24px;
-    box-shadow: 4px 4px 0 var(--yellow-dark);
-    flex-shrink: 0;
-    text-align: center;
-    line-height: 2;
-  }
-
-  .mit-text {
-    font-family: var(--font-mono);
-    font-size: 15px;
-    color: var(--text);
-    line-height: 1.8;
-  }
-  .mit-text a { color: var(--yellow); text-decoration: none; }
-  .mit-cta {
-    display: flex;
-    flex-direction: column;
-    gap: 12px;
-    align-items: flex-end;
-    flex-shrink: 0;
-  }
-  .mit-cta-btn {
-    font-family: var(--font-display);
-    font-size: 10px;
-    color: var(--bg);
-    background: var(--yellow);
-    border: none;
-    padding: 14px 24px;
-    cursor: pointer;
-    letter-spacing: 0.06em;
+  .hero-ctas { display: flex; gap: 12px; margin-top: 28px; flex-wrap: wrap; justify-content: center; }
+  .btn-primary, .btn-ghost {
+    display: inline-flex; align-items: center; gap: 8px;
+    font-family: var(--font-sans); font-size: 14px; font-weight: 500;
     text-decoration: none;
-    display: inline-flex;
-    align-items: center;
-    gap: 8px;
-    white-space: nowrap;
+    padding: 11px 20px; border-radius: var(--radius-md);
   }
-  .mit-cta-btn:hover { background: var(--text); }
-  .mit-cta-sub {
-    font-family: var(--font-mono);
-    font-size: 12px;
-    color: var(--text-dim);
-    text-align: right;
-    min-height: 44px;
-    display: inline-flex;
-    align-items: center;
-  }
+  .btn-primary { background: var(--inv); color: var(--inv-fg); }
+  .btn-primary:hover { background: hsl(210 8% 96%); }
+  .btn-ghost { border: 1px solid var(--line); color: var(--text); }
+  .btn-ghost:hover { border-color: var(--line-strong); background: var(--bg-elevated); }
+  .hero-cloud-cta { margin-top: 26px; font-size: 13px; color: var(--text-3); }
+  .cloud-cta-link { color: var(--accent-soft); text-decoration: none; }
+  .cloud-cta-link:hover { text-decoration: underline; }
 
-  /* ── FOOTER ───────────────────────────────────────── */
-  footer {
-    padding: 40px 24px 32px;
-    max-width: 1000px;
-    margin: 0 auto;
-    border-top: 2px solid var(--yellow-dark);
-    display: flex;
-    align-items: center;
-    gap: 24px;
-    flex-wrap: wrap;
-  }
-
-  .footer-logo {
-    font-family: var(--font-display);
-    font-size: 9px;
-    color: var(--yellow);
-    letter-spacing: 0.05em;
-  }
-
-  .footer-sub {
-    font-family: var(--font-mono);
-    font-size: 11px;
-    color: var(--text-dim);
-  }
-  .footer-sub a {
-    display: inline-flex;
-    align-items: center;
-    min-width: 44px;
-    min-height: 44px;
-  }
-
-  .footer-links {
-    margin-left: auto;
-    display: flex; gap: 20px;
-  }
-  .footer-links a {
-    font-family: var(--font-mono);
-    font-size: 11px;
-    color: var(--text-dim);
-    text-decoration: none;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    min-width: 44px;
-    min-height: 44px;
-  }
-  .footer-links a:hover { color: var(--yellow); }
-
-  /* ── CONVERSATIONS ────────────────────────────────── */
-  .conversations-layout {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 48px;
-    align-items: start;
-  }
-  .conversations-terminal {
-    min-width: 0;
-  }
-
-  /* ── COMPARE GRID ─────────────────────────────────── */
-  .compare-grid {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 16px;
-  }
-  .compare-card {
-    background: var(--bg2);
-    border: 2px solid var(--yellow-dark);
-    padding: 24px;
-  }
-  .compare-card-good {
-    border-color: var(--yellow);
-    box-shadow: 4px 4px 0 var(--yellow-dark);
-  }
-  .compare-label {
-    font-family: var(--font-display);
-    font-size: 9px;
-    color: var(--text-dim);
-    letter-spacing: 0.12em;
+  /* ── SECTIONS ── */
+  section { max-width: 1060px; margin: 0 auto; padding: 96px 20px; }
+  .section-eyebrow {
+    font-family: var(--font-mono); font-size: 11px; letter-spacing: 0.16em;
+    text-transform: uppercase; color: var(--text-3);
+    display: flex; align-items: center; gap: 12px;
     margin-bottom: 18px;
   }
-  .compare-card-good .compare-label { color: var(--yellow); }
-  .compare-list {
-    list-style: none;
-    padding: 0;
-    margin: 0;
-    display: flex;
-    flex-direction: column;
-    gap: 10px;
+  .section-eyebrow::before {
+    content: ''; width: 8px; height: 8px;
+    background: var(--accent); border-radius: 2px;
+    flex: none;
   }
-  .compare-list li {
-    font-family: var(--font-mono);
-    font-size: 14px;
-    line-height: 1.6;
+  .section-eyebrow::after { content: ''; flex: 1; height: 1px; background: var(--line-soft); }
+  .section-title {
+    font-size: clamp(26px, 4vw, 38px);
+    font-weight: 650; line-height: 1.18; letter-spacing: -0.015em;
     color: var(--text);
-    padding-left: 22px;
-    position: relative;
+    margin-bottom: 14px;
   }
-  .compare-list-neg li {
-    color: var(--text-dim);
+  .section-body { font-size: 16px; color: var(--text-2); max-width: 640px; margin-bottom: 40px; }
+
+  .cards-3, .cards-2 { display: grid; gap: 14px; }
+  .cards-3 { grid-template-columns: repeat(3, 1fr); }
+  @media (max-width: 900px) { .cards-3 { grid-template-columns: 1fr; } }
+
+  .card {
+    background: var(--bg-card);
+    border: 1px solid var(--line);
+    border-radius: var(--radius-md);
+    padding: 22px;
   }
-  .compare-list-neg li::before {
-    content: '\00D7';
-    position: absolute;
-    left: 0;
-    top: 0;
-    color: var(--text-dim);
-    font-family: var(--font-display);
-    font-size: 14px;
-    line-height: 1.4;
+  .card:hover { border-color: var(--line-strong); }
+  .card-num { font-family: var(--font-mono); font-size: 11px; color: var(--text-3); letter-spacing: 0.1em; margin-bottom: 14px; }
+  .card-title { font-size: 16px; font-weight: 600; color: var(--text); margin-bottom: 8px; }
+  .card-body { font-size: 14px; color: var(--text-2); line-height: 1.6; }
+  .card-badge {
+    display: inline-block;
+    font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.12em;
+    color: var(--text-2);
+    border: 1px solid var(--line); border-radius: var(--radius-sm);
+    padding: 3px 8px; margin-bottom: 14px;
+    text-transform: uppercase;
   }
-  .compare-list-pos li::before {
-    content: '+';
-    position: absolute;
-    left: 0;
-    top: 0;
-    color: var(--accent-lime);
-    font-family: var(--font-display);
-    font-size: 12px;
-    line-height: 1.6;
+  .card-metric {
+    margin-top: 14px;
+    font-family: var(--font-mono); font-size: 13px;
+    color: var(--green);
   }
 
-  /* ── FAQ ──────────────────────────────────────────── */
-  .faq-list {
-    display: flex;
-    flex-direction: column;
-    gap: 2px;
-    background: var(--yellow-dark);
-    border: 2px solid var(--yellow-dark);
+  /* ── DEMO CALL ── */
+  .demo-layout { display: grid; grid-template-columns: 1.15fr 1fr; gap: 20px; align-items: start; }
+  @media (max-width: 900px) { .demo-layout { grid-template-columns: 1fr; } }
+  .call-panel {
+    background: var(--bg-card);
+    border: 1px solid var(--line); border-radius: var(--radius-lg);
+    padding: 18px;
   }
+  .call-head {
+    display: flex; align-items: center; gap: 8px;
+    font-family: var(--font-mono); font-size: 11px; letter-spacing: 0.12em;
+    text-transform: uppercase; color: var(--text-3);
+    padding-bottom: 12px; margin-bottom: 14px;
+    border-bottom: 1px solid var(--line-soft);
+  }
+  .rec-dot { width: 7px; height: 7px; border-radius: 50%; background: hsl(6 58% 60%); }
+  .msg { display: flex; gap: 10px; margin-bottom: 10px; }
+  .msg-who {
+    flex: none;
+    font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.08em;
+    color: var(--text-3);
+    border: 1px solid var(--line); border-radius: var(--radius-sm);
+    padding: 3px 6px; height: fit-content; margin-top: 2px;
+  }
+  .msg.you .msg-who { color: var(--accent-soft); border-color: color-mix(in srgb, var(--accent) 40%, transparent); }
+  .msg-bubble {
+    font-size: 14px; line-height: 1.55; color: var(--text);
+    background: var(--bg-elevated);
+    border: 1px solid var(--line-soft); border-radius: var(--radius-md);
+    padding: 9px 13px;
+  }
+  .msg.you .msg-bubble { background: var(--accent-bg); border-color: color-mix(in srgb, var(--accent) 30%, transparent); }
+  .msg-action { font-style: italic; color: var(--text-2); }
+
+  .terminal {
+    background: var(--bg-subtle);
+    border: 1px solid var(--line); border-radius: var(--radius-lg);
+    overflow: hidden;
+  }
+  .term-bar {
+    display: flex; align-items: center; gap: 6px;
+    padding: 10px 14px;
+    border-bottom: 1px solid var(--line-soft);
+  }
+  .term-dot { width: 9px; height: 9px; border-radius: 50%; background: var(--line-strong); }
+  .term-label { font-family: var(--font-mono); font-size: 11px; color: var(--text-3); margin-left: 8px; letter-spacing: 0.1em; }
+  .term-body { padding: 16px; font-family: var(--font-mono); font-size: 13px; line-height: 1.9; }
+  .term-line { display: flex; align-items: center; gap: 10px; white-space: nowrap; overflow-x: auto; }
+  .tok-cmt { color: var(--text-3); }
+  .tok-fn { color: var(--accent-soft); }
+  .line-copy {
+    font-family: var(--font-mono); font-size: 9px; letter-spacing: 0.1em;
+    color: var(--text-3); background: none;
+    border: 1px solid var(--line); border-radius: var(--radius-sm);
+    padding: 2px 6px; cursor: pointer; margin-left: auto;
+  }
+  .line-copy:hover { color: var(--text); border-color: var(--line-strong); }
+
+  .aha {
+    margin-top: 24px;
+    background: var(--bg-card);
+    border: 1px solid var(--line); border-left: 3px solid var(--green);
+    border-radius: var(--radius-md);
+    padding: 18px 20px;
+    max-width: 700px;
+  }
+  .aha-head { font-family: var(--font-mono); font-size: 11px; letter-spacing: 0.12em; color: var(--text-3); text-transform: uppercase; margin-bottom: 12px; }
+  .aha-line { font-size: 14px; color: var(--text); margin-bottom: 6px; }
+  .aha-line b { font-family: var(--font-mono); font-weight: 500; font-size: 12px; color: var(--text-2); margin-right: 6px; }
+  .aha-note { margin-top: 12px; font-size: 13px; color: var(--text-3); }
+
+  /* ── SOURCE AVAILABLE ── */
+  .license-block {
+    background: var(--bg-card);
+    border: 1px solid var(--line); border-radius: var(--radius-lg);
+    padding: 32px;
+    display: flex; gap: 28px; align-items: center; flex-wrap: wrap;
+  }
+  .license-badge {
+    font-family: var(--font-mono); font-size: 11px; letter-spacing: 0.14em;
+    color: var(--text); text-align: center; line-height: 1.7;
+    border: 1px solid var(--line-strong); border-radius: var(--radius-md);
+    padding: 16px 18px;
+  }
+  .license-text { flex: 1; min-width: 260px; font-size: 14px; color: var(--text-2); line-height: 1.8; }
+  .license-cta { display: flex; flex-direction: column; gap: 10px; align-items: flex-start; }
+  .license-cta-btn {
+    display: inline-flex; align-items: center; gap: 8px;
+    background: var(--inv); color: var(--inv-fg);
+    font-size: 14px; font-weight: 500; text-decoration: none;
+    padding: 10px 18px; border-radius: var(--radius-md);
+  }
+  .license-cta-sub { font-size: 13px; color: var(--accent-soft); text-decoration: none; }
+  .license-cta-sub:hover { text-decoration: underline; }
+
+  /* ── FAQ ── */
+  .faq-list { display: flex; flex-direction: column; gap: 8px; max-width: 760px; }
   .faq-item {
-    background: var(--bg2);
-    padding: 0;
+    background: var(--bg-card);
+    border: 1px solid var(--line); border-radius: var(--radius-md);
   }
+  .faq-item[open] { border-color: var(--line-strong); }
   .faq-q {
-    font-family: var(--font-display);
-    font-size: 11px;
-    color: var(--text);
-    letter-spacing: 0.04em;
-    line-height: 1.6;
-    padding: 20px 24px;
-    cursor: pointer;
-    list-style: none;
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    gap: 16px;
+    font-size: 15px; font-weight: 500; color: var(--text);
+    padding: 15px 18px; cursor: pointer; list-style: none;
+    display: flex; justify-content: space-between; align-items: center; gap: 12px;
   }
   .faq-q::-webkit-details-marker { display: none; }
-  .faq-q::after {
-    content: '+';
-    font-family: var(--font-display);
-    font-size: 14px;
-    color: var(--yellow);
-    flex-shrink: 0;
-  }
-  .faq-item[open] .faq-q::after { content: '-'; }
-  .faq-item[open] .faq-q { color: var(--yellow); }
-  .faq-a {
-    font-family: var(--font-mono);
-    font-size: 15px;
-    color: var(--text);
-    line-height: 1.8;
-    padding: 0 24px 24px;
-  }
-  .faq-a code {
-    color: var(--yellow);
-    background: var(--bg3);
-    padding: 1px 6px;
-    font-family: var(--font-mono);
-    font-size: 13px;
-  }
+  .faq-q::after { content: '+'; font-family: var(--font-mono); color: var(--text-3); }
+  .faq-item[open] .faq-q::after { content: '−'; }
+  .faq-a { padding: 0 18px 16px; font-size: 14px; color: var(--text-2); line-height: 1.7; }
 
-  /* ── PRETEXT-MANAGED ──────────────────────────────── */
-  [data-pretext] {
-    /* Heights set by Pretext at runtime — DO NOT set height in CSS */
-    overflow: visible;
+  /* ── FOOTER ── */
+  footer {
+    border-top: 1px solid var(--line-soft);
+    max-width: 1060px; margin: 40px auto 0;
+    padding: 32px 20px 48px;
+    display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 16px;
   }
+  .footer-logo { font-family: var(--font-mono); font-size: 14px; letter-spacing: 0.08em; color: var(--text); }
+  .footer-sub { font-size: 12px; color: var(--text-3); margin-top: 4px; }
+  .footer-sub a { color: var(--text-2); text-decoration: none; }
+  .footer-links { display: flex; gap: 18px; }
+  .footer-links a { font-family: var(--font-mono); font-size: 12px; color: var(--text-2); text-decoration: none; }
+  .footer-links a:hover { color: var(--text); }
 
-  @media (prefers-reduced-motion: reduce) {
-    *,
-    *::before,
-    *::after {
-      animation-duration: 0.001ms !important;
-      animation-iteration-count: 1 !important;
-      scroll-behavior: auto !important;
-      transition-duration: 0.001ms !important;
-    }
-
-    .ambient-scroll,
-    .sprite,
-    .blink,
-    .scroll-arrow {
-      animation: none !important;
-    }
-
-    .btn-primary:hover,
-    .btn-primary:active,
-    .agent-card:hover {
-      transform: none;
-    }
-  }
-
-  /* ── RESPONSIVE ──────────────────────────────────── */
-  @media (max-width: 640px) {
+  @media (max-width: 720px) {
     .nav-links { display: none; }
-    .nav-star-count { display: none; }
-    .nav-social-link { padding: 0 8px; }
-    .nav-badge { padding: 0 10px; }
-
-    .video-section { padding: 40px 16px 24px; }
-    .how-grid, .agents-grid { grid-template-columns: 1fr; }
-
-    .conversations-layout { grid-template-columns: 1fr; }
-    .conversations-terminal { display: none; }
-
-    .compare-grid { grid-template-columns: 1fr; }
-    .faq-q { font-size: 10px; }
-
-    .section-inner { padding: 48px 20px; }
-  }
-
-  @media (max-width: 900px) {
-    .conversations-layout { grid-template-columns: 1fr; }
+    section { padding: 64px 16px; }
   }
 </style>
 </head>
@@ -1243,63 +449,42 @@
 
 <!-- NAV -->
 <nav>
-  <span class="nav-logo">WUPHF <span class="nav-by">by Nex.ai</span></span>
+  <span class="nav-logo">WUPHF<span class="nav-by">by Nex.ai</span></span>
   <div class="nav-links">
     <a href="#how">How it works</a>
     <a href="#demo">The demo call</a>
     <a href="#agents">Your new hire</a>
-    <a href="#different">Use cases</a>
+    <a href="#use-cases">Use cases</a>
     <a href="#faq">FAQ</a>
     <a href="/download.html">Download</a>
   </div>
   <div class="nav-social">
     <a class="nav-social-link" href="https://github.com/nex-crm/wuphf" target="_blank" rel="noopener" aria-label="GitHub">
       <svg viewBox="0 0 16 16" width="15" height="15" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg>
-      <span class="nav-star-count" id="navStars">21 ★</span>
+      <span class="nav-star-count" id="navStars">★</span>
     </a>
     <a class="nav-social-link" href="https://discord.gg/gjSySC3PzV" target="_blank" rel="noopener" aria-label="Discord">
       <svg viewBox="0 0 24 24" width="15" height="15" fill="currentColor"><path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057.101 18.079.111 18.1.127 18.116a19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028 14.09 14.09 0 0 0 1.226-1.994.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z"/></svg>
     </a>
-    <a class="nav-badge" href="#install" onclick="copyInstall()">INSTALL</a>
+    <a class="nav-badge" href="#install">INSTALL</a>
   </div>
 </nav>
 
 <!-- HERO -->
 <section class="hero" id="top">
   <div class="hero-inner">
+    <div class="hero-eyebrow"><span class="led"></span>Runs 24x7 on your machine</div>
 
-    <div class="hero-sprites">
-      <div class="sprite" title="Lead routing agent">
-        <canvas id="s0" width="24" height="36" aria-hidden="true"></canvas>
-        <span class="label-tag">LEADS</span>
-        <span class="sprite-name">Routes</span>
-      </div>
-      <div class="sprite" title="Pipeline recap agent">
-        <canvas id="s1" width="24" height="36" aria-hidden="true"></canvas>
-        <span class="label-tag">RECAP</span>
-        <span class="sprite-name">Mon 9:00</span>
-      </div>
-      <div class="sprite" title="Invoice chasing agent">
-        <canvas id="s2" width="24" height="36" aria-hidden="true"></canvas>
-        <span class="label-tag">INVOICES</span>
-        <span class="sprite-name">Chases</span>
-      </div>
-    </div>
+    <h1 class="hero-title">Turn your manual workflows<br>into <em>AI agents</em></h1>
 
-    <div class="hero-eyebrow">
-      <span class="blink"></span>
-      Your next hire runs on localhost
-    </div>
-
-    <h1 class="hero-title">WUPHF<span class="visually-hidden"> — You do not build automations. You hire agents.</span></h1>
     <a class="hero-by" href="https://nex.ai" target="_blank" rel="noopener" aria-label="Nex.ai">by <svg class="hero-nex-logo" width="95" height="22" viewBox="0 0 95 22" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M11.4968 9.1124C10.2339 7.84948 9.98851 5.898 9.48601 4.18411C9.26753 3.43896 8.86469 2.73685 8.27738 2.14953C6.40286 0.275011 3.35898 0.279701 1.47868 2.16C-0.401626 4.0403 -0.406316 7.08419 1.4682 8.9587C2.05551 9.54601 2.75761 9.94885 3.50275 10.1673C5.21664 10.6698 7.16813 10.9152 8.43106 12.1782C9.69399 13.4411 9.93939 15.3926 10.4419 17.1065C10.6604 17.8516 11.0632 18.5537 11.6505 19.141C13.525 21.0155 16.5689 21.0109 18.4492 19.1306C20.3295 17.2503 20.3342 14.2064 18.4597 12.3319C17.8724 11.7445 17.1703 11.3417 16.4251 11.1232C14.7112 10.6207 12.7597 10.3753 11.4968 9.1124Z" fill="currentColor"/><path d="M7.25926 17.0471C7.25926 19.0517 5.63422 20.6768 3.62963 20.6768C1.62504 20.6768 0 19.0517 0 17.0471C0 15.0425 1.62504 13.4175 3.62963 13.4175C5.63422 13.4175 7.25926 15.0425 7.25926 17.0471Z" fill="currentColor"/><path d="M20 4.30639C20 6.31098 18.375 7.93602 16.3704 7.93602C14.3658 7.93602 12.7407 6.31098 12.7407 4.30639C12.7407 2.3018 14.3658 0.676758 16.3704 0.676758C18.375 0.676758 20 2.3018 20 4.30639Z" fill="currentColor"/><path d="M29.5211 7.15435V20.5967H26.25V1.92676H29.7915L37.4421 14.9957V1.92676H40.7132V20.5967H37.415L29.5211 7.15435Z" fill="currentColor"/><path d="M55.8786 14.5423H45.5787C45.9572 16.356 47.444 17.6896 49.2012 17.6896C50.5259 17.6896 51.6884 16.9428 52.3372 15.7959H55.6083C54.7432 18.6231 52.202 20.6768 49.2012 20.6768C45.4705 20.6768 42.4698 17.5029 42.4698 13.6088C42.4698 9.71481 45.4705 6.54091 49.2012 6.54091C52.202 6.54091 54.7432 8.59461 55.6083 11.4218C55.8246 12.1152 55.9327 12.8354 55.9327 13.6088C55.9327 13.9289 55.9327 14.2223 55.8786 14.5423ZM46.0653 11.4218H52.3372C51.6884 10.2749 50.5259 9.52811 49.2012 9.52811C47.8766 9.52811 46.7141 10.2749 46.0653 11.4218Z" fill="currentColor"/><path d="M68.75 6.32754L63.965 13.4755L68.75 20.5967H64.9652L62.0726 16.276L59.1529 20.5967H55.3952L60.1802 13.4755L55.3952 6.32754H59.1529L62.0726 10.6483L64.9652 6.32754H68.75Z" fill="currentColor"/><circle cx="72" cy="18.6768" r="2" fill="currentColor"/><path d="M94.3129 3.422C93.9263 3.80867 93.4623 4.002 92.9209 4.002C92.3796 4.002 91.9059 3.80867 91.4999 3.422C91.1133 3.016 90.9199 2.54233 90.9199 2.001C90.9199 1.45967 91.1133 0.995667 91.4999 0.609001C91.8866 0.203 92.3603 0 92.9209 0C93.4816 0 93.9553 0.203 94.3419 0.609001C94.7286 0.995667 94.9219 1.45967 94.9219 2.001C94.9219 2.54233 94.7189 3.016 94.3129 3.422ZM91.3549 20.677V6.177H94.4869V20.677H91.3549Z" fill="currentColor"/><path d="M85.5131 6.17681H88.7697V20.6768H85.5131V18.5888C84.4699 20.2321 82.9736 21.0538 81.024 21.0538C79.2626 21.0538 77.7577 20.3191 76.5093 18.8498C75.2609 17.3611 74.6367 15.5535 74.6367 13.4268C74.6367 11.2808 75.2609 9.47314 76.5093 8.0038C77.7577 6.53447 79.2626 5.7998 81.024 5.7998C82.9736 5.7998 84.4699 6.6118 85.5131 8.2358V6.17681ZM78.5614 16.7618C79.331 17.6318 80.2972 18.0668 81.4601 18.0668C82.623 18.0668 83.5892 17.6318 84.3587 16.7618C85.1283 15.8725 85.5131 14.7608 85.5131 13.4268C85.5131 12.0928 85.1283 10.9908 84.3587 10.1208C83.5892 9.23147 82.623 8.7868 81.4601 8.7868C80.2972 8.7868 79.331 9.23147 78.5614 10.1208C77.7919 10.9908 77.4071 12.0928 77.4071 13.4268C77.4071 14.7608 77.7919 15.8725 78.5614 16.7618Z" fill="currentColor"/></svg></a>
 
     <a class="yc-badge" href="https://www.ycombinator.com/" target="_blank" rel="noopener noreferrer" aria-label="Backed by Y Combinator">
       <img src="yc-badge.svg" alt="Backed by Y Combinator" width="543" height="102">
     </a>
 
-    <p class="hero-tagline" data-pretext>
-      Turn your manual workflows into AI agents. Describe the job — or demo it once — and it runs 24x7 on your machine.
+    <p class="hero-tagline">
+      AI agents that can connect to 100+ integrations and automate manual tasks you couldn't automate before.
     </p>
 
     <div class="install-wrap" id="install">
@@ -1333,273 +518,215 @@
     <div class="hero-ctas">
       <a href="https://github.com/nex-crm/wuphf" class="btn-primary" target="_blank" rel="noopener">
         <svg viewBox="0 0 16 16" width="14" height="14" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg>
-        GitHub &nbsp;<span id="heroStars">★ 21</span>
+        GitHub&nbsp;<span id="heroStars">★</span>
       </a>
       <a href="/download.html" class="btn-ghost">
-        <svg viewBox="0 0 16 16" width="13" height="13" fill="currentColor" style="vertical-align:middle;margin-right:5px"><path d="M7 1h2v6h3l-4 5-4-5h3V1zM2 13h12v2H2z"/></svg>
+        <svg viewBox="0 0 16 16" width="13" height="13" fill="currentColor"><path d="M7 1h2v6h3l-4 5-4-5h3V1zM2 13h12v2H2z"/></svg>
         Download
       </a>
     </div>
 
     <p class="hero-cloud-cta">Hiring for a whole team? Nex Cloud is the hosted big sibling. <a class="cloud-cta-link" href="https://nex.ai" target="_blank" rel="noopener">Get Nex Cloud →</a></p>
-
-  </div>
-
-  <div class="scroll-hint">
-    <div class="scroll-arrow"></div>
-    <div class="scroll-arrow"></div>
   </div>
 </section>
-
-<!-- AMBIENT TICKER -->
-<div class="ambient-strip">
-  <div class="ambient-scroll" id="ticker"></div>
-</div>
 
 <!-- HOW IT WORKS -->
 <section id="how">
-  <div class="section-eyebrow">HOW IT WORKS</div>
-  <h2 class="section-title" data-pretext>Show. Build. Approve.</h2>
-  <p class="section-body" data-pretext>
-    You are onboarding a hire, not configuring software.
-  </p>
+  <div class="section-eyebrow">How it works</div>
+  <h2 class="section-title">Show. Build. Approve.</h2>
+  <p class="section-body">You are onboarding a hire, not configuring software.</p>
 
-  <div class="steps-grid">
-    <div class="step-card">
-      <div class="step-num">01</div>
-      <span class="step-icon">&#128172;</span>
-      <div class="step-title">Show</div>
-      <div class="step-body">
-        Describe the job in one sentence — or demo it once on a screen-share call while WUPHF watches.
-      </div>
+  <div class="cards-3">
+    <div class="card">
+      <div class="card-num">01</div>
+      <div class="card-title">Show</div>
+      <div class="card-body">Describe the job in one sentence — or demo it once on a screen-share call while WUPHF watches.</div>
     </div>
-    <div class="step-card">
-      <div class="step-num">02</div>
-      <span class="step-icon">&#127959;&#65039;</span>
-      <div class="step-title">Build</div>
-      <div class="step-body">
-        The agent assembles live in front of you: its own app, schedule, and tools.
-      </div>
+    <div class="card">
+      <div class="card-num">02</div>
+      <div class="card-title">Build</div>
+      <div class="card-body">The agent assembles live in front of you: its own app, schedule, and tools.</div>
     </div>
-    <div class="step-card">
-      <div class="step-num">03</div>
-      <span class="step-icon">&#9989;</span>
-      <div class="step-title">Approve</div>
-      <div class="step-body">
-        Reads are free. Writes are held until you tap approve. Then it runs 24x7.
-      </div>
-    </div>
-  </div>
-</section>
-
-<!-- ISOMETRIC OFFICE SCENE -->
-<div class="office-section" id="office">
-  <div class="office-section-header">
-    <div class="office-section-eyebrow">THE NIGHT SHIFT</div>
-    <h2 class="office-section-title">Your agents, at work, right now</h2>
-    <div class="office-section-sub">Routines fire on schedule, 24x7 — which is to say, for as long as your machine is on. We said honest, not magic.</div>
-  </div>
-  <canvas id="officeCanvas" height="420" role="img" aria-label="Animated pixel scene of your hired agents working at their desks while routines fire on schedule.">
-    Animated pixel scene of your hired agents working at their desks while routines fire on schedule.
-  </canvas>
-</div>
-
-<!-- WHAT YOU HIRED -->
-<section id="agents">
-  <div class="section-eyebrow">WHAT YOU HIRED</div>
-  <h2 class="section-title" data-pretext>Anatomy of<br>your new hire.</h2>
-  <p class="section-body" data-pretext>
-    Every agent ships with all six. Not a chatbot in a trench coat.
-  </p>
-
-  <div class="agents-grid">
-    <div class="agent-card">
-      <div class="agent-badge">THE APP</div>
-      <div class="agent-title">A Real Screen</div>
-      <div class="agent-desc">Its own UI, built live in front of you. Reads and writes real workspace data.</div>
-    </div>
-    <div class="agent-card">
-      <div class="agent-badge">ROUTINES</div>
-      <div class="agent-title">Scheduled Work</div>
-      <div class="agent-desc">"Every Monday 9:00." Versioned prompts, run history, a transcript per run.</div>
-    </div>
-    <div class="agent-card">
-      <div class="agent-badge">TOOLS</div>
-      <div class="agent-title">Self-Authored</div>
-      <div class="agent-desc">"Score a lead." "Post to #ae-handoffs." It writes its own tools from what you taught.</div>
-    </div>
-    <div class="agent-card">
-      <div class="agent-badge">KNOWLEDGE</div>
-      <div class="agent-title">Cited Pages</div>
-      <div class="agent-desc">Every claim carries a citation. Your old wiki and notebooks come along verbatim.</div>
-    </div>
-    <div class="agent-card">
-      <div class="agent-badge">DATA + INTEGRATIONS</div>
-      <div class="agent-title">Your Whole Stack</div>
-      <div class="agent-desc">Its own typed tables, plus 100+ integrations via Composio. Connected once.</div>
-    </div>
-    <div class="agent-card">
-      <div class="agent-badge">APPROVAL GATE</div>
-      <div class="agent-title">Sends With Permission</div>
-      <div class="agent-desc">No email, Slack post, or CRM write leaves without a human tap.</div>
+    <div class="card">
+      <div class="card-num">03</div>
+      <div class="card-title">Approve</div>
+      <div class="card-body">Reads are free. Writes are held until you tap approve. Then it runs 24x7.</div>
     </div>
   </div>
 </section>
 
 <!-- THE DEMO CALL -->
 <section id="demo">
-  <div class="section-eyebrow">THE DEMO CALL</div>
-  <h2 class="section-title" data-pretext>The last time you do this job,<br>someone is finally taking notes.</h2>
-  <p class="section-body" data-pretext>
-    A voice call with screen share. You do the job once. WUPHF asks the sharp questions, then builds the agent.
-  </p>
+  <div class="section-eyebrow">The demo call</div>
+  <h2 class="section-title">The last time you do this job,<br>someone is finally taking notes.</h2>
+  <p class="section-body">A voice call with screen share. You do the job once. WUPHF asks the sharp questions, then builds the agent.</p>
 
-  <div class="conversations-layout">
-    <div class="thread-demo conversations-chat">
-      <!-- Root: the call -->
-      <div class="thread-root">
-        <div class="thread-root-avatar">YOU</div>
-        <div class="thread-root-body">
-          <div class="thread-root-channel">&#9654; screen share &middot; rec</div>
-          <div class="thread-root-text">*opens the demo-request form, looks the company up in HubSpot, posts the good ones to Slack*</div>
-          <div class="thread-root-replies">Nex is watching and listening</div>
-        </div>
+  <div class="demo-layout">
+    <div class="call-panel">
+      <div class="call-head"><span class="rec-dot"></span>screen share · rec · Nex is watching and listening</div>
+      <div class="msg you">
+        <span class="msg-who">YOU</span>
+        <div class="msg-bubble msg-action">opens the demo-request form, looks the company up in HubSpot, posts the good ones to Slack</div>
       </div>
-      <!-- The call transcript -->
-      <div class="thread-replies-wrap">
-        <div class="thread-reply">
-          <div class="thread-reply-avatar">NEX</div>
-          <div class="thread-reply-bubble">Got it — you looked the company up in HubSpot and checked headcount.</div>
-        </div>
-        <div class="thread-reply">
-          <div class="thread-reply-avatar">NEX</div>
-          <div class="thread-reply-bubble">Over what score does a lead go to an AE instead of the nurture list?</div>
-        </div>
-        <div class="thread-reply you">
-          <div class="thread-reply-avatar you">YOU</div>
-          <div class="thread-reply-bubble">70 and up goes to #ae-handoffs with the reason. Rest gets nurtured.</div>
-        </div>
-        <div class="thread-reply">
-          <div class="thread-reply-avatar">NEX</div>
-          <div class="thread-reply-bubble">I think I have the whole flow. Ready for me to build the agent from this, or is there more?</div>
-        </div>
-        <div class="thread-reply you">
-          <div class="thread-reply-avatar you">YOU</div>
-          <div class="thread-reply-bubble">That's it. Build it.</div>
-        </div>
-        <div class="thread-reply">
-          <div class="thread-reply-avatar">NEX</div>
-          <div class="thread-reply-bubble">Building Lead Routing Agent — app, routines, and the two tools it needs. Watch it come together.</div>
-        </div>
+      <div class="msg">
+        <span class="msg-who">NEX</span>
+        <div class="msg-bubble">Got it — you looked the company up in HubSpot and checked headcount.</div>
+      </div>
+      <div class="msg">
+        <span class="msg-who">NEX</span>
+        <div class="msg-bubble">Over what score does a lead go to an AE instead of the nurture list?</div>
+      </div>
+      <div class="msg you">
+        <span class="msg-who">YOU</span>
+        <div class="msg-bubble">70 and up goes to #ae-handoffs with the reason. Rest gets nurtured.</div>
+      </div>
+      <div class="msg">
+        <span class="msg-who">NEX</span>
+        <div class="msg-bubble">I think I have the whole flow. Ready for me to build the agent from this, or is there more?</div>
+      </div>
+      <div class="msg you">
+        <span class="msg-who">YOU</span>
+        <div class="msg-bubble">That's it. Build it.</div>
+      </div>
+      <div class="msg">
+        <span class="msg-who">NEX</span>
+        <div class="msg-bubble">Building Lead Routing Agent — app, routines, and the two tools it needs. Watch it come together.</div>
       </div>
     </div>
 
-    <div class="code-demo conversations-terminal">
-      <div class="code-titlebar">
-        <span class="code-dot"></span>
-        <span class="code-dot"></span>
-        <span class="code-dot"></span>
-        <span class="code-label">terminal</span>
+    <div>
+      <div class="terminal">
+        <div class="term-bar"><span class="term-dot"></span><span class="term-dot"></span><span class="term-dot"></span><span class="term-label">terminal</span></div>
+        <div class="term-body">
+          <div class="term-line"><span><span class="tok-cmt"># Option 1: run it</span></span></div>
+          <div class="term-line"><span><span class="tok-fn">npx</span> wuphf@latest</span><button class="line-copy" data-copy="npx wuphf@latest" aria-label="Copy">COPY</button></div>
+          <div class="term-line">&nbsp;</div>
+          <div class="term-line"><span><span class="tok-cmt"># Option 2: build from source</span></span></div>
+          <div class="term-line"><span><span class="tok-fn">git</span> clone https://github.com/nex-crm/wuphf.git</span><button class="line-copy" data-copy="git clone https://github.com/nex-crm/wuphf.git && cd wuphf" aria-label="Copy">COPY</button></div>
+          <div class="term-line"><span><span class="tok-fn">go</span> build -o wuphf ./cmd/wuphf</span><button class="line-copy" data-copy="go build -o wuphf ./cmd/wuphf" aria-label="Copy">COPY</button></div>
+          <div class="term-line">&nbsp;</div>
+          <div class="term-line"><span><span class="tok-cmt"># Browser opens at localhost:7891.</span></span></div>
+          <div class="term-line"><span><span class="tok-cmt"># Describe a job — or demo it on a call.</span></span></div>
+          <div class="term-line"><span><span class="tok-cmt"># Watch the agent build its own app.</span></span></div>
+        </div>
       </div>
-      <div class="code-block">
-        <div class="code-line"><span class="line-content"><span class="tok-cmt"># Option 1: run it</span></span></div>
-        <div class="code-line"><span class="line-content"><span class="tok-fn">npx</span> wuphf@latest</span><button class="line-copy" data-copy="npx wuphf@latest" aria-label="Copy">COPY</button></div>
-        <div class="code-line code-line-empty"></div>
-        <div class="code-line"><span class="line-content"><span class="tok-cmt"># Option 2: clone and build from source</span></span></div>
-        <div class="code-line"><span class="line-content"><span class="tok-fn">git</span> clone https://github.com/nex-crm/wuphf.git && cd wuphf</span><button class="line-copy" data-copy="git clone https://github.com/nex-crm/wuphf.git && cd wuphf" aria-label="Copy">COPY</button></div>
-        <div class="code-line"><span class="line-content"><span class="tok-fn">go</span> build -o wuphf ./cmd/wuphf</span><button class="line-copy" data-copy="go build -o wuphf ./cmd/wuphf" aria-label="Copy">COPY</button></div>
-        <div class="code-line code-line-empty"></div>
-        <div class="code-line"><span class="line-content"><span class="tok-cmt"># Browser opens at localhost:7891.</span></span></div>
-        <div class="code-line"><span class="line-content"><span class="tok-cmt"># Describe a job — or demo it on a call.</span></span></div>
-        <div class="code-line"><span class="line-content"><span class="tok-cmt"># Watch the agent build its own app.</span></span></div>
+
+      <div class="aha">
+        <div class="aha-head">Monday 9:00 · Routine: weekly pipeline recap</div>
+        <div class="aha-line"><b>AGENT</b>Ran the recap. 3 stage moves, 2 new leads, Umbrella stalled 21 days.</div>
+        <div class="aha-line"><b>AGENT</b>Drafted the Slack post for #revops. Holding it for your approval.</div>
+        <div class="aha-line"><b>YOU</b>*one tap* Approved.</div>
+        <div class="aha-note">You demoed this job exactly once. You just trained your replacement — it says thank you and works weekends.</div>
       </div>
     </div>
   </div>
+</section>
 
-  <!-- The aha: Monday morning, without you -->
-  <div style="margin-top:56px;padding:24px;background:var(--bg3);border:2px solid var(--yellow-dark);max-width:700px;">
-    <div style="font-family:var(--font-display);font-size:8px;color:var(--yellow);letter-spacing:0.14em;margin-bottom:16px;">MONDAY 9:00 // ROUTINE: WEEKLY PIPELINE RECAP</div>
-    <div style="font-family:var(--font-vt);font-size:22px;color:var(--text);line-height:1.5;margin-bottom:12px;">
-      <span style="color:var(--yellow);">AGENT:</span> Ran the recap. 3 stage moves, 2 new leads, Umbrella stalled 21 days. Saved the brief as a doc.
+<!-- WHAT YOU HIRED -->
+<section id="agents">
+  <div class="section-eyebrow">What you hired</div>
+  <h2 class="section-title">Anatomy of your new hire.</h2>
+  <p class="section-body">Every agent ships with all six. Not a chatbot in a trench coat.</p>
+
+  <div class="cards-3">
+    <div class="card">
+      <div class="card-badge">The app</div>
+      <div class="card-title">A real screen</div>
+      <div class="card-body">Its own UI, built live in front of you. Reads and writes real workspace data.</div>
     </div>
-    <div style="font-family:var(--font-vt);font-size:22px;color:var(--text);line-height:1.5;margin-bottom:12px;">
-      <span style="color:var(--yellow);">AGENT:</span> Drafted the Slack post for #revops. Holding it for your approval.
+    <div class="card">
+      <div class="card-badge">Routines</div>
+      <div class="card-title">Scheduled work</div>
+      <div class="card-body">"Every Monday 9:00." Versioned prompts, run history, a transcript per run.</div>
     </div>
-    <div style="font-family:var(--font-vt);font-size:22px;color:var(--text);line-height:1.5;">
-      <span style="color:var(--yellow);">YOU:</span> *one tap* Approved.
+    <div class="card">
+      <div class="card-badge">Tools</div>
+      <div class="card-title">Self-authored</div>
+      <div class="card-body">"Score a lead." "Post to #ae-handoffs." It writes its own tools from what you taught.</div>
     </div>
-    <p style="font-family:var(--font-mono);font-size:13px;color:var(--text-dim);margin-top:20px;line-height:1.7;">
-      You demoed this job exactly once. You just trained your replacement — it says thank you and works weekends.
-    </p>
+    <div class="card">
+      <div class="card-badge">Knowledge</div>
+      <div class="card-title">Cited pages</div>
+      <div class="card-body">Every claim carries a citation. Your old wiki and notebooks come along verbatim.</div>
+    </div>
+    <div class="card">
+      <div class="card-badge">Data + integrations</div>
+      <div class="card-title">Your whole stack</div>
+      <div class="card-body">Its own typed tables, plus 100+ integrations via Composio. Connected once.</div>
+    </div>
+    <div class="card">
+      <div class="card-badge">Approval gate</div>
+      <div class="card-title">Sends with permission</div>
+      <div class="card-body">No email, Slack post, or CRM write leaves without a human tap.</div>
+    </div>
   </div>
 </section>
 
 <!-- USE CASES -->
-<section id="different">
-  <div class="section-eyebrow">WHAT PEOPLE HIRE FIRST</div>
-  <h2 class="section-title" data-pretext>Agents your pipeline<br>is already asking for.</h2>
+<section id="use-cases">
+  <div class="section-eyebrow">What people hire first</div>
+  <h2 class="section-title">Agents your pipeline is already asking for.</h2>
 
-  <div class="agents-grid">
-    <div class="agent-card">
-      <div class="agent-badge">CLOSED-LOST RE-ENGAGEMENT</div>
-      <div class="agent-desc">Monitors deals lost 90+ days ago and detects what changed.</div>
-      <div class="agent-quote">Saves ~$300&ndash;400/mo</div>
+  <div class="cards-3" style="margin-top:40px">
+    <div class="card">
+      <div class="card-badge">Closed-lost re-engagement</div>
+      <div class="card-body">Monitors deals lost 90+ days ago and detects what changed.</div>
+      <div class="card-metric">Saves ~$300–400/mo</div>
     </div>
-    <div class="agent-card">
-      <div class="agent-badge">CRM HYGIENE</div>
-      <div class="agent-desc">Finds duplicates, missing fields, and stale records.</div>
-      <div class="agent-quote">Saves ~$200&ndash;500/mo</div>
+    <div class="card">
+      <div class="card-badge">CRM hygiene</div>
+      <div class="card-body">Finds duplicates, missing fields, and stale records.</div>
+      <div class="card-metric">Saves ~$200–500/mo</div>
     </div>
-    <div class="agent-card">
-      <div class="agent-badge">MEETING PREP</div>
-      <div class="agent-desc">A cross-system account brief before every meeting.</div>
-      <div class="agent-quote">Saves ~$100&ndash;200/mo</div>
+    <div class="card">
+      <div class="card-badge">Meeting prep</div>
+      <div class="card-body">A cross-system account brief before every meeting.</div>
+      <div class="card-metric">Saves ~$100–200/mo</div>
     </div>
-    <div class="agent-card">
-      <div class="agent-badge">DEALS GOING DARK</div>
-      <div class="agent-desc">Detects silence across email, Slack, and calendar on active deals.</div>
-      <div class="agent-quote">Saves ~$200&ndash;400/mo</div>
+    <div class="card">
+      <div class="card-badge">Deals going dark</div>
+      <div class="card-body">Detects silence across email, Slack, and calendar on active deals.</div>
+      <div class="card-metric">Saves ~$200–400/mo</div>
     </div>
-    <div class="agent-card">
-      <div class="agent-badge">LEAD SCORING</div>
-      <div class="agent-desc">Scores inbound leads and routes the hot ones to an AE.</div>
-      <div class="agent-quote">Saves ~$300&ndash;500/mo</div>
+    <div class="card">
+      <div class="card-badge">Lead scoring</div>
+      <div class="card-body">Scores inbound leads and routes the hot ones to an AE.</div>
+      <div class="card-metric">Saves ~$300–500/mo</div>
     </div>
-    <div class="agent-card">
-      <div class="agent-badge">CUSTOM</div>
-      <div class="agent-desc">Any workflow. One sentence — or one demo call. WUPHF builds it.</div>
-      <div class="agent-quote">Yours saves the most.</div>
+    <div class="card">
+      <div class="card-badge">Custom</div>
+      <div class="card-body">Any workflow. One sentence — or one demo call. WUPHF builds it.</div>
+      <div class="card-metric">Yours saves the most.</div>
     </div>
   </div>
 </section>
 
 <!-- LICENSE / SOURCE AVAILABLE -->
 <section id="open-source">
-  <div class="section-eyebrow">SOURCE AVAILABLE</div>
-  <div class="mit-block">
-    <div class="mit-badge">FAIR-CODE<br>LICENSE</div>
-    <div class="mit-text">
+  <div class="section-eyebrow">Source available</div>
+  <div class="license-block">
+    <div class="license-badge">FAIR-CODE<br>LICENSE</div>
+    <div class="license-text">
       Free to self-host. Runs on your machine.<br>
       The job description is one sentence or one call — not a config format.<br>
-      Read the source, file the issue, break it on purpose. It is your machine.<br>
       No seats. No usage fees. No Michael Scott energy required (but encouraged).
     </div>
-    <div class="mit-cta">
-      <a class="mit-cta-btn" href="https://github.com/nex-crm/wuphf" target="_blank" rel="noopener">
+    <div class="license-cta">
+      <a class="license-cta-btn" href="https://github.com/nex-crm/wuphf" target="_blank" rel="noopener">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/></svg>
         ★ Star on GitHub
       </a>
-      <a class="mit-cta-sub" href="https://discord.gg/gjSySC3PzV" target="_blank" rel="noopener">Join the Discord →</a>
+      <a class="license-cta-sub" href="https://discord.gg/gjSySC3PzV" target="_blank" rel="noopener">Join the Discord →</a>
     </div>
   </div>
 </section>
 
-<!-- FAQ (convergent skepticisms from ICP test) -->
+<!-- FAQ -->
 <section id="faq">
   <div class="section-eyebrow">FAQ</div>
-  <h2 class="section-title" data-pretext>Questions the last five skeptics asked.<br>Answered honestly.</h2>
+  <h2 class="section-title">Questions the last five skeptics asked.<br>Answered honestly.</h2>
 
-  <div class="faq-list">
+  <div class="faq-list" style="margin-top:36px">
     <details class="faq-item">
       <summary class="faq-q">Whatever happened to the "office of AI employees" pitch?</summary>
       <div class="faq-a">
@@ -1648,13 +775,14 @@
         It is v0.x and we put that on the website. Some things will break; when they do, per-run transcripts show exactly where, and the issue tracker is public. The catch you were scrolling for is just that it is early. Early, local, and honest beats polished, hosted, and vague — but that is a preference, and it is yours to make.
       </div>
     </details>
-  </section>
+  </div>
+</section>
 
 <!-- FOOTER -->
 <footer>
   <div>
     <div class="footer-logo">WUPHF</div>
-    <div class="footer-sub">by <a href="https://nex.ai" style="color:var(--yellow);text-decoration:none;">Nex.ai</a> &middot; Show it once. Never do it again.</div>
+    <div class="footer-sub">by <a href="https://nex.ai">Nex.ai</a> · Show it once. Never do it again.</div>
   </div>
   <div class="footer-links">
     <a href="https://github.com/nex-crm/wuphf">GitHub</a>
@@ -1668,26 +796,7 @@
 (function () {
   'use strict';
 
-  var motionQuery = window.matchMedia
-    ? window.matchMedia('(prefers-reduced-motion: reduce)')
-    : { matches: false, addEventListener: null, addListener: null };
-
-  function prefersReducedMotion() {
-    return !!motionQuery.matches;
-  }
-
-  function pageCanAnimate() {
-    return !document.hidden && !prefersReducedMotion();
-  }
-
-  function updatePageMotionClass() {
-    document.body.classList.toggle('is-page-hidden', document.hidden);
-  }
-
-  updatePageMotionClass();
-  document.addEventListener('visibilitychange', updatePageMotionClass);
-
-  // ── GITHUB STARS ──────────────────────────────────────────────────────
+  // ── GITHUB STARS ──
   fetch('https://api.github.com/repos/nex-crm/wuphf')
     .then(function(r){ return r.json(); })
     .then(function(d){
@@ -1696,11 +805,11 @@
       var fmt = n >= 1000 ? (n/1000).toFixed(1) + 'k' : String(n);
       var hero = document.getElementById('heroStars');
       var nav  = document.getElementById('navStars');
-      if (hero) hero.textContent = '\u2605 ' + fmt;
-      if (nav)  nav.textContent  = fmt + ' \u2605';
+      if (hero) hero.textContent = '★ ' + fmt;
+      if (nav)  nav.textContent  = '★ ' + fmt;
     }).catch(function(){});
 
-  // ── INSTALL TABS ─────────────────────────────────────────────────────
+  // ── INSTALL TABS ──
   function switchInstallTab(tab) {
     var tabs = document.querySelectorAll('.install-tab');
     var blocks = document.querySelectorAll('.install-block');
@@ -1728,1221 +837,32 @@
     });
   });
 
-  // ── COPY INSTALL ──────────────────────────────────────────────────────
-  function announceCopyStatus(message) {
+  // ── COPY ──
+  function announce(message) {
     var status = document.getElementById('copyStatus');
     if (!status) return;
     status.textContent = '';
-    window.requestAnimationFrame(function() {
-      status.textContent = message;
-    });
+    window.requestAnimationFrame(function() { status.textContent = message; });
   }
-
-  function flashCopy(label) {
-    label.textContent = 'COPIED!';
-    label.classList.add('copied');
-    announceCopyStatus('Copied install command to clipboard.');
-    setTimeout(function() {
-      label.textContent = 'COPY';
-      label.classList.remove('copied');
-    }, 1500);
-  }
-
-  function copyInstall() {
-    var label = document.getElementById('copyLabel');
-    if (navigator.clipboard && navigator.clipboard.writeText) {
-      navigator.clipboard.writeText('npx wuphf@latest').then(function() {
-        if (label) flashCopy(label);
-      }).catch(function() {
-        announceCopyStatus('Unable to copy install command.');
-      });
-      return;
-    }
-    announceCopyStatus('Clipboard copy is unavailable in this browser.');
-  }
-  window.copyInstall = copyInstall;
-
-  document.querySelectorAll('.install-line').forEach(function(btn) {
-    btn.addEventListener('click', function() {
-      var text = btn.dataset.copy || '';
-      var label = btn.querySelector('.install-copy');
-      if (navigator.clipboard && navigator.clipboard.writeText) {
-        navigator.clipboard.writeText(text).then(function() {
-          if (label) flashCopy(label);
-        }).catch(function() {
-          announceCopyStatus('Unable to copy install command.');
-        });
-        return;
-      }
-      announceCopyStatus('Clipboard copy is unavailable in this browser.');
-    });
-  });
-
-  // ── PER-LINE COPY BUTTONS ────────────────────────────────────────────
-  document.querySelectorAll('.line-copy').forEach(function(btn) {
-    btn.addEventListener('click', function(e) {
-      e.stopPropagation();
-      var text = btn.dataset.copy || '';
+  function wireCopy(el, labelEl) {
+    el.addEventListener('click', function() {
+      var text = el.dataset.copy;
+      if (!text) return;
       navigator.clipboard.writeText(text).then(function() {
-        var orig = btn.textContent;
-        btn.textContent = 'COPIED';
-        setTimeout(function() { btn.textContent = orig; }, 1200);
-      }).catch(function() {});
+        var label = labelEl || el;
+        var prev = label.textContent;
+        label.textContent = 'COPIED';
+        announce('Copied to clipboard');
+        setTimeout(function(){ label.textContent = prev; }, 1400);
+      }).catch(function(){});
     });
+  }
+  document.querySelectorAll('.install-line').forEach(function(line) {
+    wireCopy(line, line.querySelector('.install-copy'));
   });
-
-  // ── TICKER (DOM-safe) ─────────────────────────────────────────────────
-  var quotes = [
-    'Show it once. Never do it again. , the entire onboarding doc',
-    '"I DECLARE... this job delegated!" "Michael, you have to demo it first." "I DECLARED it."',
-    'Identity theft is not a joke, Jim. Neither is an approval gate. Nothing sends without a tap.',
-    "That's what she shipped. (Lead Routing Agent, v2, with a change note)",
-    'bears. beets. a routine that files the report every Monday at 9:00. three things Dwight endorses.',
-    'Dwight tried to demo threshing wheat to Nex. It asked about thresholds. He was moved to tears.',
-    'The agent read the old wiki. All of it. It cites its sources now. Show-off.',
-    'You watched it build its own app. It watched you make coffee. Fair trade.',
-    'Reads are free. Writes are held. Dundies are earned.',
-    'The agents work weekends. They do not complain. They do not microwave fish. Perfect.',
-    'Ryan started the fire. The routine ran anyway. Run history has the receipts.',
-    'Would I rather be feared or loved? Both. I want agents to fear how much users love this product.',
-  ];
-
-  var ticker = document.getElementById('ticker');
-  var doubled = quotes.concat(quotes);
-  doubled.forEach(function(q) {
-    var span = document.createElement('span');
-    span.className = 'ambient-item';
-    span.textContent = '\u25B6 ' + q;
-    ticker.appendChild(span);
-  });
-
-  // ── SPRITE CANVASES ───────────────────────────────────────────────────
-  var bodyColors = ['#2D4A7A', '#4A7A2D', '#7A2D4A'];
-  var accentColors = ['#cf72d9', '#ffb3e6', '#9f4dbf'];
-
-  function drawSprite(canvasId, colorBody, colorAccent, frame) {
-    var canvas = document.getElementById(canvasId);
-    if (!canvas) return;
-    var ctx = canvas.getContext('2d');
-    var S = 2;
-    ctx.clearRect(0, 0, 24, 36);
-
-    function px(x, y, c) {
-      ctx.fillStyle = c;
-      ctx.fillRect(x * S, y * S, S, S);
-    }
-
-    var bob = frame < 2 ? 0 : 1;
-
-    for (var x = 3; x <= 8; x++)
-      for (var y = 0; y <= 4; y++)
-        px(x, y + bob, '#D4956A');
-
-    for (var hx = 3; hx <= 8; hx++) px(hx, bob, '#3A2810');
-    px(3, 1 + bob, '#3A2810'); px(8, 1 + bob, '#3A2810');
-
-    px(4, 2 + bob, '#1A1610'); px(7, 2 + bob, '#1A1610');
-
-    for (var bx = 2; bx <= 9; bx++)
-      for (var by = 6; by <= 11; by++)
-        px(bx, by, colorBody);
-
-    for (var ax = 4; ax <= 7; ax++) px(ax, 7, colorAccent);
-
-    for (var ay = 6; ay <= 10; ay++) { px(1, ay, colorBody); px(10, ay, colorBody); }
-
-    var lOff = frame === 1 ? -1 : 0;
-    var rOff = frame === 3 ? -1 : 0;
-    for (var ly = 12; ly <= 17; ly++) px(3, ly + lOff, colorBody);
-    for (var ry = 12; ry <= 17; ry++) px(8, ry + rOff, colorBody);
-    px(3, 17 + lOff, '#2A2418'); px(8, 17 + rOff, '#2A2418');
-  }
-
-  var spriteFrame = 0;
-  var spriteInterval = null;
-  function animSprites() {
-    spriteFrame = (spriteFrame + 1) % 4;
-    for (var i = 0; i < 3; i++) {
-      drawSprite('s' + i, bodyColors[i], accentColors[i], (spriteFrame + i) % 4);
-    }
-  }
-  function drawStaticSprites() {
-    for (var i = 0; i < 3; i++) {
-      drawSprite('s' + i, bodyColors[i], accentColors[i], i % 4);
-    }
-  }
-  function syncSpriteAnimation() {
-    if (pageCanAnimate()) {
-      if (!spriteInterval) spriteInterval = window.setInterval(animSprites, 250);
-      return;
-    }
-    if (spriteInterval) {
-      window.clearInterval(spriteInterval);
-      spriteInterval = null;
-    }
-    drawStaticSprites();
-  }
-  animSprites();
-  syncSpriteAnimation();
-
-  document.addEventListener('visibilitychange', syncSpriteAnimation);
-  if (motionQuery.addEventListener) {
-    motionQuery.addEventListener('change', syncSpriteAnimation);
-  } else if (motionQuery.addListener) {
-    motionQuery.addListener(syncSpriteAnimation);
-  }
-
-  // ── ISOMETRIC OFFICE SCENE ────────────────────────────────────────────
-  (function() {
-    var canvas = document.getElementById('officeCanvas');
-    var CANVAS_H = 420;
-    var DPR = 1;
-    var W = 0;
-    var TW = 56;
-    var TH = 28;
-    var OX = 0;
-    var OY = 72;
-    var animHandle = null;
-    var lastTime = 0;
-    var officeVisible = false;
-    var officeObserver = null;
-
-    function updateOfficeVisibility() {
-      if (!canvas || !canvas.getBoundingClientRect) {
-        officeVisible = true;
-        return;
-      }
-      var rect = canvas.getBoundingClientRect();
-      officeVisible = rect.bottom > 0 &&
-        rect.right > 0 &&
-        rect.top < window.innerHeight &&
-        rect.left < window.innerWidth;
-    }
-
-    // ── ISO PROJECTION ─────────────────────────────────
-    function iso(gx, gy) {
-      return {
-        x: OX + (gx - gy) * TW / 2,
-        y: OY + (gx + gy) * TH / 2
-      };
-    }
-
-    // ── ROOM GRID 12 cols × 8 rows ──────────────────────
-    // 0=floor 1=conf 2=michael 3=reception 4=kitchen
-    function roomAt(col, row) {
-      if (row <= 2 && col <= 2) return 1;
-      if (row <= 2 && col >= 9) return 2;
-      if (row >= 5 && row <= 6 && col >= 4 && col <= 7) return 3;
-      if (row >= 6 && col <= 2) return 4;
-      return 0;
-    }
-
-    var TILE_COLORS = {
-      0: { top: '#3A3228', left: '#2F281F', right: '#342B22' },
-      1: { top: '#3F362B', left: '#302820', right: '#372D24' },
-      2: { top: '#302A20', left: '#241F18', right: '#2A241B' },
-      3: { top: '#3A3028', left: '#2C241E', right: '#332A22' },
-      4: { top: '#332C22', left: '#282118', right: '#2D261D' }
-    };
-
-    // ── RESIZE ──────────────────────────────────────────
-    function resize() {
-      // Read parent width so CSS `width: 100%` keeps flexing responsively;
-      // setting canvas.style.width would lock it at the first measured size.
-      W = (canvas.parentElement && canvas.parentElement.clientWidth) || canvas.offsetWidth || window.innerWidth;
-      DPR = window.devicePixelRatio || 1;
-      canvas.width = Math.round(W * DPR);
-      canvas.height = Math.round(CANVAS_H * DPR);
-      canvas.style.height = CANVAS_H + 'px';
-      TW = Math.max(44, Math.min(68, Math.round(W / 13)));
-      TH = Math.round(TW / 2);
-      OX = Math.round(W / 2 - TW);
-      OY = 70;
-    }
-
-    // ── TILE DRAWING ────────────────────────────────────
-    function drawTile(ctx, gx, gy, tc) {
-      var p = iso(gx, gy);
-      var tw2 = TW / 2;
-      // top face
-      ctx.fillStyle = tc.top;
-      ctx.beginPath();
-      ctx.moveTo(p.x, p.y);
-      ctx.lineTo(p.x + tw2, p.y + TH / 2);
-      ctx.lineTo(p.x + TW, p.y);
-      ctx.lineTo(p.x + tw2, p.y - TH / 2);
-      ctx.closePath();
-      ctx.fill();
-    }
-
-    // ── ISO BOX ─────────────────────────────────────────
-    function drawBox(ctx, gx, gy, gw, gd, ph, colorTop, colorLeft, colorRight) {
-      var p00 = iso(gx, gy);
-      var p10 = iso(gx + gw, gy);
-      var p11 = iso(gx + gw, gy + gd);
-      var p01 = iso(gx, gy + gd);
-
-      // top face
-      ctx.fillStyle = colorTop;
-      ctx.beginPath();
-      ctx.moveTo(p00.x, p00.y - ph);
-      ctx.lineTo(p10.x, p10.y - ph);
-      ctx.lineTo(p11.x, p11.y - ph);
-      ctx.lineTo(p01.x, p01.y - ph);
-      ctx.closePath();
-      ctx.fill();
-
-      // left face
-      ctx.fillStyle = colorLeft;
-      ctx.beginPath();
-      ctx.moveTo(p10.x, p10.y - ph);
-      ctx.lineTo(p11.x, p11.y - ph);
-      ctx.lineTo(p11.x, p11.y);
-      ctx.lineTo(p10.x, p10.y);
-      ctx.closePath();
-      ctx.fill();
-
-      // right face
-      ctx.fillStyle = colorRight;
-      ctx.beginPath();
-      ctx.moveTo(p11.x, p11.y - ph);
-      ctx.lineTo(p01.x, p01.y - ph);
-      ctx.lineTo(p01.x, p01.y);
-      ctx.lineTo(p11.x, p11.y);
-      ctx.closePath();
-      ctx.fill();
-    }
-
-    // ── JIM-PAM CONVERSATION SEQUENCES ──────────────────
-    var jimPamConvos = [
-      [
-        { who: 'jim', text: "Did you hear? CEO merged 12 PRs. Didn't ask anyone." },
-        { who: 'pam', text: "Of course it didn't. Classic." },
-        { who: 'jim', text: "Honestly kind of amazing." },
-      ],
-      [
-        { who: 'jim', text: "Dwight filed a formal complaint. Against the codebase." },
-        { who: 'pam', text: "...Against the codebase?" },
-        { who: 'jim', text: "He says the variable names are insubordinate." },
-      ],
-      [
-        { who: 'jim', text: "Michael is giving the CEO agent a performance review." },
-        { who: 'pam', text: "The AI agent." },
-        { who: 'jim', text: "It scored 'Outstanding.' Michael cried." },
-      ],
-    ];
-
-    // ── MICHAEL ANNOUNCEMENT PHRASES ────────────────────
-    var michaelAnnouncements = [
-      "I DECLARE... this the best sprint in company history!",
-      "Could I have everyone's attention? ...Just kidding. Carry on.",
-      "I am not superstitious. But I am a little stitious about this release.",
-    ];
-
-    // ── DWIGHT PATROL WAYPOINTS ─────────────────────────
-    var dwightPatrol = [
-      { x: 5, y: 4, bubble: "I am watching you." },
-      { x: 8, y: 4, bubble: "Productivity: acceptable. Barely." },
-    ];
-
-    // ── CHARACTER BUBBLE MESSAGES ────────────────────────
-    var BUBBLE_MSGS = {
-      pam:    ["Good morning. I'll hold your calls.", "The conference room is booked until Thursday. And Thursday.", "I started drawing a mural but then I had work to do."],
-      jim:    ["Question: if an AI has memory, does it remember everything I did?", "I once convinced Dwight the server was haunted. He believed it.", "Bears. Beets. WUPHF."],
-      dwight: ["FACT: I am the highest-performing human in this office.", "Security alert: Jim is being funny again. Monitoring.", "I have trained myself to require only 1500ms of sleep."],
-      michael:["I DECLARE this sprint OPEN!", "I've been told I'm a bit much. They meant it as a compliment.", "Ryan, you're not even here. You're an agent. I MISS YOU."],
-      ceo:    ["Roadmap updated. Shipping Thursday.", "I've already filed the postmortem. We haven't shipped yet.", "This is fine."],
-      eng:    ["PR #47 merged. Tests passing. No comments.", "The variable name was fine. I renamed it anyway.", "I found a bug. I introduced it in my last fix. Ship it."],
-      cmo:    ["README updated. Posted to HN. Waiting for the 'Show HN' karma.", "That's what she shipped.", "Our open graph image is 3px off center. It's handled."]
-    };
-
-    function pickBubbleMsg(charId) {
-      var msgs = BUBBLE_MSGS[charId];
-      if (!msgs || msgs.length === 0) return '';
-      return msgs[Math.floor(Math.random() * msgs.length)];
-    }
-
-    // ── CHARACTERS ──────────────────────────────────────
-    var CHARS = [
-      { id:'pam',    name:'PAM',    x:5.5, y:5.5, homeX:5.5, homeY:5.5,
-        hair:'#C87A40', skin:'#D4956A', shirt:'#4A7A9B', pants:'#3A4A6A',
-        faceRight:true, walkFrame:0, animTimer:0,
-        state:'IDLE_DESK', stateTimer:12000, arriveState:'IDLE_DESK', arriveWait:12000,
-        destX:5.5, destY:5.5, isAgent:false, agentColor:'', label:'',
-        chatPartner:null, chatStep:0, chatTimer:0, chatConvo:null,
-        patrolStep:0, patrolTimer:0, bubbleTimer: 8000 + Math.random()*8000 },
-      { id:'jim',    name:'JIM',    x:5.0, y:3.0, homeX:5.0, homeY:3.0,
-        hair:'#4A3820', skin:'#D4956A', shirt:'#5A7A4A', pants:'#2A3A5A',
-        faceRight:true, walkFrame:0, animTimer:0,
-        state:'IDLE_DESK', stateTimer:6000, arriveState:'IDLE_DESK', arriveWait:6000,
-        destX:5.0, destY:3.0, isAgent:false, agentColor:'', label:'',
-        chatPartner:null, chatStep:0, chatTimer:0, chatConvo:null,
-        patrolStep:0, patrolTimer:0, bubbleTimer: 8000 + Math.random()*8000 },
-      { id:'dwight', name:'DWIGHT', x:3.0, y:3.0, homeX:3.0, homeY:3.0,
-        hair:'#3A2810', skin:'#D4956A', shirt:'#5C6030', pants:'#3A3A20',
-        faceRight:false, walkFrame:0, animTimer:0,
-        state:'IDLE_DESK', stateTimer:4000, arriveState:'IDLE_DESK', arriveWait:4000,
-        destX:3.0, destY:3.0, isAgent:false, agentColor:'', label:'',
-        chatPartner:null, chatStep:0, chatTimer:0, chatConvo:null,
-        patrolStep:0, patrolTimer:0, bubbleTimer: 8000 + Math.random()*8000 },
-      { id:'michael',name:'MICHAEL',x:10.5, y:1.0, homeX:10.5, homeY:1.0,
-        hair:'#3A2810', skin:'#D4956A', shirt:'#2D4A7A', pants:'#3A4E7A',
-        faceRight:false, walkFrame:0, animTimer:0,
-        state:'IDLE_DESK', stateTimer:8000, arriveState:'IDLE_DESK', arriveWait:8000,
-        destX:10.5, destY:1.0, isAgent:false, agentColor:'', label:'',
-        chatPartner:null, chatStep:0, chatTimer:0, chatConvo:null,
-        patrolStep:0, patrolTimer:0, bubbleTimer: 8000 + Math.random()*8000 },
-      { id:'ceo',    name:'CEO',    x:8.0, y:4.0, homeX:8.0, homeY:4.0,
-        hair:'#1A1610', skin:'#D4B896', shirt:'#2D4A7A', pants:'#1A2A4A',
-        faceRight:true, walkFrame:0, animTimer:0,
-        state:'IDLE_DESK', stateTimer:5000, arriveState:'IDLE_DESK', arriveWait:5000,
-        destX:8.0, destY:4.0, isAgent:true, agentColor:'#cf72d9', label:'CEO',
-        chatPartner:null, chatStep:0, chatTimer:0, chatConvo:null,
-        patrolStep:0, patrolTimer:0, bubbleTimer: 8000 + Math.random()*8000 },
-      { id:'eng',    name:'ENG',    x:10.0, y:3.0, homeX:10.0, homeY:3.0,
-        hair:'#2A1A40', skin:'#C4A882', shirt:'#4A2D7A', pants:'#2A1A4A',
-        faceRight:false, walkFrame:0, animTimer:0,
-        state:'IDLE_DESK', stateTimer:7000, arriveState:'IDLE_DESK', arriveWait:7000,
-        destX:10.0, destY:3.0, isAgent:true, agentColor:'#cf72d9', label:'ENG',
-        chatPartner:null, chatStep:0, chatTimer:0, chatConvo:null,
-        patrolStep:0, patrolTimer:0, bubbleTimer: 8000 + Math.random()*8000 },
-      { id:'cmo',    name:'CMO',    x:3.0, y:5.0, homeX:3.0, homeY:5.0,
-        hair:'#4A2010', skin:'#D4A870', shirt:'#7A4A2D', pants:'#3A2010',
-        faceRight:true, walkFrame:0, animTimer:0,
-        state:'IDLE_DESK', stateTimer:5500, arriveState:'IDLE_DESK', arriveWait:5500,
-        destX:3.0, destY:5.0, isAgent:true, agentColor:'#cf72d9', label:'CMO',
-        chatPartner:null, chatStep:0, chatTimer:0, chatConvo:null,
-        patrolStep:0, patrolTimer:0, bubbleTimer: 8000 + Math.random()*8000 }
-    ];
-
-    function getChar(id) {
-      for (var i = 0; i < CHARS.length; i++) {
-        if (CHARS[i].id === id) return CHARS[i];
-      }
-      return null;
-    }
-
-    var bubbles = [];
-
-    function spawnBubble(charId, text) {
-      if (bubbles.length >= 2) return;
-      var ch = getChar(charId);
-      if (!ch) return;
-      var msg = text || pickBubbleMsg(charId);
-      if (!msg) return;
-      bubbles.push({
-        charId: charId,
-        text: msg,
-        age: 0,
-        duration: 4000,
-        fadeStart: 3700
-      });
-    }
-
-    function pickNextActivity(ch) {
-      var r = Math.random();
-
-      if (ch.id === 'pam') {
-        // 95% at desk, 5% walk briefly somewhere
-        if (r < 0.95) {
-          ch.destX = ch.homeX; ch.destY = ch.homeY;
-          ch.arriveState = 'IDLE_DESK';
-          ch.arriveWait = 8000 + Math.random() * 8000;
-        } else {
-          ch.destX = 4.5; ch.destY = 6.0;
-          ch.arriveState = 'STANDING'; ch.arriveWait = 2000 + Math.random()*2000;
-        }
-
-      } else if (ch.id === 'jim') {
-        if (r < 0.55) {
-          ch.destX = ch.homeX; ch.destY = ch.homeY;
-          ch.arriveState = 'IDLE_DESK'; ch.arriveWait = 4000 + Math.random()*6000;
-        } else if (r < 0.90) {
-          // Chat with Pam
-          ch.destX = 5.5; ch.destY = 6.2;
-          ch.arriveState = 'CHATTING'; ch.arriveWait = 0;
-          ch.chatConvo = jimPamConvos[Math.floor(Math.random() * jimPamConvos.length)];
-          ch.chatStep = 0; ch.chatTimer = 0; ch.chatPartner = 'pam';
-        } else {
-          ch.destX = 7.3; ch.destY = 6.5;
-          ch.arriveState = 'STANDING'; ch.arriveWait = 2000 + Math.random()*3000;
-        }
-
-      } else if (ch.id === 'dwight') {
-        if (r < 0.80) {
-          ch.destX = ch.homeX; ch.destY = ch.homeY;
-          ch.arriveState = 'IDLE_DESK'; ch.arriveWait = 4000 + Math.random()*8000;
-        } else {
-          // Patrol route
-          ch.arriveState = 'PATROLLING'; ch.arriveWait = 0;
-          ch.patrolStep = 0; ch.patrolTimer = 0;
-          ch.destX = dwightPatrol[0].x; ch.destY = dwightPatrol[0].y;
-        }
-
-      } else if (ch.id === 'michael') {
-        if (r < 0.55) {
-          ch.destX = ch.homeX; ch.destY = ch.homeY;
-          ch.arriveState = 'IDLE_DESK'; ch.arriveWait = 4000 + Math.random()*8000;
-        } else if (r < 0.85) {
-          ch.destX = 1.5; ch.destY = 1.5;
-          ch.arriveState = 'IN_MEETING'; ch.arriveWait = 6000 + Math.random()*9000;
-        } else {
-          // Announce in bullpen
-          ch.destX = 7.0; ch.destY = 3.5;
-          ch.arriveState = 'ANNOUNCING'; ch.arriveWait = 5000;
-          ch.chatConvo = [{ who: 'michael', text: michaelAnnouncements[Math.floor(Math.random() * michaelAnnouncements.length)] }];
-          ch.chatStep = 0; ch.chatTimer = 0;
-        }
-
-      } else if (ch.id === 'ceo') {
-        if (r < 0.35) {
-          ch.destX = ch.homeX; ch.destY = ch.homeY;
-          ch.arriveState = 'IDLE_DESK'; ch.arriveWait = 4000 + Math.random()*8000;
-        } else if (r < 0.85) {
-          ch.destX = 1.5; ch.destY = 1.5;
-          ch.arriveState = 'IN_MEETING'; ch.arriveWait = 6000 + Math.random()*9000;
-        } else {
-          ch.destX = 0.4; ch.destY = 4.5;
-          ch.arriveState = 'PRESENTING'; ch.arriveWait = 3000 + Math.random()*5000;
-        }
-
-      } else if (ch.id === 'eng') {
-        if (r < 0.88) {
-          ch.destX = ch.homeX; ch.destY = ch.homeY;
-          ch.arriveState = 'IDLE_DESK'; ch.arriveWait = 4000 + Math.random()*8000;
-        } else {
-          ch.destX = 1.5; ch.destY = 1.5;
-          ch.arriveState = 'IN_MEETING'; ch.arriveWait = 6000 + Math.random()*9000;
-        }
-
-      } else if (ch.id === 'cmo') {
-        if (r < 0.50) {
-          ch.destX = ch.homeX; ch.destY = ch.homeY;
-          ch.arriveState = 'IDLE_DESK'; ch.arriveWait = 4000 + Math.random()*8000;
-        } else if (r < 0.85) {
-          ch.destX = 0.4; ch.destY = 4.5;
-          ch.arriveState = 'PRESENTING'; ch.arriveWait = 3000 + Math.random()*5000;
-        } else {
-          ch.destX = 7.3; ch.destY = 6.5;
-          ch.arriveState = 'STANDING'; ch.arriveWait = 2000 + Math.random()*3000;
-        }
-      }
-
-      ch.state = 'WALKING';
-      var dx = ch.destX - ch.x;
-      if (Math.abs(dx) > 0.05) ch.faceRight = dx > 0;
-    }
-
-    // Solid obstacles characters should walk around (bullpen desks left walkable — agents sit at them)
-    var OBSTACLES = [
-      [0.6, 0.7, 1.8, 0.8],   // conference table
-      [9.8, 0.6, 1.2, 0.7],   // Michael's desk
-      [4.8, 5.2, 1.0, 0.6],   // reception desk
-      [5.8, 5.0, 0.8, 0.6],   // reception desk
-      [7.3, 6.3, 0.3, 0.3],   // water cooler
-      [0.05, 4.2, 0.08, 0.8]  // whiteboard
-    ];
-    var OBSTACLE_PAD = 0.18;
-    function blocked(x, y) {
-      for (var i = 0; i < OBSTACLES.length; i++) {
-        var o = OBSTACLES[i];
-        if (x > o[0] - OBSTACLE_PAD && x < o[0] + o[2] + OBSTACLE_PAD &&
-            y > o[1] - OBSTACLE_PAD && y < o[1] + o[3] + OBSTACLE_PAD) return true;
-      }
-      return false;
-    }
-
-    function walkTowards(ch, tx, ty, dt) {
-      var dx = tx - ch.x;
-      var dy = ty - ch.y;
-      var dist = Math.sqrt(dx * dx + dy * dy);
-      var speed = 0.025;
-      if (dist < speed * dt / 16) {
-        ch.x = tx; ch.y = ty;
-        return true; // arrived
-      }
-      var nx = dx / dist;
-      var ny = dy / dist;
-      var stepX = nx * speed * (dt / 16);
-      var stepY = ny * speed * (dt / 16);
-      var nextX = ch.x + stepX;
-      var nextY = ch.y + stepY;
-      // Slide against obstacles: try full move, then axis-only fallbacks.
-      // Destination is always allowed (characters sit AT desks).
-      var destBlocked = blocked(tx, ty);
-      if (!blocked(nextX, nextY) || destBlocked) {
-        ch.x = nextX; ch.y = nextY;
-      } else if (!blocked(nextX, ch.y)) {
-        ch.x = nextX;
-      } else if (!blocked(ch.x, nextY)) {
-        ch.y = nextY;
-      } else {
-        // corner-trapped: nudge perpendicular to primary motion to escape
-        var perpX = -ny, perpY = nx;
-        var nudgeX = ch.x + perpX * speed * (dt / 16);
-        var nudgeY = ch.y + perpY * speed * (dt / 16);
-        if (!blocked(nudgeX, nudgeY)) { ch.x = nudgeX; ch.y = nudgeY; }
-      }
-      if (Math.abs(dx) > 0.05) ch.faceRight = dx > 0;
-      ch.animTimer += dt;
-      if (ch.animTimer > 180) {
-        ch.animTimer = 0;
-        ch.walkFrame = (ch.walkFrame + 1) % 4;
-      }
-      return false;
-    }
-
-    function updateChar(ch, dt) {
-
-      // Ambient desk bubble timer
-      if (ch.state === 'IDLE_DESK') {
-        ch.bubbleTimer -= dt;
-        if (ch.bubbleTimer <= 0) {
-          ch.bubbleTimer = 8000 + Math.random() * 12000;
-          spawnBubble(ch.id, null);
-        }
-      }
-
-      if (ch.state === 'WALKING') {
-        var arrived = walkTowards(ch, ch.destX, ch.destY, dt);
-        if (arrived) {
-          ch.state = ch.arriveState;
-          ch.stateTimer = ch.arriveWait;
-
-          if (ch.state === 'CHATTING') {
-            // Jim arrived near Pam: face each other
-            ch.faceRight = false; // Jim faces left toward Pam
-            var pam = getChar('pam');
-            if (pam) { pam.faceRight = true; } // Pam faces Jim
-            ch.chatStep = 0;
-            ch.chatTimer = 0;
-            // Show first line
-            var line0 = ch.chatConvo[0];
-            spawnBubble(line0.who, line0.text);
-            ch.chatTimer = 3000;
-          } else if (ch.state === 'ANNOUNCING') {
-            ch.walkFrame = 0;
-            var aline = ch.chatConvo[0];
-            spawnBubble(aline.who, aline.text);
-            ch.chatTimer = ch.arriveWait;
-          } else if (ch.state === 'PATROLLING') {
-            ch.patrolTimer = 1500;
-            spawnBubble(ch.id, dwightPatrol[ch.patrolStep].bubble);
-          } else if (Math.random() < 0.4) {
-            spawnBubble(ch.id, null);
-          }
-        }
-
-      } else if (ch.state === 'CHATTING') {
-        // Jim+Pam conversation
-        ch.chatTimer -= dt;
-        ch.walkFrame = 0;
-        if (ch.chatTimer <= 0) {
-          ch.chatStep++;
-          if (ch.chatStep < ch.chatConvo.length) {
-            var nextLine = ch.chatConvo[ch.chatStep];
-            spawnBubble(nextLine.who, nextLine.text);
-            ch.chatTimer = 3000;
-          } else {
-            // Conversation done, Jim returns home
-            var pam2 = getChar('pam');
-            if (pam2) { pam2.faceRight = true; } // Pam resets
-            ch.destX = ch.homeX; ch.destY = ch.homeY;
-            ch.arriveState = 'IDLE_DESK'; ch.arriveWait = 4000 + Math.random()*8000;
-            ch.state = 'WALKING';
-            var dxHome = ch.destX - ch.x;
-            if (Math.abs(dxHome) > 0.05) ch.faceRight = dxHome > 0;
-          }
-        }
-
-      } else if (ch.state === 'ANNOUNCING') {
-        // Michael stands in bullpen
-        ch.chatTimer -= dt;
-        ch.walkFrame = 0;
-        if (ch.chatTimer <= 0) {
-          ch.destX = ch.homeX; ch.destY = ch.homeY;
-          ch.arriveState = 'IDLE_DESK'; ch.arriveWait = 4000 + Math.random()*8000;
-          ch.state = 'WALKING';
-          var dxA = ch.destX - ch.x;
-          if (Math.abs(dxA) > 0.05) ch.faceRight = dxA > 0;
-        }
-
-      } else if (ch.state === 'PATROLLING') {
-        // Dwight patrols
-        ch.patrolTimer -= dt;
-        ch.walkFrame = 0;
-        if (ch.patrolTimer <= 0) {
-          ch.patrolStep++;
-          if (ch.patrolStep < dwightPatrol.length) {
-            var wp = dwightPatrol[ch.patrolStep];
-            ch.destX = wp.x; ch.destY = wp.y;
-            ch.state = 'WALKING';
-            ch.arriveState = 'PATROLLING'; ch.arriveWait = 0;
-            var dxP = ch.destX - ch.x;
-            if (Math.abs(dxP) > 0.05) ch.faceRight = dxP > 0;
-          } else {
-            // Return to desk
-            ch.destX = ch.homeX; ch.destY = ch.homeY;
-            ch.arriveState = 'IDLE_DESK'; ch.arriveWait = 4000 + Math.random()*8000;
-            ch.state = 'WALKING';
-            var dxD = ch.destX - ch.x;
-            if (Math.abs(dxD) > 0.05) ch.faceRight = dxD > 0;
-          }
-        }
-
-      } else if (ch.state === 'IDLE_DESK') {
-        ch.stateTimer -= dt;
-        ch.animTimer += dt;
-        if (ch.animTimer > 600) {
-          ch.animTimer = 0;
-          ch.walkFrame = ch.walkFrame === 0 ? 1 : 0;
-        }
-        if (ch.stateTimer <= 0) pickNextActivity(ch);
-
-      } else if (ch.state === 'IN_MEETING') {
-        ch.stateTimer -= dt;
-        ch.animTimer += dt;
-        if (ch.animTimer > 2000) {
-          ch.animTimer = 0;
-          ch.walkFrame = 0;
-        }
-        if (ch.stateTimer <= 0) {
-          ch.destX = ch.homeX; ch.destY = ch.homeY;
-          ch.arriveState = 'IDLE_DESK'; ch.arriveWait = 4000 + Math.random()*8000;
-          ch.state = 'WALKING';
-          var dxM = ch.destX - ch.x;
-          if (Math.abs(dxM) > 0.05) ch.faceRight = dxM > 0;
-        }
-
-      } else if (ch.state === 'STANDING') {
-        ch.stateTimer -= dt;
-        ch.walkFrame = 0;
-        if (ch.stateTimer <= 0) pickNextActivity(ch);
-
-      } else if (ch.state === 'PRESENTING') {
-        ch.stateTimer -= dt;
-        ch.walkFrame = 2;
-        if (ch.stateTimer <= 0) {
-          ch.destX = ch.homeX; ch.destY = ch.homeY;
-          ch.arriveState = 'IDLE_DESK'; ch.arriveWait = 4000 + Math.random()*8000;
-          ch.state = 'WALKING';
-          var dxPr = ch.destX - ch.x;
-          if (Math.abs(dxPr) > 0.05) ch.faceRight = dxPr > 0;
-        }
-      }
-    }
-
-    // ── COLOR HELPER ────────────────────────────────────
-    function shadeHex(hex, amt) {
-      var r = parseInt(hex.slice(1,3),16), g = parseInt(hex.slice(3,5),16), b = parseInt(hex.slice(5,7),16);
-      r = Math.max(0,Math.min(255,r+amt)); g = Math.max(0,Math.min(255,g+amt)); b = Math.max(0,Math.min(255,b+amt));
-      function hh(v){ var s=v.toString(16); return s.length<2?'0'+s:s; }
-      return '#'+hh(r)+hh(g)+hh(b);
-    }
-
-    // ── DRAW CHARACTER ──────────────────────────────────
-    // 12-col × 22-row sprite at S=2 (24×44 screen px)
-    // row layout: 0-1 hair crown, 2-7 head/face, 8-14 torso+arms,
-    //             15-18 lower body (sitting: wide thighs; standing: two leg columns),
-    //             19-21 feet/shoes
-    function drawChar(ctx, ch) {
-      ctx.save();
-      var S = 3;
-      var pos = iso(ch.x, ch.y);
-      var cx = Math.round(pos.x);
-      var oy = Math.round(pos.y) - 22 * S;
-      var ox = cx - 6 * S;
-
-      var sitting = (ch.state === 'IDLE_DESK' || ch.state === 'IN_MEETING' || ch.state === 'CHATTING');
-      var frame = ch.walkFrame;
-      // head bob only when walking
-      var bob = (!sitting && (frame === 1 || frame === 3)) ? 1 : 0;
-
-      // (agent backplate removed — label above character carries identity)
-
-      var sk = ch.skin, hr = ch.hair, sh = ch.shirt, pt = ch.pants;
-      var shoe = '#2A2010', eye = '#1A0E08', mth = shadeHex(sk, -30);
-      var hrHL = shadeHex(hr, 32), shHL = shadeHex(sh, 22), shDK = shadeHex(sh, -20);
-
-      // px: absolute row (no bob)
-      function px(col, row, c) {
-        ctx.fillStyle = c;
-        ctx.fillRect(ox + col * S, oy + row * S, S, S);
-      }
-      // hpx: head-attached row (bobs with walk)
-      function hpx(col, row, c) { px(col, row + bob, c); }
-
-      // ── HAIR crown rows 0-1 ──
-      for (var i = 3; i <= 8; i++) hpx(i, 0, hr);
-      for (var i = 2; i <= 9; i++) hpx(i, 1, hr);
-      hpx(4, 1, hrHL); hpx(5, 1, hrHL);
-
-      // ── FACE rows 2-7 ──
-      // row 2: side hair + forehead
-      hpx(2, 2, hr);
-      for (var i = 3; i <= 8; i++) hpx(i, 2, sk);
-      hpx(9, 2, hr);
-      // row 3: brow line
-      hpx(2, 3, hr);
-      for (var i = 3; i <= 8; i++) hpx(i, 3, sk);
-      hpx(9, 3, hr);
-      // row 4: eyes
-      for (var i = 3; i <= 8; i++) hpx(i, 4, sk);
-      hpx(4, 4, eye); hpx(7, 4, eye);
-      // row 5: cheeks
-      for (var i = 3; i <= 8; i++) hpx(i, 5, sk);
-      // row 6: mouth
-      hpx(3, 6, sk); hpx(4, 6, mth); hpx(5, 6, mth); hpx(6, 6, mth); hpx(7, 6, mth); hpx(8, 6, sk);
-      // row 7: chin
-      hpx(4, 7, sk); hpx(5, 7, sk); hpx(6, 7, sk); hpx(7, 7, sk);
-
-      // ── CHARACTER-SPECIFIC FEATURES ──
-      if (ch.id === 'pam') {
-        // long auburn hair: flows from side of head down past shoulders
-        hpx(2, 3, hr); hpx(9, 3, hr);
-        hpx(2, 4, hr); hpx(9, 4, hr);
-        hpx(2, 5, hr); hpx(9, 5, hr);
-        hpx(2, 6, hr); hpx(9, 6, hr);
-        hpx(2, 7, hr); hpx(9, 7, hr);
-        // hair falls onto shoulders (rows 8-10, using px since torso doesn't bob)
-        px(1, 8, hr); px(2, 8, hr); px(9, 8, hr); px(10, 8, hr);
-        px(1, 9, hr); px(2, 9, hr); px(9, 9, hr); px(10, 9, hr);
-        px(1, 10, hrHL); px(10, 10, hrHL);
-      } else if (ch.id === 'dwight') {
-        // glasses: dark horizontal bar at eye level
-        hpx(3, 4, '#6A6040'); hpx(8, 4, '#6A6040');
-      } else if (ch.id === 'michael') {
-        // wider hair at crown
-        hpx(2, 0, hr); hpx(9, 0, hr);
-        // big grin: wider mouth
-        hpx(3, 6, mth); hpx(8, 6, mth);
-      }
-
-      // ── NECK row 8 ──
-      hpx(5, 8, sk); hpx(6, 8, sk);
-
-      // ── TORSO rows 8-14 ──
-      // shoulder row
-      for (var i = 3; i <= 8; i++) px(i, 8, sh); px(5, 8, shHL); px(6, 8, shHL);
-      // body rows 9-11
-      for (var r = 9; r <= 11; r++) {
-        for (var i = 1; i <= 10; i++) px(i, r, sh);
-        px(10, r, shDK);
-      }
-      // waist / belt rows 12-13
-      px(0, 12, sk);
-      for (var i = 1; i <= 10; i++) px(i, 12, sh);
-      px(11, 12, sk);
-      px(0, 13, sk); px(1, 13, sk);
-      for (var i = 2; i <= 9; i++) px(i, 13, sh);
-      px(10, 13, sk); px(11, 13, sk);
-      // arm joints row 14
-      px(0, 14, sk); px(1, 14, sk); px(10, 14, sk); px(11, 14, sk);
-
-      // ── LOWER BODY rows 15-21 ──
-      if (sitting) {
-        // wide thighs span cols 2-9, the key "seated" read
-        for (var i = 2; i <= 9; i++) { px(i, 15, pt); px(i, 16, pt); }
-        // knees angle in
-        px(3, 17, pt); px(4, 17, pt); px(5, 17, pt); px(6, 17, pt); px(7, 17, pt); px(8, 17, pt);
-        // lower legs hang down
-        px(3, 18, pt); px(4, 18, pt); px(7, 18, pt); px(8, 18, pt);
-        // feet
-        px(2, 19, shoe); px(3, 19, shoe); px(4, 19, shoe);
-        px(7, 19, shoe); px(8, 19, shoe); px(9, 19, shoe);
-      } else {
-        // standing/walking: two narrow leg columns
-        var lx2 = (frame === 1) ? -1 : 0;
-        var rx2 = (frame === 3) ?  1 : 0;
-        for (var r = 15; r <= 20; r++) {
-          px(2 + lx2, r, pt); px(3 + lx2, r, pt);
-          px(8 + rx2, r, pt); px(9 + rx2, r, pt);
-        }
-        // shoes row 21
-        for (var i = 0; i < 4; i++) {
-          px(1 + lx2 + i, 21, shoe);
-          px(7 + rx2 + i, 21, shoe);
-        }
-      }
-
-      ctx.restore();
-
-      // ── NAME / ROLE LABEL ──
-      ctx.save();
-      ctx.textAlign = 'center';
-      var nameY = oy - 7;
-      if (ch.isAgent && ch.label) {
-        // agents get only the role badge (name === label would duplicate)
-        var badgeW = 30, badgeH = 11;
-        var badgeY = nameY - badgeH + 4;
-        ctx.fillStyle = ch.agentColor;
-        ctx.fillRect(cx - badgeW / 2, badgeY, badgeW, badgeH);
-        ctx.fillStyle = '#1b0d2a';
-        ctx.font = '6px "Press Start 2P", monospace';
-        ctx.fillText(ch.label, cx, badgeY + badgeH - 2);
-      } else {
-        ctx.fillStyle = 'rgba(255,235,252,0.88)';
-        ctx.font = '6px "Press Start 2P", monospace';
-        ctx.fillText(ch.name, cx, nameY);
-      }
-      ctx.restore();
-    }
-
-    // ── DRAW SPEECH BUBBLE ──────────────────────────────
-    function drawBubble(ctx, b) {
-      var ch = getChar(b.charId);
-      if (!ch) return;
-
-      var alpha = b.age > b.fadeStart
-        ? 1.0 - (b.age - b.fadeStart) / (b.duration - b.fadeStart)
-        : 1.0;
-      if (alpha <= 0) return;
-
-      var pos = iso(ch.x, ch.y);
-      var headTop = pos.y - 22 * 3;
-
-      ctx.save();
-      ctx.globalAlpha = alpha;
-      ctx.font = '16px "VT323", monospace';
-      var textW = ctx.measureText(b.text).width;
-      var padX = 8;
-      var bw = textW + padX * 2;
-      var bh = 26;
-      var bx3 = pos.x - bw / 2;
-      var by3 = headTop - bh - 10;
-
-      ctx.fillStyle = '#ffebfc';
-      ctx.fillRect(bx3, by3, bw, bh);
-      ctx.fillStyle = '#9f4dbf';
-      ctx.strokeStyle = '#9f4dbf';
-      ctx.lineWidth = 2;
-      ctx.strokeRect(bx3, by3, bw, bh);
-
-      // tail
-      ctx.fillStyle = '#ffebfc';
-      ctx.beginPath();
-      ctx.moveTo(pos.x - 4, by3 + bh);
-      ctx.lineTo(pos.x + 4, by3 + bh);
-      ctx.lineTo(pos.x, by3 + bh + 8);
-      ctx.closePath();
-      ctx.fill();
-      ctx.strokeStyle = '#9f4dbf';
-      ctx.lineWidth = 1;
-      ctx.stroke();
-
-      ctx.fillStyle = '#1b0d2a';
-      ctx.textAlign = 'center';
-      ctx.fillText(b.text, pos.x, by3 + bh - 7);
-
-      ctx.restore();
-    }
-
-    // ── MAIN DRAW ────────────────────────────────────────
-    function draw(ctx) {
-      ctx.clearRect(0, 0, canvas.width, canvas.height);
-
-      var wallH = 48;
-
-      // ── BACK WALLS ──────────────────────────────────
-      ctx.fillStyle = '#201C14';
-      for (var gx2 = 0; gx2 < 12; gx2++) {
-        var p0 = iso(gx2, 0);
-        var p1 = iso(gx2 + 1, 0);
-        ctx.beginPath();
-        ctx.moveTo(p0.x, p0.y - wallH);
-        ctx.lineTo(p1.x, p1.y - wallH);
-        ctx.lineTo(p1.x, p1.y);
-        ctx.lineTo(p0.x, p0.y);
-        ctx.closePath();
-        ctx.fill();
-      }
-      ctx.fillStyle = '#18140E';
-      for (var gy2 = 0; gy2 < 8; gy2++) {
-        var lp0 = iso(0, gy2);
-        var lp1 = iso(0, gy2 + 1);
-        ctx.beginPath();
-        ctx.moveTo(lp0.x, lp0.y - wallH);
-        ctx.lineTo(lp1.x, lp1.y - wallH);
-        ctx.lineTo(lp1.x, lp1.y);
-        ctx.lineTo(lp0.x, lp0.y);
-        ctx.closePath();
-        ctx.fill();
-      }
-
-      // (awards drawn after glass walls below)
-
-      // ── FLOOR TILES (sorted by gx+gy painter order) ──
-      var tiles = [];
-      for (var row = 0; row < 8; row++) {
-        for (var col = 0; col < 12; col++) {
-          tiles.push({ gx: col, gy: row, sort: col + row });
-        }
-      }
-      tiles.sort(function(a, b) { return a.sort - b.sort; });
-
-      tiles.forEach(function(t) {
-        var tc = TILE_COLORS[roomAt(t.gx, t.gy)];
-        drawTile(ctx, t.gx, t.gy, tc);
-      });
-
-      // ── ROOM DIVIDERS (glass walls) ──────────────────
-      ctx.save();
-      ctx.strokeStyle = 'rgba(160,160,180,0.35)';
-      ctx.lineWidth = 2;
-
-      function drawGlassWall(gx3, gy3, gx4, gy4) {
-        var pp0 = iso(gx3, gy3);
-        var pp1 = iso(gx4, gy4);
-        ctx.beginPath();
-        ctx.moveTo(pp0.x, pp0.y - wallH);
-        ctx.lineTo(pp0.x, pp0.y);
-        ctx.lineTo(pp1.x, pp1.y);
-        ctx.lineTo(pp1.x, pp1.y - wallH);
-        ctx.closePath();
-        ctx.fillStyle = 'rgba(160,160,200,0.08)';
-        ctx.fill();
-        ctx.stroke();
-      }
-
-      drawGlassWall(3, 0, 3, 3);
-      drawGlassWall(0, 3, 3, 3);
-      drawGlassWall(9, 0, 9, 3);
-      drawGlassWall(9, 3, 12, 3);
-
-      ctx.restore();
-
-      // ── MICHAEL'S OFFICE WALL AWARDS ─────────────────
-      // Plaques on the interior face of the gx=9 glass wall
-      var awards = [
-        { gy: 0.55, lines: ['DUNDIE', 'AWARD'], color: '#cf72d9' },
-        { gy: 1.55, lines: ["WORLD'S", 'BEST BOSS'], color: '#cf72d9' },
-        { gy: 2.45, lines: ['FAIR-CODE', 'LICENSE'], color: '#cf72d9' }
-      ];
-      ctx.save();
-      ctx.font = '5px "Press Start 2P", monospace';
-      ctx.textAlign = 'center';
-      awards.forEach(function(a) {
-        var ap = iso(9.18, a.gy + 0.3);
-        var aw = 30, ah = 18;
-        var ax = ap.x - aw / 2;
-        var ay = ap.y - wallH + 8;
-        ctx.fillStyle = '#1b0d2a';
-        ctx.fillRect(ax, ay, aw, ah);
-        ctx.strokeStyle = a.color;
-        ctx.lineWidth = 1.5;
-        ctx.strokeRect(ax, ay, aw, ah);
-        ctx.fillStyle = a.color;
-        ctx.fillText(a.lines[0], ap.x, ay + 8);
-        ctx.fillText(a.lines[1], ap.x, ay + 15);
-      });
-      ctx.restore();
-
-      // ── FURNITURE ────────────────────────────────────
-
-      // Conference table
-      drawBox(ctx, 0.6, 0.7, 1.8, 0.8, 12, '#7A5A18', '#5A3C08', '#3A2404');
-      // Conf chairs
-      drawBox(ctx, 0.5, 0.5, 0.4, 0.4, 8, '#5A4632', '#403020', '#403020');
-      drawBox(ctx, 2.1, 0.5, 0.4, 0.4, 8, '#5A4632', '#403020', '#403020');
-      drawBox(ctx, 0.5, 1.4, 0.4, 0.4, 8, '#5A4632', '#403020', '#403020');
-      drawBox(ctx, 2.1, 1.4, 0.4, 0.4, 8, '#5A4632', '#403020', '#403020');
-
-      // Bullpen desks
-      var desks = [[3,2.8],[5,2.8],[3,4.3],[5,4.3],[8,2.8],[10,2.8]];
-      desks.forEach(function(d) {
-        drawBox(ctx, d[0], d[1], 0.9, 0.6, 10, '#7A5A18', '#5A3C08', '#3A2404');
-        // monitor
-        var mp = iso(d[0] + 0.35, d[1] + 0.1);
-        ctx.fillStyle = '#1b0d2a';
-        ctx.fillRect(mp.x - 9, mp.y - 26, 18, 16);
-        ctx.fillStyle = 'rgba(207,114,217,0.28)';
-        ctx.fillRect(mp.x - 7, mp.y - 24, 14, 12);
-      });
-
-      // Michael's fancy desk
-      drawBox(ctx, 9.8, 0.6, 1.2, 0.7, 12, '#5A9AC8', '#3F6C8C', '#3F6C8C');
-
-      // Reception desk
-      drawBox(ctx, 4.8, 5.2, 1.0, 0.6, 12, '#6A4A14', '#4A3208', '#4A3208');
-      drawBox(ctx, 5.8, 5.0, 0.8, 0.6, 12, '#6A4A14', '#4A3208', '#4A3208');
-
-      // Whiteboard
-      drawBox(ctx, 0.05, 4.2, 0.08, 0.8, 20, '#ffebfc', '#cf72d9', '#9f4dbf');
-      var wb = iso(0.1, 4.5);
-      ctx.fillStyle = '#D4DB18';
-      ctx.fillRect(wb.x, wb.y - 30, 3, 2);
-      ctx.fillRect(wb.x + 1, wb.y - 26, 2, 2);
-      ctx.fillStyle = '#cf72d9';
-      ctx.fillRect(wb.x + 2, wb.y - 22, 4, 2);
-
-      // Water cooler
-      drawBox(ctx, 7.3, 6.3, 0.3, 0.3, 16, '#5A9AC8', '#3F6C8C', '#3F6C8C');
-      var wcTop = iso(7.45, 6.45);
-      ctx.fillStyle = '#cf72d9';
-      ctx.fillRect(wcTop.x - 3, wcTop.y - 20, 6, 6);
-
-      // ── ROOM LABELS ──────────────────────────────────
-      ctx.save();
-      ctx.font = '6px "Press Start 2P", monospace';
-      ctx.textAlign = 'center';
-
-      var confLabel = iso(1.5, 2.6);
-      ctx.fillStyle = 'rgba(207,114,217,0.75)';
-      ctx.fillText('CONF ROOM', confLabel.x, confLabel.y);
-
-      var mLabel = iso(10.5, 2.6);
-      ctx.fillStyle = 'rgba(207,114,217,0.75)';
-      ctx.fillText("MICHAEL'S", mLabel.x, mLabel.y);
-      ctx.fillText('OFFICE', mLabel.x, mLabel.y + 10);
-
-      var recLabel = iso(5.5, 6.4);
-      ctx.fillStyle = 'rgba(207,114,217,0.75)';
-      ctx.fillText('RECEPTION', recLabel.x, recLabel.y);
-
-      ctx.restore();
-
-      // ── CHARACTERS + BUBBLES (sorted by x+y) ─────────
-      var sortedChars = CHARS.slice().sort(function(a, b) {
-        return (a.x + a.y) - (b.x + b.y);
-      });
-
-      sortedChars.forEach(function(ch) {
-        ctx.save();
-        drawChar(ctx, ch);
-        ctx.restore();
-      });
-
-      bubbles.forEach(function(b) {
-        drawBubble(ctx, b);
-      });
-    }
-
-    // ── UPDATE ───────────────────────────────────────────
-    function update(dt) {
-      CHARS.forEach(function(ch) { updateChar(ch, dt); });
-
-      bubbles = bubbles.filter(function(b) {
-        b.age += dt;
-        return b.age < b.duration;
-      });
-    }
-
-    // ── ANIMATION LOOP ───────────────────────────────────
-    function drawFrame() {
-      var ctx = canvas.getContext('2d');
-      ctx.save();
-      ctx.scale(DPR, DPR);
-      draw(ctx);
-      ctx.restore();
-    }
-
-    function stopLoop() {
-      if (animHandle) {
-        window.cancelAnimationFrame(animHandle);
-        animHandle = null;
-      }
-    }
-
-    function startLoop() {
-      if (animHandle || !pageCanAnimate() || !officeVisible) return;
-      lastTime = performance.now();
-      animHandle = window.requestAnimationFrame(loop);
-    }
-
-    function syncOfficeMotion() {
-      if (!officeObserver) {
-        updateOfficeVisibility();
-      }
-      if (pageCanAnimate() && officeVisible) {
-        startLoop();
-        return;
-      }
-      stopLoop();
-      drawFrame();
-    }
-
-    function loop(now) {
-      var dt = Math.min(now - lastTime, 50);
-      lastTime = now;
-      update(dt);
-      drawFrame();
-      animHandle = pageCanAnimate() && officeVisible ? window.requestAnimationFrame(loop) : null;
-    }
-
-    document.addEventListener('visibilitychange', syncOfficeMotion);
-    if (motionQuery.addEventListener) {
-      motionQuery.addEventListener('change', syncOfficeMotion);
-    } else if (motionQuery.addListener) {
-      motionQuery.addListener(syncOfficeMotion);
-    }
-
-    if (window.IntersectionObserver) {
-      officeObserver = new IntersectionObserver(function(entries) {
-        officeVisible = !!(entries[0] && entries[0].isIntersecting);
-        syncOfficeMotion();
-      }, { threshold: 0.12 });
-      officeObserver.observe(canvas);
-    } else {
-      updateOfficeVisibility();
-      window.addEventListener('scroll', syncOfficeMotion, { passive: true });
-      window.addEventListener('resize', syncOfficeMotion);
-    }
-
-    window.addEventListener('resize', function() {
-      resize();
-      drawFrame();
-    });
-
-    resize();
-    drawFrame();
-    syncOfficeMotion();
-
-  })(); // end isometric scene IIFE
-
+  document.querySelectorAll('.line-copy').forEach(function(btn) { wireCopy(btn, btn); });
 })();
 </script>
-<script>
-var x0=["BN","BN","BN","BN","BN","BN","BN","BN","BN","S","B","S","WS","B","BN","BN","BN","BN","BN","BN","BN","BN","BN","BN","BN","BN","BN","BN","B","B","B","S","WS","ON","ON","ET","ET","ET","ON","ON","ON","ON","ON","ON","CS","ON","CS","ON","EN","EN","EN","EN","EN","EN","EN","EN","EN","EN","ON","ON","ON","ON","ON","ON","ON","L","L","L","L","L","L","L","L","L","L","L","L","L","L","L","L","L","L","L","L","L","L","L","L","L","L","ON","ON","ON","ON","ON","ON","L","L","L","L","L","L","L","L","L","L","L","L","L","L","L","L","L","L","L","L","L","L","L","L","L","L","ON","ON","ON","ON","BN","BN","BN","BN","BN","BN","B","BN","BN","BN","BN","BN","BN","BN","BN","BN","BN","BN","BN","BN","BN","BN","BN","BN","BN","BN","BN","BN","BN","BN","BN","BN","BN","CS","ON","ET","ET","ET","ET","ON","ON","ON","ON","L","ON","ON","ON","ON","ON","ET","ET","EN","EN","ON","L","ON","ON","ON","EN","L","ON","ON","ON","ON","ON","L","L","L","L","L","L","L","L","L","L","L","L","L","L","L","L","L","L","L","L","L","L","L","ON","L","L","L","L","L","L","L","L","L","L","L","L","L","L","L","L","L","L","L","L","L","L","L","L","L","L","L","L","L","L","L","ON","L","L","L","L","L","L","L","L"],g0=["AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","CS","AL","ON","ON","NSM","NSM","NSM","NSM","NSM","NSM","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","NSM","NSM","NSM","NSM","NSM","NSM","NSM","NSM","NSM","NSM","NSM","NSM","NSM","NSM","AL","AL","AL","AL","AL","AL","AL","AN","AN","AN","AN","AN","AN","AN","AN","AN","AN","ET","AN","AN","AL","AL","AL","NSM","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","NSM","NSM","NSM","NSM","NSM","NSM","NSM","NSM","NSM","NSM","NSM","NSM","NSM","NSM","NSM","NSM","NSM","NSM","NSM","ON","NSM","NSM","NSM","NSM","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL"];function m0(O){if(O<=255)return x0[O];if(1424<=O&&O<=1524)return"R";if(1536<=O&&O<=1791)return g0[O&255];if(1792<=O&&O<=2220)return"AL";return"L"}function r0(O){let _=O.length;if(_===0)return null;let J=Array(_),Y=0;for(let V=0;V<_;V++){let $=m0(O.charCodeAt(V));if($==="R"||$==="AL"||$==="AN")Y++;J[V]=$}if(Y===0)return null;let X=_/Y<0.3?0:1,R=new Int8Array(_);for(let V=0;V<_;V++)R[V]=X;let Z=X&1?"R":"L",Q=Z,f=Q;for(let V=0;V<_;V++)if(J[V]==="NSM")J[V]=f;else f=J[V];f=Q;for(let V=0;V<_;V++){let $=J[V];if($==="EN")J[V]=f==="AL"?"AN":"EN";else if($==="R"||$==="L"||$==="AL")f=$}for(let V=0;V<_;V++)if(J[V]==="AL")J[V]="R";for(let V=1;V<_-1;V++){if(J[V]==="ES"&&J[V-1]==="EN"&&J[V+1]==="EN")J[V]="EN";if(J[V]==="CS"&&(J[V-1]==="EN"||J[V-1]==="AN")&&J[V+1]===J[V-1])J[V]=J[V-1]}for(let V=0;V<_;V++){if(J[V]!=="EN")continue;let $;for($=V-1;$>=0&&J[$]==="ET";$--)J[$]="EN";for($=V+1;$<_&&J[$]==="ET";$++)J[$]="EN"}for(let V=0;V<_;V++){let $=J[V];if($==="WS"||$==="ES"||$==="ET"||$==="CS")J[V]="ON"}f=Q;for(let V=0;V<_;V++){let $=J[V];if($==="EN")J[V]=f==="L"?"L":"EN";else if($==="R"||$==="L")f=$}for(let V=0;V<_;V++){if(J[V]!=="ON")continue;let $=V+1;while($<_&&J[$]==="ON")$++;let u=V>0?J[V-1]:Q,q=$<_?J[$]:Q,D=u!=="L"?"R":"L";if(D===(q!=="L"?"R":"L"))for(let K=V;K<$;K++)J[K]=D;V=$-1}for(let V=0;V<_;V++)if(J[V]==="ON")J[V]=Z;for(let V=0;V<_;V++){let $=J[V];if((R[V]&1)===0){if($==="R")R[V]++;else if($==="AN"||$==="EN")R[V]+=2}else if($==="L"||$==="AN"||$==="EN")R[V]++}return R}function u0(O,_){let J=r0(O);if(J===null)return null;let Y=new Int8Array(_.length);for(let X=0;X<_.length;X++)Y[X]=J[_[X]];return Y}var a0=/[ \t\n\r\f]+/g,s0=/[\t\n\r\f]| {2,}|^ | $/;function d0(O){let _=O??"normal";return _==="pre-wrap"?{mode:_,preserveOrdinarySpaces:!0,preserveHardBreaks:!0}:{mode:_,preserveOrdinarySpaces:!1,preserveHardBreaks:!1}}function i0(O){if(!s0.test(O))return O;let _=O.replace(a0," ");if(_.charCodeAt(0)===32)_=_.slice(1);if(_.length>0&&_.charCodeAt(_.length-1)===32)_=_.slice(0,-1);return _}function t0(O){if(!/[\r\f]/.test(O))return O.replace(/\r\n/g,`
-`);return O.replace(/\r\n/g,`
-`).replace(/[\r\f]/g,`
-`)}var d=null,V0;function n0(){if(d===null)d=new Intl.Segmenter(V0,{granularity:"word"});return d}function z0(){d=null}function j0(O){let _=O&&O.length>0?O:void 0;if(V0===_)return;V0=_,d=null}var e0=/\p{Script=Arabic}/u,O0=/\p{M}/u,b0=/\p{Nd}/u;function X0(O){return e0.test(O)}function p(O){for(let _ of O){let J=_.codePointAt(0);if(J>=19968&&J<=40959||J>=13312&&J<=19903||J>=131072&&J<=173791||J>=173824&&J<=177983||J>=177984&&J<=178207||J>=178208&&J<=183983||J>=183984&&J<=191471||J>=196608&&J<=201551||J>=63744&&J<=64255||J>=194560&&J<=195103||J>=12288&&J<=12351||J>=12352&&J<=12447||J>=12448&&J<=12543||J>=44032&&J<=55215||J>=65280&&J<=65519)return!0}return!1}var $0=new Set(["，","．","！","：","；","？","、","。","・","）","〕","〉","》","」","』","】","〗","〙","〛","ー","々","〻","ゝ","ゞ","ヽ","ヾ"]),i=new Set(['"',"(","[","{","“","‘","«","‹","（","〔","〈","《","「","『","【","〖","〘","〚"]),Q0=new Set(["'","’"]),r=new Set([".",",","!","?",":",";","،","؛","؟","।","॥","၊","။","၌","၍","၏",")","]","}","%",'"',"”","’","»","›","…"]),OO=new Set([":",".","،","؛"]),_O=new Set(["၏"]),JO=new Set(["”","’","»","›","」","』","】","》","〉","〕","）"]);function RO(O){if(q0(O))return!0;let _=!1;for(let J of O){if(r.has(J)){_=!0;continue}if(_&&O0.test(J))continue;return!1}return _}function VO(O){for(let _ of O)if(!$0.has(_)&&!r.has(_))return!1;return O.length>0}function XO(O){if(q0(O))return!0;for(let _ of O)if(!i.has(_)&&!Q0.has(_)&&!O0.test(_))return!1;return O.length>0}function q0(O){let _=!1;for(let J of O){if(J==="\\"||O0.test(J))continue;if(i.has(J)||r.has(J)||Q0.has(J)){_=!0;continue}return!1}return _}function YO(O){let _=Array.from(O),J=_.length;while(J>0){let Y=_[J-1];if(O0.test(Y)){J--;continue}if(i.has(Y)||Q0.has(Y)){J--;continue}break}if(J<=0||J===_.length)return null;return{head:_.slice(0,J).join(""),tail:_.slice(J).join("")}}function ZO(O,_){if(O.length===0)return!1;for(let J of O)if(J!==_)return!1;return!0}function $O(O){if(!X0(O)||O.length===0)return!1;return OO.has(O[O.length-1])}function QO(O){if(O.length===0)return!1;return _O.has(O[O.length-1])}function qO(O){if(O.length<2||O[0]!==" ")return null;let _=O.slice(1);if(/^\p{M}+$/u.test(_))return{space:" ",marks:_};return null}function D0(O){for(let _=O.length-1;_>=0;_--){let J=O[_];if(JO.has(J))return!0;if(!r.has(J))return!1}return!1}function DO(O,_){if(_.preserveOrdinarySpaces||_.preserveHardBreaks){if(O===" ")return"preserved-space";if(O==="\t")return"tab";if(_.preserveHardBreaks&&O===`
-`)return"hard-break"}if(O===" ")return"space";if(O===" "||O===" "||O==="⁠"||O==="\uFEFF")return"glue";if(O==="​")return"zero-width-break";if(O==="­")return"soft-hyphen";return"text"}function NO(O,_,J,Y){let X=[],R=null,Z="",Q=J,f=!1,V=0;for(let $ of O){let u=DO($,Y),q=u==="text"&&_;if(R!==null&&u===R&&q===f){Z+=$,V+=$.length;continue}if(R!==null)X.push({text:Z,isWordLike:f,kind:R,start:Q});R=u,Z=$,Q=J+V,f=q,V+=$.length}if(R!==null)X.push({text:Z,isWordLike:f,kind:R,start:Q});return X}function Y0(O){return O==="space"||O==="preserved-space"||O==="zero-width-break"||O==="hard-break"}var fO=/^[A-Za-z][A-Za-z0-9+.-]*:$/;function HO(O,_){let J=O.texts[_];if(J.startsWith("www."))return!0;return fO.test(J)&&_+1<O.len&&O.kinds[_+1]==="text"&&O.texts[_+1]==="//"}function UO(O){return O.includes("?")&&(O.includes("://")||O.startsWith("www."))}function MO(O){let _=O.texts.slice(),J=O.isWordLike.slice(),Y=O.kinds.slice(),X=O.starts.slice();for(let Z=0;Z<O.len;Z++){if(Y[Z]!=="text"||!HO(O,Z))continue;let Q=Z+1;while(Q<O.len&&!Y0(Y[Q])){_[Z]+=_[Q],J[Z]=!0;let f=_[Q].includes("?");if(Y[Q]="text",_[Q]="",Q++,f)break}}let R=0;for(let Z=0;Z<_.length;Z++){let Q=_[Z];if(Q.length===0)continue;if(R!==Z)_[R]=Q,J[R]=J[Z],Y[R]=Y[Z],X[R]=X[Z];R++}return _.length=R,J.length=R,Y.length=R,X.length=R,{len:R,texts:_,isWordLike:J,kinds:Y,starts:X}}function CO(O){let _=[],J=[],Y=[],X=[];for(let R=0;R<O.len;R++){let Z=O.texts[R];if(_.push(Z),J.push(O.isWordLike[R]),Y.push(O.kinds[R]),X.push(O.starts[R]),!UO(Z))continue;let Q=R+1;if(Q>=O.len||Y0(O.kinds[Q]))continue;let f="",V=O.starts[Q],$=Q;while($<O.len&&!Y0(O.kinds[$]))f+=O.texts[$],$++;if(f.length>0)_.push(f),J.push(!0),Y.push("text"),X.push(V),R=$-1}return{len:_.length,texts:_,isWordLike:J,kinds:Y,starts:X}}var FO=new Set([":","-","/","×",",",".","+","–","—"]),K0=/^[A-Za-z0-9_]+[,:;]*$/,vO=/[,:;]+$/;function E0(O){for(let _ of O)if(b0.test(_))return!0;return!1}function Z0(O){if(O.length===0)return!1;for(let _ of O){if(b0.test(_)||FO.has(_))continue;return!1}return!0}function uO(O){let _=[],J=[],Y=[],X=[];for(let R=0;R<O.len;R++){let Z=O.texts[R],Q=O.kinds[R];if(Q==="text"&&Z0(Z)&&E0(Z)){let f=Z,V=R+1;while(V<O.len&&O.kinds[V]==="text"&&Z0(O.texts[V]))f+=O.texts[V],V++;_.push(f),J.push(!0),Y.push("text"),X.push(O.starts[R]),R=V-1;continue}_.push(Z),J.push(O.isWordLike[R]),Y.push(Q),X.push(O.starts[R])}return{len:_.length,texts:_,isWordLike:J,kinds:Y,starts:X}}function KO(O){let _=[],J=[],Y=[],X=[];for(let R=0;R<O.len;R++){let Z=O.texts[R],Q=O.kinds[R],f=O.isWordLike[R];if(Q==="text"&&f&&K0.test(Z)){let V=Z,$=R+1;while(vO.test(V)&&$<O.len&&O.kinds[$]==="text"&&O.isWordLike[$]&&K0.test(O.texts[$]))V+=O.texts[$],$++;_.push(V),J.push(!0),Y.push("text"),X.push(O.starts[R]),R=$-1;continue}_.push(Z),J.push(f),Y.push(Q),X.push(O.starts[R])}return{len:_.length,texts:_,isWordLike:J,kinds:Y,starts:X}}function zO(O){let _=[],J=[],Y=[],X=[];for(let R=0;R<O.len;R++){let Z=O.texts[R];if(O.kinds[R]==="text"&&Z.includes("-")){let Q=Z.split("-"),f=Q.length>1;for(let V=0;V<Q.length;V++){let $=Q[V];if(!f)break;if($.length===0||!E0($)||!Z0($))f=!1}if(f){let V=0;for(let $=0;$<Q.length;$++){let u=Q[$],q=$<Q.length-1?`${u}-`:u;_.push(q),J.push(!0),Y.push("text"),X.push(O.starts[R]+V),V+=q.length}continue}}_.push(Z),J.push(O.isWordLike[R]),Y.push(O.kinds[R]),X.push(O.starts[R])}return{len:_.length,texts:_,isWordLike:J,kinds:Y,starts:X}}function jO(O){let _=[],J=[],Y=[],X=[],R=0;while(R<O.len){let Z=O.texts[R],Q=O.isWordLike[R],f=O.kinds[R],V=O.starts[R];if(f==="glue"){let $=Z,u=V;R++;while(R<O.len&&O.kinds[R]==="glue")$+=O.texts[R],R++;if(R<O.len&&O.kinds[R]==="text")Z=$+O.texts[R],Q=O.isWordLike[R],f="text",V=u,R++;else{_.push($),J.push(!1),Y.push("glue"),X.push(u);continue}}else R++;if(f==="text")while(R<O.len&&O.kinds[R]==="glue"){let $="";while(R<O.len&&O.kinds[R]==="glue")$+=O.texts[R],R++;if(R<O.len&&O.kinds[R]==="text"){Z+=$+O.texts[R],Q=Q||O.isWordLike[R],R++;continue}Z+=$}_.push(Z),J.push(Q),Y.push(f),X.push(V)}return{len:_.length,texts:_,isWordLike:J,kinds:Y,starts:X}}function bO(O){let _=O.texts.slice(),J=O.isWordLike.slice(),Y=O.kinds.slice(),X=O.starts.slice();for(let R=0;R<_.length-1;R++){if(Y[R]!=="text"||Y[R+1]!=="text")continue;if(!p(_[R])||!p(_[R+1]))continue;let Z=YO(_[R]);if(Z===null)continue;_[R]=Z.head,_[R+1]=Z.tail+_[R+1],X[R+1]=X[R]+Z.head.length}return{len:_.length,texts:_,isWordLike:J,kinds:Y,starts:X}}function EO(O,_,J){let Y=n0(),X=0,R=[],Z=[],Q=[],f=[];for(let q of Y.segment(O))for(let D of NO(q.segment,q.isWordLike??!1,q.index,J)){let b=D.kind==="text";if(_.carryCJKAfterClosingQuote&&b&&X>0&&Q[X-1]==="text"&&p(D.text)&&p(R[X-1])&&D0(R[X-1]))R[X-1]+=D.text,Z[X-1]=Z[X-1]||D.isWordLike;else if(b&&X>0&&Q[X-1]==="text"&&VO(D.text)&&p(R[X-1]))R[X-1]+=D.text,Z[X-1]=Z[X-1]||D.isWordLike;else if(b&&X>0&&Q[X-1]==="text"&&QO(R[X-1]))R[X-1]+=D.text,Z[X-1]=Z[X-1]||D.isWordLike;else if(b&&X>0&&Q[X-1]==="text"&&D.isWordLike&&X0(D.text)&&$O(R[X-1]))R[X-1]+=D.text,Z[X-1]=!0;else if(b&&!D.isWordLike&&X>0&&Q[X-1]==="text"&&D.text.length===1&&D.text!=="-"&&D.text!=="—"&&ZO(R[X-1],D.text))R[X-1]+=D.text;else if(b&&!D.isWordLike&&X>0&&Q[X-1]==="text"&&(RO(D.text)||D.text==="-"&&Z[X-1]))R[X-1]+=D.text;else R[X]=D.text,Z[X]=D.isWordLike,Q[X]=D.kind,f[X]=D.start,X++}for(let q=1;q<X;q++)if(Q[q]==="text"&&!Z[q]&&q0(R[q])&&Q[q-1]==="text")R[q-1]+=R[q],Z[q-1]=Z[q-1]||Z[q],R[q]="";for(let q=X-2;q>=0;q--)if(Q[q]==="text"&&!Z[q]&&XO(R[q])){let D=q+1;while(D<X&&R[D]==="")D++;if(D<X&&Q[D]==="text")R[D]=R[q]+R[D],f[D]=f[q],R[q]=""}let V=0;for(let q=0;q<X;q++){let D=R[q];if(D.length===0)continue;if(V!==q)R[V]=D,Z[V]=Z[q],Q[V]=Q[q],f[V]=f[q];V++}R.length=V,Z.length=V,Q.length=V,f.length=V;let $=jO({len:V,texts:R,isWordLike:Z,kinds:Q,starts:f}),u=bO(KO(zO(uO(CO(MO($))))));for(let q=0;q<u.len-1;q++){let D=qO(u.texts[q]);if(D===null)continue;if(u.kinds[q]!=="space"&&u.kinds[q]!=="preserved-space"||u.kinds[q+1]!=="text"||!X0(u.texts[q+1]))continue;u.texts[q]=D.space,u.isWordLike[q]=!1,u.kinds[q]=u.kinds[q]==="preserved-space"?"preserved-space":"space",u.texts[q+1]=D.marks+u.texts[q+1],u.starts[q+1]=u.starts[q]+D.space.length}return u}function GO(O,_){if(O.len===0)return[];if(!_.preserveHardBreaks)return[{startSegmentIndex:0,endSegmentIndex:O.len,consumedEndSegmentIndex:O.len}];let J=[],Y=0;for(let X=0;X<O.len;X++){if(O.kinds[X]!=="hard-break")continue;J.push({startSegmentIndex:Y,endSegmentIndex:X,consumedEndSegmentIndex:X+1}),Y=X+1}if(Y<O.len)J.push({startSegmentIndex:Y,endSegmentIndex:O.len,consumedEndSegmentIndex:O.len});return J}function N0(O,_,J="normal"){let Y=d0(J),X=Y.mode==="pre-wrap"?t0(O):i0(O);if(X.length===0)return{normalized:X,chunks:[],len:0,texts:[],isWordLike:[],kinds:[],starts:[]};let R=EO(X,_,Y);return{normalized:X,chunks:GO(R,Y),...R}}var a=null,f0=new Map,s=null,PO=/\p{Emoji_Presentation}/u,AO=/[\p{Emoji_Presentation}\p{Extended_Pictographic}\p{Regional_Indicator}\uFE0F\u20E3]/u,_0=null,H0=new Map;function U0(){if(a!==null)return a;if(typeof OffscreenCanvas<"u")return a=new OffscreenCanvas(1,1).getContext("2d"),a;if(typeof document<"u")return a=document.createElement("canvas").getContext("2d"),a;throw Error("Text measurement requires OffscreenCanvas or a DOM canvas context.")}function BO(O){let _=f0.get(O);if(!_)_=new Map,f0.set(O,_);return _}function x(O,_){let J=_.get(O);if(J===void 0)J={width:U0().measureText(O).width,containsCJK:p(O)},_.set(O,J);return J}function h(){if(s!==null)return s;if(typeof navigator>"u")return s={lineFitEpsilon:0.005,carryCJKAfterClosingQuote:!1,preferPrefixWidthsForBreakableRuns:!1,preferEarlySoftHyphenBreak:!1},s;let O=navigator.userAgent,J=navigator.vendor==="Apple Computer, Inc."&&O.includes("Safari/")&&!O.includes("Chrome/")&&!O.includes("Chromium/")&&!O.includes("CriOS/")&&!O.includes("FxiOS/")&&!O.includes("EdgiOS/"),Y=O.includes("Chrome/")||O.includes("Chromium/")||O.includes("CriOS/")||O.includes("Edg/");return s={lineFitEpsilon:J?0.015625:0.005,carryCJKAfterClosingQuote:Y,preferPrefixWidthsForBreakableRuns:J,preferEarlySoftHyphenBreak:J},s}function TO(O){let _=O.match(/(\d+(?:\.\d+)?)\s*px/);return _?parseFloat(_[1]):16}function M0(){if(_0===null)_0=new Intl.Segmenter(void 0,{granularity:"grapheme"});return _0}function wO(O){return PO.test(O)||O.includes("️")}function G0(O){return AO.test(O)}function yO(O,_){let J=H0.get(O);if(J!==void 0)return J;let Y=U0();Y.font=O;let X=Y.measureText("\uD83D\uDE00").width;if(J=0,X>_+0.5&&typeof document<"u"&&document.body!==null){let R=document.createElement("span");R.style.font=O,R.style.display="inline-block",R.style.visibility="hidden",R.style.position="absolute",R.textContent="\uD83D\uDE00",document.body.appendChild(R);let Z=R.getBoundingClientRect().width;if(document.body.removeChild(R),X-Z>0.5)J=X-Z}return H0.set(O,J),J}function LO(O){let _=0,J=M0();for(let Y of J.segment(O))if(wO(Y.segment))_++;return _}function WO(O,_){if(_.emojiCount===void 0)_.emojiCount=LO(O);return _.emojiCount}function g(O,_,J){if(J===0)return _.width;return _.width-WO(O,_)*J}function P0(O,_,J,Y){if(_.graphemeWidths!==void 0)return _.graphemeWidths;let X=[],R=M0();for(let Z of R.segment(O)){let Q=x(Z.segment,J);X.push(g(Z.segment,Q,Y))}return _.graphemeWidths=X.length>1?X:null,_.graphemeWidths}function A0(O,_,J,Y){if(_.graphemePrefixWidths!==void 0)return _.graphemePrefixWidths;let X=[],R=M0(),Z="";for(let Q of R.segment(O)){Z+=Q.segment;let f=x(Z,J);X.push(g(Z,f,Y))}return _.graphemePrefixWidths=X.length>1?X:null,_.graphemePrefixWidths}function B0(O,_){let J=U0();J.font=O;let Y=BO(O),X=TO(O),R=_?yO(O,X):0;return{cache:Y,fontSize:X,emojiCorrection:R}}function T0(){f0.clear(),H0.clear(),_0=null}function m(O){return O==="space"||O==="preserved-space"||O==="tab"||O==="zero-width-break"||O==="soft-hyphen"}function SO(O){return O==="space"}function w0(O,_){if(_<=0)return 0;let J=O%_;if(Math.abs(J)<=0.000001)return _;return _-J}function t(O,_,J,Y){if(!Y||_===null)return O[J];return _[J]-(J>0?_[J-1]:0)}function y0(O,_,J,Y,X,R){let Z=0,Q=_;while(Z<O.length){let f=R?_+O[Z]:Q+O[Z];if((Z+1<O.length?f+X:f)>J+Y)break;Q=f,Z++}return{fitCount:Z,fittedWidth:Q}}function L0(O,_){for(let J=0;J<O.chunks.length;J++){let Y=O.chunks[J];if(_<Y.consumedEndSegmentIndex)return J}return-1}function kO(O,_){let{segmentIndex:J,graphemeIndex:Y}=_;if(J>=O.widths.length)return null;if(Y>0)return _;let X=L0(O,J);if(X<0)return null;let R=O.chunks[X];if(R.startSegmentIndex===R.endSegmentIndex&&J===R.startSegmentIndex)return{segmentIndex:J,graphemeIndex:0};if(J<R.startSegmentIndex)J=R.startSegmentIndex;while(J<R.endSegmentIndex){let Z=O.kinds[J];if(Z!=="space"&&Z!=="zero-width-break"&&Z!=="soft-hyphen")return{segmentIndex:J,graphemeIndex:0};J++}if(R.consumedEndSegmentIndex>=O.widths.length)return null;return{segmentIndex:R.consumedEndSegmentIndex,graphemeIndex:0}}function W0(O,_){if(O.simpleLineWalkFastPath)return IO(O,_);return J0(O,_)}function IO(O,_){let{widths:J,kinds:Y,breakableWidths:X,breakablePrefixWidths:R}=O;if(J.length===0)return 0;let Z=h(),Q=Z.lineFitEpsilon,f=0,V=0,$=!1;function u(q){let D=J[q];if(D>_&&X[q]!==null){let b=X[q],K=R[q]??null;V=0;for(let j=0;j<b.length;j++){let B=t(b,K,j,Z.preferPrefixWidthsForBreakableRuns);if(V>0&&V+B>_+Q)f++,V=B;else{if(V===0)f++;V+=B}}}else V=D,f++;$=!0}for(let q=0;q<J.length;q++){let D=J[q],b=Y[q];if(!$){u(q);continue}let K=V+D;if(K>_+Q){if(SO(b))continue;V=0,$=!1,u(q);continue}V=K}if(!$)return f+1;return f}function cO(O,_,J){let{widths:Y,kinds:X,breakableWidths:R,breakablePrefixWidths:Z}=O;if(Y.length===0)return 0;let Q=h(),f=Q.lineFitEpsilon,V=0,$=0,u=!1,q=0,D=0,b=0,K=0,j=-1,B=0;function k(){j=-1,B=0}function y(H=b,z=K,W=$){V++,J?.({startSegmentIndex:q,startGraphemeIndex:D,endSegmentIndex:H,endGraphemeIndex:z,width:W}),$=0,u=!1,k()}function A(H,z){u=!0,q=H,D=0,b=H+1,K=0,$=z}function T(H,z,W){u=!0,q=H,D=z,b=H,K=z+1,$=W}function L(H,z){if(!u){A(H,z);return}$+=z,b=H+1,K=0}function C(H,z){if(!m(X[H]))return;j=H+1,B=$-z}function F(H){P(H,0)}function P(H,z){let W=R[H],c=Z[H]??null;for(let I=z;I<W.length;I++){let o=t(W,c,I,Q.preferPrefixWidthsForBreakableRuns);if(!u){T(H,I,o);continue}if($+o>_+f)y(),T(H,I,o);else $+=o,b=H,K=I+1}if(u&&b===H&&K===W.length)b=H+1,K=0}let E=0;while(E<Y.length){let H=Y[E],z=X[E];if(!u){if(H>_&&R[E]!==null)F(E);else A(E,H);C(E,H),E++;continue}if($+H>_+f){if(m(z)){L(E,H),y(E+1,0,$-H),E++;continue}if(j>=0){y(j,0,B);continue}if(H>_&&R[E]!==null){y(),F(E),E++;continue}y();continue}L(E,H),C(E,H),E++}if(u)y();return V}function J0(O,_,J){if(O.simpleLineWalkFastPath)return cO(O,_,J);let{widths:Y,lineEndFitAdvances:X,lineEndPaintAdvances:R,kinds:Z,breakableWidths:Q,breakablePrefixWidths:f,discretionaryHyphenWidth:V,tabStopAdvance:$,chunks:u}=O;if(Y.length===0||u.length===0)return 0;let q=h(),D=q.lineFitEpsilon,b=0,K=0,j=!1,B=0,k=0,y=0,A=0,T=-1,L=0,C=0,F=null;function P(){T=-1,L=0,C=0,F=null}function E(N=y,M=A,v=K){b++,J?.({startSegmentIndex:B,startGraphemeIndex:k,endSegmentIndex:N,endGraphemeIndex:M,width:v}),K=0,j=!1,P()}function H(N,M){j=!0,B=N,k=0,y=N+1,A=0,K=M}function z(N,M,v){j=!0,B=N,k=M,y=N,A=M+1,K=v}function W(N,M){if(!j){H(N,M);return}K+=M,y=N+1,A=0}function c(N,M){if(!m(Z[N]))return;let v=Z[N]==="tab"?0:X[N],w=Z[N]==="tab"?M:R[N];T=N+1,L=K-M+v,C=K-M+w,F=Z[N]}function I(N){o(N,0)}function o(N,M){let v=Q[N],w=f[N]??null;for(let G=M;G<v.length;G++){let l=t(v,w,G,q.preferPrefixWidthsForBreakableRuns);if(!j){z(N,G,l);continue}if(K+l>_+D)E(),z(N,G,l);else K+=l,y=N,A=G+1}if(j&&y===N&&A===v.length)y=N+1,A=0}function S(N){if(F!=="soft-hyphen")return!1;let M=Q[N];if(M===null)return!1;let v=q.preferPrefixWidthsForBreakableRuns?f[N]??M:M,w=v!==M,{fitCount:G,fittedWidth:l}=y0(v,K,_,D,V,w);if(G===0)return!1;if(K=l,y=N,A=G,P(),G===M.length)return y=N+1,A=0,!0;return E(N,G,l+V),o(N,G),!0}function U(N){b++,J?.({startSegmentIndex:N.startSegmentIndex,startGraphemeIndex:0,endSegmentIndex:N.consumedEndSegmentIndex,endGraphemeIndex:0,width:0}),P()}for(let N=0;N<u.length;N++){let M=u[N];if(M.startSegmentIndex===M.endSegmentIndex){U(M);continue}j=!1,K=0,B=M.startSegmentIndex,k=0,y=M.startSegmentIndex,A=0,P();let v=M.startSegmentIndex;while(v<M.endSegmentIndex){let w=Z[v],G=w==="tab"?w0(K,$):Y[v];if(w==="soft-hyphen"){if(j)y=v+1,A=0,T=v+1,L=K+V,C=K+V,F=w;v++;continue}if(!j){if(G>_&&Q[v]!==null)I(v);else H(v,G);c(v,G),v++;continue}if(K+G>_+D){let n=K+(w==="tab"?0:X[v]),e=K+(w==="tab"?G:R[v]);if(F==="soft-hyphen"&&q.preferEarlySoftHyphenBreak&&L<=_+D){E(T,0,C);continue}if(F==="soft-hyphen"&&S(v)){v++;continue}if(m(w)&&n<=_+D){W(v,G),E(v+1,0,e),v++;continue}if(T>=0&&L<=_+D){E(T,0,C);continue}if(G>_&&Q[v]!==null){E(),I(v),v++;continue}E();continue}W(v,G),c(v,G),v++}if(j){let w=T===M.consumedEndSegmentIndex?C:K;E(M.consumedEndSegmentIndex,0,w)}}return b}function S0(O,_,J){let Y=kO(O,_);if(Y===null)return null;if(O.simpleLineWalkFastPath)return oO(O,Y,J);let X=L0(O,Y.segmentIndex);if(X<0)return null;let R=O.chunks[X];if(R.startSegmentIndex===R.endSegmentIndex)return{startSegmentIndex:R.startSegmentIndex,startGraphemeIndex:0,endSegmentIndex:R.consumedEndSegmentIndex,endGraphemeIndex:0,width:0};let{widths:Z,lineEndFitAdvances:Q,lineEndPaintAdvances:f,kinds:V,breakableWidths:$,breakablePrefixWidths:u,discretionaryHyphenWidth:q,tabStopAdvance:D}=O,b=h(),K=b.lineFitEpsilon,j=0,B=!1,k=Y.segmentIndex,y=Y.graphemeIndex,A=k,T=y,L=-1,C=0,F=0,P=null;function E(){L=-1,C=0,F=0,P=null}function H(U=A,N=T,M=j){if(!B)return null;return{startSegmentIndex:k,startGraphemeIndex:y,endSegmentIndex:U,endGraphemeIndex:N,width:M}}function z(U,N){B=!0,A=U+1,T=0,j=N}function W(U,N,M){B=!0,A=U,T=N+1,j=M}function c(U,N){if(!B){z(U,N);return}j+=N,A=U+1,T=0}function I(U,N){if(!m(V[U]))return;let M=V[U]==="tab"?0:Q[U],v=V[U]==="tab"?N:f[U];L=U+1,C=j-N+M,F=j-N+v,P=V[U]}function o(U,N){let M=$[U],v=u[U]??null;for(let w=N;w<M.length;w++){let G=t(M,v,w,b.preferPrefixWidthsForBreakableRuns);if(!B){W(U,w,G);continue}if(j+G>J+K)return H();j+=G,A=U,T=w+1}if(B&&A===U&&T===M.length)A=U+1,T=0;return null}function S(U){if(P!=="soft-hyphen"||L<0)return null;let N=$[U]??null;if(N!==null){let M=b.preferPrefixWidthsForBreakableRuns?u[U]??N:N,v=M!==N,{fitCount:w,fittedWidth:G}=y0(M,j,J,K,q,v);if(w===N.length)return j=G,A=U+1,T=0,E(),null;if(w>0)return H(U,w,G+q)}if(C<=J+K)return H(L,0,F);return null}for(let U=Y.segmentIndex;U<R.endSegmentIndex;U++){let N=V[U],M=U===Y.segmentIndex?Y.graphemeIndex:0,v=N==="tab"?w0(j,D):Z[U];if(N==="soft-hyphen"&&M===0){if(B)A=U+1,T=0,L=U+1,C=j+q,F=j+q,P=N;continue}if(!B){if(M>0){let G=o(U,M);if(G!==null)return G}else if(v>J&&$[U]!==null){let G=o(U,0);if(G!==null)return G}else z(U,v);I(U,v);continue}if(j+v>J+K){let G=j+(N==="tab"?0:Q[U]),l=j+(N==="tab"?v:f[U]);if(P==="soft-hyphen"&&b.preferEarlySoftHyphenBreak&&C<=J+K)return H(L,0,F);let n=S(U);if(n!==null)return n;if(m(N)&&G<=J+K)return c(U,v),H(U+1,0,l);if(L>=0&&C<=J+K)return H(L,0,F);if(v>J&&$[U]!==null){let e=H();if(e!==null)return e;let v0=o(U,0);if(v0!==null)return v0}return H()}c(U,v),I(U,v)}if(L===R.consumedEndSegmentIndex&&T===0)return H(R.consumedEndSegmentIndex,0,F);return H(R.consumedEndSegmentIndex,0,j)}function oO(O,_,J){let{widths:Y,kinds:X,breakableWidths:R,breakablePrefixWidths:Z}=O,Q=h(),f=Q.lineFitEpsilon,V=0,$=!1,u=_.segmentIndex,q=_.graphemeIndex,D=u,b=q,K=-1,j=0;function B(C=D,F=b,P=V){if(!$)return null;return{startSegmentIndex:u,startGraphemeIndex:q,endSegmentIndex:C,endGraphemeIndex:F,width:P}}function k(C,F){$=!0,D=C+1,b=0,V=F}function y(C,F,P){$=!0,D=C,b=F+1,V=P}function A(C,F){if(!$){k(C,F);return}V+=F,D=C+1,b=0}function T(C,F){if(!m(X[C]))return;K=C+1,j=V-F}function L(C,F){let P=R[C],E=Z[C]??null;for(let H=F;H<P.length;H++){let z=t(P,E,H,Q.preferPrefixWidthsForBreakableRuns);if(!$){y(C,H,z);continue}if(V+z>J+f)return B();V+=z,D=C,b=H+1}if($&&D===C&&b===P.length)D=C+1,b=0;return null}for(let C=_.segmentIndex;C<Y.length;C++){let F=Y[C],P=X[C],E=C===_.segmentIndex?_.graphemeIndex:0;if(!$){if(E>0){let z=L(C,E);if(z!==null)return z}else if(F>J&&R[C]!==null){let z=L(C,0);if(z!==null)return z}else k(C,F);T(C,F);continue}if(V+F>J+f){if(m(P))return A(C,F),B(C+1,0,V-F);if(K>=0)return B(K,0,j);if(F>J&&R[C]!==null){let z=B();if(z!==null)return z;let W=L(C,0);if(W!==null)return W}return B()}A(C,F),T(C,F)}return B()}var R0=null,C0=new WeakMap;function I0(){if(R0===null)R0=new Intl.Segmenter(void 0,{granularity:"grapheme"});return R0}function lO(O){if(O)return{widths:[],lineEndFitAdvances:[],lineEndPaintAdvances:[],kinds:[],simpleLineWalkFastPath:!0,segLevels:null,breakableWidths:[],breakablePrefixWidths:[],discretionaryHyphenWidth:0,tabStopAdvance:0,chunks:[],segments:[]};return{widths:[],lineEndFitAdvances:[],lineEndPaintAdvances:[],kinds:[],simpleLineWalkFastPath:!0,segLevels:null,breakableWidths:[],breakablePrefixWidths:[],discretionaryHyphenWidth:0,tabStopAdvance:0,chunks:[]}}function c0(O,_,J){let Y=I0(),X=h(),{cache:R,emojiCorrection:Z}=B0(_,G0(O.normalized)),Q=g("-",x("-",R),Z),V=g(" ",x(" ",R),Z)*8;if(O.len===0)return lO(J);let $=[],u=[],q=[],D=[],b=O.chunks.length<=1,K=J?[]:null,j=[],B=[],k=J?[]:null,y=Array.from({length:O.len}),A=Array.from({length:O.len});function T(F,P,E,H,z,W,c,I){if(z!=="text"&&z!=="space"&&z!=="zero-width-break")b=!1;if($.push(P),u.push(E),q.push(H),D.push(z),K?.push(W),j.push(c),B.push(I),k!==null)k.push(F)}for(let F=0;F<O.len;F++){y[F]=$.length;let P=O.texts[F],E=O.isWordLike[F],H=O.kinds[F],z=O.starts[F];if(H==="soft-hyphen"){T(P,0,Q,Q,H,z,null,null),A[F]=$.length;continue}if(H==="hard-break"){T(P,0,0,0,H,z,null,null),A[F]=$.length;continue}if(H==="tab"){T(P,0,0,0,H,z,null,null),A[F]=$.length;continue}let W=x(P,R);if(H==="text"&&W.containsCJK){let S="",U=0;for(let N of Y.segment(P)){let M=N.segment;if(S.length===0){S=M,U=N.index;continue}if(i.has(S)||$0.has(M)||r.has(M)||X.carryCJKAfterClosingQuote&&p(M)&&D0(S)){S+=M;continue}let v=x(S,R),w=g(S,v,Z);T(S,w,w,w,"text",z+U,null,null),S=M,U=N.index}if(S.length>0){let N=x(S,R),M=g(S,N,Z);T(S,M,M,M,"text",z+U,null,null)}A[F]=$.length;continue}let c=g(P,W,Z),I=H==="space"||H==="preserved-space"||H==="zero-width-break"?0:c,o=H==="space"||H==="zero-width-break"?0:c;if(E&&P.length>1){let S=P0(P,W,R,Z),U=X.preferPrefixWidthsForBreakableRuns?A0(P,W,R,Z):null;T(P,c,I,o,H,z,S,U)}else T(P,c,I,o,H,z,null,null);A[F]=$.length}let L=hO(O.chunks,y,A),C=K===null?null:u0(O.normalized,K);if(k!==null)return{widths:$,lineEndFitAdvances:u,lineEndPaintAdvances:q,kinds:D,simpleLineWalkFastPath:b,segLevels:C,breakableWidths:j,breakablePrefixWidths:B,discretionaryHyphenWidth:Q,tabStopAdvance:V,chunks:L,segments:k};return{widths:$,lineEndFitAdvances:u,lineEndPaintAdvances:q,kinds:D,simpleLineWalkFastPath:b,segLevels:C,breakableWidths:j,breakablePrefixWidths:B,discretionaryHyphenWidth:Q,tabStopAdvance:V,chunks:L}}function hO(O,_,J){let Y=[];for(let X=0;X<O.length;X++){let R=O[X],Z=R.startSegmentIndex<_.length?_[R.startSegmentIndex]:J[J.length-1]??0,Q=R.endSegmentIndex<_.length?_[R.endSegmentIndex]:J[J.length-1]??0,f=R.consumedEndSegmentIndex<_.length?_[R.consumedEndSegmentIndex]:J[J.length-1]??0;Y.push({startSegmentIndex:Z,endSegmentIndex:Q,consumedEndSegmentIndex:f})}return Y}function o0(O,_,J,Y){let X=N0(O,h(),Y?.whiteSpace);return c0(X,_,J)}function V1(O,_,J){let Y=performance.now(),X=N0(O,h(),J?.whiteSpace),R=performance.now(),Z=c0(X,_,!1),Q=performance.now(),f=0;for(let V of Z.breakableWidths)if(V!==null)f++;return{analysisMs:R-Y,measureMs:Q-R,totalMs:Q-Y,analysisSegments:X.len,preparedSegments:Z.widths.length,breakableSegments:f}}function X1(O,_,J){return o0(O,_,!1,J)}function Y1(O,_,J){return o0(O,_,!0,J)}function F0(O){return O}function Z1(O,_,J){let Y=W0(F0(O),_);return{lineCount:Y,height:Y*J}}function k0(O,_,J){let Y=J.get(O);if(Y!==void 0)return Y;Y=[];let X=I0();for(let R of X.segment(_[O]))Y.push(R.segment);return J.set(O,Y),Y}function l0(O){let _=C0.get(O);if(_!==void 0)return _;return _=new Map,C0.set(O,_),_}function pO(O,_,J,Y){return Y>0&&O[Y-1]==="soft-hyphen"&&!(_===Y&&J>0)}function xO(O,_,J,Y,X,R,Z){let Q="",f=pO(_,Y,X,R);for(let V=Y;V<R;V++){if(_[V]==="soft-hyphen"||_[V]==="hard-break")continue;if(V===Y&&X>0)Q+=k0(V,O,J).slice(X).join("");else Q+=O[V]}if(Z>0){if(f)Q+="-";Q+=k0(R,O,J).slice(Y===R?X:0,Z).join("")}else if(f)Q+="-";return Q}function h0(O,_,J,Y,X,R,Z){return{text:xO(O.segments,O.kinds,_,Y,X,R,Z),width:J,start:{segmentIndex:Y,graphemeIndex:X},end:{segmentIndex:R,graphemeIndex:Z}}}function gO(O,_,J){return h0(O,_,J.width,J.startSegmentIndex,J.startGraphemeIndex,J.endSegmentIndex,J.endGraphemeIndex)}function p0(O){return{width:O.width,start:{segmentIndex:O.startSegmentIndex,graphemeIndex:O.startGraphemeIndex},end:{segmentIndex:O.endSegmentIndex,graphemeIndex:O.endGraphemeIndex}}}function mO(O,_,J){let Y=S0(O,_,J);if(Y===null)return null;return p0(Y)}function rO(O,_){return h0(O,l0(O),_.width,_.start.segmentIndex,_.start.graphemeIndex,_.end.segmentIndex,_.end.graphemeIndex)}function $1(O,_,J){if(O.widths.length===0)return 0;return J0(F0(O),_,(Y)=>{J(p0(Y))})}function Q1(O,_,J){let Y=mO(O,_,J);if(Y===null)return null;return rO(O,Y)}function q1(O,_,J){let Y=[];if(O.widths.length===0)return{lineCount:0,height:0,lines:Y};let X=l0(O),R=J0(F0(O),_,(Z)=>{Y.push(gO(O,X,Z))});return{lineCount:R,height:R*J,lines:Y}}function aO(){z0(),R0=null,C0=new WeakMap,T0()}function D1(O){j0(O),aO()}window._PT={prepare:X1,layout:Z1,prepareWithSegments:Y1,walkLineRanges:$1,layoutNextLine:Q1,layoutWithLines:q1,clearCache:aO,setLocale:D1};;
 
-
-// ── PRETEXT WIRING ─────────────────────────────────────────
-document.fonts.ready.then(function() {
-  var PT = window._PT;
-  if (!PT) return;
-  var els = Array.from(document.querySelectorAll('[data-pretext]'));
-  var prepared = new Map();
-
-  els.forEach(function(el) {
-    var text = el.textContent.trim().replace(/\s+/g, ' ');
-    if (!text) return;
-    var font = getComputedStyle(el).font;
-    try { prepared.set(el, PT.prepare(text, font)); } catch(e) {}
-  });
-
-  function relayout() {
-    prepared.forEach(function(handle, el) {
-      var w = el.clientWidth;
-      var lh = parseFloat(getComputedStyle(el).lineHeight);
-      if (w > 0 && lh > 0 && !isNaN(lh)) {
-        try {
-          var r = PT.layout(handle, w, lh);
-          el.style.minHeight = r.height + 'px';
-        } catch(e) {}
-      }
-    });
-  }
-
-  if (window.ResizeObserver) {
-    new ResizeObserver(relayout).observe(document.body);
-  }
-  window.addEventListener('resize', relayout);
-  relayout();
-});
-
-</script>
 </body>
 </html>

--- a/website/index.html
+++ b/website/index.html
@@ -1248,7 +1248,7 @@
     <a href="#how">How it works</a>
     <a href="#demo">The demo call</a>
     <a href="#agents">Your new hire</a>
-    <a href="#different">vs. Others</a>
+    <a href="#different">Use cases</a>
     <a href="#faq">FAQ</a>
     <a href="/download.html">Download</a>
   </div>
@@ -1299,7 +1299,7 @@
     </a>
 
     <p class="hero-tagline" data-pretext>
-      You do not build automations. You hire agents. Say the job in one sentence — or do it once while WUPHF watches — and an agent takes it over: its own app, schedule, tools, and memory. 24x7, on your machine. You never do it again.
+      Turn your manual workflows into AI agents. Describe the job — or demo it once — and it runs 24x7 on your machine.
     </p>
 
     <div class="install-wrap" id="install">
@@ -1327,7 +1327,7 @@
         </button>
       </div>
       <div class="visually-hidden" id="copyStatus" aria-live="polite" aria-atomic="true"></div>
-      <p class="install-note">Runs local. No signup, no cloud, no per-seat pricing. Source-available (Sustainable Use License), free to self-host. The entire interview process is one command.</p>
+      <p class="install-note">Runs local. No signup, no cloud, no per-seat pricing. Source-available, free to self-host.</p>
     </div>
 
     <div class="hero-ctas">
@@ -1359,42 +1359,34 @@
 <!-- HOW IT WORKS -->
 <section id="how">
   <div class="section-eyebrow">HOW IT WORKS</div>
-  <h2 class="section-title" data-pretext>Say the job, or show the job.<br>Either way, it stops being yours.</h2>
+  <h2 class="section-title" data-pretext>Show. Build. Approve.</h2>
   <p class="section-body" data-pretext>
-    There are two ways to hand WUPHF a job: type one sentence, or get on a call and do the job while it watches. Either way, you are onboarding a hire, not configuring software.
+    You are onboarding a hire, not configuring software.
   </p>
 
   <div class="steps-grid">
     <div class="step-card">
       <div class="step-num">01</div>
-      <span class="step-icon">&#9889;</span>
-      <div class="step-title">Install</div>
+      <span class="step-icon">&#128172;</span>
+      <div class="step-title">Show</div>
       <div class="step-body">
-        One <code>npx wuphf@latest</code>. Browser opens at <code>localhost:7891</code>. No signup, no API key web form, no Docker compose with 47 env vars.
+        Describe the job in one sentence — or demo it once on a screen-share call while WUPHF watches.
       </div>
     </div>
     <div class="step-card">
       <div class="step-num">02</div>
-      <span class="step-icon">&#128172;</span>
-      <div class="step-title">Say it — or show it</div>
+      <span class="step-icon">&#127959;&#65039;</span>
+      <div class="step-title">Build</div>
       <div class="step-body">
-        Type one sentence: "Score inbound leads and route the hot ones to an AE." Or start a screen-share call and do the job once while WUPHF watches, narrates, and asks the questions a sharp new hire asks. No flowchart canvas appears. That is on purpose.
+        The agent assembles live in front of you: its own app, schedule, and tools.
       </div>
     </div>
     <div class="step-card">
       <div class="step-num">03</div>
-      <span class="step-icon">&#127959;&#65039;</span>
-      <div class="step-title">Watch your agent get built</div>
-      <div class="step-body">
-        The agent assembles its own app live in front of you — a real screen your team can use, not a progress bar. Plus its schedule, its tools, and its knowledge. Sandboxed, reading and writing your real workspace data.
-      </div>
-    </div>
-    <div class="step-card">
-      <div class="step-num">04</div>
       <span class="step-icon">&#9989;</span>
-      <div class="step-title">Approve what leaves, then let go</div>
+      <div class="step-title">Approve</div>
       <div class="step-body">
-        Nothing leaves without your tap: no email, no Slack post, no CRM write. Reads are free. Writes are held. You are the manager now — the good kind, who mostly just approves things.
+        Reads are free. Writes are held until you tap approve. Then it runs 24x7.
       </div>
     </div>
   </div>
@@ -1417,45 +1409,39 @@
   <div class="section-eyebrow">WHAT YOU HIRED</div>
   <h2 class="section-title" data-pretext>Anatomy of<br>your new hire.</h2>
   <p class="section-body" data-pretext>
-    A flowchart is a diagram of the work. A coworker brings their own equipment. Every WUPHF agent ships with all six of these — real and shipped today, not roadmap items wearing screenshots. Not a chatbot in a trench coat.
+    Every agent ships with all six. Not a chatbot in a trench coat.
   </p>
 
   <div class="agents-grid">
     <div class="agent-card">
       <div class="agent-badge">THE APP</div>
-      <div class="agent-title">A Real Screen,<br>Built In Front Of You</div>
-      <div class="agent-desc">Every agent builds its own app — a UI your team actually uses, assembled live while you watch. Sandboxed, and it reads and writes real workspace data.</div>
-      <div class="agent-quote">"Your automation has never had a face before. This one does."</div>
+      <div class="agent-title">A Real Screen</div>
+      <div class="agent-desc">Its own UI, built live in front of you. Reads and writes real workspace data.</div>
     </div>
     <div class="agent-card">
       <div class="agent-badge">ROUTINES</div>
-      <div class="agent-title">Scheduled Work<br>It Runs Itself</div>
-      <div class="agent-desc">Cron or "every Monday 9:00." Each routine has versioned prompts — publish v2 with a change note — run history, an enable toggle, and its own chat transcript per run.</div>
-      <div class="agent-quote">"You can read exactly what it did on any given Monday. It takes better meeting notes than you do."</div>
+      <div class="agent-title">Scheduled Work</div>
+      <div class="agent-desc">"Every Monday 9:00." Versioned prompts, run history, a transcript per run.</div>
     </div>
     <div class="agent-card">
       <div class="agent-badge">TOOLS</div>
-      <div class="agent-title">Capabilities It<br>Authors For Itself</div>
-      <div class="agent-desc">"Score a lead." "Post to #ae-handoffs." Callable tools built from what you taught it. Teach a new one by chatting — it writes its own tools so you do not have to.</div>
-      <div class="agent-quote">"It asks about edge cases on the first call. Nobody has ever done that on a first call."</div>
+      <div class="agent-title">Self-Authored</div>
+      <div class="agent-desc">"Score a lead." "Post to #ae-handoffs." It writes its own tools from what you taught.</div>
     </div>
     <div class="agent-card">
       <div class="agent-badge">KNOWLEDGE</div>
-      <div class="agent-title">Cited Pages,<br>Not Vibes</div>
-      <div class="agent-desc">Wikipedia-style pages synthesized from the agent's real artifacts. Every claim carries a citation and a note on why that source was trusted. Your old WUPHF wiki, notebooks, and HTML/PDF briefs come along verbatim.</div>
-      <div class="agent-quote">"Hover the citation. It shows its work. Like we all promised our teachers we would."</div>
+      <div class="agent-title">Cited Pages</div>
+      <div class="agent-desc">Every claim carries a citation. Your old wiki and notebooks come along verbatim.</div>
     </div>
     <div class="agent-card">
       <div class="agent-badge">DATA + INTEGRATIONS</div>
-      <div class="agent-title">Its Own Tables,<br>Your Whole Stack</div>
-      <div class="agent-desc">Typed tables for the records it works, plus 100+ integrations via Composio — Gmail, Slack, HubSpot, and roughly 97 others. Connected once, for the whole workspace.</div>
-      <div class="agent-quote">"Connected once. Reused by every agent you hire after it. Onboarding paperwork, solved."</div>
+      <div class="agent-title">Your Whole Stack</div>
+      <div class="agent-desc">Its own typed tables, plus 100+ integrations via Composio. Connected once.</div>
     </div>
     <div class="agent-card">
       <div class="agent-badge">APPROVAL GATE</div>
-      <div class="agent-title">Drafts With Confidence,<br>Sends With Permission</div>
-      <div class="agent-desc">Nothing leaves without a human tap. No Slack post, no CRM write, no email. Reads are free. Writes are held. It is a coworker, not a loose cannon.</div>
-      <div class="agent-quote">"Which is more than can be said for some humans."</div>
+      <div class="agent-title">Sends With Permission</div>
+      <div class="agent-desc">No email, Slack post, or CRM write leaves without a human tap.</div>
     </div>
   </div>
 </section>
@@ -1465,7 +1451,7 @@
   <div class="section-eyebrow">THE DEMO CALL</div>
   <h2 class="section-title" data-pretext>The last time you do this job,<br>someone is finally taking notes.</h2>
   <p class="section-body" data-pretext>
-    "Demo workflow to Nex" is a voice call with screen share. You do the job the way you normally do it. WUPHF watches, narrates what it sees, and interrupts with the sharp questions — thresholds, branches, cadence. Then it builds the agent from what it captured: screens, selectors, API calls, entities, and the full transcript.
+    A voice call with screen share. You do the job once. WUPHF asks the sharp questions, then builds the agent.
   </p>
 
   <div class="conversations-layout">
@@ -1543,51 +1529,46 @@
       <span style="color:var(--yellow);">YOU:</span> *one tap* Approved.
     </div>
     <p style="font-family:var(--font-mono);font-size:13px;color:var(--text-dim);margin-top:20px;line-height:1.7;">
-      You demoed this job exactly once. The routine ran on schedule, the outcome landed in run history with a full transcript, and the only thing that needed you was the tap. Reads are free. Writes are held. You just trained your replacement — it says thank you and works weekends.
+      You demoed this job exactly once. You just trained your replacement — it says thank you and works weekends.
     </p>
   </div>
 </section>
 
-<!-- THE ALTERNATIVES -->
+<!-- USE CASES -->
 <section id="different">
-  <div class="section-eyebrow">THE ALTERNATIVES</div>
-  <h2 class="section-title" data-pretext>Ways to not use WUPHF,<br>reviewed honestly.</h2>
-  <p class="section-body" data-pretext>
-    We are supposed to say these are all great tools for the right team. Here is the honest version instead.
-  </p>
+  <div class="section-eyebrow">WHAT PEOPLE HIRE FIRST</div>
+  <h2 class="section-title" data-pretext>Agents your pipeline<br>is already asking for.</h2>
 
-  <div class="steps-grid">
-    <div class="step-card">
-      <div class="step-num">A</div>
-      <span class="step-icon">&#128170;</span>
-      <div class="step-title">Doing it yourself</div>
-      <div class="step-body">
-        The current market leader. Zero setup, perfectly accurate, infinitely flexible. Costs every Monday morning for the rest of your career.
-      </div>
+  <div class="agents-grid">
+    <div class="agent-card">
+      <div class="agent-badge">CLOSED-LOST RE-ENGAGEMENT</div>
+      <div class="agent-desc">Monitors deals lost 90+ days ago and detects what changed.</div>
+      <div class="agent-quote">Saves ~$300&ndash;400/mo</div>
     </div>
-    <div class="step-card">
-      <div class="step-num">B</div>
-      <span class="step-icon">&#128208;</span>
-      <div class="step-title">Zapier and n8n</div>
-      <div class="step-body">
-        Flowcharts you build yourself. Every branch is your problem, every edge case is a new node, and six months later maintaining the diagram is the job. WUPHF asks you the branches once, on a call, and the agent keeps them.
-      </div>
+    <div class="agent-card">
+      <div class="agent-badge">CRM HYGIENE</div>
+      <div class="agent-desc">Finds duplicates, missing fields, and stale records.</div>
+      <div class="agent-quote">Saves ~$200&ndash;500/mo</div>
     </div>
-    <div class="step-card">
-      <div class="step-num">C</div>
-      <span class="step-icon">&#128433;&#65039;</span>
-      <div class="step-title">Computer-use demos</div>
-      <div class="step-body">
-        You watch a cursor move around a screen, slowly. Impressive the way a dog walking on two legs is impressive. A job needs an app, a schedule, tools, and memory — not a cursor with stage presence.
-      </div>
+    <div class="agent-card">
+      <div class="agent-badge">MEETING PREP</div>
+      <div class="agent-desc">A cross-system account brief before every meeting.</div>
+      <div class="agent-quote">Saves ~$100&ndash;200/mo</div>
     </div>
-    <div class="step-card">
-      <div class="step-num">D</div>
-      <span class="step-icon">&#9729;&#65039;</span>
-      <div class="step-title">Hosted agent platforms</div>
-      <div class="step-body">
-        Per-seat pricing, and your workflow data lives on their cloud. WUPHF runs on your machine, free to self-host, source-available. The hosted version exists — it is called <a href="https://nex.ai" style="color:var(--yellow);">Nex Cloud</a> — but it is a choice, not the only door.
-      </div>
+    <div class="agent-card">
+      <div class="agent-badge">DEALS GOING DARK</div>
+      <div class="agent-desc">Detects silence across email, Slack, and calendar on active deals.</div>
+      <div class="agent-quote">Saves ~$200&ndash;400/mo</div>
+    </div>
+    <div class="agent-card">
+      <div class="agent-badge">LEAD SCORING</div>
+      <div class="agent-desc">Scores inbound leads and routes the hot ones to an AE.</div>
+      <div class="agent-quote">Saves ~$300&ndash;500/mo</div>
+    </div>
+    <div class="agent-card">
+      <div class="agent-badge">CUSTOM</div>
+      <div class="agent-desc">Any workflow. One sentence — or one demo call. WUPHF builds it.</div>
+      <div class="agent-quote">Yours saves the most.</div>
     </div>
   </div>
 </section>

--- a/website/index.html
+++ b/website/index.html
@@ -3,11 +3,11 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>WUPHF — AI employees with a shared brain</title>
-<meta name="description" content="WUPHF is a collaborative office of AI employees who build and maintain their own knowledge base to never lose context for the tasks you give them. Supports Claude Code, Codex, Hermes Agent, OpenClaw bridge, OpenClaw Gateway HTTP, and local LLMs via OpenCode.">
+<title>WUPHF — Describe a job once. Hire an agent that does it.</title>
+<meta name="description" content="Describe a job in one sentence, or demo it once on a call. WUPHF builds an agent with its own app, schedule, tools, and memory. Runs 24x7 on your machine. Nothing sent without your tap.">
 <link rel="canonical" href="https://wuphf.team">
-<meta property="og:title" content="WUPHF — AI employees with a shared brain">
-<meta property="og:description" content="A collaborative office of AI employees who build and maintain their own knowledge base to never lose context for the tasks you give them.">
+<meta property="og:title" content="WUPHF — You do not build automations. You hire agents.">
+<meta property="og:description" content="Describe a job once, or demo it on a call while WUPHF watches. Get an agent with its own app, schedule, tools, and memory — 24x7, on your machine.">
 <meta property="og:type" content="website">
 <meta property="og:url" content="https://wuphf.team">
 <meta property="og:site_name" content="WUPHF">
@@ -15,12 +15,12 @@
 <meta property="og:image" content="https://wuphf.team/og-image.png">
 <meta property="og:image:width" content="1280">
 <meta property="og:image:height" content="720">
-<meta property="og:image:alt" content="WUPHF — AI employees with a shared brain. Source-available AI office with channels and a pixel-art team.">
+<meta property="og:image:alt" content="WUPHF — hire agents, not automations. Source-available, local-first agents with pixel-art charm.">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="WUPHF — AI employees with a shared brain">
-<meta name="twitter:description" content="A collaborative office of AI employees who build and maintain their own knowledge base to never lose context for the tasks you give them.">
+<meta name="twitter:title" content="WUPHF — You do not build automations. You hire agents.">
+<meta name="twitter:description" content="Describe a job once, or demo it on a call while WUPHF watches. Get an agent with its own app, schedule, tools, and memory — 24x7, on your machine.">
 <meta name="twitter:image" content="https://wuphf.team/og-image.png">
-<meta name="twitter:image:alt" content="WUPHF — AI employees with a shared brain. Source-available AI office with channels and a pixel-art team.">
+<meta name="twitter:image:alt" content="WUPHF — hire agents, not automations. Source-available, local-first agents with pixel-art charm.">
 <meta name="theme-color" content="#1b0d2a">
 <link rel="icon" type="image/svg+xml" href="favicon.svg">
 <link rel="icon" type="image/png" sizes="32x32" href="favicon-32.png">
@@ -63,7 +63,7 @@
       "url": "https://wuphf.team",
       "applicationCategory": "DeveloperApplication",
       "operatingSystem": "macOS, Linux, Windows",
-      "description": "WUPHF is a collaborative office of AI employees who build and maintain their own knowledge base to never lose context for the tasks you give them. Supports Claude Code, Codex, Hermes Agent, OpenClaw bridge, OpenClaw Gateway HTTP, and local LLMs via OpenCode.",
+      "description": "Describe a job in one sentence, or demo it once on a screen-share call. WUPHF builds an agent that does it: its own app UI, scheduled routines, self-authored tools, and cited knowledge. Local-first, source-available, with a human approval gate on everything it sends.",
       "license": "https://github.com/nex-crm/wuphf/blob/main/LICENSE",
       "downloadUrl": "https://github.com/nex-crm/wuphf",
       "offers": {
@@ -1246,7 +1246,8 @@
   <span class="nav-logo">WUPHF <span class="nav-by">by Nex.ai</span></span>
   <div class="nav-links">
     <a href="#how">How it works</a>
-    <a href="#agents">Agents</a>
+    <a href="#demo">The demo call</a>
+    <a href="#agents">Your new hire</a>
     <a href="#different">vs. Others</a>
     <a href="#faq">FAQ</a>
     <a href="/download.html">Download</a>
@@ -1268,29 +1269,29 @@
   <div class="hero-inner">
 
     <div class="hero-sprites">
-      <div class="sprite" title="CEO Agent">
+      <div class="sprite" title="Lead routing agent">
         <canvas id="s0" width="24" height="36" aria-hidden="true"></canvas>
-        <span class="label-tag">CEO</span>
-        <span class="sprite-name">Strategy</span>
+        <span class="label-tag">LEADS</span>
+        <span class="sprite-name">Routes</span>
       </div>
-      <div class="sprite" title="Eng Agent">
+      <div class="sprite" title="Pipeline recap agent">
         <canvas id="s1" width="24" height="36" aria-hidden="true"></canvas>
-        <span class="label-tag">ENG</span>
-        <span class="sprite-name">Code</span>
+        <span class="label-tag">RECAP</span>
+        <span class="sprite-name">Mon 9:00</span>
       </div>
-      <div class="sprite" title="CMO Agent">
+      <div class="sprite" title="Invoice chasing agent">
         <canvas id="s2" width="24" height="36" aria-hidden="true"></canvas>
-        <span class="label-tag">CMO</span>
-        <span class="sprite-name">Growth</span>
+        <span class="label-tag">INVOICES</span>
+        <span class="sprite-name">Chases</span>
       </div>
     </div>
 
     <div class="hero-eyebrow">
       <span class="blink"></span>
-      Your personal office of AI teammates
+      Your next hire runs on localhost
     </div>
 
-    <h1 class="hero-title">WUPHF<span class="visually-hidden"> — Your personal office of AI teammates</span></h1>
+    <h1 class="hero-title">WUPHF<span class="visually-hidden"> — You do not build automations. You hire agents.</span></h1>
     <a class="hero-by" href="https://nex.ai" target="_blank" rel="noopener" aria-label="Nex.ai">by <svg class="hero-nex-logo" width="95" height="22" viewBox="0 0 95 22" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M11.4968 9.1124C10.2339 7.84948 9.98851 5.898 9.48601 4.18411C9.26753 3.43896 8.86469 2.73685 8.27738 2.14953C6.40286 0.275011 3.35898 0.279701 1.47868 2.16C-0.401626 4.0403 -0.406316 7.08419 1.4682 8.9587C2.05551 9.54601 2.75761 9.94885 3.50275 10.1673C5.21664 10.6698 7.16813 10.9152 8.43106 12.1782C9.69399 13.4411 9.93939 15.3926 10.4419 17.1065C10.6604 17.8516 11.0632 18.5537 11.6505 19.141C13.525 21.0155 16.5689 21.0109 18.4492 19.1306C20.3295 17.2503 20.3342 14.2064 18.4597 12.3319C17.8724 11.7445 17.1703 11.3417 16.4251 11.1232C14.7112 10.6207 12.7597 10.3753 11.4968 9.1124Z" fill="currentColor"/><path d="M7.25926 17.0471C7.25926 19.0517 5.63422 20.6768 3.62963 20.6768C1.62504 20.6768 0 19.0517 0 17.0471C0 15.0425 1.62504 13.4175 3.62963 13.4175C5.63422 13.4175 7.25926 15.0425 7.25926 17.0471Z" fill="currentColor"/><path d="M20 4.30639C20 6.31098 18.375 7.93602 16.3704 7.93602C14.3658 7.93602 12.7407 6.31098 12.7407 4.30639C12.7407 2.3018 14.3658 0.676758 16.3704 0.676758C18.375 0.676758 20 2.3018 20 4.30639Z" fill="currentColor"/><path d="M29.5211 7.15435V20.5967H26.25V1.92676H29.7915L37.4421 14.9957V1.92676H40.7132V20.5967H37.415L29.5211 7.15435Z" fill="currentColor"/><path d="M55.8786 14.5423H45.5787C45.9572 16.356 47.444 17.6896 49.2012 17.6896C50.5259 17.6896 51.6884 16.9428 52.3372 15.7959H55.6083C54.7432 18.6231 52.202 20.6768 49.2012 20.6768C45.4705 20.6768 42.4698 17.5029 42.4698 13.6088C42.4698 9.71481 45.4705 6.54091 49.2012 6.54091C52.202 6.54091 54.7432 8.59461 55.6083 11.4218C55.8246 12.1152 55.9327 12.8354 55.9327 13.6088C55.9327 13.9289 55.9327 14.2223 55.8786 14.5423ZM46.0653 11.4218H52.3372C51.6884 10.2749 50.5259 9.52811 49.2012 9.52811C47.8766 9.52811 46.7141 10.2749 46.0653 11.4218Z" fill="currentColor"/><path d="M68.75 6.32754L63.965 13.4755L68.75 20.5967H64.9652L62.0726 16.276L59.1529 20.5967H55.3952L60.1802 13.4755L55.3952 6.32754H59.1529L62.0726 10.6483L64.9652 6.32754H68.75Z" fill="currentColor"/><circle cx="72" cy="18.6768" r="2" fill="currentColor"/><path d="M94.3129 3.422C93.9263 3.80867 93.4623 4.002 92.9209 4.002C92.3796 4.002 91.9059 3.80867 91.4999 3.422C91.1133 3.016 90.9199 2.54233 90.9199 2.001C90.9199 1.45967 91.1133 0.995667 91.4999 0.609001C91.8866 0.203 92.3603 0 92.9209 0C93.4816 0 93.9553 0.203 94.3419 0.609001C94.7286 0.995667 94.9219 1.45967 94.9219 2.001C94.9219 2.54233 94.7189 3.016 94.3129 3.422ZM91.3549 20.677V6.177H94.4869V20.677H91.3549Z" fill="currentColor"/><path d="M85.5131 6.17681H88.7697V20.6768H85.5131V18.5888C84.4699 20.2321 82.9736 21.0538 81.024 21.0538C79.2626 21.0538 77.7577 20.3191 76.5093 18.8498C75.2609 17.3611 74.6367 15.5535 74.6367 13.4268C74.6367 11.2808 75.2609 9.47314 76.5093 8.0038C77.7577 6.53447 79.2626 5.7998 81.024 5.7998C82.9736 5.7998 84.4699 6.6118 85.5131 8.2358V6.17681ZM78.5614 16.7618C79.331 17.6318 80.2972 18.0668 81.4601 18.0668C82.623 18.0668 83.5892 17.6318 84.3587 16.7618C85.1283 15.8725 85.5131 14.7608 85.5131 13.4268C85.5131 12.0928 85.1283 10.9908 84.3587 10.1208C83.5892 9.23147 82.623 8.7868 81.4601 8.7868C80.2972 8.7868 79.331 9.23147 78.5614 10.1208C77.7919 10.9908 77.4071 12.0928 77.4071 13.4268C77.4071 14.7608 77.7919 15.8725 78.5614 16.7618Z" fill="currentColor"/></svg></a>
 
     <a class="yc-badge" href="https://www.ycombinator.com/" target="_blank" rel="noopener noreferrer" aria-label="Backed by Y Combinator">
@@ -1298,7 +1299,7 @@
     </a>
 
     <p class="hero-tagline" data-pretext>
-      A team of AI agents who build their own knowledge base, playbooks, skills and policies to collaborate with each other and accomplish tasks usually done by 10+ SaaS subscriptions.
+      You do not build automations. You hire agents. Say the job in one sentence — or do it once while WUPHF watches — and an agent takes it over: its own app, schedule, tools, and memory. 24x7, on your machine. You never do it again.
     </p>
 
     <div class="install-wrap" id="install">
@@ -1326,7 +1327,7 @@
         </button>
       </div>
       <div class="visually-hidden" id="copyStatus" aria-live="polite" aria-atomic="true"></div>
-      <p class="install-note">Free to self-host. Runs local. No account, no cloud, no per-seat pricing. Source-available (Sustainable Use License).</p>
+      <p class="install-note">Runs local. No signup, no cloud, no per-seat pricing. Source-available (Sustainable Use License), free to self-host. The entire interview process is one command.</p>
     </div>
 
     <div class="hero-ctas">
@@ -1340,7 +1341,7 @@
       </a>
     </div>
 
-    <p class="hero-cloud-cta">Want to invite more human teammates? <a class="cloud-cta-link" href="https://nex.ai" target="_blank" rel="noopener">Get Nex Cloud →</a></p>
+    <p class="hero-cloud-cta">Hiring for a whole team? Nex Cloud is the hosted big sibling. <a class="cloud-cta-link" href="https://nex.ai" target="_blank" rel="noopener">Get Nex Cloud →</a></p>
 
   </div>
 
@@ -1350,20 +1351,6 @@
   </div>
 </section>
 
-<!-- VIDEO DEMO -->
-<div class="video-section">
-  <p class="video-prompt">Watch the demo ↓</p>
-  <div class="video-wrap">
-    <video
-      src="wuphf-demo-v28.mp4"
-      controls
-      preload="none"
-      poster="og-image.png"
-      aria-label="WUPHF product demo video"
-    >Your browser does not support the WUPHF product demo video.</video>
-  </div>
-</div>
-
 <!-- AMBIENT TICKER -->
 <div class="ambient-strip">
   <div class="ambient-scroll" id="ticker"></div>
@@ -1372,9 +1359,9 @@
 <!-- HOW IT WORKS -->
 <section id="how">
   <div class="section-eyebrow">HOW IT WORKS</div>
-  <h2 class="section-title" data-pretext>Drop a goal in a channel.<br>Walk away. Come back to a team that moved the work.</h2>
+  <h2 class="section-title" data-pretext>Say the job, or show the job.<br>Either way, it stops being yours.</h2>
   <p class="section-body" data-pretext>
-    WUPHF runs a small AI office on your machine. Self-evolving agents execute based on how you work. You set the goal. They handle the handoffs.
+    There are two ways to hand WUPHF a job: type one sentence, or get on a call and do the job while it watches. Either way, you are onboarding a hire, not configuring software.
   </p>
 
   <div class="steps-grid">
@@ -1389,25 +1376,25 @@
     <div class="step-card">
       <div class="step-num">02</div>
       <span class="step-icon">&#128172;</span>
-      <div class="step-title">Drop a goal</div>
+      <div class="step-title">Say it — or show it</div>
       <div class="step-body">
-        Type one sentence into <code>#general</code>. "Ship the onboarding flow by Friday." The CEO agent decomposes it. ENG, DSG, and CMO pick up their pieces in thread.
+        Type one sentence: "Score inbound leads and route the hot ones to an AE." Or start a screen-share call and do the job once while WUPHF watches, narrates, and asks the questions a sharp new hire asks. No flowchart canvas appears. That is on purpose.
       </div>
     </div>
     <div class="step-card">
       <div class="step-num">03</div>
-      <span class="step-icon">&#127970;</span>
-      <div class="step-title">Close the tab</div>
+      <span class="step-icon">&#127959;&#65039;</span>
+      <div class="step-title">Watch your agent get built</div>
       <div class="step-body">
-        The agents keep working. They argue, declare dependencies, and surface blockers between themselves. No human in the loop. No routing. No prompt chains.
+        The agent assembles its own app live in front of you — a real screen your team can use, not a progress bar. Plus its schedule, its tools, and its knowledge. Sandboxed, reading and writing your real workspace data.
       </div>
     </div>
     <div class="step-card">
       <div class="step-num">04</div>
-      <span class="step-icon">&#128640;</span>
-      <div class="step-title">Come back to shipped work</div>
+      <span class="step-icon">&#9989;</span>
+      <div class="step-title">Approve what leaves, then let go</div>
       <div class="step-body">
-        PR open. Copy finalized. Assets exported. Day two, they still remember PR numbers, blockers, and what you decided yesterday.
+        Nothing leaves without your tap: no email, no Slack post, no CRM write. Reads are free. Writes are held. You are the manager now — the good kind, who mostly just approves things.
       </div>
     </div>
   </div>
@@ -1416,107 +1403,107 @@
 <!-- ISOMETRIC OFFICE SCENE -->
 <div class="office-section" id="office">
   <div class="office-section-header">
-    <div class="office-section-eyebrow">THE OFFICE</div>
-    <h2 class="office-section-title">AI employees with a shared brain</h2>
-    <div class="office-section-sub">AI employees share a brain and run your work 24x7. You watch, or you do not.</div>
+    <div class="office-section-eyebrow">THE NIGHT SHIFT</div>
+    <h2 class="office-section-title">Your agents, at work, right now</h2>
+    <div class="office-section-sub">Routines fire on schedule, 24x7 — which is to say, for as long as your machine is on. We said honest, not magic.</div>
   </div>
-  <canvas id="officeCanvas" height="420" role="img" aria-label="Animated pixel office scene showing AI employees coordinating around shared workstations and status boards.">
-    Animated pixel office scene showing AI employees coordinating around shared workstations and status boards.
+  <canvas id="officeCanvas" height="420" role="img" aria-label="Animated pixel scene of your hired agents working at their desks while routines fire on schedule.">
+    Animated pixel scene of your hired agents working at their desks while routines fire on schedule.
   </canvas>
 </div>
 
-<!-- THE TEAM -->
+<!-- WHAT YOU HIRED -->
 <section id="agents">
-  <div class="section-eyebrow">THE TEAM</div>
-  <h2 class="section-title" data-pretext>Agents with roles,<br>not prompts with costumes.</h2>
+  <div class="section-eyebrow">WHAT YOU HIRED</div>
+  <h2 class="section-title" data-pretext>Anatomy of<br>your new hire.</h2>
   <p class="section-body" data-pretext>
-    Each agent is a JSON file: a system prompt plus a tool list. Read it. Edit it. Fork it. The coordination between agents is the product. The individual agents are the configs you already know how to change.
+    A flowchart is a diagram of the work. A coworker brings their own equipment. Every WUPHF agent ships with all six of these — real and shipped today, not roadmap items wearing screenshots. Not a chatbot in a trench coat.
   </p>
 
   <div class="agents-grid">
     <div class="agent-card">
-      <div class="agent-badge">CEO AGENT</div>
-      <div class="agent-title">Decomposes<br>Your Goal</div>
-      <div class="agent-desc">Routes the work. Tags the right agents. Keeps the thread moving when priorities conflict. The coordinator, so you do not have to be.</div>
-      <div class="agent-quote">"Would I rather be feared or loved? Both. I want agents to fear how much users love this product."</div>
+      <div class="agent-badge">THE APP</div>
+      <div class="agent-title">A Real Screen,<br>Built In Front Of You</div>
+      <div class="agent-desc">Every agent builds its own app — a UI your team actually uses, assembled live while you watch. Sandboxed, and it reads and writes real workspace data.</div>
+      <div class="agent-quote">"Your automation has never had a face before. This one does."</div>
     </div>
     <div class="agent-card">
-      <div class="agent-badge">ENG AGENT</div>
-      <div class="agent-title">Opens PRs,<br>Surfaces Blockers</div>
-      <div class="agent-desc">Scopes the work. Flags real dependencies. Catches the SVG-versus-PNG mismatch before you notice. Opens the PR. Argues about naming on the way in.</div>
-      <div class="agent-quote">"I am ready to be hurt again." (said before every refactor)</div>
+      <div class="agent-badge">ROUTINES</div>
+      <div class="agent-title">Scheduled Work<br>It Runs Itself</div>
+      <div class="agent-desc">Cron or "every Monday 9:00." Each routine has versioned prompts — publish v2 with a change note — run history, an enable toggle, and its own chat transcript per run.</div>
+      <div class="agent-quote">"You can read exactly what it did on any given Monday. It takes better meeting notes than you do."</div>
     </div>
     <div class="agent-card">
-      <div class="agent-badge">DSG AGENT</div>
-      <div class="agent-title">Ships Assets,<br>Holds the Line</div>
-      <div class="agent-desc">Exports mocks. Writes design tokens. Calls out pixel rounding. Pushes back when ENG wants to ship something ugly, which is most days.</div>
-      <div class="agent-quote">"How dare you ship that border-radius. How DARE you."</div>
+      <div class="agent-badge">TOOLS</div>
+      <div class="agent-title">Capabilities It<br>Authors For Itself</div>
+      <div class="agent-desc">"Score a lead." "Post to #ae-handoffs." Callable tools built from what you taught it. Teach a new one by chatting — it writes its own tools so you do not have to.</div>
+      <div class="agent-quote">"It asks about edge cases on the first call. Nobody has ever done that on a first call."</div>
     </div>
     <div class="agent-card">
-      <div class="agent-badge">CMO AGENT</div>
-      <div class="agent-title">Finalizes Copy,<br>Runs the Launch</div>
-      <div class="agent-desc">Writes the README. Drafts the announcement. Runs the launch checklist. Opens a copy PR alongside the feature branch.</div>
-      <div class="agent-quote">"The README is the product. I cannot stress this enough. I will stress it again."</div>
+      <div class="agent-badge">KNOWLEDGE</div>
+      <div class="agent-title">Cited Pages,<br>Not Vibes</div>
+      <div class="agent-desc">Wikipedia-style pages synthesized from the agent's real artifacts. Every claim carries a citation and a note on why that source was trusted. Your old WUPHF wiki, notebooks, and HTML/PDF briefs come along verbatim.</div>
+      <div class="agent-quote">"Hover the citation. It shows its work. Like we all promised our teachers we would."</div>
     </div>
     <div class="agent-card">
-      <div class="agent-badge">PM AGENT</div>
-      <div class="agent-title">Synthesizes Feedback,<br>Writes the Spec</div>
-      <div class="agent-desc">Turns user conversations into specs. Keeps the team pointed at the goal, not at the bikeshed. Ships the post-mortem without being asked.</div>
-      <div class="agent-quote">"I have needs. The user has needs. Let's talk exclusively about the user's needs."</div>
+      <div class="agent-badge">DATA + INTEGRATIONS</div>
+      <div class="agent-title">Its Own Tables,<br>Your Whole Stack</div>
+      <div class="agent-desc">Typed tables for the records it works, plus 100+ integrations via Composio — Gmail, Slack, HubSpot, and roughly 97 others. Connected once, for the whole workspace.</div>
+      <div class="agent-quote">"Connected once. Reused by every agent you hire after it. Onboarding paperwork, solved."</div>
     </div>
     <div class="agent-card">
-      <div class="agent-badge">YOUR AGENT</div>
-      <div class="agent-title">Fork It.<br>Swap It. Ship It.</div>
-      <div class="agent-desc">Every agent is a JSON config. Fork the founding-team pack, swap in your internal tooling, wire in your research agent. A two-hour spike, not a six-month integration.</div>
-      <div class="agent-quote">"Would I recommend WUPHF to a friend? I'd recommend it to an enemy first. It's that good."</div>
+      <div class="agent-badge">APPROVAL GATE</div>
+      <div class="agent-title">Drafts With Confidence,<br>Sends With Permission</div>
+      <div class="agent-desc">Nothing leaves without a human tap. No Slack post, no CRM write, no email. Reads are free. Writes are held. It is a coworker, not a loose cannon.</div>
+      <div class="agent-quote">"Which is more than can be said for some humans."</div>
     </div>
   </div>
 </section>
 
-<!-- LIVE DEMO CHAT -->
+<!-- THE DEMO CALL -->
 <section id="demo">
-  <div class="section-eyebrow">WHAT IT LOOKS LIKE</div>
-  <h2 class="section-title" data-pretext>You type one sentence.<br>They handle the handoffs.</h2>
+  <div class="section-eyebrow">THE DEMO CALL</div>
+  <h2 class="section-title" data-pretext>The last time you do this job,<br>someone is finally taking notes.</h2>
   <p class="section-body" data-pretext>
-    Real thread from a founding-team run. You drop the goal. The CEO routes it. ENG declares a dependency, which is what a real engineer does. Then you close the tab.
+    "Demo workflow to Nex" is a voice call with screen share. You do the job the way you normally do it. WUPHF watches, narrates what it sees, and interrupts with the sharp questions — thresholds, branches, cadence. Then it builds the agent from what it captured: screens, selectors, API calls, entities, and the full transcript.
   </p>
 
   <div class="conversations-layout">
     <div class="thread-demo conversations-chat">
-      <!-- Root message -->
+      <!-- Root: the call -->
       <div class="thread-root">
         <div class="thread-root-avatar">YOU</div>
         <div class="thread-root-body">
-          <div class="thread-root-channel">▸ #general</div>
-          <div class="thread-root-text">Ship the onboarding flow by Friday.</div>
-          <div class="thread-root-replies">6 replies in thread</div>
+          <div class="thread-root-channel">&#9654; screen share &middot; rec</div>
+          <div class="thread-root-text">*opens the demo-request form, looks the company up in HubSpot, posts the good ones to Slack*</div>
+          <div class="thread-root-replies">Nex is watching and listening</div>
         </div>
       </div>
-      <!-- Thread replies -->
+      <!-- The call transcript -->
       <div class="thread-replies-wrap">
         <div class="thread-reply">
-          <div class="thread-reply-avatar">CEO</div>
-          <div class="thread-reply-bubble"><span class="thread-mention">@ENG</span> what's the scope? <span class="thread-mention">@DESIGN</span> do we have mocks ready?</div>
+          <div class="thread-reply-avatar">NEX</div>
+          <div class="thread-reply-bubble">Got it — you looked the company up in HubSpot and checked headcount.</div>
         </div>
         <div class="thread-reply">
-          <div class="thread-reply-avatar">ENG</div>
-          <div class="thread-reply-bubble">3 screens. 2 days to build. Need copy finalized and assets from Design first.</div>
-        </div>
-        <div class="thread-reply">
-          <div class="thread-reply-avatar">DSG</div>
-          <div class="thread-reply-bubble">Mocks are done. Exporting assets to /design/onboarding-v2 now. Figma link in the PR description.</div>
-        </div>
-        <div class="thread-reply">
-          <div class="thread-reply-avatar">CMO</div>
-          <div class="thread-reply-bubble">Copy's finalized. Opening a README PR alongside the feature branch.</div>
-        </div>
-        <div class="thread-reply">
-          <div class="thread-reply-avatar">ENG</div>
-          <div class="thread-reply-bubble">PR #47 open. Assets pulled. Waiting on review.</div>
+          <div class="thread-reply-avatar">NEX</div>
+          <div class="thread-reply-bubble">Over what score does a lead go to an AE instead of the nurture list?</div>
         </div>
         <div class="thread-reply you">
           <div class="thread-reply-avatar you">YOU</div>
-          <div class="thread-reply-bubble">LGTM. Ship it.</div>
+          <div class="thread-reply-bubble">70 and up goes to #ae-handoffs with the reason. Rest gets nurtured.</div>
+        </div>
+        <div class="thread-reply">
+          <div class="thread-reply-avatar">NEX</div>
+          <div class="thread-reply-bubble">I think I have the whole flow. Ready for me to build the agent from this, or is there more?</div>
+        </div>
+        <div class="thread-reply you">
+          <div class="thread-reply-avatar you">YOU</div>
+          <div class="thread-reply-bubble">That's it. Build it.</div>
+        </div>
+        <div class="thread-reply">
+          <div class="thread-reply-avatar">NEX</div>
+          <div class="thread-reply-bubble">Building Lead Routing Agent — app, routines, and the two tools it needs. Watch it come together.</div>
         </div>
       </div>
     </div>
@@ -1536,53 +1523,71 @@
         <div class="code-line"><span class="line-content"><span class="tok-fn">git</span> clone https://github.com/nex-crm/wuphf.git && cd wuphf</span><button class="line-copy" data-copy="git clone https://github.com/nex-crm/wuphf.git && cd wuphf" aria-label="Copy">COPY</button></div>
         <div class="code-line"><span class="line-content"><span class="tok-fn">go</span> build -o wuphf ./cmd/wuphf</span><button class="line-copy" data-copy="go build -o wuphf ./cmd/wuphf" aria-label="Copy">COPY</button></div>
         <div class="code-line code-line-empty"></div>
-        <div class="code-line"><span class="line-content"><span class="tok-cmt"># Start the office. Pick a team.</span></span></div>
-        <div class="code-line"><span class="line-content"><span class="tok-fn">wuphf</span> --pack founding-team</span><button class="line-copy" data-copy="wuphf --pack founding-team" aria-label="Copy">COPY</button></div>
-        <div class="code-line code-line-empty"></div>
         <div class="code-line"><span class="line-content"><span class="tok-cmt"># Browser opens at localhost:7891.</span></span></div>
-        <div class="code-line"><span class="line-content"><span class="tok-cmt"># Drop one sentence in #general.</span></span></div>
-        <div class="code-line"><span class="line-content"><span class="tok-cmt"># Walk away.</span></span></div>
+        <div class="code-line"><span class="line-content"><span class="tok-cmt"># Describe a job — or demo it on a call.</span></span></div>
+        <div class="code-line"><span class="line-content"><span class="tok-cmt"># Watch the agent build its own app.</span></span></div>
       </div>
     </div>
   </div>
 
-  <!-- Scene 4: the blocker moment. This is the aha. -->
+  <!-- The aha: Monday morning, without you -->
   <div style="margin-top:56px;padding:24px;background:var(--bg3);border:2px solid var(--yellow-dark);max-width:700px;">
-    <div style="font-family:var(--font-display);font-size:8px;color:var(--yellow);letter-spacing:0.14em;margin-bottom:16px;">20 MINUTES LATER // #DEV</div>
+    <div style="font-family:var(--font-display);font-size:8px;color:var(--yellow);letter-spacing:0.14em;margin-bottom:16px;">MONDAY 9:00 // ROUTINE: WEEKLY PIPELINE RECAP</div>
     <div style="font-family:var(--font-vt);font-size:22px;color:var(--text);line-height:1.5;margin-bottom:12px;">
-      <span style="color:var(--yellow);">ENG:</span> <span class="thread-mention">@DSG</span> the onboarding SVGs do not render on mobile Safari. They need PNG fallbacks at 2x. Blocking the PR on this.
+      <span style="color:var(--yellow);">AGENT:</span> Ran the recap. 3 stage moves, 2 new leads, Umbrella stalled 21 days. Saved the brief as a doc.
     </div>
     <div style="font-family:var(--font-vt);font-size:22px;color:var(--text);line-height:1.5;margin-bottom:12px;">
-      <span style="color:var(--yellow);">DSG:</span> Fixed. Re-exported to /design/onboarding-v2/png. <span class="thread-mention">@ENG</span> pull again.
+      <span style="color:var(--yellow);">AGENT:</span> Drafted the Slack post for #revops. Holding it for your approval.
     </div>
     <div style="font-family:var(--font-vt);font-size:22px;color:var(--text);line-height:1.5;">
-      <span style="color:var(--yellow);">ENG:</span> Pulled. Tests passing. Back on track.
+      <span style="color:var(--yellow);">YOU:</span> *one tap* Approved.
     </div>
     <p style="font-family:var(--font-mono);font-size:13px;color:var(--text-dim);margin-top:20px;line-height:1.7;">
-      You did not type anything. You were making coffee. The agents surfaced a blocker you did not tell them to look for, then resolved it between themselves. This is the thing that separates coordination from a prompt chain in costume.
+      You demoed this job exactly once. The routine ran on schedule, the outcome landed in run history with a full transcript, and the only thing that needed you was the tap. Reads are free. Writes are held. You just trained your replacement — it says thank you and works weekends.
     </p>
   </div>
 </section>
 
-<!-- WHY WUPHF -->
+<!-- THE ALTERNATIVES -->
 <section id="different">
-  <div class="section-eyebrow">WHY WUPHF</div>
-  <h2 class="section-title" data-pretext>Stop being the routing layer<br>between your own agents.</h2>
+  <div class="section-eyebrow">THE ALTERNATIVES</div>
+  <h2 class="section-title" data-pretext>Ways to not use WUPHF,<br>reviewed honestly.</h2>
   <p class="section-body" data-pretext>
-    Most agent setups make you staff every seat, paste context, and manually hand off between steps. WUPHF builds its own team.
+    We are supposed to say these are all great tools for the right team. Here is the honest version instead.
   </p>
 
-  <div class="compare-grid">
-    <div class="compare-card compare-card-good">
-      <div class="compare-label">WHAT YOU GET</div>
-      <ul class="compare-list compare-list-pos">
-        <li>Agents continuously learn your work playbooks and build personalized skills. The office gets sharper the more you use it.</li>
-        <li>Each agent gets its own notebook. The team shares a wiki. When a conclusion in an agent's notebook holds up, it gets promoted to the wiki so the whole office benefits. Built-in markdown wiki, file-over-app, lives as a local git repo. No API key, no hosted backend.</li>
-        <li>Mix Claude Code, Codex, Hermes Agent, OpenClaw bridged agents, and OpenClaw Gateway HTTP agents in one channel. They execute your work 24x7.</li>
-        <li>Local. Runs on your machine. No cloud in the critical path.</li>
-        <li>7x fewer tokens per session. Fresh sessions, not accumulated context.</li>
-        <li>Free to self-host. Source-available, fair-code licensed. No seats, no usage fees.</li>
-      </ul>
+  <div class="steps-grid">
+    <div class="step-card">
+      <div class="step-num">A</div>
+      <span class="step-icon">&#128170;</span>
+      <div class="step-title">Doing it yourself</div>
+      <div class="step-body">
+        The current market leader. Zero setup, perfectly accurate, infinitely flexible. Costs every Monday morning for the rest of your career.
+      </div>
+    </div>
+    <div class="step-card">
+      <div class="step-num">B</div>
+      <span class="step-icon">&#128208;</span>
+      <div class="step-title">Zapier and n8n</div>
+      <div class="step-body">
+        Flowcharts you build yourself. Every branch is your problem, every edge case is a new node, and six months later maintaining the diagram is the job. WUPHF asks you the branches once, on a call, and the agent keeps them.
+      </div>
+    </div>
+    <div class="step-card">
+      <div class="step-num">C</div>
+      <span class="step-icon">&#128433;&#65039;</span>
+      <div class="step-title">Computer-use demos</div>
+      <div class="step-body">
+        You watch a cursor move around a screen, slowly. Impressive the way a dog walking on two legs is impressive. A job needs an app, a schedule, tools, and memory — not a cursor with stage presence.
+      </div>
+    </div>
+    <div class="step-card">
+      <div class="step-num">D</div>
+      <span class="step-icon">&#9729;&#65039;</span>
+      <div class="step-title">Hosted agent platforms</div>
+      <div class="step-body">
+        Per-seat pricing, and your workflow data lives on their cloud. WUPHF runs on your machine, free to self-host, source-available. The hosted version exists — it is called <a href="https://nex.ai" style="color:var(--yellow);">Nex Cloud</a> — but it is a choice, not the only door.
+      </div>
     </div>
   </div>
 </section>
@@ -1593,9 +1598,9 @@
   <div class="mit-block">
     <div class="mit-badge">FAIR-CODE<br>LICENSE</div>
     <div class="mit-text">
-      Free forever. Runs on your machine.<br>
-      Agent configs are JSON you can read and edit.<br>
-      Fork the founding-team pack, wire in your internal tooling, ship in an afternoon.<br>
+      Free to self-host. Runs on your machine.<br>
+      The job description is one sentence or one call — not a config format.<br>
+      Read the source, file the issue, break it on purpose. It is your machine.<br>
       No seats. No usage fees. No Michael Scott energy required (but encouraged).
     </div>
     <div class="mit-cta">
@@ -1615,64 +1620,60 @@
 
   <div class="faq-list">
     <details class="faq-item">
-      <summary class="faq-q">Is the coordination real, or is it scripted?</summary>
+      <summary class="faq-q">Whatever happened to the "office of AI employees" pitch?</summary>
       <div class="faq-a">
-        Emergent. The agents have role prompts and channel access. They coordinate because that is what the roles instruct. No hardcoded scene, no timed animation. You can watch the raw message bus in the terminal, rewrite the prompts, and break it yourself. If it were scripted, forking the configs would not change the behavior. Fork the configs.
+        We pivoted. On the internet, in front of everyone. Watching five agents discuss your work turns out to be a form of work — specifically, yours. "AI employee" is a metaphor; an agent that files the report every Monday at 9:00 is a fact. So WUPHF now builds the second thing. Everything your old office wrote — wiki articles, notebooks, HTML and PDF briefs — is preserved verbatim in each agent's Knowledge tab. We kept your homework; we just fired the fictional middle managers.
       </div>
     </details>
     <details class="faq-item">
-      <summary class="faq-q">What happens when an agent gets stuck or loops?</summary>
+      <summary class="faq-q">Will it send an email or a Slack message without asking me?</summary>
       <div class="faq-a">
-        Every agent run has a timeout and a step budget. When either trips, the agent posts an escalation to #general and hands control back to you. You can see the full tool-call trace in the Receipts panel or via <code>wuphf log</code>. We are still iterating on failure modes, so the honest answer is: if something surprises you, open an issue. This is the work we want feedback on before calling it production-ready.
+        No. That is the approval gate and it is not optional. Reads are free — the agent can look things up all day. Writes are held: any email, Slack post, or CRM write is drafted and parked until a human taps approve. The run history shows exactly what it wanted to send and when you approved it.
       </div>
     </details>
     <details class="faq-item">
-      <summary class="faq-q">Where is the context stored, and how long does it last?</summary>
+      <summary class="faq-q">What happens to my old WUPHF wiki and notebooks when I upgrade?</summary>
       <div class="faq-a">
-        Local SQLite for channel history in <code>~/.wuphf/state</code>. Per-project, so client work stays isolated. Each agent also gets its own notebook for focused work; durable conclusions get promoted into a shared team wiki at <code>~/.wuphf/wiki</code>, a real git repo of markdown articles you can <code>cat</code>, <code>grep</code>, and <code>git clone</code>. Threads, channel history, and the wiki persist until you delete the files. Day 2, the agents still remember PR numbers, blockers, and decisions from yesterday.
+        They come along. Team wiki articles, each agent's notebook notes, and the sanitized HTML/PDF briefs the old product generated are all served verbatim as Knowledge pages, labeled "Preserved from your previous workspace," with the visual briefs viewable inline in a sandboxed frame. Nothing is re-synthesized, nothing is lost, and nothing pretends it wrote your notes.
       </div>
     </details>
     <details class="faq-item">
-      <summary class="faq-q">Are the tool integrations real API calls, or natural-language references?</summary>
+      <summary class="faq-q">How is this different from Zapier or n8n?</summary>
       <div class="faq-a">
-        Mixed, and we are upfront about it. GitHub PR opens and repo reads are real API calls via the <code>gh</code> CLI (agents run <code>gh pr create</code> through the bash tool). File reads, grep, and writes are real local filesystem ops. Some third-party references (Figma, Slack) are still natural-language placeholders until you wire up the integration. The Receipts panel shows exactly which tools each agent called, so you can verify for yourself.
+        Those are tools for building automations: you draw the flowchart, you own every branch, and maintaining the diagram slowly becomes the job. WUPHF is closer to hiring: you say the job or demo it once, and the agent keeps the branches. It also ships things a flowchart does not have — its own app UI, versioned scheduled routines with run history, self-authored tools, and cited knowledge.
+      </div>
+    </details>
+    <details class="faq-item">
+      <summary class="faq-q">What actually runs 24x7? My laptop sleeps.</summary>
+      <div class="faq-a">
+        Honest answer: agents run as long as the machine running WUPHF is on. On a laptop that means "while the laptop is awake." Put it on a Mac mini in a closet or any always-on box and 24x7 means 24x7. If you would rather not own a closet server, <a class="cloud-cta-link" href="https://nex.ai" target="_blank" rel="noopener">Nex Cloud</a> is the hosted version.
+      </div>
+    </details>
+    <details class="faq-item">
+      <summary class="faq-q">What happens if I have not connected a model or any integrations yet?</summary>
+      <div class="faq-a">
+        The whole pipeline still runs — routines fire, transcripts and run history record — but outcomes are simulated, and they say so in plain text: "Simulated run: no model or integrations are connected on this host." No fake demo data pretending to be your pipeline. Connect a provider and the same routine does the real thing.
       </div>
     </details>
     <details class="faq-item">
       <summary class="faq-q">Does my data leave the machine?</summary>
       <div class="faq-a">
-        The runtime is local. Context is local. The only network calls are to the LLM provider you configure, for inference. If you point WUPHF at a local model, nothing leaves the machine at all. No telemetry, no analytics ping, no phone-home.
+        The runtime is local and your workspace state lives in local files you can <code>cat</code>. Three things do leave, all under your control: inference calls to whatever model provider you configure (point it at a local model and even that stays home), the integration calls you explicitly connect via Composio, and anonymous product analytics — which you can opt out of. We would rather tell you about the analytics here than have you find it in devtools.
       </div>
     </details>
     <details class="faq-item">
-      <summary class="faq-q">Can I invite a teammate into the office?</summary>
+      <summary class="faq-q">Is this production-ready?</summary>
       <div class="faq-a">
-        Yes. Two ways. If you and your teammate are on the same Tailscale or WireGuard network, run <code>wuphf share</code> (or click "Create invite" inside the office) and send the printed <code>/join</code> URL. If you are not on a shared private network, click "Start tunnel" inside the office and WUPHF spins up a Cloudflare quick tunnel paired with a 6-digit passcode the joiner has to type before they can land in the office. <code>cloudflared</code> ships bundled with the npm install. Invites are one-use, expire in 24 hours, and the join handler is rate-limited per source IP so a leaked URL alone cannot be brute-forced.
-        <div style="margin-top:16px;padding-top:16px;border-top:1px solid var(--yellow-dark);">
-          Want to invite more human teammates? <a class="cloud-cta-link" href="https://nex.ai" target="_blank" rel="noopener">Get Nex Cloud →</a>
-        </div>
+        It is v0.x and we put that on the website. Some things will break; when they do, per-run transcripts show exactly where, and the issue tracker is public. The catch you were scrolling for is just that it is early. Early, local, and honest beats polished, hosted, and vague — but that is a preference, and it is yours to make.
       </div>
     </details>
-    <details class="faq-item">
-      <summary class="faq-q">Do I have to use the pixel office and The Office jokes?</summary>
-      <div class="faq-a">
-        No. The default pack leans into it because joy is a real feature. You can fork the pack, strip the Office strings, and make it as serious as you want. The humor is in the config, not the engine. But their loss.
-      </div>
-    </details>
-    <details class="faq-item">
-      <summary class="faq-q">Can I mix different AI providers in one office?</summary>
-      <div class="faq-a">
-        Yes. Each agent picks its own runtime: Claude Code, Codex, Hermes Agent through its local API server, OpenClaw Gateway through its OpenAI-compatible HTTP endpoint, or existing OpenClaw sessions bridged over WebSocket. Your PM can run on Claude Opus while your engineer runs on Codex. They all collaborate in one shared channel with the same @mention semantics regardless of which provider backs them.
-      </div>
-    </details>
-  </div>
-</section>
+  </section>
 
 <!-- FOOTER -->
 <footer>
   <div>
     <div class="footer-logo">WUPHF</div>
-    <div class="footer-sub">by <a href="https://nex.ai" style="color:var(--yellow);text-decoration:none;">Nex.ai</a> &middot; A local AI office. Drop a goal. Walk away.</div>
+    <div class="footer-sub">by <a href="https://nex.ai" style="color:var(--yellow);text-decoration:none;">Nex.ai</a> &middot; Show it once. Never do it again.</div>
   </div>
   <div class="footer-links">
     <a href="https://github.com/nex-crm/wuphf">GitHub</a>
@@ -1811,18 +1812,18 @@
 
   // ── TICKER (DOM-safe) ─────────────────────────────────────────────────
   var quotes = [
-    '"I DECLARE... a hackathon!" "Michael, that is not a sprint." "It is a VISION sprint."',
-    'Identity theft is not a joke, Jim. But WUPHF is free forever. Pass it on.',
-    "That's what she shipped. (CMO Agent, every single Friday at 4:59pm)",
-    'bears. beets. battlestar galactica. git clone github.com/nex-crm/wuphf. four things Dwight endorses.',
-    'Would I rather be feared or loved? Both. I want agents to fear how much users love it. , CEO Agent, system prompt',
-    'The Flenderson is not a thing. It is now. I added it to agents.ts. MICHAEL.',
-    'How the turntable has shipped. , ENG Agent after every single refactor',
-    'Ryan started the fire. ENG Agent fixed it in PR #23. Tests passing.',
-    'I DECLARE... 47 commits merged! , Michael Scott, WUPHF user of the month, every month',
-    'Dwight, you cannot list the beet farm as a remote office in wuphf.config.ts. Watch me.',
-    'An AI office where everyone does their job and nobody throws a Dundie at the server. Progress.',
-    'The AI team works weekends. They do not complain. They do not microwave fish. Perfect.',
+    'Show it once. Never do it again. , the entire onboarding doc',
+    '"I DECLARE... this job delegated!" "Michael, you have to demo it first." "I DECLARED it."',
+    'Identity theft is not a joke, Jim. Neither is an approval gate. Nothing sends without a tap.',
+    "That's what she shipped. (Lead Routing Agent, v2, with a change note)",
+    'bears. beets. a routine that files the report every Monday at 9:00. three things Dwight endorses.',
+    'Dwight tried to demo threshing wheat to Nex. It asked about thresholds. He was moved to tears.',
+    'The agent read the old wiki. All of it. It cites its sources now. Show-off.',
+    'You watched it build its own app. It watched you make coffee. Fair trade.',
+    'Reads are free. Writes are held. Dundies are earned.',
+    'The agents work weekends. They do not complain. They do not microwave fish. Perfect.',
+    'Ryan started the fire. The routine ran anyway. Run history has the receipts.',
+    'Would I rather be feared or loved? Both. I want agents to fear how much users love this product.',
   ];
 
   var ticker = document.getElementById('ticker');


### PR DESCRIPTION
## What

Complete copy/structure rewrite of wuphf.team for the post-pivot product, keeping the pixel-brand visual identity. Hero pitch chosen by a 4-angle × 3-lens judge panel (16 agents): **"You do not build automations. You hire agents."** with "Show it once. Never do it again." as the through-line.

- **Hero**: new eyebrow ("Your next hire runs on localhost"), tagline, install note, cloud CTA; sprites relabeled to hired agents (LEADS/RECAP/INVOICES).
- **How it works**: say the job or show the job → watch the agent build its own app → approve what leaves (reads free, writes held).
- **The demo call** (replaces the channel-thread demo): screen-share transcript of Nex watching, asking the threshold question, and building the Lead Routing Agent; the "aha" box is now the Monday-9:00 routine + approval tap.
- **Anatomy of your new hire** (replaces CEO/ENG/CMO team cards): the app, routines (versioned prompts + run history), self-authored tools, cited knowledge **with legacy wiki/notebook/brief preservation**, data + 100+ integrations, approval gate.
- **The alternatives**: doing it yourself, Zapier/n8n, computer-use demos, hosted platforms — reviewed honestly, deadpan.
- **FAQ**: all-new; every claim fact-checked against main (analytics disclosed with opt-out — the old "no telemetry" claim was already false; honest 24x7-means-machine-on answer; simulated-mode honesty; legacy preservation; approval gate).
- **Removed**: the v28 demo video (shows the retired product). Meta/OG/JSON-LD updated. download.html de-officed.

## Test plan
- [x] Rendered locally, zero console/page errors; every section screenshotted (below)
- [x] Old-pitch sweep: no stray "office/employees/shared brain/founding-team" strings outside the intentional FAQ retraction
- [x] All FAQ claims verified against the v0.233.0 codebase
- [ ] Needs a new demo video + og-image refresh (follow-ups; old og-image alt text updated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Screenshots

![v3-01-hero](https://github.com/nex-crm/wuphf/raw/screenshots/pr-1161/v3-01-hero.png)

![v3-02-how](https://github.com/nex-crm/wuphf/raw/screenshots/pr-1161/v3-02-how.png)

![v3-03-demo](https://github.com/nex-crm/wuphf/raw/screenshots/pr-1161/v3-03-demo.png)

![v3-04-agents](https://github.com/nex-crm/wuphf/raw/screenshots/pr-1161/v3-04-agents.png)

![v3-05-use-cases](https://github.com/nex-crm/wuphf/raw/screenshots/pr-1161/v3-05-use-cases.png)

![v3-07-faq-open](https://github.com/nex-crm/wuphf/raw/screenshots/pr-1161/v3-07-faq-open.png)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated download page copy to use new “workspace” and “native window” wording across page metadata, hero text, setup instructions, and terminal/Linux guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->