### PR TITLE
fix: operator QA round-2 batch — approval polling, stall retry, honest feed + sidebar, legacy knowledge polish

### DIFF
--- a/bench/slice-1/runner/runner.go
+++ b/bench/slice-1/runner/runner.go
@@ -95,14 +95,36 @@ type QueryResult struct {
 	// Classifier output for sanity.
 	ClassifierClass      string
 	ClassifierConfidence float64
+	// Rank-sensitive metrics computed from the ORDERED got list against the
+	// binary-relevant expected set. recall@20 is saturated on this corpus
+	// (every query returns its full expected set inside top-20), so these are
+	// the metrics that actually move when fusion/rerank reorder the union.
+	// Defined only for in-scope queries (len(expected) > 0); OOS queries leave
+	// them at zero and are excluded from the macro-averages.
+	NDCG10     float64
+	RecallAt1  float64
+	RecallAt3  float64
+	RecallAt5  float64
+	RecallAt10 float64
+	MRR        float64
 }
 
 // Aggregate is the final scoreboard.
 type Aggregate struct {
-	TotalQueries       int
-	PassingQueries     int
-	MicroRecall        float64 // sum(intersection) / sum(|expected|)
-	PassRate           float64 // passingQueries / totalQueries
+	TotalQueries   int
+	PassingQueries int
+	MicroRecall    float64 // sum(intersection) / sum(|expected|)
+	PassRate       float64 // passingQueries / totalQueries
+	// Macro-averaged rank-sensitive metrics over in-scope queries only.
+	// These are the discriminating baselines for the RRF-fusion and
+	// cross-encoder-rerank changes; recall@20 / pass-rate are saturated.
+	ScoredQueries      int // in-scope queries (len(expected) > 0)
+	MeanNDCG10         float64
+	MeanRecallAt1      float64
+	MeanRecallAt3      float64
+	MeanRecallAt5      float64
+	MeanRecall10       float64
+	MeanMRR            float64
 	RetrievalP50Ms     float64
 	RetrievalP95Ms     float64
 	ClassifyP95Micros  int64
@@ -391,6 +413,12 @@ func Run(ctx context.Context, cfg Config) (*Aggregate, []QueryResult, error) {
 			ClassifyMicros:       classifyMicros,
 			ClassifierClass:      string(klass),
 			ClassifierConfidence: conf,
+			NDCG10:               scoreNDCG(q.ExpectedFactIDs, got, 10),
+			RecallAt1:            scoreRecallAtK(q.ExpectedFactIDs, got, 1),
+			RecallAt3:            scoreRecallAtK(q.ExpectedFactIDs, got, 3),
+			RecallAt5:            scoreRecallAtK(q.ExpectedFactIDs, got, 5),
+			RecallAt10:           scoreRecallAtK(q.ExpectedFactIDs, got, 10),
+			MRR:                  scoreMRR(q.ExpectedFactIDs, got),
 		}
 		results = append(results, res)
 		_ = qi
@@ -406,6 +434,7 @@ func Run(ctx context.Context, cfg Config) (*Aggregate, []QueryResult, error) {
 	}
 
 	var totalExpected, totalHit int
+	var sumNDCG, sumR1, sumR3, sumR5, sumR10, sumMRR float64
 	classBuckets := map[string]*ClassBreakdown{}
 	for _, r := range results {
 		if r.Passed {
@@ -415,6 +444,17 @@ func Run(ctx context.Context, cfg Config) (*Aggregate, []QueryResult, error) {
 		}
 		totalExpected += len(r.Query.ExpectedFactIDs)
 		totalHit += r.Intersection
+		// Rank-sensitive metrics are only meaningful where there are relevant
+		// docs to rank; OOS queries (no expected facts) are excluded.
+		if len(r.Query.ExpectedFactIDs) > 0 {
+			agg.ScoredQueries++
+			sumNDCG += r.NDCG10
+			sumR1 += r.RecallAt1
+			sumR3 += r.RecallAt3
+			sumR5 += r.RecallAt5
+			sumR10 += r.RecallAt10
+			sumMRR += r.MRR
+		}
 
 		cb, ok := classBuckets[r.Query.QueryClass]
 		if !ok {
@@ -454,6 +494,15 @@ func Run(ctx context.Context, cfg Config) (*Aggregate, []QueryResult, error) {
 		agg.MicroRecall = float64(totalHit) / float64(totalExpected)
 	} else {
 		agg.MicroRecall = 1.0
+	}
+	if agg.ScoredQueries > 0 {
+		n := float64(agg.ScoredQueries)
+		agg.MeanNDCG10 = sumNDCG / n
+		agg.MeanRecallAt1 = sumR1 / n
+		agg.MeanRecallAt3 = sumR3 / n
+		agg.MeanRecallAt5 = sumR5 / n
+		agg.MeanRecall10 = sumR10 / n
+		agg.MeanMRR = sumMRR / n
 	}
 	agg.RetrievalP50Ms = percentile(allLatencyMs, 0.50)
 	agg.RetrievalP95Ms = percentile(allLatencyMs, 0.95)
@@ -593,6 +642,19 @@ func FormatReport(agg *Aggregate, results []QueryResult) string {
 	fmt.Fprintf(&b, "  Reconcile wall time      : %d ms\n", agg.ReconcileWallMs)
 	fmt.Fprintf(&b, "  SQLite size              : %d bytes\n", agg.IndexBytesSQLite)
 	fmt.Fprintf(&b, "  Bleve size               : %d bytes\n\n", agg.IndexBytesBleve)
+
+	// Rank-sensitive retrieval quality — the discriminating baseline for
+	// fusion/rerank changes. recall@20 above is saturated on this corpus;
+	// these macro-averages (in-scope queries only) are what a reranker swap
+	// must actually move. Observability layer, OFFICE-671.
+	fmt.Fprintf(&b, "Rank-sensitive retrieval quality (macro avg, %d in-scope queries)\n", agg.ScoredQueries)
+	fmt.Fprintf(&b, "----------------------------------------------------------------\n")
+	fmt.Fprintf(&b, "  nDCG@10                  : %.4f\n", agg.MeanNDCG10)
+	fmt.Fprintf(&b, "  recall@1                 : %.4f\n", agg.MeanRecallAt1)
+	fmt.Fprintf(&b, "  recall@3                 : %.4f\n", agg.MeanRecallAt3)
+	fmt.Fprintf(&b, "  recall@5                 : %.4f\n", agg.MeanRecallAt5)
+	fmt.Fprintf(&b, "  recall@10                : %.4f\n", agg.MeanRecall10)
+	fmt.Fprintf(&b, "  MRR                      : %.4f\n\n", agg.MeanMRR)
 
 	fmt.Fprintf(&b, "Per-class breakdown\n-------------------\n")
 	classes := make([]string, 0, len(agg.PerClass))

--- a/bench/slice-1/runner/scoring.go
+++ b/bench/slice-1/runner/scoring.go
@@ -1,0 +1,105 @@
+package runner
+
+import "math"
+
+// scoring.go — rank-sensitive retrieval metrics for the Slice 1 observability
+// layer. recall@20 / pass-rate are saturated on this corpus (every in-scope
+// query returns its full expected set inside top-20), so they cannot show
+// whether a fusion or rerank change actually reordered the union toward the
+// top. These metrics can: they reward putting relevant facts at low ranks.
+//
+// All metrics use binary relevance (a fact is relevant iff its ID is in the
+// query's expected set) and operate on the ORDERED `got` list as returned by
+// WikiIndex.Search. No LLM, no external credential, fully deterministic.
+
+// scoreRecallAtK computes recall@k = |expected ∩ got[:k]| / |expected|: the
+// fraction of relevant facts that appear within the top-k retrieved results.
+//
+// Returns 0 for out-of-scope queries (empty expected set) — those carry no
+// relevant docs to rank and are excluded from the macro-averages by the
+// caller. Note recall@1 is bounded above by 1/|expected| on multi-fact
+// queries, so on this corpus nDCG@10 and MRR are the sharper discriminators;
+// recall@1/@3 still move when a rerank lifts a single relevant fact to the top.
+func scoreRecallAtK(expected, got []string, k int) float64 {
+	if len(expected) == 0 {
+		return 0
+	}
+	if k > len(got) {
+		k = len(got)
+	}
+	gset := make(map[string]struct{}, len(expected))
+	for _, e := range expected {
+		gset[e] = struct{}{}
+	}
+	hit := 0
+	for i := 0; i < k; i++ {
+		if _, ok := gset[got[i]]; ok {
+			hit++
+		}
+	}
+	return float64(hit) / float64(len(expected))
+}
+
+// scoreNDCG computes the normalised discounted cumulative gain at rank k with
+// binary relevance:
+//
+//	DCG@k  = Σ_{i=1..k} rel_i / log2(i+1)
+//	IDCG@k = Σ_{i=1..min(k,|expected|)} 1 / log2(i+1)   (ideal ordering)
+//	nDCG@k = DCG@k / IDCG@k
+//
+// rel_i is 1 when got[i-1] is in the expected set, else 0. Returns 0 for
+// out-of-scope queries (no ideal gain exists to normalise against).
+func scoreNDCG(expected, got []string, k int) float64 {
+	if len(expected) == 0 {
+		return 0
+	}
+	gset := make(map[string]struct{}, len(expected))
+	for _, e := range expected {
+		gset[e] = struct{}{}
+	}
+	limit := k
+	if limit > len(got) {
+		limit = len(got)
+	}
+	var dcg float64
+	for i := 0; i < limit; i++ {
+		if _, ok := gset[got[i]]; ok {
+			// rank position is i+1; discount uses log2(position+1).
+			dcg += 1.0 / math.Log2(float64(i+2))
+		}
+	}
+	// Ideal DCG: as many relevant docs as possible packed at the top, capped
+	// by both k and the number of relevant docs available.
+	ideal := len(expected)
+	if ideal > k {
+		ideal = k
+	}
+	var idcg float64
+	for i := 0; i < ideal; i++ {
+		idcg += 1.0 / math.Log2(float64(i+2))
+	}
+	if idcg == 0 {
+		return 0
+	}
+	return dcg / idcg
+}
+
+// scoreMRR computes the reciprocal rank of the FIRST relevant fact in the
+// ordered got list (1/rank, 1-indexed). Returns 0 when no relevant fact is
+// retrieved or the query is out of scope. MRR is the cleanest single-number
+// signal for "did the retriever put a right answer near the top".
+func scoreMRR(expected, got []string) float64 {
+	if len(expected) == 0 {
+		return 0
+	}
+	gset := make(map[string]struct{}, len(expected))
+	for _, e := range expected {
+		gset[e] = struct{}{}
+	}
+	for i, g := range got {
+		if _, ok := gset[g]; ok {
+			return 1.0 / float64(i+1)
+		}
+	}
+	return 0
+}

--- a/bench/slice-1/runner/scoring_test.go
+++ b/bench/slice-1/runner/scoring_test.go
@@ -1,0 +1,84 @@
+package runner
+
+import (
+	"math"
+	"testing"
+)
+
+const eps = 1e-9
+
+func almostEqual(a, b float64) bool { return math.Abs(a-b) < eps }
+
+func TestScoreRecallAtK(t *testing.T) {
+	cases := []struct {
+		name     string
+		expected []string
+		got      []string
+		k        int
+		want     float64
+	}{
+		{"out of scope returns zero", nil, []string{"a", "b"}, 3, 0},
+		{"perfect single fact at top", []string{"a"}, []string{"a", "b", "c"}, 1, 1},
+		{"relevant fact below k misses", []string{"c"}, []string{"a", "b", "c"}, 2, 0},
+		{"relevant fact within k hits", []string{"c"}, []string{"a", "b", "c"}, 3, 1},
+		{"two of three relevant in topk", []string{"a", "b", "z"}, []string{"a", "b", "c"}, 3, 2.0 / 3.0},
+		{"recall@1 capped by expected size", []string{"a", "b"}, []string{"a", "b"}, 1, 0.5},
+		{"k larger than got is clamped", []string{"b"}, []string{"a", "b"}, 50, 1},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := scoreRecallAtK(c.expected, c.got, c.k); !almostEqual(got, c.want) {
+				t.Fatalf("scoreRecallAtK(%v,%v,%d) = %v, want %v", c.expected, c.got, c.k, got, c.want)
+			}
+		})
+	}
+}
+
+func TestScoreNDCG(t *testing.T) {
+	// IDCG@k constants for binary relevance, ideal ordering.
+	idcg1 := 1.0                    // 1/log2(2)
+	idcg2 := 1.0 + 1.0/math.Log2(3) // ranks 1,2
+	cases := []struct {
+		name     string
+		expected []string
+		got      []string
+		k        int
+		want     float64
+	}{
+		{"out of scope returns zero", nil, []string{"a"}, 10, 0},
+		{"single relevant at top is perfect", []string{"a"}, []string{"a", "b", "c"}, 10, 1},
+		{"single relevant at rank 2", []string{"b"}, []string{"a", "b", "c"}, 10, (1.0 / math.Log2(3)) / idcg1},
+		{"two relevant ideally ordered", []string{"a", "b"}, []string{"a", "b", "c"}, 10, idcg2 / idcg2},
+		{"two relevant reordered", []string{"a", "c"}, []string{"a", "b", "c"}, 10, (1.0 + 1.0/math.Log2(4)) / idcg2},
+		{"none retrieved", []string{"z"}, []string{"a", "b", "c"}, 10, 0},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := scoreNDCG(c.expected, c.got, c.k); !almostEqual(got, c.want) {
+				t.Fatalf("scoreNDCG(%v,%v,%d) = %v, want %v", c.expected, c.got, c.k, got, c.want)
+			}
+		})
+	}
+}
+
+func TestScoreMRR(t *testing.T) {
+	cases := []struct {
+		name     string
+		expected []string
+		got      []string
+		want     float64
+	}{
+		{"out of scope returns zero", nil, []string{"a"}, 0},
+		{"first relevant at rank 1", []string{"a"}, []string{"a", "b", "c"}, 1},
+		{"first relevant at rank 3", []string{"c"}, []string{"a", "b", "c"}, 1.0 / 3.0},
+		{"earliest of several wins", []string{"b", "c"}, []string{"a", "b", "c"}, 0.5},
+		{"none retrieved", []string{"z"}, []string{"a", "b", "c"}, 0},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := scoreMRR(c.expected, c.got); !almostEqual(got, c.want) {
+				t.Fatalf("scoreMRR(%v,%v) = %v, want %v", c.expected, c.got, got, c.want)
+			}
+		})
+	}
+}

--- a/internal/team/broker_requests_interviews.go
+++ b/internal/team/broker_requests_interviews.go
@@ -65,7 +65,7 @@ func requestOptionDefaults(kind string) ([]interviewOption, string) {
 		}, "balanced"
 	case "interview":
 		return []interviewOption{
-			{ID: "answer_directly", Label: "Answer directly", Description: "Respond in your own words below."},
+			{ID: "answer_directly", Label: "Answer directly", Description: "Respond in your own words below.", RequiresText: true, TextHint: "Type your answer for the team."},
 			{ID: "need_more_context", Label: "Need more context", Description: "Ask the office to bring back more context before you decide.", RequiresText: true, TextHint: "Type what context is missing or what should be clarified next."},
 		}, "answer_directly"
 	case "freeform", "secret":

--- a/internal/team/broker_requests_interviews_test.go
+++ b/internal/team/broker_requests_interviews_test.go
@@ -713,6 +713,16 @@ func TestBrokerHumanInterviewDoesNotBlockAndCancelsOnHumanMessage(t *testing.T) 
 	if created.Request.Blocking || created.Request.Required {
 		t.Fatalf("human interviews must be non-blocking, got %+v", created.Request)
 	}
+	var answerDirectly *interviewOption
+	for i := range created.Request.Options {
+		if created.Request.Options[i].ID == "answer_directly" {
+			answerDirectly = &created.Request.Options[i]
+			break
+		}
+	}
+	if answerDirectly == nil || !answerDirectly.RequiresText || strings.TrimSpace(answerDirectly.TextHint) == "" {
+		t.Fatalf("expected answer_directly to require text, got %+v", answerDirectly)
+	}
 	if b.HasBlockingRequest() {
 		t.Fatal("human interview should not count as a blocking request")
 	}

--- a/web/src/components/lifecycle/DecisionInbox.tsx
+++ b/web/src/components/lifecycle/DecisionInbox.tsx
@@ -621,8 +621,8 @@ function RequestBody({
       <RequestItem
         request={fullRequest}
         isPending={isPending}
-        onAnswer={(choiceId) => {
-          void answerRequest(fullRequest.id, choiceId).then(() => {
+        onAnswer={(choiceId, customText) => {
+          void answerRequest(fullRequest.id, choiceId, customText).then(() => {
             void queryClient.invalidateQueries({ queryKey: ["requests"] });
             void queryClient.invalidateQueries({ queryKey: ["lifecycle"] });
           });

--- a/web/src/components/lifecycle/RequestItem.test.tsx
+++ b/web/src/components/lifecycle/RequestItem.test.tsx
@@ -5,17 +5,26 @@ import type { AgentRequest } from "../../api/client";
 import { RequestItem } from "./RequestItem";
 
 describe("<RequestItem>", () => {
-  it("collects text before answering legacy direct-answer interviews", () => {
-    const request: AgentRequest = {
-      id: "request-200",
+  function makeInterviewRequest(
+    id: string,
+    options: AgentRequest["options"] = [
+      { id: "answer_directly", label: "Answer directly" },
+    ],
+  ): AgentRequest {
+    return {
+      id,
       from: "research",
       question: "What should we ask next?",
       title: "Human interview",
       blocking: false,
       status: "pending",
-      options: [{ id: "answer_directly", label: "Answer directly" }],
+      options,
       kind: "interview",
     };
+  }
+
+  it("collects text before answering legacy direct-answer interviews", () => {
+    const request = makeInterviewRequest("request-200");
     const onAnswer = vi.fn();
 
     render(
@@ -34,5 +43,40 @@ describe("<RequestItem>", () => {
       "answer_directly",
       "Ask whether they already use a workaround.",
     );
+  });
+
+  it("resets text mode when the request changes", () => {
+    const firstRequest = makeInterviewRequest("request-201");
+    const secondRequest = makeInterviewRequest("request-202", [
+      { id: "accept", label: "Accept" },
+    ]);
+    const onAnswer = vi.fn();
+
+    const { rerender } = render(
+      <RequestItem
+        request={firstRequest}
+        isPending={true}
+        onAnswer={onAnswer}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Answer directly/i }));
+    fireEvent.change(screen.getByRole("textbox"), {
+      target: { value: "Stale text from the first request." },
+    });
+
+    rerender(
+      <RequestItem
+        request={secondRequest}
+        isPending={true}
+        onAnswer={onAnswer}
+      />,
+    );
+
+    expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /Accept/i }));
+
+    expect(onAnswer).toHaveBeenCalledTimes(1);
+    expect(onAnswer).toHaveBeenCalledWith("accept");
   });
 });

--- a/web/src/components/lifecycle/RequestItem.test.tsx
+++ b/web/src/components/lifecycle/RequestItem.test.tsx
@@ -1,0 +1,38 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import type { AgentRequest } from "../../api/client";
+import { RequestItem } from "./RequestItem";
+
+describe("<RequestItem>", () => {
+  it("collects text before answering legacy direct-answer interviews", () => {
+    const request: AgentRequest = {
+      id: "request-200",
+      from: "research",
+      question: "What should we ask next?",
+      title: "Human interview",
+      blocking: false,
+      status: "pending",
+      options: [{ id: "answer_directly", label: "Answer directly" }],
+      kind: "interview",
+    };
+    const onAnswer = vi.fn();
+
+    render(
+      <RequestItem request={request} isPending={true} onAnswer={onAnswer} />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Answer directly/i }));
+    fireEvent.change(screen.getByRole("textbox"), {
+      target: { value: "Ask whether they already use a workaround." },
+    });
+    fireEvent.click(
+      screen.getByRole("button", { name: /Send as Answer directly/i }),
+    );
+
+    expect(onAnswer).toHaveBeenCalledWith(
+      "answer_directly",
+      "Ask whether they already use a workaround.",
+    );
+  });
+});

--- a/web/src/components/lifecycle/RequestItem.tsx
+++ b/web/src/components/lifecycle/RequestItem.tsx
@@ -85,6 +85,7 @@ export function RequestItem({
 
       {isPending && options.length > 0 ? (
         <RequestActions
+          key={request.id}
           request={request}
           options={options}
           onAnswer={onAnswer}
@@ -107,8 +108,12 @@ interface RequestActionsProps {
 }
 
 function RequestActions({ request, options, onAnswer }: RequestActionsProps) {
+  // Caller passes `key={request.id}` so the subtree fully remounts on
+  // request switch, so text-entry state can't leak from one request to the
+  // next without us needing an explicit reset effect here.
   const [textOption, setTextOption] = useState<InterviewOption | null>(null);
   const [customText, setCustomText] = useState("");
+
   const submitText = () => {
     const text = customText.trim();
     if (!(textOption && text)) return;

--- a/web/src/components/lifecycle/RequestItem.tsx
+++ b/web/src/components/lifecycle/RequestItem.tsx
@@ -1,11 +1,17 @@
-import type { AgentRequest } from "../../api/client";
+import { useState } from "react";
+
+import type { AgentRequest, InterviewOption } from "../../api/client";
 import { formatRelativeTime } from "../../lib/format";
+import {
+  requestOptionNeedsText,
+  requestOptionTextHint,
+} from "../../lib/requestOptions";
 import { RedactedBadge } from "../ui/RedactedBadge";
 
 interface RequestItemProps {
   request: AgentRequest;
   isPending: boolean;
-  onAnswer?: (choiceId: string) => void;
+  onAnswer?: (choiceId: string, customText?: string) => void;
 }
 
 /**
@@ -77,27 +83,109 @@ export function RequestItem({
         </div>
       ) : null}
 
-      {isPending && options.length > 0 && (
-        <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
-          {options.map((opt) => (
-            <button
-              type="button"
-              key={opt.id}
-              className={`btn btn-sm ${opt.id === request.recommended_id ? "btn-primary" : "btn-ghost"}`}
-              title={opt.description}
-              onClick={() => onAnswer?.(opt.id)}
-            >
-              {opt.label}
-            </button>
-          ))}
-        </div>
-      )}
+      {isPending && options.length > 0 ? (
+        <RequestActions
+          request={request}
+          options={options}
+          onAnswer={onAnswer}
+        />
+      ) : null}
 
       {!isPending && (
         <div style={{ fontSize: 12, color: "var(--green)", fontWeight: 500 }}>
           Answered
         </div>
       )}
+    </div>
+  );
+}
+
+interface RequestActionsProps {
+  request: AgentRequest;
+  options: InterviewOption[];
+  onAnswer?: (choiceId: string, customText?: string) => void;
+}
+
+function RequestActions({ request, options, onAnswer }: RequestActionsProps) {
+  const [textOption, setTextOption] = useState<InterviewOption | null>(null);
+  const [customText, setCustomText] = useState("");
+  const submitText = () => {
+    const text = customText.trim();
+    if (!(textOption && text)) return;
+    onAnswer?.(textOption.id, text);
+    setTextOption(null);
+    setCustomText("");
+  };
+
+  if (textOption) {
+    return (
+      <div style={{ display: "grid", gap: 8 }}>
+        <textarea
+          className="interview-bar-textarea"
+          placeholder={requestOptionTextHint(request, textOption)}
+          value={customText}
+          onChange={(e) => setCustomText(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Escape") {
+              e.preventDefault();
+              setTextOption(null);
+              setCustomText("");
+            }
+            if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+              e.preventDefault();
+              submitText();
+            }
+          }}
+          rows={3}
+        />
+        <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+          <button
+            type="button"
+            className="btn btn-sm btn-ghost"
+            onClick={() => {
+              setTextOption(null);
+              setCustomText("");
+            }}
+          >
+            Back
+          </button>
+          <button
+            type="button"
+            className="btn btn-sm btn-primary"
+            disabled={!customText.trim()}
+            onClick={submitText}
+          >
+            Send as {textOption.label}
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+      {options.map((opt) => {
+        const needsText = requestOptionNeedsText(request, opt);
+        return (
+          <button
+            type="button"
+            key={opt.id}
+            className={`btn btn-sm ${opt.id === request.recommended_id ? "btn-primary" : "btn-ghost"}`}
+            title={opt.description}
+            onClick={() => {
+              if (needsText) {
+                setTextOption(opt);
+                setCustomText("");
+                return;
+              }
+              onAnswer?.(opt.id);
+            }}
+          >
+            {opt.label}
+            {needsText ? " · type" : ""}
+          </button>
+        );
+      })}
     </div>
   );
 }

--- a/web/src/components/messages/InterviewBar.test.tsx
+++ b/web/src/components/messages/InterviewBar.test.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 import type { AgentRequest } from "../../api/client";
@@ -29,9 +29,11 @@ vi.mock("../../api/client", async () => {
         },
       ],
     }),
+    answerRequest: vi.fn().mockResolvedValue({}),
   };
 });
 
+import * as clientMod from "../../api/client";
 import { InterviewBar } from "./InterviewBar";
 
 function wrap(ui: ReactNode) {
@@ -263,5 +265,41 @@ describe("<InterviewBar> approval UX", () => {
 
     expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
     expect(screen.getByText("Approve the new plan?")).toBeInTheDocument();
+  });
+
+  it("collects text for legacy direct-answer interviews", async () => {
+    const legacyInterview: AgentRequest = {
+      id: "request-legacy-interview",
+      from: "research",
+      channel: "general",
+      kind: "interview",
+      status: "pending",
+      question: "What should we ask next?",
+      options: [{ id: "answer_directly", label: "Answer directly" }],
+      blocking: false,
+      created_at: "2026-05-06T00:00:00Z",
+    };
+    const answerSpy = vi.mocked(clientMod.answerRequest);
+    answerSpy.mockClear();
+
+    setPending([legacyInterview]);
+    render(wrap(<InterviewBar />));
+
+    fireEvent.click(screen.getByRole("button", { name: /Answer directly/i }));
+    const textbox = screen.getByRole("textbox");
+    fireEvent.change(textbox, {
+      target: { value: "Ask whether the buyer has budget authority." },
+    });
+    fireEvent.click(
+      screen.getByRole("button", { name: /Send as Answer directly/i }),
+    );
+
+    await waitFor(() => {
+      expect(answerSpy).toHaveBeenCalledWith(
+        "request-legacy-interview",
+        "answer_directly",
+        "Ask whether the buyer has budget authority.",
+      );
+    });
   });
 });

--- a/web/src/components/messages/InterviewBar.tsx
+++ b/web/src/components/messages/InterviewBar.tsx
@@ -15,6 +15,10 @@ import {
 } from "../../api/client";
 import { useRequests } from "../../hooks/useRequests";
 import { parseApprovalContext } from "../../lib/parseApprovalContext";
+import {
+  requestOptionNeedsText,
+  requestOptionTextHint,
+} from "../../lib/requestOptions";
 import { useAppStore } from "../../stores/app";
 import { SkillCompareView } from "../apps/SkillCompareView";
 import { useOnboardingDMContext } from "../onboarding/OnboardingDMRoute";
@@ -203,7 +207,7 @@ export function InterviewBar() {
   };
 
   const handleOption = (option: InterviewOption) => {
-    if (option.requires_text) {
+    if (requestOptionNeedsText(current, option)) {
       setTextMode({ option });
       setCustomText("");
       return;
@@ -345,7 +349,7 @@ export function InterviewBar() {
             <textarea
               ref={textareaRef}
               className="interview-bar-textarea"
-              placeholder={textMode.option.text_hint || "Type your answer..."}
+              placeholder={requestOptionTextHint(current, textMode.option)}
               value={customText}
               onChange={(e) => setCustomText(e.target.value)}
               onKeyDown={(e) => {
@@ -401,7 +405,7 @@ export function InterviewBar() {
               >
                 <span className="interview-bar-opt-num">{i + 1}</span>
                 <span className="interview-bar-opt-label">{opt.label}</span>
-                {opt.requires_text ? (
+                {requestOptionNeedsText(current, opt) ? (
                   <span className="interview-bar-text-hint"> · type</span>
                 ) : null}
               </button>

--- a/web/src/lib/requestOptions.ts
+++ b/web/src/lib/requestOptions.ts
@@ -1,0 +1,22 @@
+import type { AgentRequest, InterviewOption } from "../api/client";
+
+export function requestOptionNeedsText(
+  request: AgentRequest,
+  option: InterviewOption,
+): boolean {
+  return Boolean(
+    option.requires_text ||
+      (request.kind === "interview" && option.id === "answer_directly"),
+  );
+}
+
+export function requestOptionTextHint(
+  request: AgentRequest,
+  option: InterviewOption,
+): string {
+  if (option.text_hint) return option.text_hint;
+  if (request.kind === "interview" && option.id === "answer_directly") {
+    return "Type your answer for the team.";
+  }
+  return "Type your answer...";
+}


### PR DESCRIPTION
## What

Six fixes from today's live QA run-through of the operator surface (fresh stack from main `8f2301d6a`, clean workspace, real broker + agent service). Every fix ships a regression test that failed before the fix at the layer the bug lived.

### 1. Apps can now learn approval outcomes (`feat(apps)`, 668f45097)
A mutating integration call returns `{status:"needs_approval", request_id}`, but apps had no way to poll that id — the live refund-form app stayed **"Awaiting" forever** after the human rejected the Slack post. Now:
- `GET /requests?id=<request_id>` filters to one request (applied **after** visibility checks, so it can only narrow access; implies `include_resolved` so the terminal decision is observable).
- Scaffold bridge gains `getActionStatus(requestId)` → `pending | approved | rejected | unknown`.
- `AI_RULES.md` mandates polling until resolution.

### 2. Transient provider errors fast-retry instead of blocking (`fix(headless)`, 273191a4e)
A provider connection drop mid-turn killed the app-builder session; office-mode turns never retried, so the task fell to BlockTask and a 60s build stalled ~3 minutes **twice** (9.5 min total, zero UI feedback). Now: transient stream/provider failures (EOF, resets, 5xx, the bare exit-status shape a dropped claude stream produces) re-enqueue the same turn up to 2× in the queue fast path, office-mode tasks get one prompt-annotated recovery retry, and a `reconnecting` HeadlessEvent is emitted.

### 3. Interrupted ≠ failed in the build feed (`fix(apps)`, ac77f606e)
The feed painted a dangling tool row as a red ✗ when the session died mid-call (live: "✗ Team Status" for a call that never ran). Turn-level errors now resolve open rows to a neutral "interrupted" (◦, muted), and the new `reconnecting` event renders as a visible retry row. Also removes two literal NUL bytes that shipped inside `buildActivity.ts` template literals — git was treating the source file as binary.

### 4. Mock draft agents stop impersonating inventory (`fix(operator)`, e1317dbd7)
Sidebar counted 3 mock drafts into the Agents badge and rendered them identically to real agents, with a fabricated "from N conversations" chip and fake artifacts. Badge now counts real agents only; mocks sit under a ghosted **Suggested** section; detail pill reads "Suggested"; fabricated chip suppressed; artifacts heading says "Example artifacts".

### 5. Derived agent names cut at clause boundaries (`fix(operator)`, 34fdcc2b6)
"A refund-approval form that posts approved refunds to Slack" produced **"Refund-approval Form That Agent"**. Now cuts before the first function word → "Refund-approval Form Agent".

### 6. Legacy knowledge pages render clean (`fix(knowledge)`, f300d0de9)
Preserved pages showed the raw `<!-- wuphf:entity-article … -->` machine comment as body text and mangled slug titles ("Add diana"). Comments are stripped; the first H1 wins as title. Verified live: 51 pages, zero leaks, "Add Diana".

## Test plan

- [x] Failing-first regression tests per fix (Go: `TestGetRequestsFilterByID`, `TestScaffoldBridgeActionStatusContract`, `TestHeadlessQueueRetriesOfficeTurnAfterTransientProviderError`, `TestLegacyPageStripsHTMLComments`, `TestLegacyPageTitlePrefersFirstH1`; web: buildActivity, OperatorSidebar/OperatorApp/InternalToolDetail, deriveAppName)
- [x] `go test ./internal/team` green (only the documented machine-local `TestConfigEndpointAndHealth` flake)
- [x] Full web suite: 262 files / 2378 tests green; `tsc --noEmit` clean
- [x] Live verification on rebuilt broker: `?id=` filter returns the answered request with its reject choice; knowledge pages clean
- [x] Screenshots (sidebar Suggested section, mock detail) — embedded below

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Screenshots

![01-sidebar-suggested-section](https://github.com/nex-crm/wuphf/raw/screenshots/pr-1162/01-sidebar-suggested-section.png)

![02-suggested-detail-honest](https://github.com/nex-crm/wuphf/raw/screenshots/pr-1162/02-suggested-detail-honest.png)