### PR TITLE
feat(operator): app edit route + owner improve auth + scaffold table rule [release]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -286,6 +286,7 @@ jobs:
             sudo apt-get install -y ripgrep
           fi
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # ratchet:actions/setup-go@v6
+        id: setup-go
         with:
           go-version-file: go.mod
       - name: Check VERSION sentinel
@@ -349,7 +350,11 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # ratchet:actions/cache@v5.0.5
         with:
           path: ${{ env.GOBIN }}/govulncheck
-          key: govulncheck-${{ runner.os }}-v1.1.4
+          # The Go version is part of the key: govulncheck embeds the
+          # toolchain's source-processing packages, so a binary compiled
+          # under an older Go fails with "file requires newer Go version"
+          # the moment go.mod's toolchain directive moves past it.
+          key: govulncheck-${{ runner.os }}-v1.1.4-go${{ steps.setup-go.outputs.go-version }}
       - name: Install govulncheck
         if: steps.cache-govulncheck.outputs.cache-hit != 'true'
         run: go install golang.org/x/vuln/cmd/govulncheck@v1.1.4

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/nex-crm/wuphf
 
 go 1.25.11
 
+toolchain go1.26.5
+
 require (
 	github.com/blevesearch/bleve/v2 v2.6.0
 	github.com/charmbracelet/bubbletea v1.3.10
@@ -15,6 +17,7 @@ require (
 	github.com/modelcontextprotocol/go-sdk v1.6.1
 	github.com/sahilm/fuzzy v0.1.2
 	github.com/slack-go/slack v0.25.0
+	github.com/wailsapp/wails/v2 v2.12.0
 	go.uber.org/goleak v1.3.0
 	golang.org/x/net v0.55.0
 	golang.org/x/sync v0.20.0
@@ -76,7 +79,6 @@ require (
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jchv/go-winloader v0.0.0-20210711035445-715c2860da7e // indirect
 	github.com/json-iterator/go v0.0.0-20171115153421-f7279a603ede // indirect
-	github.com/kr/text v0.2.0 // indirect
 	github.com/labstack/echo/v4 v4.13.3 // indirect
 	github.com/labstack/gommon v0.4.2 // indirect
 	github.com/leaanthony/go-ansi-parser v1.6.1 // indirect
@@ -108,10 +110,9 @@ require (
 	github.com/valyala/fasttemplate v1.2.2 // indirect
 	github.com/wailsapp/go-webview2 v1.0.22 // indirect
 	github.com/wailsapp/mimetype v1.4.1 // indirect
-	github.com/wailsapp/wails/v2 v2.12.0 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
-	github.com/yuin/goldmark v1.7.13 // indirect
+	github.com/yuin/goldmark v1.7.17 // indirect
 	github.com/yuin/goldmark-emoji v1.0.6 // indirect
 	go.etcd.io/bbolt v1.4.0 // indirect
 	go.opencensus.io v0.24.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -89,7 +89,6 @@ github.com/clipperhouse/displaywidth v0.11.0/go.mod h1:bkrFNkf81G8HyVqmKGxsPufD3
 github.com/clipperhouse/uax29/v2 v2.7.0 h1:+gs4oBZ2gPfVrKPthwbMzWZDaAFPGYK72F0NJv2v7Vk=
 github.com/clipperhouse/uax29/v2 v2.7.0/go.mod h1:EFJ2TJMRUaplDxHKj1qAEhCtQPW2tJSwu5BF98AuoVM=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
-github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -180,6 +179,8 @@ github.com/labstack/echo/v4 v4.13.3 h1:pwhpCPrTl5qry5HRdM5FwdXnhXSLSY+WE+YQSeCaa
 github.com/labstack/echo/v4 v4.13.3/go.mod h1:o90YNEeQWjDozo584l7AwhJMHN0bOC4tAfg+Xox9q5g=
 github.com/labstack/gommon v0.4.2 h1:F8qTUNXgG1+6WQmqoUWnz8WiEU60mXVVw0P4ht1WRA0=
 github.com/labstack/gommon v0.4.2/go.mod h1:QlUFxVM+SNXhDL/Z7YhocGIBYOiwB0mXm1+1bAPHPyU=
+github.com/leaanthony/debme v1.2.1 h1:9Tgwf+kjcrbMQ4WnPcEIUcQuIZYqdWftzZkBr+i/oOc=
+github.com/leaanthony/debme v1.2.1/go.mod h1:3V+sCm5tYAgQymvSOfYQ5Xx2JCr+OXiD9Jkw3otUjiA=
 github.com/leaanthony/go-ansi-parser v1.6.1 h1:xd8bzARK3dErqkPFtoF9F3/HgN8UQk0ed1YDKpEz01A=
 github.com/leaanthony/go-ansi-parser v1.6.1/go.mod h1:+vva/2y4alzVmmIEpk9QDhA7vLC5zKDTRwfZGOp3IWU=
 github.com/leaanthony/gosod v1.0.4 h1:YLAbVyd591MRffDgxUOU1NwLhT9T1/YiwjKZpkNFeaI=
@@ -191,6 +192,8 @@ github.com/leaanthony/u v1.1.1/go.mod h1:9+o6hejoRljvZ3BzdYlVL0JYCwtnAsVuN9pVTQc
 github.com/lucasb-eyer/go-colorful v1.4.0 h1:UtrWVfLdarDgc44HcS7pYloGHJUjHV/4FwW4TvVgFr4=
 github.com/lucasb-eyer/go-colorful v1.4.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/matryer/is v1.4.0/go.mod h1:8I/i5uYgLzgsgEloJE1U6xx5HkBQpAZvepWuujKwMRU=
+github.com/matryer/is v1.4.1 h1:55ehd8zaGABKLXQUe2awZ99BD/PTc2ls+KV/dXphgEQ=
+github.com/matryer/is v1.4.1/go.mod h1:8I/i5uYgLzgsgEloJE1U6xx5HkBQpAZvepWuujKwMRU=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
@@ -268,8 +271,8 @@ github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavM
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJuqunuUZ/Dhy/avygyECGrLceyNeo4LiM=
 github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=
 github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
-github.com/yuin/goldmark v1.7.13 h1:GPddIs617DnBLFFVJFgpo1aBfe/4xcvMc3SB5t/D0pA=
-github.com/yuin/goldmark v1.7.13/go.mod h1:ip/1k0VRfGynBgxOz0yCqHrbZXhcjxyuS66Brc7iBKg=
+github.com/yuin/goldmark v1.7.17 h1:p36OVWwRb246iHxA/U4p8OPEpOTESm4n+g+8t0EE5uA=
+github.com/yuin/goldmark v1.7.17/go.mod h1:ip/1k0VRfGynBgxOz0yCqHrbZXhcjxyuS66Brc7iBKg=
 github.com/yuin/goldmark-emoji v1.0.6 h1:QWfF2FYaXwL74tfGOW5izeiZepUDroDJfWubQI9HTHs=
 github.com/yuin/goldmark-emoji v1.0.6/go.mod h1:ukxJDKFpdFb5x0a5HqbdlcKtebh086iJpI31LTKmWuA=
 go.etcd.io/bbolt v1.4.0 h1:TU77id3TnN/zKr7CO/uk+fBCwF2jGcMuw2B/FMAzYIk=

--- a/internal/team/broker_apps.go
+++ b/internal/team/broker_apps.go
@@ -605,17 +605,27 @@ func buildAppImprovePrompt(app CustomApp, change string) string {
 }
 
 // appWriterAllowed reports whether the request may write/delete app bytes:
-// either the authenticated agent is the App Builder, or the caller is a human
-// session. Other agents (which all hold the broker token) are rejected so they
-// cannot register or remove apps directly outside the build path.
+// the authenticated agent is the App Builder, the caller is an invited human
+// session, or the caller is the OWNER — bare token auth with no agent
+// identity claimed. Agents always claim their slug via the agent header (and
+// any non-app-builder slug is rejected above), so a header-less token caller
+// is the human driving the web UI, not an agent sidestepping the gate: the
+// header is cooperative, and an agent omitting it gains nothing it could not
+// already do with the token it holds. Without the owner lane the operator
+// UI's own edit path (submitAppEdit → POST /apps/{id}/improve) 403'd for the
+// only human in a single-owner workspace.
 func (b *Broker) appWriterAllowed(r *http.Request, actor string) bool {
 	if strings.EqualFold(strings.TrimSpace(actor), appBuilderSlug) {
 		return true
 	}
-	if a, ok := requestActorFromContext(r.Context()); ok && a.Kind == requestActorKindHuman {
+	a, ok := requestActorFromContext(r.Context())
+	if !ok {
+		return false
+	}
+	if a.Kind == requestActorKindHuman {
 		return true
 	}
-	return false
+	return a.Kind == requestActorKindBroker && strings.TrimSpace(actor) == ""
 }
 
 func writeAppError(w http.ResponseWriter, err error) {

--- a/internal/team/broker_apps_rename_test.go
+++ b/internal/team/broker_apps_rename_test.go
@@ -205,3 +205,70 @@ func patchAppRename(t *testing.T, url, token, agentSlug, body string) (int, map[
 	}
 	return resp.StatusCode, out
 }
+
+// TestAppImproveOwnerToken locks in the OWNER lane on app mutations: the
+// human owner authenticates with the bare web token and NO agent identity
+// header (agents always claim a slug via X-WUPHF-Agent). Regression for the
+// live 2026-07-06 finding where the operator UI's own submitAppEdit path
+// 403'd — appWriterAllowed knew only the app-builder slug and cookie-session
+// humans, so the single-owner localhost human could never improve an app.
+func TestAppImproveOwnerToken(t *testing.T) {
+	t.Setenv("WUPHF_RUNTIME_HOME", t.TempDir())
+
+	b := newTestBroker(t)
+	if err := b.StartOnPort(0); err != nil {
+		t.Fatalf("start broker: %v", err)
+	}
+	defer b.Stop()
+	base := fmt.Sprintf("http://%s", b.Addr())
+
+	body, _ := json.Marshal(map[string]any{"name": "Editable", "html": validAppHTML})
+	created := postAppsAsAgent(t, base+"/apps", b.Token(), appBuilderSlug, body)
+	app, _ := created["app"].(map[string]any)
+	id, _ := app["id"].(string)
+	if id == "" {
+		t.Fatalf("no app id in register response: %v", created)
+	}
+
+	post := func(sub, agentSlug, payload string) (int, map[string]any) {
+		req, _ := http.NewRequest(http.MethodPost, base+"/apps/"+id+sub, strings.NewReader(payload))
+		req.Header.Set("Authorization", "Bearer "+b.Token())
+		req.Header.Set("Content-Type", "application/json")
+		if agentSlug != "" {
+			req.Header.Set("X-WUPHF-Agent", agentSlug)
+		}
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("POST %s: %v", sub, err)
+		}
+		defer resp.Body.Close()
+		raw, _ := io.ReadAll(resp.Body)
+		var out map[string]any
+		if len(raw) > 0 {
+			_ = json.Unmarshal(raw, &out)
+		}
+		return resp.StatusCode, out
+	}
+
+	// The owner (token, no agent header) may improve; the reply carries the
+	// settled edit channel.
+	status, out := post("/improve", "", `{"change":"make the header sticky"}`)
+	if status != http.StatusOK {
+		t.Fatalf("owner POST /improve status = %d (%v), want 200", status, out)
+	}
+	if ch, _ := out["channel"].(string); strings.TrimSpace(ch) == "" {
+		t.Fatalf("owner improve returned no channel: %v", out)
+	}
+
+	// Same for opening the edit session directly.
+	status, out = post("/edit-session", "", `{}`)
+	if status != http.StatusOK {
+		t.Fatalf("owner POST /edit-session status = %d (%v), want 200", status, out)
+	}
+
+	// A non-app-builder AGENT identity stays rejected.
+	status, _ = post("/improve", "pam", `{"change":"nope"}`)
+	if status != http.StatusForbidden {
+		t.Fatalf("agent POST /improve status = %d, want 403", status)
+	}
+}

--- a/internal/team/custom_app_scaffold_test.go
+++ b/internal/team/custom_app_scaffold_test.go
@@ -330,6 +330,18 @@ func TestScaffoldBridgeActionStatusContract(t *testing.T) {
 			t.Errorf("AI_RULES.md missing %q — the polling mandate is not part of the app-builder contract", want)
 		}
 	}
+
+	// Regression for the live 2026-07-06 generated-app bug: a filter memo keyed
+	// on the STABLE reactTable instance froze against the empty initial table
+	// (counts updated, rows never rendered). The rules must warn against it.
+	for _, want := range []string{
+		"NEVER memoize on the `reactTable` instance",
+		"tableQuery.data",
+	} {
+		if !strings.Contains(rules, want) {
+			t.Errorf("AI_RULES.md missing %q — the stale-memo table rule is not part of the app-builder contract", want)
+		}
+	}
 }
 
 func TestParseAppBuilderTaskAppID(t *testing.T) {

--- a/templates/app-scaffold/AI_RULES.md
+++ b/templates/app-scaffold/AI_RULES.md
@@ -129,6 +129,22 @@ The `useTable` return is `{ reactTable, refineCore }`:
   `tableQuery.data?.total`, plus `setFilters` / `setSorters` for server-driven
   filtering.
 
+**NEVER memoize on the `reactTable` instance.** The instance is a STABLE
+reference — it never changes identity when data arrives — so
+`useMemo(() => reactTable.getRowModel().rows.filter(...), [reactTable, ...])`
+computes once against an EMPTY table and never recomputes: your counts update
+(they derive from `tableQuery.data`) while the list renders "no rows" forever.
+This shipped as a live bug. Read `getRowModel()` during render, or derive rows
+from `tableQuery.data` and depend on that:
+
+```tsx
+// WRONG — frozen on the empty initial table:
+const rows = useMemo(() => reactTable.getRowModel().rows.filter(f), [reactTable, f]);
+// RIGHT — recomputes when the data actually changes:
+const data = tableQuery.data?.data ?? [];
+const rows = useMemo(() => data.filter(f), [data, f]);
+```
+
 ### A simple list — `useList`
 
 ```tsx

--- a/web/e2e/screenshots/operator-edit-route.mjs
+++ b/web/e2e/screenshots/operator-edit-route.mjs
@@ -1,0 +1,74 @@
+// Capture the operator's new app-EDIT route (PR: operator-app-edit-route):
+// the agent detail header carries an "Edit app" action, and clicking it opens
+// the build experience in edit mode — the edit-scoped chat docked beside the
+// live app. Before this, the only chat affordance (Ask Agent) teaches tools,
+// and a UI bug report sent there was misauthored into a garbage tool.
+//
+// Run via the wrapper:
+//   web/e2e/screenshots/publish.sh operator-edit-route <pr-number>
+
+import process from "node:process";
+
+import { DEFAULT_BASE, launchBrowser, shotElement, shotPage } from "./lib.mjs";
+
+const OUT = process.env.WUPHF_SCREENSHOTS_OUT;
+if (!OUT) {
+  console.error("WUPHF_SCREENSHOTS_OUT is not set; run via publish.sh");
+  process.exit(2);
+}
+
+const APP = {
+  id: "app_69cebd17418462a4",
+  slug: "reporting-agent",
+  name: "Reporting Agent",
+  icon: "📊",
+  summary: "Live view of all office tasks with status filters and search",
+  entry: "index.html",
+  version: 2,
+  status: "ready",
+};
+
+const { browser, context, page } = await launchBrowser();
+
+// Playwright routes match LIFO: register the catch-all FIRST so the
+// specific list + detail mocks (registered after) win.
+await context.route("**/api/apps/**", (r) => r.fulfill({ json: {} }));
+await context.route("**/api/apps", (r) => r.fulfill({ json: { apps: [APP] } }));
+await context.route(`**/api/apps/${APP.id}`, (r) =>
+  r.fulfill({
+    json: { app: APP, html: "<!doctype html><body><h1>Office Tasks</h1></body>" },
+  }),
+);
+await context.route("**/api/requests*", (r) =>
+  r.fulfill({ json: { requests: [] } }),
+);
+await context.route("**/agent/**", (r) =>
+  r.fulfill({ status: 404, json: { error: "not in this capture" } }),
+);
+await context.route("**/web-token", (r) =>
+  r.fulfill({ json: { token: "screenshot-token" } }),
+);
+
+await page.goto(`${DEFAULT_BASE}/?token=screenshot-token#/operator`, {
+  waitUntil: "load",
+});
+await page.waitForSelector(".opr-sidebar", { timeout: 15_000 });
+
+// Open the agent detail.
+await page
+  .locator(".opr-agent-rail-item", { hasText: "Reporting Agent" })
+  .click();
+
+// 1. The header actions now carry "Edit app" beside "Ask Agent".
+await page.waitForSelector(".opr-detail-actions", { timeout: 10_000 });
+await shotElement(page, ".opr-app-detail", OUT, "01-detail-edit-app-action");
+
+// 2. Edit mode: the edit-scoped chat docks beside the live app.
+await page.getByRole("button", { name: /edit app/i }).click();
+await page.waitForSelector(".opr-build-exp.is-live", { timeout: 10_000 });
+await page
+  .getByText(/tell me what to change about/i)
+  .waitFor({ timeout: 10_000 });
+await shotPage(page, OUT, "02-edit-mode-docked-chat");
+
+await browser.close();

--- a/web/src/operator/OperatorApp.tsx
+++ b/web/src/operator/OperatorApp.tsx
@@ -63,6 +63,13 @@ export function OperatorApp() {
   // Two builders: the app builder (primary, real) and the legacy workflow
   // builder (kept for the workflow-tab path).
   const [appBuilding, setAppBuilding] = useState(false);
+  // Set → the build experience opens in EDIT mode scoped to this app (the
+  // "Edit app" affordance on the detail). Cleared with the rest of the
+  // sub-state on close/finish.
+  const [editingApp, setEditingApp] = useState<{
+    id: string;
+    name: string;
+  } | null>(null);
   const [building, setBuilding] = useState(false);
   // The workflow just built in the builder, carried so its clarified steps
   // survive the handoff instead of falling back to the seeded mock.
@@ -96,6 +103,7 @@ export function OperatorApp() {
   function resetSubState() {
     setSelectedId(null);
     setAppBuilding(false);
+    setEditingApp(null);
     setBuilding(false);
     setBuiltDraft(null);
     setOpenOnWorkflowTab(false);
@@ -152,6 +160,7 @@ export function OperatorApp() {
           key={selectedId}
           appId={selectedId as string}
           onBack={() => setSelectedId(null)}
+          onEditApp={setEditingApp}
         />
       );
     }
@@ -195,10 +204,15 @@ export function OperatorApp() {
       />
 
       <main className="opr-main">
-        {appBuilding ? (
+        {appBuilding || editingApp ? (
           <OperatorBuildExperience
+            key={editingApp?.id ?? "new"}
             demo={demoBuild ?? undefined}
-            onClose={() => setAppBuilding(false)}
+            editApp={editingApp ?? undefined}
+            onClose={() => {
+              setAppBuilding(false);
+              setEditingApp(null);
+            }}
             onFinish={finishApp}
           />
         ) : building ? (

--- a/web/src/operator/surfaces/OperatorAppDetail.test.tsx
+++ b/web/src/operator/surfaces/OperatorAppDetail.test.tsx
@@ -216,3 +216,48 @@ describe("OperatorAppDetail", () => {
     );
   });
 });
+
+describe("OperatorAppDetail edit affordance", () => {
+  it("offers Edit app on a ready agent and hands back the app identity", () => {
+    useOperatorAppMock.mockReturnValue({
+      data: detail({ status: "ready" }, "<html>hi</html>"),
+      isError: false,
+    });
+    const onEditApp = vi.fn();
+    const { getByRole } = render(
+      <OperatorAppDetail
+        appId="app_abc"
+        onBack={() => {}}
+        onEditApp={onEditApp}
+      />,
+    );
+    fireEvent.click(getByRole("button", { name: /edit app/i }));
+    expect(onEditApp).toHaveBeenCalledWith({
+      id: "app_abc",
+      name: "Open Tasks",
+    });
+  });
+
+  it("hides Edit app while building and when no handler is wired", () => {
+    useOperatorAppMock.mockReturnValue({
+      data: detail({ status: "building" }, ""),
+      isError: false,
+    });
+    const { queryByRole, rerender } = render(
+      <OperatorAppDetail
+        appId="app_abc"
+        onBack={() => {}}
+        onEditApp={vi.fn()}
+      />,
+    );
+    expect(queryByRole("button", { name: /edit app/i })).toBeNull();
+
+    // Ready but no handler (e.g. inside the build experience): no dead button.
+    useOperatorAppMock.mockReturnValue({
+      data: detail({ status: "ready" }, "<html>hi</html>"),
+      isError: false,
+    });
+    rerender(<OperatorAppDetail appId="app_abc" onBack={() => {}} />);
+    expect(queryByRole("button", { name: /edit app/i })).toBeNull();
+  });
+});

--- a/web/src/operator/surfaces/OperatorAppDetail.tsx
+++ b/web/src/operator/surfaces/OperatorAppDetail.tsx
@@ -12,6 +12,7 @@ import {
   ChevronsRight,
   Maximize2,
   Minimize2,
+  Pencil,
   Sparkles,
   Trash2,
   X,
@@ -71,12 +72,21 @@ interface OperatorAppDetailProps {
    * the UI. Used by the build experience; a manual tab click cancels the walk.
    */
   buildWalk?: boolean;
+  /**
+   * Opens the app-EDIT chat (AppBuilderChat in editApp mode → the broker's
+   * improve path, which republishes a new version). This is deliberately a
+   * SEPARATE affordance from Ask Agent: Ask Agent teaches/runs the agent's
+   * tools, and a UI change or bug report sent there would be misauthored as
+   * a tool. Absent in the build experience (the build chat is already docked).
+   */
+  onEditApp?: (app: { id: string; name: string }) => void;
 }
 
 export function OperatorAppDetail({
   appId,
   onBack,
   buildWalk,
+  onEditApp,
 }: OperatorAppDetailProps) {
   const [tab, setTab] = useState<AppTab>("ui");
   const [chatOpen, setChatOpen] = useState(false);
@@ -194,6 +204,16 @@ export function OperatorAppDetail({
             </div>
             {ready ? (
               <div className="opr-detail-actions">
+                {app && onEditApp ? (
+                  <button
+                    type="button"
+                    className="opr-btn opr-btn-sm"
+                    onClick={() => onEditApp({ id: app.id, name: app.name })}
+                  >
+                    <Pencil size={13} strokeWidth={1.9} aria-hidden={true} />
+                    Edit app
+                  </button>
+                ) : null}
                 <button
                   type="button"
                   className="opr-btn opr-btn-sm"

--- a/web/src/operator/surfaces/OperatorBuildExperience.test.tsx
+++ b/web/src/operator/surfaces/OperatorBuildExperience.test.tsx
@@ -10,11 +10,17 @@ vi.mock("./AppBuilderChat", () => ({
   AppBuilderChat: ({
     panelMode,
     onBuildingApp,
+    editApp,
   }: {
     panelMode?: boolean;
     onBuildingApp?: (id: string) => void;
+    editApp?: { id: string; name: string };
   }) => (
-    <div data-testid="builder-chat" data-panel={String(Boolean(panelMode))}>
+    <div
+      data-testid="builder-chat"
+      data-panel={String(Boolean(panelMode))}
+      data-edit-app={editApp?.id ?? ""}
+    >
       <button type="button" onClick={() => onBuildingApp?.("app_live123")}>
         scaffold
       </button>
@@ -59,5 +65,24 @@ describe("OperatorBuildExperience", () => {
     expect(detail.getAttribute("data-build-walk")).toBe("true");
     expect(getByTestId("builder-chat").getAttribute("data-panel")).toBe("true");
     expect(container.querySelector(".opr-build-exp.is-live")).not.toBeNull();
+  });
+
+  it("edit mode starts LIVE on the existing app: docked chat, no tab walk, editApp scoped", () => {
+    const { getByTestId, getByText } = render(
+      <OperatorBuildExperience
+        onClose={() => {}}
+        onFinish={() => {}}
+        editApp={{ id: "app_live123", name: "Open Tasks" }}
+      />,
+    );
+    // No describe phase: the app already exists, so the layout opens live.
+    const detailEl = getByTestId("app-detail");
+    expect(detailEl.getAttribute("data-app-id")).toBe("app_live123");
+    // An edit republishes in place — the first-build tab walk must not run.
+    expect(detailEl.getAttribute("data-build-walk")).toBe("false");
+    const chat = getByTestId("builder-chat");
+    expect(chat.getAttribute("data-panel")).toBe("true");
+    expect(chat.getAttribute("data-edit-app")).toBe("app_live123");
+    expect(getByText("Editing Open Tasks")).toBeTruthy();
   });
 });

--- a/web/src/operator/surfaces/OperatorBuildExperience.tsx
+++ b/web/src/operator/surfaces/OperatorBuildExperience.tsx
@@ -22,16 +22,26 @@ interface OperatorBuildExperienceProps {
    * agent as it builds.
    */
   demo?: DemoCapture;
+  /**
+   * Edit mode: the chat opens scoped to an EXISTING app (AppBuilderChat's
+   * editApp → the broker improve path) with the live app already docked
+   * beside it, so a change request republishes a new version in place.
+   */
+  editApp?: { id: string; name: string };
 }
 
 export function OperatorBuildExperience({
   onClose,
   onFinish,
   demo,
+  editApp,
 }: OperatorBuildExperienceProps) {
   // Set the instant the build scaffolds; flips the layout from a centered
-  // describe chat to "live preview + docked chat".
-  const [buildingAppId, setBuildingAppId] = useState<string | null>(null);
+  // describe chat to "live preview + docked chat". Edit mode starts live:
+  // the app already exists, so the preview docks immediately.
+  const [buildingAppId, setBuildingAppId] = useState<string | null>(
+    editApp?.id ?? null,
+  );
   const live = Boolean(buildingAppId);
 
   return (
@@ -42,7 +52,9 @@ export function OperatorBuildExperience({
             key={buildingAppId}
             appId={buildingAppId}
             onBack={onClose}
-            buildWalk={true}
+            // The tab walk is a first-build ceremony; an edit republishes in
+            // place, so the operator stays on the tab they are looking at.
+            buildWalk={!editApp}
           />
         </div>
       ) : null}
@@ -52,7 +64,7 @@ export function OperatorBuildExperience({
           <div className="opr-ask-bar">
             <span className="opr-ask-bar-title">
               <Sparkles size={13} strokeWidth={2} aria-hidden={true} />
-              Building your agent
+              {editApp ? `Editing ${editApp.name}` : "Building your agent"}
             </span>
             <button
               type="button"
@@ -69,6 +81,7 @@ export function OperatorBuildExperience({
           <AppBuilderChat
             panelMode={live}
             demo={demo}
+            editApp={editApp}
             onClose={onClose}
             onBuildingApp={setBuildingAppId}
             onFinish={onFinish}


### PR DESCRIPTION
## What

The three fixes from the 2026-07-06 clean-slate QA pass, each with a failing-first regression test and verified live end to end on a fresh workspace.

### 1. Edit app — a real edit route on the agent detail (`feat(operator)`)
The operator surface had NO path to change a built app: the only chat affordance (Ask Agent) teaches tools, so a UI bug report sent there was misauthored into a garbage tool (`BUGAPPUI`) that polluted the agent's purpose line. The agent detail header now carries an **Edit app** action that opens the build experience in edit mode — `AppBuilderChat` scoped to the existing app (`editApp` → `submitAppEdit` → the broker improve path) docked beside the live app, no first-build tab walk. A change request republishes a new version in place.

**Live verification**: "Rename the dashboard heading" sent through the new affordance → v3 republished in 100s.

### 2. Owner token may improve/edit apps (`fix(apps)`)
`appWriterAllowed` knew only the app-builder slug and invited cookie-session humans, so the single-owner localhost human — bare token auth, no agent identity header — could never call `POST /apps/{id}/improve` or `/edit-session`: the FE's own `submitAppEdit` 403'd for the only human in the workspace. A header-less token caller is now recognized as the owner. Agents always claim their slug via `X-WUPHF-Agent` (non-app-builder slugs stay rejected), so no agent gains anything it could not already do with the token it holds.

### 3. Scaffold rule: never memoize on the stable `reactTable` instance (`docs(scaffold)`)
A live generated app froze its task list against the empty initial table — `filteredRows` was `useMemo`'d on the `reactTable` instance, whose identity never changes when data arrives, so counts updated while the list said "no rows" forever. `AI_RULES.md` now documents the wrong/right pattern (derive rows from `tableQuery.data`), locked in by the scaffold contract test.

## Test plan

- [x] `TestAppImproveOwnerToken` — owner (token, no header) improve/edit-session 200 (observed 403 pre-fix); non-app-builder agent stays 403
- [x] `TestScaffoldBridgeActionStatusContract` extended — stale-memo rule locked into AI_RULES
- [x] `OperatorAppDetail` / `OperatorBuildExperience` tests — Edit app affordance renders on ready agents only, hands back app identity; edit mode starts live, no tab walk, editApp-scoped chat
- [x] Full operator web suite 189 tests green; `tsc --noEmit` clean; `go vet` + `gofmt` clean
- [x] Live e2e on a fresh workspace: Edit app → docked edit chat → owner-token improve accepted → v3 republished in 100s
- [x] Screenshots below

## Security note (for the reviewer)

Automated review flagged the owner lane in `appWriterAllowed` ("header absence is not proof of humanness"). Assessment: the pre-existing gate was already **cooperative, not cryptographic** — any broker-token holder could pass it by sending `X-WUPHF-Agent: app-builder` (the slug is format-validated, not identity-bound). The gate's real purpose is preventing *accidental* agent writes (honest agents always send their own slug and stay rejected); this PR preserves exactly that. A non-forgeable owner identity (dedicated owner credential or login session for the localhost owner) would harden every owner-gated surface, not just apps — filed as a follow-up architectural decision, out of scope here.

## Release

PR title carries `[release]` — merge with a commit title containing the marker so auto-release cuts the next version from this merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Screenshots

![01-detail-edit-app-action](https://github.com/nex-crm/wuphf/raw/screenshots/pr-1164/01-detail-edit-app-action.png)

![02-edit-mode-docked-chat](https://github.com/nex-crm/wuphf/raw/screenshots/pr-1164/02-edit-mode-docked-chat.png)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an “Edit app” action in the operator app details view for eligible apps.
  * Introduced an edit mode that opens the app in a live, docked chat experience with updated context.
  * Improved scaffolding guidance to help avoid stale table data in generated UI patterns.

* **Bug Fixes**
  * Corrected permission handling so owner-level app actions work reliably in the right cases.
  * Fixed CI caching to avoid reusing incompatible tooling builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->