### PR TITLE
fix(gbrain): treat unresolvable WUPHF_GBRAIN_COMMAND as not installed

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -328,10 +328,14 @@ func gbrainBackendReady() bool {
 }
 
 func gbrainBinaryInstalled() bool {
+	// An explicit WUPHF_GBRAIN_COMMAND is authoritative (mirrors
+	// gbrain.BinaryPath): if it does not resolve, gbrain is not installed —
+	// no PATH fallback. The explicit command usually re-homes the brain, and
+	// substituting the user-global binary would point the implicit default at
+	// the wrong (possibly locked) brain.
 	if cmd := strings.TrimSpace(os.Getenv("WUPHF_GBRAIN_COMMAND")); cmd != "" {
-		if _, err := exec.LookPath(cmd); err == nil {
-			return true
-		}
+		_, err := exec.LookPath(cmd)
+		return err == nil
 	}
 	if _, err := exec.LookPath("gbrain"); err == nil {
 		return true

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -293,6 +293,25 @@ func TestResolveMemoryBackendDefaultsToGBrainWhenReady(t *testing.T) {
 	})
 }
 
+func TestResolveMemoryBackendExplicitCommandMissingDoesNotFallBack(t *testing.T) {
+	// An explicit WUPHF_GBRAIN_COMMAND that no longer resolves (e.g. a reaped
+	// wrapper script) must not silently fall back to the PATH gbrain: the
+	// explicit command usually re-homes the brain, and the PATH binary points
+	// at the user-global one. Not installed → markdown default.
+	withTempConfig(t, func(_ string) {
+		t.Setenv("WUPHF_NO_NEX", "")
+		t.Setenv("WUPHF_MEMORY_BACKEND", "")
+		t.Setenv("WUPHF_OPENAI_API_KEY", "sk-test-openai")
+		t.Setenv("WUPHF_ANTHROPIC_API_KEY", "")
+		t.Setenv("ANTHROPIC_API_KEY", "")
+		fakeGBrainOnPath(t)
+		t.Setenv("WUPHF_GBRAIN_COMMAND", filepath.Join(t.TempDir(), "missing-wrapper.sh"))
+		if got := ResolveMemoryBackend(""); got != MemoryBackendMarkdown {
+			t.Fatalf("expected markdown when explicit gbrain command is missing, got %q", got)
+		}
+	})
+}
+
 func TestResolveMemoryBackendDefaultsToMarkdownWhenGBrainInstalledButNoEmbedder(t *testing.T) {
 	// Installed but with no embedding provider (no OpenAI key, no local ollama
 	// embedder) gbrain is not "ready": semantic search cannot run, and a

--- a/internal/gbrain/cli.go
+++ b/internal/gbrain/cli.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/nex-crm/wuphf/internal/config"
@@ -31,11 +32,28 @@ type SearchResult struct {
 	Stale       bool    `json:"stale"`
 }
 
+// missingCommandWarn de-duplicates the unresolvable-WUPHF_GBRAIN_COMMAND
+// warning: BinaryPath is called on every gbrain invocation and the condition
+// is sticky for the process lifetime, so one stderr line is enough.
+var missingCommandWarn sync.Once
+
+// BinaryPath resolves the gbrain executable. An explicitly configured
+// WUPHF_GBRAIN_COMMAND is authoritative: if it does not resolve, gbrain is
+// treated as not installed rather than falling back to a PATH `gbrain`. The
+// explicit command usually exists to isolate the brain (wrapper scripts that
+// re-home gbrain); silently substituting the user-global binary points every
+// call at the user-global brain — and when another process holds that brain's
+// lock, each call becomes a hung connect instead of a fast, visible failure.
 func BinaryPath() string {
 	if candidate := strings.TrimSpace(os.Getenv("WUPHF_GBRAIN_COMMAND")); candidate != "" {
-		if path, err := exec.LookPath(candidate); err == nil {
-			return path
+		path, err := exec.LookPath(candidate)
+		if err != nil {
+			missingCommandWarn.Do(func() {
+				fmt.Fprintf(os.Stderr, "gbrain: WUPHF_GBRAIN_COMMAND=%q does not resolve to an executable (%v); gbrain disabled — fix or unset it\n", candidate, err)
+			})
+			return ""
 		}
+		return path
 	}
 	if path, err := exec.LookPath("gbrain"); err == nil {
 		return path

--- a/internal/gbrain/cli_test.go
+++ b/internal/gbrain/cli_test.go
@@ -1,0 +1,57 @@
+package gbrain
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// writeFakeGbrain drops an executable named "gbrain" into dir and returns its
+// path, so PATH-fallback behavior can be observed without a real install.
+func writeFakeGbrain(t *testing.T, dir string) string {
+	t.Helper()
+	fake := filepath.Join(dir, "gbrain")
+	if err := os.WriteFile(fake, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write fake gbrain: %v", err)
+	}
+	return fake
+}
+
+func TestBinaryPathExplicitCommandResolves(t *testing.T) {
+	dir := t.TempDir()
+	wrapper := filepath.Join(dir, "gbrain-wrapper.sh")
+	if err := os.WriteFile(wrapper, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write wrapper: %v", err)
+	}
+	t.Setenv("WUPHF_GBRAIN_COMMAND", wrapper)
+	if got := BinaryPath(); got != wrapper {
+		t.Fatalf("BinaryPath() = %q, want explicit command %q", got, wrapper)
+	}
+}
+
+func TestBinaryPathExplicitCommandMissingDoesNotFallBack(t *testing.T) {
+	dir := t.TempDir()
+	writeFakeGbrain(t, dir)
+	t.Setenv("PATH", dir)
+	// The explicit command points at a file that no longer exists (e.g. a
+	// wrapper script reaped by macOS /tmp cleanup). Falling back to the PATH
+	// gbrain silently swaps in the user-global brain — the exact thing an
+	// explicit command isolates against — so this must disable gbrain instead.
+	t.Setenv("WUPHF_GBRAIN_COMMAND", filepath.Join(dir, "missing-wrapper.sh"))
+	if got := BinaryPath(); got != "" {
+		t.Fatalf("BinaryPath() = %q, want empty: explicit WUPHF_GBRAIN_COMMAND that does not resolve must not fall back to PATH", got)
+	}
+	if IsInstalled() {
+		t.Fatal("IsInstalled() = true, want false when the explicit command does not resolve")
+	}
+}
+
+func TestBinaryPathEmptyCommandUsesPathFallback(t *testing.T) {
+	dir := t.TempDir()
+	fake := writeFakeGbrain(t, dir)
+	t.Setenv("PATH", dir)
+	t.Setenv("WUPHF_GBRAIN_COMMAND", "")
+	if got := BinaryPath(); got != fake {
+		t.Fatalf("BinaryPath() = %q, want PATH fallback %q", got, fake)
+	}
+}

--- a/internal/gbrain/cli_test.go
+++ b/internal/gbrain/cli_test.go
@@ -46,6 +46,21 @@ func TestBinaryPathExplicitCommandMissingDoesNotFallBack(t *testing.T) {
 	}
 }
 
+func TestBinaryPathExplicitBareNameResolvesViaPath(t *testing.T) {
+	dir := t.TempDir()
+	wrapper := filepath.Join(dir, "gbrain-wrapper")
+	if err := os.WriteFile(wrapper, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write wrapper: %v", err)
+	}
+	t.Setenv("PATH", dir)
+	// A bare name (no path separator) is resolved through PATH by
+	// exec.LookPath — same authoritative semantics as an absolute path.
+	t.Setenv("WUPHF_GBRAIN_COMMAND", "gbrain-wrapper")
+	if got := BinaryPath(); got != wrapper {
+		t.Fatalf("BinaryPath() = %q, want bare name resolved via PATH to %q", got, wrapper)
+	}
+}
+
 func TestBinaryPathEmptyCommandUsesPathFallback(t *testing.T) {
 	dir := t.TempDir()
 	fake := writeFakeGbrain(t, dir)


### PR DESCRIPTION
## What

An explicitly configured `WUPHF_GBRAIN_COMMAND` that no longer resolves to an executable is now treated as **gbrain not installed** instead of silently falling back to the `gbrain` on PATH. Applied to both resolution copies:

- `internal/gbrain.BinaryPath` — plus a once-per-process stderr warning naming the unresolvable value, so the misconfiguration is visible.
- `internal/config.gbrainBinaryInstalled` — the implicit memory-backend default probe, so a broken explicit command resolves the default to `markdown` instead of claiming gbrain readiness through the fallback binary.

Behavior with `WUPHF_GBRAIN_COMMAND` unset is unchanged (PATH lookup still applies).

## Why

Live incident on a QA stack: the wrapper script that `WUPHF_GBRAIN_COMMAND` pointed at was reaped by macOS's periodic /tmp cleanup. The silent fallback swapped in the user-global gbrain — whose brain was lock-held by a long-running `gbrain serve` — so every broker knowledge call became a 30s hung MCP connect (`connect gbrain mcp: context deadline exceeded`) and knowledge was silently served from the per-app file cache. An explicit command exists precisely to re-home the brain; substituting the global binary defeats that and turns a fast, diagnosable failure into a slow, invisible one.

## Test plan

- [x] `TestBinaryPathExplicitCommandMissingDoesNotFallBack` — fails against the old fallback behavior, passes with the fix
- [x] `TestBinaryPathExplicitCommandResolves`, `TestBinaryPathEmptyCommandUsesPathFallback` — explicit-resolves and unset-env paths unchanged
- [x] `TestResolveMemoryBackendExplicitCommandMissingDoesNotFallBack` — implicit default resolves to markdown when the explicit command is missing
- [x] `go vet`, `gofmt`, `golangci-lint run ./internal/gbrain/...` clean
- [x] Live-verified on the QA stack: with a valid wrapper, knowledge synthesis writes through gbrain (warm reads 1.6s vs the prior 30s timeout); unit-verified the fail-fast path

No web/ changes — no screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Explicitly configured gbrain commands are now authoritative. If the command cannot be found, the app no longer silently falls back to another `gbrain` executable on the system path.
  * Added a clear one-time warning when the configured command is unavailable.
  * Memory backend selection now correctly falls back to Markdown when the configured gbrain command cannot be resolved.

* **Tests**
  * Added coverage for explicit commands, PATH resolution, missing commands, and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->