### PR TITLE
fix(analytics): stamp every event with app_name so wuphf exceptions attribute correctly

### DIFF
--- a/web/src/lib/analytics.test.ts
+++ b/web/src/lib/analytics.test.ts
@@ -124,7 +124,7 @@ describe("configured via runtime injection", () => {
       session_recording_enabled: true,
     });
     await vi.waitFor(() => expect(mockPosthog.init).toHaveBeenCalled());
-    const cfg = mockPosthog.init.mock.calls[0][1];
+    const [, cfg] = mockPosthog.init.mock.calls[0];
     // PostHog default: typed text (inputs) is masked, on-screen text is not.
     expect(cfg?.session_recording?.maskAllInputs).toBe(true);
     expect(cfg?.session_recording?.maskTextSelector).toBeUndefined();
@@ -192,15 +192,17 @@ describe("onboarding email (the single PII egress)", () => {
     expect(mockPosthog.capture).not.toHaveBeenCalled();
   });
 
-  it.each(["seed-user-15", "not-an-email", "no@domain", "@nope.com"])(
-    "ignores a non-email value (%s) — never attaches it or emits the event",
-    async (junk) => {
-      recordOnboardingEmailCaptured(junk);
-      await flush();
-      expect(mockPosthog.setPersonProperties).not.toHaveBeenCalled();
-      expect(mockPosthog.capture).not.toHaveBeenCalled();
-    },
-  );
+  it.each([
+    "seed-user-15",
+    "not-an-email",
+    "no@domain",
+    "@nope.com",
+  ])("ignores a non-email value (%s) — never attaches it or emits the event", async (junk) => {
+    recordOnboardingEmailCaptured(junk);
+    await flush();
+    expect(mockPosthog.setPersonProperties).not.toHaveBeenCalled();
+    expect(mockPosthog.capture).not.toHaveBeenCalled();
+  });
 });
 
 describe("live consent changes", () => {
@@ -237,9 +239,46 @@ describe("sanitize_properties", () => {
       session_recording_enabled: false,
     });
     await vi.waitFor(() => expect(mockPosthog.init).toHaveBeenCalled());
-    const cfg = mockPosthog.init.mock.calls[0][1];
+    const [, cfg] = mockPosthog.init.mock.calls[0];
     const enriched = cfg?.sanitize_properties?.({ a: 1 }) ?? {};
     expect(enriched.theme).toBe("noir-gold");
+    expect(enriched.app_name).toBe("wuphf-web");
     document.documentElement.removeAttribute("data-theme");
+  });
+
+  it("keeps the authoritative app name when callers supply a different value", async () => {
+    configureAnalytics({
+      configured: true,
+      posthog_key: "phc_runtime",
+      telemetry_enabled: true,
+      session_recording_enabled: false,
+    });
+    await vi.waitFor(() => expect(mockPosthog.init).toHaveBeenCalled());
+    const [, cfg] = mockPosthog.init.mock.calls[0];
+    const enriched =
+      cfg?.sanitize_properties?.({ app_name: "another-app" }) ?? {};
+    expect(enriched.app_name).toBe("wuphf-web");
+  });
+
+  it("stamps autocaptured exception properties through the init hook", async () => {
+    configureAnalytics({
+      configured: true,
+      posthog_key: "phc_runtime",
+      telemetry_enabled: true,
+      session_recording_enabled: false,
+    });
+    await vi.waitFor(() => expect(mockPosthog.init).toHaveBeenCalled());
+    const [, cfg] = mockPosthog.init.mock.calls[0];
+    const enriched =
+      cfg?.sanitize_properties?.({
+        $exception_list: [
+          {
+            type: "Error",
+            value: "No Listener: tabs:outgoing.message.ready",
+          },
+        ],
+        $exception_level: "error",
+      }) ?? {};
+    expect(enriched.app_name).toBe("wuphf-web");
   });
 });

--- a/web/src/lib/analytics.ts
+++ b/web/src/lib/analytics.ts
@@ -41,6 +41,9 @@ import type { PostHog } from "posthog-js";
 
 const DEFAULT_POSTHOG_HOST = "https://us.i.posthog.com";
 
+/** Stable app identity attached to every captured event. */
+const APP_NAME = "wuphf-web";
+
 /** Source tag attached to onboarding funnel events, for filtering in PostHog. */
 export const ONBOARDING_SOURCE = "onboarding-welcome";
 
@@ -143,9 +146,10 @@ export function __resetAnalyticsForTests(): void {
 }
 
 /**
- * Strip anything we never want to send and enrich with the active theme. Runs
- * on every captured event. Defense in depth: properties are constructed to be
- * content-free at the call site, but this guarantees it centrally.
+ * Strip anything we never want to send and enrich with app identity and the
+ * active theme. Runs on every captured event. Defense in depth: properties are
+ * constructed to be content-free at the call site, but this guarantees it
+ * centrally.
  */
 function sanitizeProperties(
   props: Record<string, unknown>,
@@ -157,6 +161,7 @@ function sanitizeProperties(
   }
   const version = import.meta.env.VITE_PUBLIC_APP_VERSION;
   if (typeof version === "string" && version) out.app_version = version;
+  out.app_name = APP_NAME;
   return out;
 }
 


### PR DESCRIPTION
## Root cause

Wuphf events in the shared PostHog project had no explicit app identity, including autocaptured `$exception` events. That made browser errors attributable only by reverse-engineering `$current_url`, which led to a wuphf exception being misattributed to annex even though annex and app do not emit these PostHog exceptions.

## Fix

- Export a single `APP_NAME` constant with the value `wuphf-web`.
- Stamp `app_name` unconditionally in `sanitizeProperties` after copying event properties, so caller-supplied values cannot override the authoritative identity.
- Keep enrichment in the `sanitize_properties` init hook (option A). The installed posthog-js 1.386.6 routes autocaptured exceptions through the normal `capture("$exception", ...)` pipeline, which applies this hook after combining event and super-properties.
- Add regression coverage for normal enrichment, caller override resistance, and `$exception`-shaped properties passed through the init hook.

## Verification

- `cd web && bunx tsc --noEmit` — passed
- `bash scripts/test-web.sh web/src/lib/analytics.test.ts` — passed, 23/23 tests
- `cd web && bunx biome check --write src/lib/analytics.ts src/lib/analytics.test.ts` — passed
- `cd web && bunx biome check src/lib/analytics.ts src/lib/analytics.test.ts` — passed, no fixes or warnings
- `bunx secretlint` — passed full-repo scan

## Screenshots

Exempt: refactor/no visible UI delta (analytics-only).

## Related work

PR #1166 is a complementary exception-noise filter and changes the same analytics file. This PR intentionally does not merge or reconcile that separate behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Analytics event properties now consistently include a stable application name alongside the active theme.
  * Sanitization preserves authoritative app identity and retains exception-related properties during event capture.
  * Improved onboarding analytics handling to avoid unintended email-derived person properties and to prevent unwanted capture emissions for non-email inputs.
* **Tests**
  * Expanded and updated analytics test coverage to reflect the refined sanitization and onboarding scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->