### PR TITLE
fix(security): remove headerless broker-token fallback in appWriterAl…

### DIFF
--- a/internal/team/broker_apps.go
+++ b/internal/team/broker_apps.go
@@ -605,15 +605,10 @@ func buildAppImprovePrompt(app CustomApp, change string) string {
 }
 
 // appWriterAllowed reports whether the request may write/delete app bytes:
-// the authenticated agent is the App Builder, the caller is an invited human
-// session, or the caller is the OWNER — bare token auth with no agent
-// identity claimed. Agents always claim their slug via the agent header (and
-// any non-app-builder slug is rejected above), so a header-less token caller
-// is the human driving the web UI, not an agent sidestepping the gate: the
-// header is cooperative, and an agent omitting it gains nothing it could not
-// already do with the token it holds. Without the owner lane the operator
-// UI's own edit path (submitAppEdit → POST /apps/{id}/improve) 403'd for the
-// only human in a single-owner workspace.
+// the authenticated agent is the App Builder, or the caller is an invited human
+// session. The web UI produces requestActorKindHuman via humanSessionFromRequest.
+// The broker-kind fallback lane was removed because all agents hold WUPHF_BROKER_TOKEN
+// and could omit X-WUPHF-Agent to bypass app ownership checks.
 func (b *Broker) appWriterAllowed(r *http.Request, actor string) bool {
 	if strings.EqualFold(strings.TrimSpace(actor), appBuilderSlug) {
 		return true
@@ -622,10 +617,7 @@ func (b *Broker) appWriterAllowed(r *http.Request, actor string) bool {
 	if !ok {
 		return false
 	}
-	if a.Kind == requestActorKindHuman {
-		return true
-	}
-	return a.Kind == requestActorKindBroker && strings.TrimSpace(actor) == ""
+	return a.Kind == requestActorKindHuman
 }
 
 func writeAppError(w http.ResponseWriter, err error) {


### PR DESCRIPTION
Fixes #1175

## Summary

Removes the insecure `a.Kind == requestActorKindBroker && actor == ""` fallback lane in `appWriterAllowed` (`internal/team/broker_apps.go`). 

Previously, any agent process holding `WUPHF_BROKER_TOKEN` could bypass app ownership checks and perform destructive actions (`DELETE /apps/{id}`, `POST /apps/{id}/rollback`, `PATCH /apps/{id}`) by omitting the advisory `X-WUPHF-Agent` header on raw HTTP requests.

## Changes

- Removed the broker-token fallback lane from `appWriterAllowed()`.
- Restricted non-App-Builder app mutations strictly to verified human sessions (`requestActorKindHuman`).

## Diff Overview

```diff
 func (b *Broker) appWriterAllowed(r *http.Request, actor string) bool {
 	if strings.EqualFold(strings.TrimSpace(actor), appBuilderSlug) {
 		return true
 	}
 	a, ok := requestActorFromContext(r.Context())
 	if !ok {
 		return false
 	}
-	if a.Kind == requestActorKindHuman {
-		return true
-	}
-	return a.Kind == requestActorKindBroker && strings.TrimSpace(actor) == ""
+	return a.Kind == requestActorKindHuman
 }

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened authorization for app modifications.
  * Restricted app-byte changes to approved App Builder actions and authenticated human sessions.
  * Removed an unintended fallback access path for app registration, editing, deletion, rollback, improvement, and preview actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->