### PR TITLE
 fix(security): cap request body size to 512KB on visual artifact end…

### DIFF
--- a/internal/team/broker_rich_artifact.go
+++ b/internal/team/broker_rich_artifact.go
@@ -57,6 +57,7 @@ func (b *Broker) handleVisualArtifacts(w http.ResponseWriter, r *http.Request) {
 		}
 		writeJSON(w, http.StatusOK, map[string]any{"artifacts": artifacts})
 	case http.MethodPost:
+		r.Body = http.MaxBytesReader(w, r.Body, 512*1024)
 		var body RichArtifactCreateRequest
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid json"})
@@ -129,6 +130,7 @@ func (b *Broker) handleVisualArtifactSubpath(w http.ResponseWriter, r *http.Requ
 			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 			return
 		}
+		r.Body = http.MaxBytesReader(w, r.Body, 512*1024)
 		var body RichArtifactPromoteRequest
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid json"})

--- a/internal/team/broker_rich_artifact.go
+++ b/internal/team/broker_rich_artifact.go
@@ -60,6 +60,11 @@ func (b *Broker) handleVisualArtifacts(w http.ResponseWriter, r *http.Request) {
 		r.Body = http.MaxBytesReader(w, r.Body, 512*1024)
 		var body RichArtifactCreateRequest
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			var maxErr *http.MaxBytesError
+			if errors.As(err, &maxErr) {
+				writeJSON(w, http.StatusRequestEntityTooLarge, map[string]string{"error": "request body too large"})
+				return
+			}
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid json"})
 			return
 		}
@@ -133,6 +138,11 @@ func (b *Broker) handleVisualArtifactSubpath(w http.ResponseWriter, r *http.Requ
 		r.Body = http.MaxBytesReader(w, r.Body, 512*1024)
 		var body RichArtifactPromoteRequest
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			var maxErr *http.MaxBytesError
+			if errors.As(err, &maxErr) {
+				writeJSON(w, http.StatusRequestEntityTooLarge, map[string]string{"error": "request body too large"})
+				return
+			}
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid json"})
 			return
 		}


### PR DESCRIPTION
fixes #1177
## Summary

Enforces a `512 KB` request body size limit (`http.MaxBytesReader`) on the `POST /visual-artifacts` (artifact creation) and `POST /visual-artifacts/{id}/promote` (artifact promotion) HTTP routes in `internal/team/broker_rich_artifact.go`.

Prior to this fix, both endpoints decoded JSON directly from `r.Body` without a stream size cap. An attacker or prompt-injected agent sending an unbounded payload could trigger memory exhaustion (OOM), crashing the broker process and killing active agent turns.

---

## Root Cause

`json.NewDecoder(r.Body).Decode(&body)` reads directly from the unbuffered HTTP request stream. Without wrapping `r.Body` in `http.MaxBytesReader`, an oversized payload (e.g. 500MB+ `markdown_summary`) is buffered into heap memory during JSON parsing, consuming system RAM until the Go runtime or OS OOM-killer terminates the process.

While other endpoints in `internal/team/` enforced body caps (`/agent-files/write` at 512KB, `/apps/{id}/db` at 1MB), the visual artifact endpoints were missing this guard.

---

## Changes

- Added `r.Body = http.MaxBytesReader(w, r.Body, 512*1024)` before `json.NewDecoder` in `handleVisualArtifacts` (`POST /visual-artifacts`).
- Added `r.Body = http.MaxBytesReader(w, r.Body, 512*1024)` before `json.NewDecoder` in `handleVisualArtifactSubpath` (`POST /visual-artifacts/{id}/promote`).

---

## Code Diff

```diff
--- a/internal/team/broker_rich_artifact.go
+++ b/internal/team/broker_rich_artifact.go
@@ -57,6 +57,7 @@ func (b *Broker) handleVisualArtifacts(w http.ResponseWriter, r *http.Request) {
 		}
 		writeJSON(w, http.StatusOK, map[string]any{"artifacts": artifacts})
 	case http.MethodPost:
+		r.Body = http.MaxBytesReader(w, r.Body, 512*1024)
 		var body RichArtifactCreateRequest
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid json"})
@@ -128,6 +129,7 @@ func (b *Broker) handleVisualArtifactSubpath(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 			return
 		}
+		r.Body = http.MaxBytesReader(w, r.Body, 512*1024)
 		var body RichArtifactPromoteRequest
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid json"})

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a 512 KiB size limit for visual artifact requests.
  * Requests exceeding the limit now receive a clear HTTP 413 error response.
  * Existing handling for valid requests and other invalid input remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->