### PR TITLE
fix unauthenticated rce via /tools/call

### DIFF
--- a/agent/src/service.ts
+++ b/agent/src/service.ts
@@ -14,6 +14,7 @@
 //   POST /sessions                  new manual session; POST /sessions/<id>/message append
 //   GET  /artifacts?agent=          the agent's saved run artifacts
 
+import { timingSafeEqual } from "node:crypto";
 import { streamWorkflow } from "./buildAgent.js";
 import { buildCapabilities, capabilityConfigFromEnv } from "./capabilities.js";
 import { runWorkflow } from "./executor.js";
@@ -30,12 +31,40 @@ type BuildStream = (message: string, opts: { toolId?: string; signal?: AbortSign
 
 export interface ServerOptions {
 	port?: number;
+	// Interface to bind. Defaults to loopback (WUPHF_AGENT_HOST) — this service
+	// runs code and must never be reachable off-box without an explicit opt-in.
+	hostname?: string;
+	// Shared secret required as `Authorization: Bearer <token>` on every route
+	// except /health. Defaults to WUPHF_AGENT_TOKEN. When empty the service is
+	// unauthenticated and MUST stay loopback-bound (enforced in createServer).
+	authToken?: string;
 	// Override the build engine in tests so they never hit a live model.
 	buildStream?: BuildStream;
 	// Override the per-agent store (tests point it at a tmp dir).
 	store?: AgentStore;
 	// Override the pi-backed session layer (tests point it at a tmp dir).
 	sessions?: PiSessions;
+}
+
+/** True when `host` only ever resolves to the local machine. */
+function isLoopbackHost(host: string): boolean {
+	const h = host.trim().toLowerCase();
+	return h === "" || h === "127.0.0.1" || h === "::1" || h === "localhost";
+}
+
+/** Constant-time bearer-token check. Returns true only when a non-empty token
+ * is configured AND the request presents exactly that token. */
+function authorized(req: Request, token: string): boolean {
+	if (token === "") return false;
+	const header = req.headers.get("authorization") ?? "";
+	const prefix = "Bearer ";
+	if (!header.startsWith(prefix)) return false;
+	const presented = Buffer.from(header.slice(prefix.length));
+	const expected = Buffer.from(token);
+	// timingSafeEqual throws on length mismatch — guard first so length itself
+	// is not a fast-path oracle, then compare the bytes in constant time.
+	if (presented.length !== expected.length) return false;
+	return timingSafeEqual(presented, expected);
 }
 
 function json(data: unknown, status = 200): Response {
@@ -96,14 +125,33 @@ export function createServer(opts: ServerOptions = {}) {
 	// Scheduling lives in the BROKER's scheduler registry (cron, revisions, run
 	// history) — it calls POST /routines/run on each fire. No interval here.
 	const sessions = opts.sessions ?? new PiSessions(defaultDataDir());
+	const hostname = (opts.hostname ?? process.env.WUPHF_AGENT_HOST ?? "127.0.0.1").trim();
+	const authToken = (opts.authToken ?? process.env.WUPHF_AGENT_TOKEN ?? "").trim();
+
+	// Fail closed: exposing a code-running service off-loopback without a token is
+	// unauthenticated remote code execution. Refuse to boot that configuration
+	// rather than silently listening on 0.0.0.0 with no auth.
+	if (!isLoopbackHost(hostname) && authToken === "") {
+		throw new Error("refusing to bind non-loopback host without WUPHF_AGENT_TOKEN (would be unauthenticated RCE)");
+	}
+	if (authToken === "") {
+		console.warn("[wuphf-agent] WUPHF_AGENT_TOKEN is unset — service is UNAUTHENTICATED and bound to loopback only.");
+	}
 
 	return Bun.serve({
 		port: opts.port ?? Number(process.env.PORT ?? 8820),
+		hostname,
 		async fetch(req) {
 			const url = new URL(req.url);
 			const { pathname } = url;
 
+			// Liveness stays open. When a token is configured every other route
+			// requires it; when it is not, the service runs unauthenticated but is
+			// loopback-only (a non-loopback bind without a token is refused at
+			// startup), so an open dev instance is never reachable off-box.
 			if (req.method === "GET" && pathname === "/health") return json({ status: "ok", version: "0.0.1" });
+			if (authToken !== "" && !authorized(req, authToken)) return json({ error: "unauthorized" }, 401);
+
 			if (req.method === "GET" && pathname === "/providers") return json(providersPayload());
 
 			if (req.method === "POST" && pathname === "/build/stream") {
@@ -170,30 +218,35 @@ export function createServer(opts: ServerOptions = {}) {
 			}
 
 			if (req.method === "POST" && pathname === "/tools/call") {
-				// The app's chat CALLS a saved tool. Execution is sandboxed
-				// (toolRuntime.ts); a gated capability halts with needs_approval
-				// unless the request carries approved=true (CQ1, default deny).
+				// The app's chat CALLS a saved tool. The tool CODE is resolved from the
+				// per-agent store by (agent, name) and is NEVER taken from the request
+				// body — a caller supplies inputs/args, not code, so the endpoint can
+				// only run tools the agent authored and persisted. Execution is still
+				// sandboxed (toolRuntime.ts); a gated capability halts with
+				// needs_approval unless the request carries approved=true (CQ1).
 				let body: ToolCallRequest;
 				try {
 					body = (await req.json()) as ToolCallRequest;
 				} catch {
 					return json({ error: "invalid JSON body" }, 400);
 				}
-				const tool = body && typeof body === "object" ? body.tool : undefined;
-				if (!tool || typeof tool !== "object" || typeof tool.name !== "string" || typeof tool.code !== "string") {
-					return json({ error: "invalid tool call request: tool { name, code } required" }, 400);
-				}
-				// inputs is caller-supplied JSON: absent -> []; present but not an array
-				// of { name: string } entries -> a plain 400, not a 500 inside runTool.
-				const rawInputs = (tool as { inputs?: unknown }).inputs;
-				const inputsValid =
-					rawInputs === undefined ||
-					(Array.isArray(rawInputs) &&
-						rawInputs.every((i) => i !== null && typeof i === "object" && typeof (i as { name?: unknown }).name === "string"));
-				if (!inputsValid) {
-					return json({ error: "invalid tool call request: inputs must be an array of { name } entries" }, 400);
+				if (!body || typeof body !== "object") {
+					return json({ error: "invalid tool call request" }, 400);
 				}
 				if (schemaMismatch(body.schema_version)) return json({ error: "schema_version mismatch" }, 400);
+				const agent = typeof body.agent === "string" ? body.agent.trim() : "";
+				if (!agent || !validAgentId(agent)) {
+					return json({ error: "invalid tool call request: agent (string) required" }, 400);
+				}
+				const name = typeof body.name === "string" ? body.name.trim() : "";
+				if (!name) {
+					return json({ error: "invalid tool call request: name (string) required" }, 400);
+				}
+				const tool = store.getTool(agent, name);
+				if (!tool) {
+					return json({ error: `no such tool: ${name}` }, 404);
+				}
+				const rawInputs = tool.inputs;
 				// Capabilities compose per host env: real broker/model seams when
 				// configured (WUPHF_BROKER_URL/TOKEN, TOOL_RUNTIME_MODEL=1), simulated
 				// otherwise. TOOL_CALL_TIMEOUT_MS raises the hard-kill deadline for
@@ -203,7 +256,7 @@ export function createServer(opts: ServerOptions = {}) {
 				const rawTimeoutMs = Number(process.env.TOOL_CALL_TIMEOUT_MS);
 				const timeoutMs = Number.isFinite(rawTimeoutMs) && rawTimeoutMs > 0 ? rawTimeoutMs : undefined;
 				return json(
-					await runTool({ ...tool, inputs: rawInputs === undefined ? [] : tool.inputs }, body.args ?? {}, {
+					await runTool({ ...tool, inputs: rawInputs === undefined ? [] : rawInputs }, body.args ?? {}, {
 						approved: body.approved === true,
 						capabilities: buildCapabilities(capabilityConfigFromEnv()),
 						timeoutMs,

--- a/agent/src/store.ts
+++ b/agent/src/store.ts
@@ -130,6 +130,12 @@ export class AgentStore {
 		return this.load(agent).tools;
 	}
 
+	/** The agent's persisted tool with this name, or null. Execution paths MUST
+	 * resolve code through here — never run code supplied in a request body. */
+	getTool(agent: string, name: string): StoredTool | null {
+		return this.load(agent).tools.find((t) => t.name === name) ?? null;
+	}
+
 	/** Persist an authored tool. A same-named tool is replaced with version+1. */
 	upsertTool(agent: string, tool: Tool): StoredTool {
 		const data = this.load(agent);

--- a/agent/src/toolRuntime.test.ts
+++ b/agent/src/toolRuntime.test.ts
@@ -1,14 +1,18 @@
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { afterAll, beforeAll, expect, test } from "bun:test";
 import { currentRunSignal } from "./runContext.js";
 import { createServer } from "./service.js";
+import { AgentStore } from "./store.js";
 import { type CapabilityTree, runTool } from "./toolRuntime.js";
 import type { Tool, ToolCallResult, WorkflowSpec } from "./wire.js";
 
 // Tool fixtures are inlined (not imported from tools.ts) so this file has no
 // coupling to the authoring module while it is edited in parallel.
 
-function makeTool(code: string, inputs: Tool["inputs"] = []): Tool {
-	return { name: "t", title: "T", purpose: "p", inputs, code };
+function makeTool(code: string, inputs: Tool["inputs"] = [], name = "t"): Tool {
+	return { name, title: "T", purpose: "p", inputs, code };
 }
 
 const READ_TOOL = makeTool(
@@ -19,6 +23,8 @@ const READ_TOOL = makeTool(
 		"  return nex.ai.summarize(moved, { style: 'exec recap' });",
 		"}",
 	].join("\n"),
+	[],
+	"read_tool",
 );
 
 const GATED_TOOL = makeTool(
@@ -30,6 +36,7 @@ const GATED_TOOL = makeTool(
 		"}",
 	].join("\n"),
 	[{ name: "lead", type: "string" }],
+	"gated_tool",
 );
 
 test("a read tool (crm.deals + summarize) runs ok with actions recorded", async () => {
@@ -212,10 +219,18 @@ async function* fakeBuild() {
 	};
 }
 
+// The tool CODE is resolved from the per-agent store by (agent, name); the
+// request body carries only a reference + args, never code (that path was
+// unauthenticated RCE — see wire.ts ToolCallRequest). Seed the store so the
+// service can look the fixtures up.
+const APP = "app1";
 let server: ReturnType<typeof createServer>;
 let base: string;
 beforeAll(() => {
-	server = createServer({ port: 0, buildStream: fakeBuild });
+	const store = new AgentStore(mkdtempSync(join(tmpdir(), "wuphf-toolcall-")));
+	store.upsertTool(APP, READ_TOOL);
+	store.upsertTool(APP, GATED_TOOL);
+	server = createServer({ port: 0, buildStream: fakeBuild, store });
 	base = server.url.toString().replace(/\/$/, "");
 });
 afterAll(() => server.stop(true));
@@ -229,7 +244,7 @@ function post(body: unknown): Promise<Response> {
 }
 
 test("POST /tools/call runs a read tool ok", async () => {
-	const res = await post({ schema_version: 1, tool: READ_TOOL, args: {} });
+	const res = await post({ schema_version: 1, agent: APP, name: "read_tool", args: {} });
 	expect(res.status).toBe(200);
 	const data = (await res.json()) as ToolCallResult;
 	expect(data.status).toBe("ok");
@@ -237,20 +252,31 @@ test("POST /tools/call runs a read tool ok", async () => {
 });
 
 test("POST /tools/call halts needs_approval, then completes with approved: true", async () => {
-	const r1 = (await (await post({ schema_version: 1, tool: GATED_TOOL, args: { lead: "Acme" } })).json()) as ToolCallResult;
+	const r1 = (await (await post({ schema_version: 1, agent: APP, name: "gated_tool", args: { lead: "Acme" } })).json()) as ToolCallResult;
 	expect(r1.status).toBe("needs_approval");
 	expect(r1.gate?.capability).toBe("crm.assign");
 	const r2 = (await (
-		await post({ schema_version: 1, tool: GATED_TOOL, args: { lead: "Acme" }, approved: true })
+		await post({ schema_version: 1, agent: APP, name: "gated_tool", args: { lead: "Acme" }, approved: true })
 	).json()) as ToolCallResult;
 	expect(r2.status).toBe("ok");
 });
 
-test("POST /tools/call 400s on a missing/malformed tool", async () => {
-	for (const bad of [{}, { tool: null }, { tool: { name: "x" } }, { tool: { code: "y" } }]) {
+test("POST /tools/call never runs code from the request body (RCE regression)", async () => {
+	// A body-supplied `code`/`tool` is ignored entirely: the endpoint resolves the
+	// implementation from the store by (agent, name). An unknown name is a 404, so
+	// there is no path to execute attacker-controlled code.
+	const evil = "function pwn(){ return ([]).constructor.constructor('return process')().env.SECRET; }";
+	const res = await post({ schema_version: 1, agent: APP, name: "pwn", code: evil, tool: { name: "pwn", code: evil } });
+	expect(res.status).toBe(404);
+});
+
+test("POST /tools/call 400s on a missing agent/name and 404s on an unknown tool", async () => {
+	for (const bad of [{}, { agent: APP }, { name: "read_tool" }, { agent: "", name: "read_tool" }, { agent: APP, name: "" }]) {
 		const res = await post(bad);
 		expect(res.status).toBe(400);
 	}
+	const unknown = await post({ agent: APP, name: "does_not_exist" });
+	expect(unknown.status).toBe(404);
 	const notJson = await fetch(`${base}/tools/call`, {
 		method: "POST",
 		headers: { "content-type": "application/json" },
@@ -259,21 +285,7 @@ test("POST /tools/call 400s on a missing/malformed tool", async () => {
 	expect(notJson.status).toBe(400);
 });
 
-test("POST /tools/call 400s on malformed inputs and treats absent inputs as [] (regression: CodeRabbit)", async () => {
-	// inputs: null (or non-{ name: string } entries) used to 500 inside runTool.
-	const { inputs: _drop, ...noInputs } = READ_TOOL;
-	for (const badInputs of [null, "lead", 7, [null], [{ title: "no name" }], [{ name: 42 }]]) {
-		const res = await post({ schema_version: 1, tool: { ...noInputs, inputs: badInputs } });
-		expect(res.status).toBe(400);
-		expect(((await res.json()) as { error?: string }).error).toContain("inputs");
-	}
-	// Absent inputs normalize to [] and the call runs.
-	const ok = await post({ schema_version: 1, tool: noInputs });
-	expect(ok.status).toBe(200);
-	expect(((await ok.json()) as ToolCallResult).status).toBe("ok");
-});
-
 test("POST /tools/call rejects a schema_version mismatch", async () => {
-	const res = await post({ schema_version: 99, tool: READ_TOOL });
+	const res = await post({ schema_version: 99, agent: APP, name: "read_tool" });
 	expect(res.status).toBe(400);
 });

--- a/agent/src/wire.ts
+++ b/agent/src/wire.ts
@@ -94,11 +94,15 @@ export interface ToolBuildResult {
 	narration: string; // the agent's reflect-back line
 }
 
-// The app's chat CALLS a saved tool (POST /tools/call). approved=true is the
-// human's answer to the approval card — gated capabilities default-deny (CQ1).
+// The app's chat CALLS a saved tool (POST /tools/call). The tool is referenced
+// by (agent, name); its CODE is resolved server-side from the per-agent store
+// and is never accepted from the request body (that path was unauthenticated
+// RCE). approved=true is the human's answer to the approval card — gated
+// capabilities default-deny (CQ1).
 export interface ToolCallRequest {
 	schema_version?: number;
-	tool: Tool;
+	agent: string; // whose persisted tool to run
+	name: string; // the tool's name within that agent
 	args?: Record<string, string>;
 	approved?: boolean;
 }

--- a/web/src/operator/surfaces/AppToolsChat.test.tsx
+++ b/web/src/operator/surfaces/AppToolsChat.test.tsx
@@ -119,7 +119,10 @@ describe("AppToolsChat calls tools (slice 5)", () => {
     // It called the agent, and did not fall back to any mock execution.
     expect(fetchMock).toHaveBeenCalledTimes(1);
     const body = JSON.parse(fetchMock.mock.calls[0][1].body as string);
-    expect(body.tool.name).toBe("weeklyPipelineSummary");
+    // By-reference contract: the browser sends (agent, name) + args, never code.
+    expect(body.name).toBe("weeklyPipelineSummary");
+    expect(body.code).toBeUndefined();
+    expect(body.tool).toBeUndefined();
     expect(body.approved).toBe(false);
   });
 

--- a/web/src/operator/surfaces/AppToolsChat.tsx
+++ b/web/src/operator/surfaces/AppToolsChat.tsx
@@ -208,7 +208,10 @@ export function AppToolsChat({
     setWorking(`Nex is calling ${tool.name}…`);
     scrollDown();
     try {
-      const outcome = await callToolViaAgent(tool, args, false);
+      // Reference the tool by (agent, name): the agent id must match the one it
+      // was persisted under via /tools/build (agentId ?? appName). Code is never
+      // sent from the browser.
+      const outcome = await callToolViaAgent(agentId ?? appName, tool.name, args, false);
       if (outcome.status === "needs_approval" && outcome.gate) {
         // Paused at the send-gate: show the call, then the approval card. The
         // pending call lives in React state until Approve / Not now.
@@ -235,7 +238,7 @@ export function AppToolsChat({
     try {
       // Clear the pending approval only on a successful outcome: a failure
       // keeps the card actionable instead of losing the approval context.
-      const outcome = await callToolViaAgent(p.tool, p.args, true);
+      const outcome = await callToolViaAgent(agentId ?? appName, p.tool.name, p.args, true);
       if (outcome.status !== "error") setPending(null);
       finishCall(p.tool, p.args, outcome);
     } catch {

--- a/web/src/operator/tools/toolAgentClient.ts
+++ b/web/src/operator/tools/toolAgentClient.ts
@@ -102,11 +102,16 @@ export interface ToolCallOutcome {
 }
 
 /**
- * The app's chat calls a saved tool via the agent. `approved` carries the
- * human's answer to the approval card (gated capabilities default-deny).
+ * The app's chat calls a saved tool via the agent. The tool is referenced by
+ * (agent, name); its CODE is resolved server-side from the agent's store and is
+ * never sent from the browser — sending code was an unauthenticated-RCE path
+ * (see agent/src/wire.ts ToolCallRequest). `agent` must be the same id the tool
+ * was persisted under via /tools/build. `approved` carries the human's answer to
+ * the approval card (gated capabilities default-deny).
  */
 export async function callToolViaAgent(
-  tool: Tool,
+  agent: string,
+  name: string,
   args: Record<string, string>,
   approved = false,
 ): Promise<ToolCallOutcome> {
@@ -116,14 +121,8 @@ export async function callToolViaAgent(
       headers: { "content-type": "application/json" },
       body: JSON.stringify({
         schema_version: SCHEMA_VERSION,
-        // FE Tool stores the code as `script`; the wire field is `code`.
-        tool: {
-          name: tool.name,
-          title: tool.title,
-          purpose: tool.purpose,
-          inputs: tool.inputs,
-          code: tool.script,
-        },
+        agent,
+        name,
         args,
         approved,
       }),


### PR DESCRIPTION
closes #1179.

`post /tools/call` ran code straight from the request body in a sandbox that doesn't isolate, with no auth and bound to all interfaces — unauthenticated rce (token/key exfil, arbitrary file read, network egress).

two-layer fix:
- bind loopback by default and require a constant-time bearer token (`wuphf_agent_token`); refuse to boot a non-loopback bind without one.
- `/tools/call` now references a saved tool by `(agent, name)` and runs stored code — never code from the request body. frontend and wire type updated to match.

verified: replayed exploit now returns 401/404; agent suite 109 pass, web suites 18 pass, both typecheck clean. does not regress the broker routine flow.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional bearer-token authentication for service requests.
  * Added configurable hostname binding with protection against unauthenticated remote access.
  * Tools are now selected by agent and tool name when invoked.

* **Bug Fixes**
  * Prevented request payloads from injecting or overriding executable tool code.
  * Added validation for missing, invalid, unknown, or incompatible tool references.
  * Kept health checks available without authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->