### PR TITLE
feat(operator): build gate v2 — per-integration connect rows with logos

### DIFF
--- a/web/src/components/messages/ConnectIntegrationCard.tsx
+++ b/web/src/components/messages/ConnectIntegrationCard.tsx
@@ -39,6 +39,14 @@ interface ConnectIntegrationCardProps {
   onSkip: () => void;
   /** Cancel the request entirely. */
   onDismiss: () => void;
+  /**
+   * The catalog's brand logo URL, when the caller resolved one. Rendered
+   * ahead of the curated brand SVG / generic glyph — same precedence the
+   * integrations surfaces use.
+   */
+  logoUrl?: string;
+  /** Notify the host when the connection lands (build gate auto-proceed). */
+  onConnected?: () => void;
 }
 
 function platformName(request: AgentRequest): string {
@@ -55,7 +63,10 @@ export function ConnectIntegrationCard({
   submitting,
   onSkip,
   onDismiss,
+  logoUrl,
+  onConnected,
 }: ConnectIntegrationCardProps) {
+  const [logoFailed, setLogoFailed] = useState(false);
   const queryClient = useQueryClient();
   const platform = (request.platform ?? "").trim();
   const name = platformName(request);
@@ -96,7 +107,8 @@ export function ConnectIntegrationCard({
     showNotice(`${name} connected.`, "success");
     void queryClient.invalidateQueries({ queryKey: ["requests"] });
     void queryClient.invalidateQueries({ queryKey: ["requests-badge"] });
-  }, [status, name, queryClient]);
+    onConnected?.();
+  }, [status, name, queryClient, onConnected]);
 
   const connectMutation = useMutation({
     mutationFn: () => startIntegrationConnection("composio", platform),
@@ -221,12 +233,22 @@ export function ConnectIntegrationCard({
     (Boolean(pending) && status !== "failed" && status !== "connected");
   const failed = status === "failed";
   const brandLogo = platform ? <ToolkitBrandLogo platform={platform} /> : null;
+  const catalogLogo =
+    logoUrl && !logoFailed ? (
+      <img
+        className="eac-logo-img"
+        src={logoUrl}
+        alt=""
+        loading="lazy"
+        onError={() => setLogoFailed(true)}
+      />
+    ) : null;
 
   return (
     <div className="eac eac-connect">
       <header className="eac-head">
         <div className="eac-logo" aria-hidden="true">
-          {brandLogo ?? <GenericIntegrationLogo />}
+          {catalogLogo ?? brandLogo ?? <GenericIntegrationLogo />}
         </div>
         <div className="eac-headings">
           <span className="eac-eyebrow">Connect to continue</span>

--- a/web/src/operator/builder/describedIntegrations.ts
+++ b/web/src/operator/builder/describedIntegrations.ts
@@ -7,7 +7,10 @@
 // deliberate keyword map over the operator's own words — deterministic and
 // testable; no model call before the build even starts.
 
-import { listIntegrations } from "../../api/integrations";
+import {
+  type IntegrationCatalogItem,
+  listIntegrations,
+} from "../../api/integrations";
 
 /** One external system the description names. `generic` marks category words
  *  ("our CRM") that name a family rather than a product. */
@@ -113,4 +116,92 @@ export async function missingIntegrations(
   } catch {
     return [];
   }
+}
+
+/** One concrete, catalog-resolved thing the gate can offer to connect. A
+ *  product ref maps to itself; a generic ref ("a CRM") expands to its family
+ *  products, any one of which satisfies the ref. */
+export interface GateConnectTarget {
+  /** Display label ("HubSpot"). */
+  label: string;
+  /** Canonical catalog platform slug the connect flow needs. */
+  platform: string;
+  provider: string;
+  /** The catalog's brand logo, when it has one. */
+  logoUrl?: string;
+  connected: boolean;
+  /** Which described ref this target satisfies (index into the refs array). */
+  refIndex: number;
+  /** True when the ref is a family word — the UI says "any one works". */
+  generic: boolean;
+}
+
+/** Family-word refs expand to these product labels for the connect rows. */
+const FAMILY_PRODUCTS: Record<string, string[]> = {
+  "a CRM (HubSpot, Salesforce, Pipedrive…)": [
+    "HubSpot",
+    "Salesforce",
+    "Pipedrive",
+  ],
+};
+
+function bestCatalogMatch(
+  label: string,
+  items: IntegrationCatalogItem[],
+): IntegrationCatalogItem | null {
+  if (items.length === 0) return null;
+  const needle = label.trim().toLowerCase();
+  return (
+    items.find(
+      (i) =>
+        i.name.trim().toLowerCase() === needle ||
+        i.platform.trim().toLowerCase() === needle,
+    ) ?? items[0]
+  );
+}
+
+/**
+ * Resolve the gate's connect rows against the live catalog: canonical
+ * platform slug, provider, brand logo, and current connected state per
+ * offerable product. Unresolvable labels are dropped (the workspace-data
+ * path still covers them); any API failure yields [] so the gate can fall
+ * back to its two-button form rather than block.
+ */
+export async function resolveGateTargets(
+  refs: DescribedIntegration[],
+): Promise<GateConnectTarget[]> {
+  const out: GateConnectTarget[] = [];
+  await Promise.all(
+    refs.map(async (ref, refIndex) => {
+      const labels = ref.generic
+        ? (FAMILY_PRODUCTS[ref.label] ?? ref.platforms)
+        : [ref.label];
+      await Promise.all(
+        labels.map(async (label) => {
+          try {
+            const res = await listIntegrations({ search: label, limit: 5 });
+            const match = bestCatalogMatch(label, res.items ?? []);
+            if (!match) return;
+            out.push({
+              label: match.name || label,
+              platform: match.platform,
+              provider: match.provider || "composio",
+              logoUrl: match.logo_url,
+              connected:
+                match.state === "connected" ||
+                (match.connections?.length ?? 0) > 0,
+              refIndex,
+              generic: Boolean(ref.generic),
+            });
+          } catch {
+            // Dropped — see above.
+          }
+        }),
+      );
+    }),
+  );
+  // Stable order: by ref, then label, so rows don't jump between resolves.
+  return out.sort(
+    (a, b) => a.refIndex - b.refIndex || a.label.localeCompare(b.label),
+  );
 }

--- a/web/src/operator/surfaces/AppBuilderChat.tsx
+++ b/web/src/operator/surfaces/AppBuilderChat.tsx
@@ -10,13 +10,10 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { ArrowRight, Check, Send, X } from "lucide-react";
 
 import { type CustomApp, listApps, submitAppEdit } from "../../api/apps";
+import type { AgentRequest } from "../../api/client";
 import { AppActivity } from "../../components/apps/AppActivity";
+import { ConnectIntegrationCard } from "../../components/messages/ConnectIntegrationCard";
 import { tryCreateRoutine } from "../agents/agentStateClient";
-import {
-  type DescribedIntegration,
-  describedIntegrations,
-  missingIntegrations,
-} from "../builder/describedIntegrations";
 import { capturePromptSeed, type DemoCapture } from "../apps/demoCapture";
 import {
   appBuildState,
@@ -24,6 +21,13 @@ import {
   resolveNewAppId,
   useBuildApp,
 } from "../apps/useOperatorApps";
+import {
+  type DescribedIntegration,
+  describedIntegrations,
+  type GateConnectTarget,
+  missingIntegrations,
+  resolveGateTargets,
+} from "../builder/describedIntegrations";
 import { Eyebrow } from "../components/primitives";
 import { buildToolFromChat } from "../tools/toolAgentClient";
 
@@ -90,6 +94,29 @@ interface AppBuilderChatProps {
   initialPrompt?: string;
 }
 
+// A synthetic `connect` request so ConnectIntegrationCard can drive the real
+// connect flow (Composio sign-in gate + OAuth + status polling) for one gate
+// row. Local id — the card never answers a real broker request here.
+function gateConnectRequest(target: GateConnectTarget): AgentRequest {
+  return {
+    id: `build-gate-connect-${target.provider}-${target.platform}`,
+    from: "",
+    question: "",
+    title: `Connect ${target.label}`,
+    platform: target.platform,
+    kind: "connect",
+  };
+}
+
+/** Labels of gate refs the catalog offered NO connect row for. */
+function gateUnconnectable(gate: {
+  missing: DescribedIntegration[];
+  targets: GateConnectTarget[];
+}): string[] {
+  const connectable = new Set(gate.targets.map((t) => t.refIndex));
+  return gate.missing.filter((_, i) => !connectable.has(i)).map((m) => m.label);
+}
+
 export function AppBuilderChat({
   onClose,
   onFinish,
@@ -146,6 +173,9 @@ export function AppBuilderChat({
     description: string;
     display?: string;
     missing: DescribedIntegration[];
+    /** Catalog-resolved connect rows (logo + name + Connect). Empty → the
+     *  gate falls back to its two-button text form. */
+    targets: GateConnectTarget[];
   } | null>(null);
   // App ids we have OBSERVED in a "building" state during this in-flight build.
   // A new build only completes on a building -> terminal transition: without
@@ -185,6 +215,7 @@ export function AppBuilderChat({
     return () => window.clearInterval(tick);
   }, [phase, queryClient]);
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: say/setupDemoExtras are instance functions; completion re-evaluates on poll data and phase
   useEffect(() => {
     if (phase !== "building") return;
     const apps = appsQuery.data ?? [];
@@ -252,7 +283,7 @@ export function AppBuilderChat({
     // build, which creates its own captured routine) gets a starter routine —
     // the described workflow on a weekly schedule. Told, not asked: the chat
     // reports it with a one-line veto path (pause on the Routines tab).
-    if (!failed && !refineId && !demo && starterRoutineRef.current) {
+    if (!(failed || refineId || demo) && starterRoutineRef.current) {
       const routinePrompt = starterRoutineRef.current;
       starterRoutineRef.current = null;
       void (async () => {
@@ -281,7 +312,7 @@ export function AppBuilderChat({
             : `“${appName}” is ready. Tell me any change to refine it, or open it.`,
       },
     ]);
-  }, [appsQuery.data, phase, appName, onBuildingApp]);
+  }, [appsQuery.data, phase, appName, onBuildingApp, demo]);
 
   const lastMsgId = messages[messages.length - 1]?.id;
   // biome-ignore lint/correctness/useExhaustiveDependencies: scroll on each new message
@@ -307,6 +338,65 @@ export function AppBuilderChat({
     demoStartedRef.current = true;
     void send(capturePromptSeed(demo), { display: demo.goal });
   }, []);
+
+  // While the gate is open, watch for the referenced integrations landing —
+  // the moment every described system is connected (via the rows below, or
+  // anywhere else in the product) the build proceeds with the ORIGINAL
+  // description. The operator already pressed Send; connecting was the only
+  // thing in the way.
+  const gateRefs = pendingGate?.missing ?? null;
+  const gateTargets = pendingGate?.targets ?? null;
+  // Mirror the gate in a ref so the interval can read-and-consume it without
+  // side effects inside a state updater (StrictMode double-invokes updaters —
+  // a send() in there could fire two builds).
+  const pendingGateRef = useRef(pendingGate);
+  pendingGateRef.current = pendingGate;
+  // biome-ignore lint/correctness/useExhaustiveDependencies: send/say are instance functions; the poll re-arms only when the gate changes
+  useEffect(() => {
+    if (!(gateRefs && gateTargets) || gateTargets.length === 0) return;
+    // Only refs with an offerable connect row can ever flip to connected in
+    // this card. Refs the catalog could not resolve (no row) must not hold
+    // the build hostage — they ride along as an honest note instead.
+    const connectable = new Set(gateTargets.map((t) => t.refIndex));
+    let cancelled = false;
+    let proceeding = false;
+    const tick = window.setInterval(() => {
+      void missingIntegrations(gateRefs).then((still) => {
+        if (cancelled || proceeding) return;
+        const stillLabels = new Set(still.map((m) => m.label));
+        const blocked = gateRefs.some(
+          (ref, i) => connectable.has(i) && stillLabels.has(ref.label),
+        );
+        if (blocked) return;
+        const gate = pendingGateRef.current;
+        if (!gate) return;
+        proceeding = true;
+        setPendingGate(null);
+        const leftover = gate.missing.filter((m) => stillLabels.has(m.label));
+        say(
+          leftover.length > 0
+            ? "Connected — building it now (the rest rides along as a note)."
+            : "All connected — building it now.",
+        );
+        const description =
+          leftover.length > 0
+            ? `${gate.description}\n\nNote: ${leftover
+                .map((m) => m.label)
+                .join(", ")} ${
+                leftover.length === 1 ? "is" : "are"
+              } not connected in this workspace yet. Ground that part in live workspace data for now, say so plainly in the app, and structure it so the integration can be wired in once connected.`
+            : gate.description;
+        void send(description, {
+          display: gate.display ?? gate.description,
+          skipIntegrationGate: true,
+        });
+      });
+    }, 4_000);
+    return () => {
+      cancelled = true;
+      window.clearInterval(tick);
+    };
+  }, [gateRefs, gateTargets]);
 
   // The onboarding first-workflow handoff starts the build the same way: the
   // user already pressed "Start your first workflow", so the text is sent as
@@ -397,12 +487,18 @@ export function AppBuilderChat({
     // systems that are not connected, hold the send and put the choice to the
     // operator instead of letting the builder silently re-scope the job onto
     // whatever data it can reach.
-    if (!opts?.skipIntegrationGate && !(editApp?.id ?? newAppId) && !demo) {
+    if (!(opts?.skipIntegrationGate || (editApp?.id ?? newAppId) || demo)) {
       const refs = describedIntegrations(description);
       const missing = await missingIntegrations(refs);
       if (missing.length > 0) {
+        const targets = await resolveGateTargets(missing);
         setDraft("");
-        setPendingGate({ description, display: opts?.display, missing });
+        setPendingGate({
+          description,
+          display: opts?.display,
+          missing,
+          targets: targets.filter((t) => !t.connected),
+        });
         return;
       }
     }
@@ -518,22 +614,67 @@ export function AppBuilderChat({
             <div className="opr-edit-msgwrap">
               <div className="opr-msg opr-msg-ai opr-gate-card">
                 <div>
-                  This workflow mentions{" "}
-                  {pendingGate.missing.map((m) => m.label).join(" and ")} — not
-                  connected yet. I can build against your live workspace data
-                  now and wire {pendingGate.missing.length === 1 ? "it" : "them"}{" "}
-                  in when you connect, or hold on while you connect first.
+                  {pendingGate.targets.length > 0 ? (
+                    <>
+                      This workflow needs{" "}
+                      {pendingGate.missing.map((m) => m.label).join(" and ")} —
+                      not connected yet. Connect below and I will build the
+                      moment everything is live — or build against your
+                      workspace data now.
+                      {pendingGate.missing.some((m) => m.generic) ? (
+                        <> For the CRM, any one of the options works.</>
+                      ) : null}
+                      {gateUnconnectable(pendingGate).length > 0 ? (
+                        <>
+                          {" "}
+                          ({gateUnconnectable(pendingGate).join(", ")}{" "}
+                          {gateUnconnectable(pendingGate).length === 1
+                            ? "has"
+                            : "have"}{" "}
+                          no one-click connect yet — it rides along as an honest
+                          note either way.)
+                        </>
+                      ) : null}
+                    </>
+                  ) : (
+                    <>
+                      This workflow mentions{" "}
+                      {pendingGate.missing.map((m) => m.label).join(" and ")} —
+                      not connected yet. I can build against your live workspace
+                      data now and wire{" "}
+                      {pendingGate.missing.length === 1 ? "it" : "them"} in when
+                      you connect, or hold on while you connect first.
+                    </>
+                  )}
                 </div>
+                {pendingGate.targets.length > 0 ? (
+                  <ul className="opr-gate-connect-list">
+                    {pendingGate.targets.map((t) => (
+                      <li
+                        key={`${t.provider}:${t.platform}`}
+                        className="opr-gate-connect-row"
+                      >
+                        <ConnectIntegrationCard
+                          request={gateConnectRequest(t)}
+                          submitting={false}
+                          logoUrl={t.logoUrl}
+                          onSkip={() => {}}
+                          onDismiss={() => {}}
+                        />
+                      </li>
+                    ))}
+                  </ul>
+                ) : null}
                 <div className="opr-gate-actions">
                   <button
                     type="button"
-                    className="opr-btn opr-btn-primary opr-btn-sm"
+                    className={`opr-btn opr-btn-sm${
+                      pendingGate.targets.length > 0 ? "" : " opr-btn-primary"
+                    }`}
                     onClick={() => {
                       const gate = pendingGate;
                       setPendingGate(null);
-                      const names = gate.missing
-                        .map((m) => m.label)
-                        .join(", ");
+                      const names = gate.missing.map((m) => m.label).join(", ");
                       void send(
                         `${gate.description}\n\nNote: ${names} ${
                           gate.missing.length === 1 ? "is" : "are"
@@ -547,22 +688,24 @@ export function AppBuilderChat({
                   >
                     Build with workspace data
                   </button>
-                  <button
-                    type="button"
-                    className="opr-btn opr-btn-sm"
-                    onClick={() => {
-                      const gate = pendingGate;
-                      setPendingGate(null);
-                      // Put the described workflow back in the composer so
-                      // nothing typed is lost while they go connect.
-                      setDraft(gate.description);
-                      say(
-                        "Holding off. Connect it from any agent's Integrations tab (connections are shared across the office) — your description is still in the composer for when you are back.",
-                      );
-                    }}
-                  >
-                    I will connect it first
-                  </button>
+                  {pendingGate.targets.length === 0 ? (
+                    <button
+                      type="button"
+                      className="opr-btn opr-btn-sm"
+                      onClick={() => {
+                        const gate = pendingGate;
+                        setPendingGate(null);
+                        // Put the described workflow back in the composer so
+                        // nothing typed is lost while they go connect.
+                        setDraft(gate.description);
+                        say(
+                          "Holding off. Connect it from any agent's Integrations tab (connections are shared across the office) — your description is still in the composer for when you are back.",
+                        );
+                      }}
+                    >
+                      I will connect it first
+                    </button>
+                  ) : null}
                 </div>
               </div>
             </div>

--- a/web/src/styles/global.css
+++ b/web/src/styles/global.css
@@ -1048,6 +1048,14 @@ body {
   border: 1px solid var(--border);
   box-shadow: 0 1px 2px var(--overlay-soft);
 }
+
+/* Catalog brand logo inside the connect card's logo tile. */
+.eac-logo-img {
+  width: 28px;
+  height: 28px;
+  object-fit: contain;
+  display: block;
+}
 .eac-headings {
   display: flex;
   flex-direction: column;

--- a/web/src/styles/operator-shell.css
+++ b/web/src/styles/operator-shell.css
@@ -4862,3 +4862,48 @@
   gap: var(--space-1-5);
   flex-wrap: wrap;
 }
+
+/* Gate v2: per-integration connect rows inside the build gate. The embedded
+   ConnectIntegrationCard is the full product connect card; in the gate it
+   reads as a row, so compact its chrome without forking the component. */
+.opr-gate-connect-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1-5);
+}
+.opr-gate-connect-row .eac {
+  margin: 0;
+  padding: 10px 12px;
+  background: var(--t-figure-bg);
+  border: 1px solid var(--t-line);
+  border-radius: var(--t-r-sm);
+}
+.opr-gate-connect-row .eac-head {
+  margin: 0;
+  align-items: center;
+}
+.opr-gate-connect-row .eac-eyebrow,
+.opr-gate-connect-row .eac-connect-sub,
+.opr-gate-connect-row .eac-connect-question {
+  display: none;
+}
+.opr-gate-connect-row .eac-headline {
+  font-size: 13.5px;
+  margin: 0;
+}
+.opr-gate-connect-row .eac-logo-img {
+  width: 22px;
+  height: 22px;
+  object-fit: contain;
+  display: block;
+}
+
+/* Inside the gate the card's Skip/Dismiss are noise — the gate's own
+   "Build with workspace data" is the one escape hatch. */
+.opr-gate-connect-row .eac-reject,
+.opr-gate-connect-row .eac-dismiss {
+  display: none;
+}


### PR DESCRIPTION
The ask-before-building gate now offers the fix, not just the choice: every missing integration renders as a row — catalog logo, name, and a live **Connect** button (the existing ConnectIntegrationCard end to end: Composio sign-in gate → OAuth → status polling).

- Generic family refs expand to products: "audit our CRM" offers **HubSpot / Salesforce / Pipedrive**, any one works.
- **Auto-proceed:** a 4s poll watches the described integrations; the moment every connectable ref is live, the build fires with the original description. Unresolvable refs (not in the catalog) never block — they ride along as the honest workspace-data note.
- StrictMode-safe (gate consumed via ref mirror, no side effects in state updaters). Skip/Dismiss hidden in gate rows; "Build with workspace data" stays the one escape hatch.

## Test plan
- [x] tsc clean, biome 0 errors, operator suite 193/193
- [x] Live: 3 logo'd rows for "audit our CRM … post to Slack" (Slack SVG, HubSpot catalog logo, Salesforce), sign-in-chained connect labels, escape hatch present
- [x] Live: unresolvable ref (Stripe on keyless catalog) degrades to the note path instead of blocking auto-proceed
- [ ] CI green

![gate](https://raw.githubusercontent.com/najmuzzaman-mohammad/wuphf/screenshots/pr-1186/integration-gate.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VMKUf7PCLHtjSa6kUwuvtF