### PR TITLE
feat(operator): connect affordances where the need appears; lean app-builder toolset

### DIFF
--- a/internal/team/headless_codex_recovery.go
+++ b/internal/team/headless_codex_recovery.go
@@ -78,6 +78,15 @@ func (l *Launcher) headlessTurnCompletedDurably(slug string, active *headlessCod
 	if task != nil && taskHasDurableCompletionState(task) {
 		return true, ""
 	}
+	// The App Builder's durable evidence IS the app registry: a manifest
+	// created or republished during this turn proves the work landed, no
+	// office task-state write required. Without this, every successful build
+	// was judged by office-agent evidence (task writes, channel posts) the
+	// App Builder never produces, got "blocked", and burned a retry turn —
+	// observed on every build in the 2026-08-15 QA pass.
+	if isAppBuilderSlug(slug) && l.appRegistryTouchedSince(active.StartedAt) {
+		return true, ""
+	}
 	if l.agentPostedSubstantiveMessageSince(slug, active.StartedAt) {
 		return true, ""
 	}
@@ -444,4 +453,29 @@ func (l *Launcher) timedOutTurnAlreadyRecovered(task *teamTask, slug string, sta
 			review == "ready_for_review" || review == "approved"
 	}
 	return l.agentPostedSubstantiveMessageSince(slug, startedAt)
+}
+
+// appRegistryTouchedSince reports whether any custom app's manifest was
+// created or updated at/after t — the App Builder's durable-completion
+// evidence. Manifest stamps are RFC3339; unparseable stamps are skipped.
+func (l *Launcher) appRegistryTouchedSince(t time.Time) bool {
+	if l == nil || l.broker == nil || t.IsZero() {
+		return false
+	}
+	apps, err := l.broker.appStore().List()
+	if err != nil {
+		return false
+	}
+	for _, app := range apps {
+		for _, stamp := range []string{app.UpdatedAt, app.CreatedAt} {
+			ts, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(stamp))
+			if err != nil {
+				continue
+			}
+			if !ts.Before(t) {
+				return true
+			}
+		}
+	}
+	return false
 }

--- a/internal/teammcp/server.go
+++ b/internal/teammcp/server.go
@@ -8,6 +8,7 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
 	"github.com/nex-crm/wuphf/internal/action"
+	"github.com/nex-crm/wuphf/internal/company"
 	"github.com/nex-crm/wuphf/internal/config"
 	"github.com/nex-crm/wuphf/internal/team"
 )
@@ -225,6 +226,42 @@ func configureServerTools(server *mcp.Server, slug string, channel string, oneOn
 		if isLead || isLibrarian {
 			registerWikiLinkTool(server)
 		}
+		if hasActionProvider() {
+			registerActionTools(server)
+		}
+		return
+	}
+
+	// App Builder: the operator-era build agent. It has no teammates and no
+	// user-visible channel — the 2026-08-15 QA pass showed it never calls the
+	// office coordination tools (inbox/outbox/status/members/channels/DMs/
+	// shared tasks), which cost ~100k tokens of schema per turn anyway. It
+	// keeps a voice (team_broadcast feeds the edit-channel wake loop and the
+	// durability heuristics), the human-facing request tools, context/memory
+	// grounding, its app publish tools, and external actions. The office
+	// coordination surface is deliberately absent: every agent is its own
+	// surface now, and there is no office UI left to read those posts.
+	if slug == company.AppBuilderSlug {
+		mcp.AddTool(server, officeWriteTool(
+			"team_broadcast",
+			"Post a progress note to the build channel.",
+		), handleTeamBroadcast)
+		mcp.AddTool(server, readOnlyTool(
+			"team_poll",
+			"Read recent messages in the build channel (e.g. the operator's edit request).",
+		), handleTeamPoll)
+		mcp.AddTool(server, officeWriteTool(
+			"team_request",
+			"Create a structured request for the human: confirmation, choice, approval, freeform answer, or private/secret answer.",
+		), handleTeamRequest)
+		mcp.AddTool(server, officeWriteTool(
+			"human_message",
+			"Send a direct note to the human.",
+		), handleHumanMessage)
+		registerContextTools(server)
+		registerSharedMemoryTools(server)
+		registerRoutineTools(server)
+		registerAppTools(server, slug)
 		if hasActionProvider() {
 			registerActionTools(server)
 		}

--- a/web/src/operator/components/AppIntegrationBanner.tsx
+++ b/web/src/operator/components/AppIntegrationBanner.tsx
@@ -1,0 +1,111 @@
+// AppIntegrationBanner — the host-side answer to an app that says "No CRM
+// connected" with nowhere to click. The sandboxed app iframe cannot reach the
+// host's connect flow, so when a READY agent's own description references
+// external systems that are not connected, the UI tab shows this banner above
+// the frame: what the agent wants, and gate-style connect rows (logo + name +
+// live Connect) to fix it in place. It disappears on its own the moment the
+// referenced systems are live — or stays hidden for this app if dismissed.
+
+import { useEffect, useState } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { X } from "lucide-react";
+
+import type { CustomApp } from "../../api/apps";
+import {
+  describedIntegrations,
+  type GateConnectTarget,
+  missingIntegrations,
+  resolveGateTargets,
+} from "../builder/describedIntegrations";
+import { IntegrationConnectRows } from "./IntegrationConnectRows";
+
+const DISMISS_KEY_PREFIX = "wuphf.operator.integrationBanner.dismissed.";
+
+function isDismissed(appId: string): boolean {
+  try {
+    return window.localStorage.getItem(DISMISS_KEY_PREFIX + appId) === "1";
+  } catch {
+    return false;
+  }
+}
+
+export function AppIntegrationBanner({ app }: { app: CustomApp }) {
+  const [dismissed, setDismissed] = useState(() => isDismissed(app.id));
+  const queryClient = useQueryClient();
+
+  // What the agent's own words say it wants, minus what is connected. Polled
+  // gently so connecting (here or anywhere else) clears the banner without a
+  // reload. Resolves [] on any API failure — the banner never blocks the app.
+  const refs = describedIntegrations(
+    `${app.summary ?? ""} ${app.description ?? ""}`,
+  );
+  const wanted = useQuery({
+    queryKey: ["app-integration-banner", app.id],
+    enabled: !dismissed && refs.length > 0,
+    queryFn: async (): Promise<GateConnectTarget[]> => {
+      const missing = await missingIntegrations(refs);
+      if (missing.length === 0) return [];
+      const targets = await resolveGateTargets(missing);
+      return targets.filter((t) => !t.connected);
+    },
+    refetchInterval: (query) =>
+      (query.state.data?.length ?? 0) > 0 ? 5_000 : false,
+    staleTime: 0,
+  });
+
+  const targets = wanted.data ?? [];
+
+  // The moment everything lands, refresh the app frame's dependents so the
+  // app itself can pick up the new connections on its next data read.
+  useEffect(() => {
+    if (wanted.isSuccess && targets.length === 0) {
+      void queryClient.invalidateQueries({
+        queryKey: ["operator-app", app.id],
+      });
+    }
+  }, [wanted.isSuccess, targets.length, queryClient, app.id]);
+
+  if (dismissed || refs.length === 0 || targets.length === 0) return null;
+
+  const labels = refs.map((r) => r.label);
+  const joined =
+    labels.length <= 1
+      ? labels.join("")
+      : labels.length === 2
+        ? labels.join(" and ")
+        : `${labels.slice(0, -1).join(", ")}, and ${labels[labels.length - 1]}`;
+  // "Any one is enough" applies when the refs are a family — either the
+  // generic word ("a CRM") or several named products from the same family.
+  const CRM_FAMILY = new Set(["hubspot", "salesforce", "pipedrive"]);
+  const familyOnly =
+    refs.some((r) => r.generic) ||
+    (refs.length > 1 &&
+      refs.every((r) => r.platforms.some((p) => CRM_FAMILY.has(p))));
+  return (
+    <div className="opr-app-int-banner">
+      <div className="opr-app-int-banner-head">
+        <span className="opr-app-int-banner-lead">
+          This agent wants {joined} — connect below and it runs on live data.
+          {familyOnly ? " Any one CRM is enough." : ""}
+        </span>
+        <button
+          type="button"
+          className="opr-icon-btn"
+          aria-label="Dismiss — keep running on workspace data"
+          title="Dismiss — keep running on workspace data"
+          onClick={() => {
+            setDismissed(true);
+            try {
+              window.localStorage.setItem(DISMISS_KEY_PREFIX + app.id, "1");
+            } catch {
+              // Session-only dismiss is fine.
+            }
+          }}
+        >
+          <X size={14} strokeWidth={1.9} aria-hidden={true} />
+        </button>
+      </div>
+      <IntegrationConnectRows targets={targets} />
+    </div>
+  );
+}

--- a/web/src/operator/components/IntegrationConnectRows.tsx
+++ b/web/src/operator/components/IntegrationConnectRows.tsx
@@ -1,0 +1,48 @@
+// The gate-style connect rows: one row per catalog-resolved integration —
+// logo, name, and a live Connect button (the full ConnectIntegrationCard
+// flow: Composio sign-in gate → OAuth → status polling). Shared between the
+// build gate (AppBuilderChat) and the app-detail integration banner so both
+// surfaces offer the fix, not just the observation.
+
+import type { AgentRequest } from "../../api/client";
+import { ConnectIntegrationCard } from "../../components/messages/ConnectIntegrationCard";
+import type { GateConnectTarget } from "../builder/describedIntegrations";
+
+// A synthetic `connect` request so ConnectIntegrationCard can drive the real
+// connect flow for one row. Local id — never answers a real broker request.
+function connectRequest(target: GateConnectTarget): AgentRequest {
+  return {
+    id: `connect-row-${target.provider}-${target.platform}`,
+    from: "",
+    question: "",
+    title: `Connect ${target.label}`,
+    platform: target.platform,
+    kind: "connect",
+  };
+}
+
+export function IntegrationConnectRows({
+  targets,
+}: {
+  targets: GateConnectTarget[];
+}) {
+  if (targets.length === 0) return null;
+  return (
+    <ul className="opr-gate-connect-list">
+      {targets.map((t) => (
+        <li
+          key={`${t.provider}:${t.platform}`}
+          className="opr-gate-connect-row"
+        >
+          <ConnectIntegrationCard
+            request={connectRequest(t)}
+            submitting={false}
+            logoUrl={t.logoUrl}
+            onSkip={() => {}}
+            onDismiss={() => {}}
+          />
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/web/src/operator/surfaces/AppBuilderChat.tsx
+++ b/web/src/operator/surfaces/AppBuilderChat.tsx
@@ -10,9 +10,7 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { ArrowRight, Check, Send, X } from "lucide-react";
 
 import { type CustomApp, listApps, submitAppEdit } from "../../api/apps";
-import type { AgentRequest } from "../../api/client";
 import { AppActivity } from "../../components/apps/AppActivity";
-import { ConnectIntegrationCard } from "../../components/messages/ConnectIntegrationCard";
 import { tryCreateRoutine } from "../agents/agentStateClient";
 import { capturePromptSeed, type DemoCapture } from "../apps/demoCapture";
 import {
@@ -28,6 +26,7 @@ import {
   missingIntegrations,
   resolveGateTargets,
 } from "../builder/describedIntegrations";
+import { IntegrationConnectRows } from "../components/IntegrationConnectRows";
 import { Eyebrow } from "../components/primitives";
 import { buildToolFromChat } from "../tools/toolAgentClient";
 
@@ -92,20 +91,6 @@ interface AppBuilderChatProps {
    * workflow" CTA that carried it here. Ignored in edit/demo mode.
    */
   initialPrompt?: string;
-}
-
-// A synthetic `connect` request so ConnectIntegrationCard can drive the real
-// connect flow (Composio sign-in gate + OAuth + status polling) for one gate
-// row. Local id — the card never answers a real broker request here.
-function gateConnectRequest(target: GateConnectTarget): AgentRequest {
-  return {
-    id: `build-gate-connect-${target.provider}-${target.platform}`,
-    from: "",
-    question: "",
-    title: `Connect ${target.label}`,
-    platform: target.platform,
-    kind: "connect",
-  };
 }
 
 /** Labels of gate refs the catalog offered NO connect row for. */
@@ -648,22 +633,7 @@ export function AppBuilderChat({
                   )}
                 </div>
                 {pendingGate.targets.length > 0 ? (
-                  <ul className="opr-gate-connect-list">
-                    {pendingGate.targets.map((t) => (
-                      <li
-                        key={`${t.provider}:${t.platform}`}
-                        className="opr-gate-connect-row"
-                      >
-                        <ConnectIntegrationCard
-                          request={gateConnectRequest(t)}
-                          submitting={false}
-                          logoUrl={t.logoUrl}
-                          onSkip={() => {}}
-                          onDismiss={() => {}}
-                        />
-                      </li>
-                    ))}
-                  </ul>
+                  <IntegrationConnectRows targets={pendingGate.targets} />
                 ) : null}
                 <div className="opr-gate-actions">
                   <button

--- a/web/src/operator/surfaces/AppToolsTab.tsx
+++ b/web/src/operator/surfaces/AppToolsTab.tsx
@@ -7,7 +7,7 @@
 // docs/specs/operator-workflows-as-tools.md.
 
 import { useState } from "react";
-import { ChevronDown, Wrench } from "lucide-react";
+import { ChevronDown, Sparkles, Wrench } from "lucide-react";
 
 import { Eyebrow } from "../components/primitives";
 import type { Tool } from "../tools/mockTools";
@@ -15,9 +15,11 @@ import { useAppTools } from "../tools/toolsContext";
 
 interface AppToolsTabProps {
   appName: string;
+  /** Open the agent's chat (the Ask Agent dock) — where tools are taught. */
+  onTeach?: () => void;
 }
 
-export function AppToolsTab({ appName }: AppToolsTabProps) {
+export function AppToolsTab({ appName, onTeach }: AppToolsTabProps) {
   const { tools } = useAppTools();
   const [openId, setOpenId] = useState<string | null>(null);
 
@@ -32,9 +34,27 @@ export function AppToolsTab({ appName }: AppToolsTabProps) {
       </div>
 
       {tools.length === 0 ? (
-        <div className="opr-empty-hint">
-          No tools yet. Open the chat and teach {appName} a task — it'll build a
-          tool for it.
+        <div className="opr-empty">
+          <span className="opr-empty-glyph" aria-hidden={true}>
+            <Wrench size={16} strokeWidth={1.9} />
+          </span>
+          <div className="opr-empty-title">No tools yet</div>
+          <div className="opr-empty-hint">
+            Teach {appName} a task in its chat — "score a lead", "draft the
+            follow-up" — and it writes the tool for it.
+          </div>
+          {onTeach ? (
+            <div className="opr-empty-actions">
+              <button
+                type="button"
+                className="opr-btn opr-btn-primary opr-btn-sm"
+                onClick={onTeach}
+              >
+                <Sparkles size={13} strokeWidth={1.9} aria-hidden={true} />
+                Teach a tool in chat
+              </button>
+            </div>
+          ) : null}
         </div>
       ) : (
         <div className="opr-tool-catalog">

--- a/web/src/operator/surfaces/OperatorAppDetail.tsx
+++ b/web/src/operator/surfaces/OperatorAppDetail.tsx
@@ -5,8 +5,8 @@
 // produced (md/html/pdf) collected below the app.
 
 import { useEffect, useRef, useState } from "react";
-import { useQueryClient } from "@tanstack/react-query";
 import type { UseQueryResult } from "@tanstack/react-query";
+import { useQueryClient } from "@tanstack/react-query";
 import {
   ArrowLeft,
   ChevronsLeft,
@@ -35,6 +35,7 @@ import {
 } from "../apps/useOperatorApps";
 import { ArtifactsTab } from "../artifacts/ArtifactsTab";
 import type { Artifact } from "../artifacts/artifacts";
+import { AppIntegrationBanner } from "../components/AppIntegrationBanner";
 import { EmptyState } from "../components/EmptyState";
 import { Eyebrow, type TabDef, Tabs } from "../components/primitives";
 import { RoutinesTab } from "../routines/RoutinesTab";
@@ -299,6 +300,7 @@ export function OperatorAppDetail({
                   setRequestedSession(sessionId);
                   setChatOpen(true);
                 }}
+                onOpenChat={() => setChatOpen(true)}
               />
             ) : null}
           </div>
@@ -429,11 +431,14 @@ function TabBody({
   appId,
   query,
   onOpenRoutineSession,
+  onOpenChat,
 }: {
   tab: AppTab;
   appId: string;
   query: UseQueryResult<CustomAppDetail>;
   onOpenRoutineSession?: (sessionId: string) => void;
+  /** Open the Ask Agent dock — the Tools tab's teach affordance. */
+  onOpenChat?: () => void;
 }) {
   const app = query.data?.app;
   switch (tab) {
@@ -446,7 +451,9 @@ function TabBody({
         />
       );
     case "tools":
-      return <AppToolsTab appName={app?.name ?? "This app"} />;
+      return (
+        <AppToolsTab appName={app?.name ?? "This app"} onTeach={onOpenChat} />
+      );
     case "data":
       return app ? (
         <AppDataTab appId={app.id} />
@@ -538,6 +545,9 @@ function UiTab({
   if (ready) {
     return (
       <div className="opr-app-frame">
+        {/* Host-side connect affordance: the sandboxed app can say "no CRM
+            connected" but cannot offer the fix — this banner can. */}
+        <AppIntegrationBanner app={app} />
         <CustomAppFrame appId={app.id} title={app.name} html={detail.html} />
       </div>
     );

--- a/web/src/styles/operator-shell.css
+++ b/web/src/styles/operator-shell.css
@@ -4907,3 +4907,28 @@
 .opr-gate-connect-row .eac-dismiss {
   display: none;
 }
+
+/* Host-side integration banner above a ready app's frame — the app can say
+   "no CRM connected"; only the host can offer the fix. */
+.opr-app-int-banner {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding: 12px 14px;
+  margin-bottom: var(--space-2);
+  border: 1px solid color-mix(in srgb, var(--t-yellow) 40%, var(--t-line));
+  border-left: 3px solid var(--t-yellow);
+  border-radius: var(--t-r-sm);
+  background: color-mix(in srgb, var(--t-yellow) 6%, var(--t-surface));
+}
+.opr-app-int-banner-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--space-2);
+}
+.opr-app-int-banner-lead {
+  font-size: 13.5px;
+  line-height: 1.55;
+  color: var(--t-ink);
+}


### PR DESCRIPTION
QA follow-up on "the CRM agent says no CRM connected with no way to connect on the UI" + the team-tools question.

1. **UI-tab integration banner** — when a ready agent's description references unconnected systems, the host shows connect rows (logo + name + live Connect) above the sandboxed frame; disappears when connected, dismissible per-app.
2. **Tools tab** — dead-end text becomes an empty state with a "Teach a tool in chat" button that opens the Ask Agent dock.
3. **Lean App Builder toolset** — the build agent registered the full office coordination surface (~27 tools / ~125k schema tokens per turn) and provably called none of it. Now: broadcast/poll, human request tools, context/memory, app publish tools, actions. Office tools stay for office-era agents until the office-deletion PR.
4. **Durability gate** — the App Builder's durable evidence is the app registry (manifest created/republished during the turn). Kills the false "blocked" + retry that every build paid for.

## Test plan
- [x] go test ./internal/team ./internal/teammcp green; golangci-lint 0 issues
- [x] operator web suite 193/193; tsc + biome clean
- [x] Live: banner with real HubSpot/Salesforce/Pipedrive logos + working connect buttons on the CRM Hygiene Agent; teach affordance opens the dock
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VMKUf7PCLHtjSa6kUwuvtF