### PR TITLE
fix: first-run experience — build survivability, honest onboarding, server-owned starter routine

### DIFF
--- a/internal/onboarding/verify.go
+++ b/internal/onboarding/verify.go
@@ -171,7 +171,7 @@ func InstallSteps(name string) []InstallStep {
 			},
 			{
 				Title:   "Sign in to Claude",
-				Detail:  "Sign in once and the office can run turns on your account.",
+				Detail:  "Sign in once and your agents run on your account.",
 				Command: signInCmd,
 			},
 			{

--- a/internal/team/broker_apps.go
+++ b/internal/team/broker_apps.go
@@ -74,6 +74,9 @@ func (b *Broker) handleApps(w http.ResponseWriter, r *http.Request) {
 		// of compiling on demand while the operator watches. Fail-safe; the
 		// on-demand compile remains as the fallback.
 		go b.precompileAppWorkflowAsync(app.ID)
+		// First human build -> mint the starter routine server-side (the FE
+		// chat used to own this and lost it whenever it unmounted mid-build).
+		go b.mintStarterRoutineForFirstBuild(app)
 		// A republish rewrites the source and may change the dependency set, so
 		// any running live-preview server is now stale. Stop it and pre-warm a
 		// fresh one in the background: the new deps (e.g. the refine stack)

--- a/internal/team/broker_apps_starter_routine.go
+++ b/internal/team/broker_apps_starter_routine.go
@@ -1,0 +1,167 @@
+package team
+
+import (
+	"fmt"
+	"log"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/nex-crm/wuphf/internal/calendar"
+)
+
+// Starter routine for a first build — SERVER-side.
+//
+// The described workflow IS the recurring job, so a brand-new operator-built
+// agent gets one standing routine minted from its build description. This
+// used to live in the builder chat's completion effect (FE), which only fired
+// while that chat stayed mounted: the 2026-08-16 fresh-workspace QA pass lost
+// the starter routine because the operator navigated away (and the broker
+// restarted) before the build landed. Registration is the durable completion
+// signal, so the mint belongs here.
+
+// starterScheduleRule maps described-cadence phrasing to a cron expr and the
+// label prefix the Routines tab shows. First match wins; the FE's old
+// hardcoded Monday-9:00 stays as the default.
+var starterScheduleRules = []struct {
+	re     *regexp.Regexp
+	expr   string
+	prefix string
+}{
+	{regexp.MustCompile(`(?i)\bevery\s+(week\s?day|business day|work\s?day)|weekday (morning|afternoon)s?\b`), "0 9 * * 1-5", "Weekday"},
+	{regexp.MustCompile(`(?i)\b(every|each)\s+(day|morning|evening|night)\b|\bdaily\b`), "0 9 * * *", "Daily"},
+	{regexp.MustCompile(`(?i)\b(every|each)\s+hour\b|\bhourly\b`), "0 * * * *", "Hourly"},
+	{regexp.MustCompile(`(?i)\b(every|each)\s+monday\b`), "0 9 * * 1", "Weekly"},
+	{regexp.MustCompile(`(?i)\b(every|each)\s+tuesday\b`), "0 9 * * 2", "Weekly"},
+	{regexp.MustCompile(`(?i)\b(every|each)\s+wednesday\b`), "0 9 * * 3", "Weekly"},
+	{regexp.MustCompile(`(?i)\b(every|each)\s+thursday\b`), "0 9 * * 4", "Weekly"},
+	{regexp.MustCompile(`(?i)\b(every|each)\s+friday\b`), "0 9 * * 5", "Weekly"},
+	{regexp.MustCompile(`(?i)\b(every|each)\s+week\b|\bweekly\b`), "0 9 * * 1", "Weekly"},
+}
+
+// deriveStarterSchedule reads the operator's own cadence out of the build
+// description. Returns the cron expr and a human label prefix.
+func deriveStarterSchedule(description string) (expr, prefix string) {
+	for _, r := range starterScheduleRules {
+		if r.re.MatchString(description) {
+			return r.expr, r.prefix
+		}
+	}
+	return "0 9 * * 1", "Weekly"
+}
+
+// buildDescriptionForApp recovers the operator's original workflow text from
+// the app's build task ("Build a new internal tool named …\n\nWhat it should
+// do:\n<text>"). Falls back to the raw details, then the app summary.
+func (b *Broker) buildDescriptionForApp(app CustomApp) string {
+	taskID := strings.TrimPrefix(strings.TrimSpace(app.EditChannel), "task-")
+	if taskID == "" || taskID == app.EditChannel {
+		return ""
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	for i := range b.tasks {
+		if !strings.EqualFold(b.tasks[i].ID, taskID) {
+			continue
+		}
+		details := b.tasks[i].Details
+		if idx := strings.Index(details, "What it should do:"); idx >= 0 {
+			details = details[idx+len("What it should do:"):]
+		}
+		return strings.TrimSpace(details)
+	}
+	return ""
+}
+
+// mintStarterRoutineForFirstBuild creates the standing routine for a
+// human-initiated FIRST build (version 1). No-ops for refines, agent-created
+// apps, apps whose agent already has a routine, or descriptions we cannot
+// recover. Runs off the registration request path; failures log and stop —
+// a missing starter routine must never fail a publish.
+func (b *Broker) mintStarterRoutineForFirstBuild(app CustomApp) {
+	if app.Version != 1 || !strings.EqualFold(strings.TrimSpace(app.CreatedBy), "human") {
+		return
+	}
+	description := b.buildDescriptionForApp(app)
+	if description == "" {
+		return
+	}
+	expr, prefix := deriveStarterSchedule(description)
+	sched, err := calendar.ParseCron(expr)
+	if err != nil {
+		log.Printf("starter-routine: bad derived schedule %q: %v", expr, err)
+		return
+	}
+	now := time.Now().UTC()
+	nextRun := sched.Next(now).Format(time.RFC3339)
+
+	base := strings.TrimSpace(strings.TrimSuffix(strings.TrimSpace(app.Name), "Agent"))
+	if base == "" {
+		base = app.Name
+	}
+	label := fmt.Sprintf("%s %s run", prefix, base)
+	slug := deriveSchedulerSlugFromLabel(label)
+	if slug == "" {
+		return
+	}
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	// The agent already has a routine (a demo capture, a re-register, an
+	// operator-made one): never stack a second.
+	for i := range b.scheduler {
+		if b.scheduler[i].Kind == "agent_routine" &&
+			b.scheduler[i].TargetType == "agent" &&
+			b.scheduler[i].TargetID == app.ID {
+			return
+		}
+	}
+	taken := func(s string) bool {
+		if s == "routines" || s == "system-specs" {
+			return true
+		}
+		for i := range b.scheduler {
+			if b.scheduler[i].Slug == s {
+				return true
+			}
+		}
+		return false
+	}
+	unique := slug
+	for n := 2; taken(unique); n++ {
+		unique = fmt.Sprintf("%s-%d", slug, n)
+	}
+	job := schedulerJob{
+		Slug:         unique,
+		Kind:         "agent_routine",
+		Label:        label,
+		TargetType:   "agent",
+		TargetID:     app.ID,
+		ScheduleExpr: expr,
+		Payload:      description,
+		NextRun:      nextRun,
+		DueAt:        nextRun,
+		Status:       "scheduled",
+		Enabled:      true,
+	}
+	b.scheduler = append(b.scheduler, job)
+	rev := snapshotSchedulerRevision(job)
+	rev.ChangeNote = "Starter routine minted from the build description"
+	rev.Author = appBuilderSlug
+	saved := b.recordSchedulerRevisionLocked(unique, rev)
+	b.recordSchedulerActivityLocked(unique, schedulerActivity{
+		Kind:    "created",
+		Actor:   appBuilderSlug,
+		Summary: "Starter routine created with the new agent",
+		Detail:  fmt.Sprintf("Initial revision v%d", saved.Version),
+	})
+	if err := b.saveLocked(); err != nil {
+		for i := len(b.scheduler) - 1; i >= 0; i-- {
+			if b.scheduler[i].Slug == unique {
+				b.scheduler = append(b.scheduler[:i], b.scheduler[i+1:]...)
+				break
+			}
+		}
+		log.Printf("starter-routine: persist failed for %s: %v", app.ID, err)
+	}
+}

--- a/internal/team/broker_apps_starter_routine_test.go
+++ b/internal/team/broker_apps_starter_routine_test.go
@@ -1,0 +1,99 @@
+package team
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestDeriveStarterScheduleReadsDescribedCadence(t *testing.T) {
+	cases := []struct {
+		text   string
+		expr   string
+		prefix string
+	}{
+		{"Chase our unpaid invoices. Every weekday morning, find invoices past due.", "0 9 * * 1-5", "Weekday"},
+		{"Each morning, summarize yesterday's tickets.", "0 9 * * *", "Daily"},
+		{"Post a digest every Friday.", "0 9 * * 5", "Weekly"},
+		{"Check the queue hourly and page me.", "0 * * * *", "Hourly"},
+		{"Screen inbound applicants and keep a shortlist.", "0 9 * * 1", "Weekly"},
+	}
+	for _, c := range cases {
+		expr, prefix := deriveStarterSchedule(c.text)
+		if expr != c.expr || prefix != c.prefix {
+			t.Errorf("deriveStarterSchedule(%q) = %q/%q, want %q/%q", c.text, expr, prefix, c.expr, c.prefix)
+		}
+	}
+}
+
+// 2026-08-16 fresh-workspace QA regression: the starter routine used to be
+// minted by the builder chat (FE) and was lost whenever that chat unmounted
+// before the build landed. Registration is the durable signal — the broker
+// mints it now.
+func TestMintStarterRoutineForFirstBuild(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	b := newTestBroker(t)
+
+	b.mu.Lock()
+	b.tasks = append(b.tasks, teamTask{
+		ID:      "VANCE-2",
+		Channel: "task-VANCE-2",
+		Title:   "Build app: Chase Agent",
+		Details: "Build a new internal tool named \"Chase Agent\".\n\nWhat it should do:\nChase our unpaid invoices. Every weekday morning, find invoices past their due date and draft reminders.",
+		Owner:   appBuilderSlug,
+	})
+	b.mu.Unlock()
+
+	app := CustomApp{
+		ID:          "app_1234567890abcdef",
+		Name:        "Chase Agent",
+		Version:     1,
+		CreatedBy:   "human",
+		EditChannel: "task-VANCE-2",
+	}
+	b.mintStarterRoutineForFirstBuild(app)
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	var minted *schedulerJob
+	for i := range b.scheduler {
+		if b.scheduler[i].TargetID == app.ID && b.scheduler[i].Kind == "agent_routine" {
+			minted = &b.scheduler[i]
+			break
+		}
+	}
+	if minted == nil {
+		t.Fatalf("expected a starter routine for %s, scheduler=%+v", app.ID, b.scheduler)
+	}
+	if minted.ScheduleExpr != "0 9 * * 1-5" {
+		t.Errorf("expected the described weekday cadence, got %q", minted.ScheduleExpr)
+	}
+	if !strings.Contains(minted.Payload, "unpaid invoices") {
+		t.Errorf("expected the operator's description as the prompt, got %q", minted.Payload)
+	}
+	if !strings.HasPrefix(minted.Label, "Weekday Chase") {
+		t.Errorf("expected a cadence-labeled name, got %q", minted.Label)
+	}
+	if minted.NextRun == "" || minted.DueAt == "" {
+		t.Errorf("expected armed next-run stamps, got %+v", minted)
+	}
+	if _, err := time.Parse(time.RFC3339, minted.NextRun); err != nil {
+		t.Errorf("next run is not RFC3339: %v", err)
+	}
+
+	// Idempotent: a republish (version 2) and a re-mint both no-op.
+	before := len(b.scheduler)
+	b.mu.Unlock()
+	b.mintStarterRoutineForFirstBuild(app)
+	app2 := app
+	app2.Version = 2
+	b.mintStarterRoutineForFirstBuild(app2)
+	agentApp := app
+	agentApp.ID = "app_fedcba0987654321"
+	agentApp.CreatedBy = appBuilderSlug
+	b.mintStarterRoutineForFirstBuild(agentApp)
+	b.mu.Lock()
+	if len(b.scheduler) != before {
+		t.Errorf("expected no additional routines, got %d -> %d", before, len(b.scheduler))
+	}
+}

--- a/internal/team/broker_channel_access.go
+++ b/internal/team/broker_channel_access.go
@@ -25,12 +25,13 @@ import "time"
 // channel-create handler guards against this by rejecting create requests
 // whose slug matches this set; keep the two lists in sync.
 var reservedChannelSlugs = map[string]bool{
-	"system":      true,
-	"nex":         true,
-	"you":         true,
-	"human":       true,
-	"ceo":         true,
-	LibrarianSlug: true,
+	"system":       true,
+	"nex":          true,
+	"you":          true,
+	"human":        true,
+	"ceo":          true,
+	LibrarianSlug:  true,
+	appBuilderSlug: true,
 }
 
 func (b *Broker) canAccessChannelLocked(slug, channel string) bool {
@@ -56,6 +57,15 @@ func (b *Broker) canAccessChannelLocked(slug, channel string) bool {
 	// notifications — those still flow only to channels where it is an enabled
 	// member (or is explicitly @-tagged); see notificationTargetsForMessage.
 	if slug == LibrarianSlug {
+		return true
+	}
+	// The App Builder is a system agent, not a roster member: a fresh
+	// operator workspace deliberately seeds ZERO agents, so membership can
+	// never authorize it — yet it owns every build task and must stream
+	// build narration into the task channel. Without this bypass every
+	// build post bounced with "channel access denied" and the operator
+	// watched a silent build (2026-08-16 fresh-workspace QA).
+	if isAppBuilderSlug(slug) {
 		return true
 	}
 	return b.channelHasMemberLocked(channel, slug)

--- a/internal/team/broker_defaults.go
+++ b/internal/team/broker_defaults.go
@@ -324,6 +324,29 @@ func (b *Broker) normalizeLoadedStateLocked() {
 			b.tasks[i].Channel = "general"
 		}
 	}
+	// Heal task channels missing their own task's owner. A workspace seeded
+	// before the App Builder was registered minted its first build channel
+	// with no agent member, so every streamed build post bounced with
+	// "channel access denied" (2026-08-16 fresh-workspace QA). The owner is
+	// only added when it is a registered member now.
+	ownerByChannel := make(map[string]string, len(b.tasks))
+	for i := range b.tasks {
+		if owner := normalizeActorSlug(b.tasks[i].Owner); owner != "" {
+			ownerByChannel[normalizeChannelSlug(b.tasks[i].Channel)] = owner
+		}
+	}
+	for i := range b.channels {
+		if strings.TrimSpace(b.channels[i].TaskID) == "" {
+			continue
+		}
+		owner := ownerByChannel[b.channels[i].Slug]
+		if owner == "" || owner == "ceo" || isHumanMessageSender(owner) ||
+			b.findMemberLocked(owner) == nil ||
+			containsString(b.channels[i].Members, owner) {
+			continue
+		}
+		b.channels[i].Members = uniqueSlugs(append(b.channels[i].Members, owner))
+	}
 	for i := range b.requests {
 		if strings.TrimSpace(b.requests[i].Channel) == "" {
 			b.requests[i].Channel = "general"

--- a/internal/team/broker_onboarding.go
+++ b/internal/team/broker_onboarding.go
@@ -1,6 +1,7 @@
 package team
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"sort"
@@ -103,7 +104,10 @@ func (b *Broker) onboardingCompleteFn(task string, skipTask bool, blueprintID st
 	companyName = strings.TrimSpace(companyName)
 	if companyName != "" {
 		if runtimeHome := config.RuntimeHomeDir(); runtimeHome != "" {
-			if err := workspaces.UpdateCompanyNameByRuntimeHome(runtimeHome, companyName); err != nil {
+			// Ad-hoc runtime homes (WUPHF_RUNTIME_HOME pointing outside the
+			// registry) are legitimately absent — the config fallback below
+			// carries the name for them, so not-found is not an error.
+			if err := workspaces.UpdateCompanyNameByRuntimeHome(runtimeHome, companyName); err != nil && !errors.Is(err, workspaces.ErrWorkspaceNotFound) {
 				log.Printf("onboarding: sync company name to registry: %v", err)
 			}
 		}

--- a/internal/team/headless_codex.go
+++ b/internal/team/headless_codex.go
@@ -118,7 +118,12 @@ var (
 	// force-killed legitimate orchestration mid-flight — the recovery path
 	// then blocked the office task, leaving its work half-done. Give office
 	// turns their own generous budget, operator-tunable via WUPHF_OFFICE_TIMEOUT.
-	headlessCodexOfficeTurnTimeout        = headlessCodexTurnTimeoutEnv("WUPHF_OFFICE_TIMEOUT", 10*time.Minute)
+	headlessCodexOfficeTurnTimeout = headlessCodexTurnTimeoutEnv("WUPHF_OFFICE_TIMEOUT", 10*time.Minute)
+	// App Builder builds: cold-start installs + full scaffold writes make
+	// these the longest legitimate turns. Killed at the 10m office budget,
+	// a first build burns the whole turn and restarts from scratch on
+	// recovery (2026-08-16 QA: 50-minute first build).
+	headlessCodexAppBuildTurnTimeout      = headlessCodexTurnTimeoutEnv("WUPHF_BUILD_TIMEOUT", 25*time.Minute)
 	headlessCodexOfficeLaunchTurnTimeout  = headlessCodexTurnTimeoutEnv("WUPHF_OFFICE_LAUNCH_TIMEOUT", 10*time.Minute)
 	headlessCodexLocalWorktreeTurnTimeout = headlessCodexTurnTimeoutEnv("WUPHF_WORKTREE_TIMEOUT", 12*time.Minute)
 	headlessCodexStaleCancelAfter         = 90 * time.Second

--- a/internal/team/headless_codex_queue.go
+++ b/internal/team/headless_codex_queue.go
@@ -860,6 +860,14 @@ func (l *Launcher) beginHeadlessCodexTurn(lane headlessLane) (headlessCodexTurn,
 // TaskID that does not match the real task ID, so without the slug fallback
 // an office orchestration turn would silently drop to the tight default.
 func (l *Launcher) headlessCodexTurnTimeoutForTurn(slug string, turn headlessCodexTurn) time.Duration {
+	// App Builder builds are the longest legitimate turns in the system: a
+	// cold first build pays bun install + a full scaffold + dozens of writes.
+	// The 10m office budget force-killed one mid-write on the 2026-08-16
+	// fresh-workspace QA pass ("signal: killed" at exactly 600s) and the
+	// operator watched "Building" for 50 minutes across the kill + recovery.
+	if isAppBuilderSlug(slug) {
+		return headlessCodexAppBuildTurnTimeout
+	}
 	if task := l.timedOutTaskForTurn(slug, turn); task != nil {
 		if strings.EqualFold(strings.TrimSpace(task.ExecutionMode), "local_worktree") {
 			return headlessCodexLocalWorktreeTurnTimeout
@@ -889,6 +897,11 @@ func (l *Launcher) headlessCodexTurnTimeoutForTurn(slug string, turn headlessCod
 // it is not what falsely blocked tasks in prod (the 4m hard timeout was). slug
 // is threaded only to resolve the task identically to the timeout path.
 func (l *Launcher) headlessCodexStaleCancelAfterForTurn(slug string, turn headlessCodexTurn) time.Duration {
+	// Builds join worktree/launch turns as effectively un-preemptable: they
+	// are long, single-shot, and restarting one wastes the most work.
+	if isAppBuilderSlug(slug) {
+		return l.headlessCodexTurnTimeoutForTurn(slug, turn)
+	}
 	if task := l.timedOutTaskForTurn(slug, turn); task != nil {
 		if strings.EqualFold(strings.TrimSpace(task.ExecutionMode), "local_worktree") {
 			return l.headlessCodexTurnTimeoutForTurn(slug, turn)

--- a/internal/team/headless_codex_recovery.go
+++ b/internal/team/headless_codex_recovery.go
@@ -290,6 +290,11 @@ func headlessTimedOutRetryPrompt(slug string, prompt string, timeout time.Durati
 	note := fmt.Sprintf("Previous attempt by @%s timed out after %s without a durable task handoff. Retry #%d.", strings.TrimSpace(slug), timeout, attempt)
 	if external {
 		note += " This is a live external-action task. Do the smallest useful live external step now. If Slack target discovery is already known, use it. If the first live Slack target fails, retry once against the resolved writable target; if that still fails, pivot immediately to the smallest useful live Notion or Drive action and report the exact blocker. Do not write repo docs or planning artifacts as substitutes."
+	} else if isAppBuilderSlug(slug) {
+		// A timed-out build usually left real progress on disk (scaffold
+		// copied, src files written). Restarting from scratch doubles the
+		// wasted work — RESUME from it.
+		note += " The previous attempt likely left partial work in the app directory. Inspect what is already there and RESUME from it — do not recopy the scaffold or rewrite finished files. Finish the remaining work and register/republish the app before you stop."
 	} else {
 		note += " For this retry, move immediately from claim/status into targeted file reads and edits, then leave the task in review/done/blocked before you stop. If you cannot ship the whole slice, ship the smallest runnable sub-slice and mark that state explicitly."
 	}
@@ -358,7 +363,15 @@ func (l *Launcher) recoverTimedOutHeadlessTurn(slug string, turn headlessCodexTu
 	// Timeouts are never classified as transient stream failures — the
 	// provider was reachable, the turn just ran long — so the transient
 	// office retry does not apply here.
-	if shouldRetryHeadlessTurn(task, turn, false) {
+	//
+	// App Builder builds are the exception: a timed-out build blocked into
+	// the self-heal lane cost the operator a 41-minute silent "Building"
+	// on the 2026-08-16 fresh-workspace QA pass. A prompt requeue (with the
+	// timed-out retry prompt telling the agent to resume, not restart) is
+	// strictly better than the slow escalation for a first-build task.
+	retryable := shouldRetryHeadlessTurn(task, turn, false) ||
+		(isAppBuilderSlug(slug) && turn.Attempts < headlessCodexLocalWorktreeRetryLimit)
+	if retryable {
 		retryTurn := turn
 		retryTurn.Attempts++
 		retryTurn.EnqueuedAt = time.Now()

--- a/internal/team/headless_codex_recovery_test.go
+++ b/internal/team/headless_codex_recovery_test.go
@@ -262,6 +262,66 @@ func TestShouldRetryHeadlessTurnAllowsOneTransientOfficeRetry(t *testing.T) {
 	}
 }
 
+// 2026-08-16 fresh-workspace QA regression: a timed-out App Builder BUILD
+// turn must requeue promptly with a resume prompt — the old path blocked the
+// task into the slow self-heal lane, and the operator watched "Building" for
+// 41 silent minutes before a recovery turn restarted the build from scratch.
+func TestRecoverTimedOutHeadlessTurnRequeuesAppBuilderBuild(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	b := newTestBroker(t)
+	task := newOfficeModeTaskForTest(t, b)
+
+	l := newHeadlessLauncherForTest(t)
+	l.broker = b
+
+	turn := headlessCodexTurn{
+		Prompt:  "Build the Chase Agent app for #" + task.ID,
+		Channel: task.Channel,
+		TaskID:  task.ID,
+	}
+	lane := l.laneForTurn("app-builder", turn)
+	l.headless.mu.Lock()
+	l.headless.workers[lane] = true // keep the queue inspectable: no worker spawns
+	l.headless.mu.Unlock()
+
+	l.recoverTimedOutHeadlessTurn("app-builder", turn, time.Now().UTC().Add(-2*time.Second), 10*time.Minute)
+
+	l.headless.mu.Lock()
+	queued := append([]headlessCodexTurn(nil), l.headless.queues[lane]...)
+	l.headless.mu.Unlock()
+	if len(queued) != 1 {
+		t.Fatalf("expected one queued timeout-recovery retry for the build, got %+v", queued)
+	}
+	retry := queued[0]
+	if retry.Attempts != 1 {
+		t.Fatalf("expected retry attempt 1, got %+v", retry)
+	}
+	if !strings.Contains(retry.Prompt, "RESUME from it") {
+		t.Fatalf("expected the resume-not-restart note in the retry prompt, got %q", retry.Prompt)
+	}
+
+	updated := taskByIDForTest(t, b, task.ID)
+	if updated.Blocked() || updated.Status() == "blocked" {
+		t.Fatalf("expected the build task to stay active during the prompt retry, got status=%s blocked=%v", updated.Status(), updated.Blocked())
+	}
+
+	// Simulate the retry running and timing out again: drain the queue (a
+	// pending queued turn reads as recovery-in-progress, correctly masking a
+	// duplicate requeue) and recover with the retried turn. Budget spent
+	// (attempts >= 2): the old BlockTask fallback takes over.
+	l.headless.mu.Lock()
+	l.headless.queues[lane] = nil
+	l.headless.mu.Unlock()
+	second := retry
+	second.Attempts = 2
+	l.recoverTimedOutHeadlessTurn("app-builder", second, time.Now().UTC().Add(time.Second), 10*time.Minute)
+	updated = taskByIDForTest(t, b, task.ID)
+	if !updated.Blocked() && updated.Status() != "blocked" {
+		t.Fatalf("expected the budget-spent timeout to fall back to BlockTask, got status=%s blocked=%v", updated.Status(), updated.Blocked())
+	}
+}
+
 func TestRecoverFailedHeadlessTurnRetriesOfficeTaskOnceOnTransientFailure(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 

--- a/templates/app-scaffold/AI_RULES.md
+++ b/templates/app-scaffold/AI_RULES.md
@@ -450,3 +450,12 @@ power the live preview's **select to edit** and runtime-error surfacing. They ar
 dev-only — `vite.config.ts` injects the inspector and the production single-file
 build strips all of it — so leave both in place. You may freely rewrite
 `src/main.tsx`; the inspector loads via `index.html`, not the entry file.
+
+## Integration copy — point at the host, not invented surfaces
+
+When an integration is not connected, say so plainly and stop. The HOST
+renders the connect affordance (a banner with a real Connect button above
+your app). NEVER invent navigation like "Settings → Integrations" — those
+surfaces are the host's, they move, and wrong directions strand the
+operator. Good: "Gmail is not connected yet — use the Connect button
+above." Bad: "Connect Gmail in Settings → Integrations."

--- a/web/src/components/apps/AppActivity.tsx
+++ b/web/src/components/apps/AppActivity.tsx
@@ -87,8 +87,8 @@ export function AppActivity({ appId }: AppActivityProps) {
       </button>
       {open ? (
         <div className="app-build-activity__list" ref={scrollRef}>
-          {items.map((item) => (
-            <ActivityRow key={item.id} item={item} />
+          {collapseRepeats(items).map(({ item, repeats }) => (
+            <ActivityRow key={item.id} item={item} repeats={repeats} />
           ))}
         </div>
       ) : null}
@@ -96,7 +96,39 @@ export function AppActivity({ appId }: AppActivityProps) {
   );
 }
 
-function ActivityRow({ item }: { item: BuildActivityItem }) {
+/** Merge runs of finished rows that read identically ("Working", "Running a
+ * setup step") into one row with a ×N count — a wall of repeats says less
+ * than one line saying it happened N times. The trailing row stays separate
+ * while it is running so the live spinner keeps its own line. */
+function collapseRepeats(
+  items: BuildActivityItem[],
+): { item: BuildActivityItem; repeats: number }[] {
+  const out: { item: BuildActivityItem; repeats: number }[] = [];
+  for (const item of items) {
+    const prev = out[out.length - 1];
+    if (
+      prev &&
+      prev.item.status === "done" &&
+      item.status === "done" &&
+      prev.item.verb === item.verb &&
+      prev.item.target === item.target
+    ) {
+      prev.repeats += 1;
+      prev.item = item;
+    } else {
+      out.push({ item, repeats: 1 });
+    }
+  }
+  return out;
+}
+
+function ActivityRow({
+  item,
+  repeats = 1,
+}: {
+  item: BuildActivityItem;
+  repeats?: number;
+}) {
   return (
     <div
       className={`app-build-activity__row app-build-activity__row--${item.status}`}
@@ -112,7 +144,10 @@ function ActivityRow({ item }: { item: BuildActivityItem }) {
           "✓"
         )}
       </span>
-      <span className="app-build-activity__verb">{item.verb}</span>
+      <span className="app-build-activity__verb">
+        {item.verb}
+        {repeats > 1 ? ` ×${repeats}` : ""}
+      </span>
       {item.target ? (
         <span className="app-build-activity__target" title={item.target}>
           {item.target}

--- a/web/src/components/apps/AppLivePreview.tsx
+++ b/web/src/components/apps/AppLivePreview.tsx
@@ -107,14 +107,20 @@ export function AppLivePreview({
       <div className="app-build-preview__state" role="status">
         <span className="app-build-preview__spinner" aria-hidden="true" />
         <p className="app-build-preview__state-title">Starting live preview…</p>
+        <p className="app-build-preview__state-detail">
+          Warming up — your agent's page opens here the moment it is ready.
+        </p>
         {data?.boot_log ? (
-          <pre className="app-build-preview__bootlog-text">{data.boot_log}</pre>
-        ) : (
-          <p className="app-build-preview__state-detail">
-            Installing dependencies and booting the dev server — this is a one
-            time warm-up.
-          </p>
-        )}
+          // Raw boot output is developer material: available on demand, never
+          // the default face of a first build (2026-08-16 fresh-workspace QA
+          // put npm dependency lines in front of a brand-new operator).
+          <details className="app-build-preview__bootlog">
+            <summary>Show technical detail</summary>
+            <pre className="app-build-preview__bootlog-text">
+              {data.boot_log}
+            </pre>
+          </details>
+        ) : null}
       </div>
     );
   }

--- a/web/src/components/onboarding/PrePickScreen.stories.tsx
+++ b/web/src/components/onboarding/PrePickScreen.stories.tsx
@@ -30,7 +30,7 @@ const CLAUDE_INSTALL_STEPS = {
     },
     {
       title: "Sign in to Claude",
-      detail: "Sign in once and the office can run turns on your account.",
+      detail: "Sign in once and your agents run on your account.",
       command: "claude auth login",
     },
     {

--- a/web/src/components/onboarding/PrePickScreen.test.tsx
+++ b/web/src/components/onboarding/PrePickScreen.test.tsx
@@ -751,7 +751,7 @@ describe("CodeRabbit click-handler guard (PR #889)", () => {
         },
         {
           title: "Sign in to Claude",
-          detail: "Sign in once and the office can run turns on your account.",
+          detail: "Sign in once and your agents run on your account.",
           command: "claude auth login",
         },
         { title: "Verify", detail: "Press Verify and we confirm." },

--- a/web/src/components/onboarding/PrePickScreen.tsx
+++ b/web/src/components/onboarding/PrePickScreen.tsx
@@ -766,10 +766,8 @@ export function PrePickScreen({ onComplete }: PrePickScreenProps) {
               <div className="pre-pick-eyebrow">WUPHF</div>
               <h1 className="pre-pick-headline">Pick a default runtime.</h1>
               <p className="pre-pick-subhead">
-                New agents inherit this runtime when they're created — you can
-                change it later in Settings, one agent at a time. Gateway
-                imports (OpenClaw, Hermes) are managed from the Integrations
-                app.
+                New agents run on this engine. You can change it any time in
+                Settings.
               </p>
             </div>
 
@@ -805,6 +803,7 @@ export function PrePickScreen({ onComplete }: PrePickScreenProps) {
                   runtime={expandedRuntime.spec.binary}
                   label={expandedRuntime.spec.label}
                   onVerified={handleVerified}
+                  autoVerify={expandedRuntime.signedIn === true}
                 />
               ) : null}
 
@@ -893,8 +892,7 @@ export function PrePickScreen({ onComplete }: PrePickScreenProps) {
             </div>
 
             <p className="pre-pick-helper">
-              You can change this any time in{" "}
-              <strong>Settings &rarr; Runtimes</strong>.
+              You can change this any time in <strong>Settings</strong>.
             </p>
 
             {submitError ? (

--- a/web/src/components/onboarding/RuntimeGuidePanel.tsx
+++ b/web/src/components/onboarding/RuntimeGuidePanel.tsx
@@ -30,6 +30,13 @@ interface RuntimeGuidePanelProps {
    * parent advance the primary button copy to "Next" without re-probing.
    */
   onVerified?: (runtime: string, result: VerifyResult) => void;
+  /**
+   * The runtime already probed as signed in: run verify immediately on mount
+   * and keep the install tutorial collapsed unless the verify FAILS. A
+   * signed-in operator should see their checkmarks, not "1. Install …"
+   * (2026-08-16 fresh-workspace QA).
+   */
+  autoVerify?: boolean;
 }
 
 const STATUS_COPY: Record<
@@ -46,6 +53,7 @@ export function RuntimeGuidePanel({
   runtime,
   label,
   onVerified,
+  autoVerify,
 }: RuntimeGuidePanelProps) {
   const [steps, setSteps] = useState<InstallStep[]>([]);
   const [stepsLoaded, setStepsLoaded] = useState(false);
@@ -82,8 +90,23 @@ export function RuntimeGuidePanel({
 
   const handleVerify = useCallback(() => verify(runtime), [verify, runtime]);
 
+  // Already signed in -> the panel IS the verify: fire it once on mount.
+  const autoFiredRef = useState(() => ({ fired: false }))[0];
+  useEffect(() => {
+    if (autoVerify && !autoFiredRef.fired && phase === "idle") {
+      autoFiredRef.fired = true;
+      verify(runtime);
+    }
+  }, [autoVerify, autoFiredRef, phase, verify, runtime]);
+
   const failedStep = result?.failed_step ?? "";
   const verifying = phase === "running";
+  // With autoVerify the tutorial steps only appear when something FAILED —
+  // a passing signed-in runtime needs no install walkthrough.
+  const showSteps =
+    stepsLoaded &&
+    steps.length > 0 &&
+    (!autoVerify || (phase === "done" && result?.status !== "pass"));
 
   return (
     <section
@@ -93,7 +116,7 @@ export function RuntimeGuidePanel({
     >
       <p className="pre-pick-guide-heading">Set up {label}</p>
 
-      {stepsLoaded && steps.length > 0 ? (
+      {showSteps ? (
         <ol className="pre-pick-guide-steps">
           {steps.map((step, index) => (
             <GuideStep

--- a/web/src/components/onboarding/wizard/steps/StepFirstIssue.tsx
+++ b/web/src/components/onboarding/wizard/steps/StepFirstIssue.tsx
@@ -27,9 +27,10 @@ import { useCallback } from "react";
 import {
   ONBOARDING_ANALYTICS_CONSENT_COPY,
   ONBOARDING_EMAIL_COPY,
-  ONBOARDING_FIRST_ISSUE_EXAMPLE,
+  ONBOARDING_FIRST_ISSUE_EXAMPLES,
   ONBOARDING_WIZARD_COPY,
   type OnboardingWizardStepProps,
+  pickFirstIssueExample,
 } from "../wizardSteps";
 
 const COPY = ONBOARDING_WIZARD_COPY["first-issue"];
@@ -40,11 +41,12 @@ export function StepFirstIssue({
   setAnswers,
 }: OnboardingWizardStepProps) {
   const resetToExample = useCallback(() => {
-    setAnswers({ firstIssue: ONBOARDING_FIRST_ISSUE_EXAMPLE });
+    setAnswers({ firstIssue: pickFirstIssueExample() });
   }, [setAnswers]);
 
-  const isExample =
-    answers.firstIssue.trim() === ONBOARDING_FIRST_ISSUE_EXAMPLE.trim();
+  const isExample = ONBOARDING_FIRST_ISSUE_EXAMPLES.some(
+    (ex) => answers.firstIssue.trim() === ex.trim(),
+  );
 
   return (
     <div

--- a/web/src/components/onboarding/wizard/useOnboardingWizard.ts
+++ b/web/src/components/onboarding/wizard/useOnboardingWizard.ts
@@ -46,7 +46,7 @@ import {
 import { OPERATOR_FIRST_WORKFLOW_SEED_KEY } from "../../../operator/firstWorkflowSeed";
 import { HOME_COMPOSER_DRAFT_CHANNEL, useAppStore } from "../../../stores/app";
 import {
-  ONBOARDING_FIRST_ISSUE_EXAMPLE,
+  pickFirstIssueExample,
   ONBOARDING_WIZARD_STEP_IDS,
   type OnboardingAnswers,
   type OnboardingWizardStepId,
@@ -103,7 +103,7 @@ function initialAnswers(): OnboardingAnswers {
     ownerRole: "",
     email: "",
     keepInTouch: true,
-    firstIssue: ONBOARDING_FIRST_ISSUE_EXAMPLE,
+    firstIssue: pickFirstIssueExample(),
     telemetryConsent: true,
     recordingConsent: true,
   };

--- a/web/src/components/onboarding/wizard/wizardSteps.ts
+++ b/web/src/components/onboarding/wizard/wizardSteps.ts
@@ -92,12 +92,27 @@ export interface OnboardingWizardStepProps {
 }
 
 /**
- * The prefilled first-issue example. RevOps framing: WUPHF operates on the
- * user's CRM, it is not a CRM itself. This is the same example the office tour
- * finish handoff used, kept verbatim so the two surfaces stay in lockstep.
+ * The prefilled first-issue examples. One is picked at mount — the pitch is
+ * "a microapp for EVERY manual workflow", so the prefill must not read as
+ * CRM-only (2026-08-15 fresh-workspace QA: a recruiter or finance operator
+ * saw a RevOps product on every onboarding screen). WUPHF operates on the
+ * user's systems; it is not a CRM.
  */
-export const ONBOARDING_FIRST_ISSUE_EXAMPLE =
-  "Audit our CRM for duplicate accounts, deals missing an owner, and opportunities with no activity in 30 days, then propose a cleanup plan";
+export const ONBOARDING_FIRST_ISSUE_EXAMPLES: readonly string[] = [
+  "Audit our CRM for duplicate accounts, deals missing an owner, and opportunities with no activity in 30 days, then propose a cleanup plan",
+  "Chase our unpaid invoices: find anything past its due date, draft a polite reminder for each customer, and flag 30+ days overdue for my review",
+  "Screen inbound job applications against our role requirements, keep a shortlist of strong candidates, and draft a friendly note for the rest",
+];
+
+/** Back-compat: the canonical example (tests and the tour handoff pin it). */
+export const ONBOARDING_FIRST_ISSUE_EXAMPLE = ONBOARDING_FIRST_ISSUE_EXAMPLES[0];
+
+/** Pick the prefill for this visit. */
+export function pickFirstIssueExample(): string {
+  return ONBOARDING_FIRST_ISSUE_EXAMPLES[
+    Math.floor(Math.random() * ONBOARDING_FIRST_ISSUE_EXAMPLES.length)
+  ];
+}
 
 /**
  * Per-step copy. `eyebrow` is the small-caps kicker above the headline,
@@ -115,17 +130,17 @@ export const ONBOARDING_WIZARD_COPY: Record<
   meet: {
     eyebrow: "WELCOME TO WUPHF",
     headline: "Meet WUPHF.",
-    body: "WUPHF is where you spin up AI agents that run your workflows end to end. Each agent owns one workflow, runs it start to finish, and reports back in a channel you can see.",
+    body: "WUPHF is where you spin up AI agents that run your workflows end to end. Each agent owns one workflow, runs it start to finish, and reports back in its own chat.",
   },
   wiki: {
     eyebrow: "YOUR COMPANY BRAIN",
     headline: "Write the rules once.",
-    body: "Your company brain holds the rules your agents run on. Capture account tiering, deal stages, and the dedupe policy a single time, and every agent reads them as first-class context before it touches a record.",
+    body: "Your company brain holds the rules your agents run on. Write down how you score a lead, when an invoice counts as overdue, or what makes a ticket urgent — once — and every agent reads it before touching your data.",
   },
   "first-issue": {
     eyebrow: "YOUR FIRST WORKFLOW",
     headline: "Hand off your first workflow.",
-    body: "Write the first thing you want run. We prefilled a CRM cleanup so there is real work the moment you walk in. Edit it, or write your own.",
+    body: "Write the first thing you want run. We prefilled an example so there is real work the moment you walk in. Edit it, or write your own.",
   },
 };
 
@@ -249,7 +264,7 @@ export const ONBOARDING_WIZARD_LABELS = {
    * look around first. Maps to the broker's skip_task path. The only escape in
    * the wizard (no Esc, no skip-all).
    */
-  firstIssueSkip: "Skip and explore the office first",
+  firstIssueSkip: "Skip and look around first",
   /** Shown while the broker seeds the office after Finish. */
   seeding: "Setting up your office…",
 } as const;

--- a/web/src/operator/apps/useOperatorApps.test.ts
+++ b/web/src/operator/apps/useOperatorApps.test.ts
@@ -135,6 +135,25 @@ describe("deriveAppName", () => {
     expect(deriveAppName(seed)).toBe("Lead Routing Agent");
   });
 
+  // 2026-08-16 fresh-workspace QA: "Chase our unpaid invoices" was named
+  // "Chase Agent" (plural nouns missed the role table), and a recruiting
+  // description using scoring verbs was claimed by Lead Routing.
+  it("names invoice chasing and applicant screening by their nouns", () => {
+    expect(
+      deriveAppName(
+        "Chase our unpaid invoices: find anything past its due date and draft a reminder",
+      ),
+    ).toBe("Invoice Agent");
+    expect(
+      deriveAppName(
+        "Screen inbound job applicants for our warehouse role, score fit 0-100, keep a shortlist",
+      ),
+    ).toBe("Recruiting Agent");
+    expect(deriveAppName("Triage inbound support tickets by urgency")).toBe(
+      "Support Triage Agent",
+    );
+  });
+
   it("synthesizes <lead words> Agent for an unknown domain", () => {
     // "for" is a function word — the clause is cut before it, so the
     // preposition never lands in the name.

--- a/web/src/operator/apps/useOperatorApps.ts
+++ b/web/src/operator/apps/useOperatorApps.ts
@@ -169,18 +169,26 @@ const AGENT_ROLES: ReadonlyArray<[RegExp, string]> = [
     /\b(hygiene|dedupe|duplicate|clean[- ]?up|data quality)\b/i,
     "CRM Hygiene Agent",
   ],
+  // Recruiting outranks lead routing: hiring language ("score fit", "inbound
+  // applicants") reuses scoring/routing verbs, so the noun cues must win.
   [
-    /\b(lead|score|scoring|route|routing|inbound|demo request)\b/i,
+    /\b(hiring|recruit(?:ing|er)?|candidates?|interviews?|applicants?|job applications?)\b/i,
+    "Recruiting Agent",
+  ],
+  // Nouns accept plurals; bare verbs ("score", "route", "inbound") are gone —
+  // they collide with every other domain ("score a task", "inbound tickets").
+  [
+    /\b(leads?|lead routing|demo requests?)\b/i,
     "Lead Routing Agent",
   ],
-  [/\b(pipeline|deal|forecast)\b/i, "Pipeline Agent"],
-  [/\b(sales|quota|outreach|prospect)\b/i, "Sales Agent"],
-  [/\b(support|ticket|escalation|incident)\b/i, "Support Triage Agent"],
-  [/\b(expense|invoice|reimburse|billing|spend)\b/i, "Expense Agent"],
-  [/\b(email|inbox|follow[- ]?up|reply|nurture)\b/i, "Follow-up Agent"],
-  [/\b(report|summar|digest|dashboard|recap|kpi|metric)\b/i, "Reporting Agent"],
-  [/\b(onboard|welcome|signup|sign-up)\b/i, "Onboarding Agent"],
-  [/\b(hiring|recruit|candidate|interview)\b/i, "Recruiting Agent"],
+  [/\b(pipelines?|deals?|forecasts?)\b/i, "Pipeline Agent"],
+  [/\b(sales|quotas?|outreach|prospects?)\b/i, "Sales Agent"],
+  [/\b(support|tickets?|escalations?|incidents?)\b/i, "Support Triage Agent"],
+  [/\b(invoices?|billing|receivables?|dunning)\b/i, "Invoice Agent"],
+  [/\b(expenses?|reimburse|spend)\b/i, "Expense Agent"],
+  [/\b(email|inbox|follow[- ]?ups?|replies|nurture)\b/i, "Follow-up Agent"],
+  [/\b(reports?|summar|digests?|dashboards?|recaps?|kpis?|metrics?)\b/i, "Reporting Agent"],
+  [/\b(onboard|welcome|signups?|sign-ups?)\b/i, "Onboarding Agent"],
 ];
 
 // Relative pronouns, prepositions, and other connectives that must never land

--- a/web/src/operator/surfaces/AppBuilderChat.tsx
+++ b/web/src/operator/surfaces/AppBuilderChat.tsx
@@ -11,7 +11,10 @@ import { ArrowRight, Check, Send, X } from "lucide-react";
 
 import { type CustomApp, listApps, submitAppEdit } from "../../api/apps";
 import { AppActivity } from "../../components/apps/AppActivity";
-import { tryCreateRoutine } from "../agents/agentStateClient";
+import {
+  tryCreateRoutine,
+  tryListRoutines,
+} from "../agents/agentStateClient";
 import { capturePromptSeed, type DemoCapture } from "../apps/demoCapture";
 import {
   appBuildState,
@@ -265,23 +268,18 @@ export function AppBuilderChat({
     setNewAppId(candidate.id);
     setPhase("done");
     const failed = state === "failed";
-    // First-build ceremony: a brand-new agent (not a refine, not a demo-call
-    // build, which creates its own captured routine) gets a starter routine —
-    // the described workflow on a weekly schedule. Told, not asked: the chat
-    // reports it with a one-line veto path (pause on the Routines tab).
+    // First-build ceremony: the BROKER mints the starter routine at
+    // registration (durable — this chat used to own the create and lost it
+    // whenever it unmounted mid-build, 2026-08-16 QA). The chat only
+    // announces what landed, with the one-line veto path.
     if (!(failed || refineId || demo) && starterRoutineRef.current) {
-      const routinePrompt = starterRoutineRef.current;
       starterRoutineRef.current = null;
       void (async () => {
-        const created = await tryCreateRoutine({
-          agent: candidate.id,
-          name: `Weekly ${appName.replace(/\s*Agent$/i, "").trim() || appName} run`,
-          prompt: routinePrompt,
-          schedule: "0 9 * * 1",
-        });
-        if (created) {
+        const routines = await tryListRoutines(candidate.id);
+        const starter = routines?.[0];
+        if (starter) {
           say(
-            "I also set up its weekly routine — Mondays 9:00, running the workflow you described. Pause or reword it any time on the Routines tab.",
+            `I also set up its routine — “${starter.name}” (${humanSchedule(starter.schedule)}), running the workflow you described. Pause or reword it any time on the Routines tab.`,
           );
         }
       })();
@@ -753,7 +751,11 @@ export function AppBuilderChat({
           <input
             className="opr-composer-input"
             aria-label="Describe what this agent should do"
-            placeholder="Describe what this agent should do…"
+            placeholder={
+              phase === "building"
+                ? `One build at a time — “${appName || "this agent"}” is almost ready`
+                : "Describe what this agent should do…"
+            }
             value={draft}
             disabled={phase === "building"}
             onChange={(e) => setDraft(e.target.value)}

--- a/web/src/operator/surfaces/SettingsSurface.tsx
+++ b/web/src/operator/surfaces/SettingsSurface.tsx
@@ -11,6 +11,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { type ConfigStatus, get, getConfig, post } from "../../api/client";
 import { getUsage } from "../../api/platform";
+import { openProviderSwitcher } from "../../components/ui/ProviderSwitcher";
 import { Eyebrow, SurfaceHeader } from "../components/primitives";
 
 /** 4.6M / 227k style token formatting for the usage readout. */
@@ -40,8 +41,10 @@ export function SettingsSurface() {
     retry: false,
   });
   // Full config snapshot for the read-only Runtime readout.
+  // Shares the office-era ["config"] key: the provider switcher invalidates
+  // it after a switch, so the engine label refreshes without extra wiring.
   const snapshot = useQuery({
-    queryKey: ["operator-config-snapshot"],
+    queryKey: ["config"],
     queryFn: () => getConfig().catch(() => null),
     staleTime: 5 * 60 * 1000,
     retry: false,
@@ -173,9 +176,17 @@ export function SettingsSurface() {
               <div>
                 <div className="opr-set-label">Engine</div>
                 <div className="opr-set-help">
-                  Your agents run on {runtimeLabel}, picked during setup.
+                  Your agents run on {runtimeLabel}. Switching restarts them on
+                  the new engine.
                 </div>
               </div>
+              <button
+                type="button"
+                className="opr-btn opr-btn-sm"
+                onClick={openProviderSwitcher}
+              >
+                Change engine
+              </button>
             </div>
           ) : null}
         </div>

--- a/web/src/styles/apps.css
+++ b/web/src/styles/apps.css
@@ -1084,3 +1084,18 @@
     display: none;
   }
 }
+
+/* Boot log disclosure: collapsed by default, developer material on demand. */
+.app-build-preview__bootlog {
+  margin-top: var(--space-2, 8px);
+  max-width: 100%;
+}
+.app-build-preview__bootlog > summary {
+  cursor: pointer;
+  font-size: 11.5px;
+  color: var(--text-secondary, #8a8f98);
+  user-select: none;
+}
+.app-build-preview__bootlog[open] > summary {
+  margin-bottom: 6px;
+}


### PR DESCRIPTION
## What

A fresh-workspace QA pass (clean runtime home, onboarding from scratch, an invoice-chasing first workflow — a deliberately non-CRM persona) surfaced a first-build death spiral plus a batch of first-run honesty gaps.

### The first-build death spiral (operator watched "Building" for 50 minutes)
1. The 10-minute office turn budget force-killed a legitimate first build mid-write (`signal: killed` at exactly 600s). → Builds get their own `WUPHF_BUILD_TIMEOUT` (25m default) and are un-preemptable like worktree turns.
2. The killed build then BLOCKED into the slow self-heal lane — 41 silent minutes before a recovery turn restarted from scratch. → Timed-out builds now requeue promptly with a resume-not-restart prompt (regression-tested).
3. Every streamed build post bounced `channel access denied`: fresh workspaces seed ZERO roster members, so channel membership can never authorize the App Builder. → It joins ceo/librarian as a trusted system sender; boot heals channels missing their task's owner.

### Server-owned starter routine
The "described workflow = weekly routine" ceremony lived in the builder chat and silently vanished if that chat unmounted before the build landed (exactly what happens on a 50-minute build). The broker now mints it at first registration, deriving the cadence from the operator's own words ("every weekday morning" → Weekdays 9:00); the chat just announces it.

### Onboarding honesty + polish
- No more "Gateway imports (OpenClaw, Hermes)", "the office can run turns", "Settings → Runtimes" (didn't exist), or channels vocabulary.
- Signed-in runtimes **auto-verify** instead of showing the 3-step install tutorial.
- Company-brain copy speaks all workflows, not just CRM; the first-workflow prefill rotates 3 diverse examples.
- Settings gains a **real** engine switcher (reuses ProviderSwitcher), making the onboarding promise true.
- Live-preview boot shows a friendly warm-up with raw bun/npm output behind a disclosure; build activity collapses repeated rows to "×N".
- `deriveAppName`: "Chase our unpaid invoices" now names **Invoice Agent** (was "Chase Agent"); recruiting descriptions no longer land as Lead Routing.

## Test plan
- [x] Go: build + vet + full `./internal/team` green (incl. new timeout-requeue and starter-routine regression suites)
- [x] Web: 2399 tests green (263 files) + tsc
- [x] Live on the fresh workspace: resumed build landed v1 with streamed narration (relay posts confirmed), routine renders "Weekdays 9:00", send-gate veto + approve both verified in chat

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V9n6uZhopKDdZoXQ37ry17

## Screenshots (live fresh-workspace pass)

**Send-gate on the taught reminder tool** — pause, exact subject + recipient, veto/approve:
![send-gate](https://raw.githubusercontent.com/najmuzzaman-mohammad/wuphf/screenshots/pr-1190/03-send-gate.png)

**Server-minted starter routine** — described cadence renders as "Weekdays 9:00":
![routine](https://raw.githubusercontent.com/najmuzzaman-mohammad/wuphf/screenshots/pr-1190/04-starter-routine.png)

**Gmail gate banner on the built agent** — real connect row, honest empty state:
![gate](https://raw.githubusercontent.com/najmuzzaman-mohammad/wuphf/screenshots/pr-1190/02-gmail-gate-banner.png)

**Runtime step (pre-fix reference)** — the jargon and tutorial-for-signed-in flow this PR removes:
![runtime](https://raw.githubusercontent.com/najmuzzaman-mohammad/wuphf/screenshots/pr-1190/01-runtime-step.png)