### PR TITLE
fix: first-run audit round 2 — honest build failures, working picker paths, curated installs

### DIFF
--- a/internal/onboarding/prereqs.go
+++ b/internal/onboarding/prereqs.go
@@ -3,6 +3,7 @@ package onboarding
 import (
 	"context"
 	"os/exec"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -227,21 +228,21 @@ func probeCodexSession(ctx context.Context, path string) bool {
 // any provider has stored credentials. The CLI prints a banner with a
 // count like "0 credentials" / "2 credentials". Zero-count or parse
 // failure → not signed in.
+// opencodeCredentialCount pulls the credential count out of `opencode
+// providers list` output ("3 credentials" / "1 credential").
+var opencodeCredentialCount = regexp.MustCompile(`(?:^|\s)(\d+)\s+credentials?\b`)
+
 func probeOpencodeSession(ctx context.Context, path string) bool {
 	out, err := exec.CommandContext(ctx, path, "providers", "list").CombinedOutput()
 	if err != nil {
 		return false
 	}
 	text := strings.ToLower(string(out))
-	if strings.Contains(text, "0 credentials") {
-		return false
-	}
-	// Match "<N> credential" where N >= 1. The trailing space (or "s")
-	// disambiguates from "0 credentials".
-	for _, n := range []string{"1 credential", "2 credential", "3 credential", "4 credential", "5 credential", "6 credential", "7 credential", "8 credential", "9 credential"} {
-		if strings.Contains(text, n) {
-			return true
-		}
+	// Word-boundary match: the old substring check read "10 credentials" as
+	// "0 credentials" and reported a configured user as signed OUT
+	// (2026-08-16 first-run audit).
+	if m := opencodeCredentialCount.FindStringSubmatch(text); m != nil {
+		return m[1] != "0"
 	}
 	// Fallback: any provider name in the rendered table implies a session.
 	// Suppress noise from the "Credentials ~/.local/share/..." header by

--- a/internal/onboarding/verify.go
+++ b/internal/onboarding/verify.go
@@ -117,14 +117,15 @@ func VerifyRuntime(ctx context.Context, name string) VerifyResult {
 		Version: r.Version,
 	}
 
+	label := verifyDisplayName(name)
 	if !r.Found {
 		res.Status = VerifyStatusNotInstalled
-		res.FailedStep = fmt.Sprintf("Install %s", name)
+		res.FailedStep = verifyStepTitle(verifyInstallStepTitles, name, fmt.Sprintf("Install %s", label))
 		res.Command = installCommands[name]
 		if res.Command != "" {
-			res.Hint = fmt.Sprintf("%s is not on your PATH yet. Run the install command, then verify again.", name)
+			res.Hint = fmt.Sprintf("%s is not installed on this computer yet. Run the install command, then verify again.", label)
 		} else {
-			res.Hint = fmt.Sprintf("%s is not on your PATH yet. Install it from the linked guide, then verify again.", name)
+			res.Hint = fmt.Sprintf("%s is not installed on this computer yet. Install it from the linked guide, then verify again.", label)
 		}
 		return res
 	}
@@ -135,7 +136,7 @@ func VerifyRuntime(ctx context.Context, name string) VerifyResult {
 		res.Status = VerifyStatusAuthRequired
 		res.Command = r.SignInCommand
 		res.SignInCommand = r.SignInCommand
-		res.FailedStep = fmt.Sprintf("Sign in to %s", name)
+		res.FailedStep = verifyStepTitle(verifySignInStepTitles, name, fmt.Sprintf("Sign in to %s", label))
 		res.Hint = "Run the sign-in command, then verify again."
 		return res
 	}
@@ -147,6 +148,48 @@ func VerifyRuntime(ctx context.Context, name string) VerifyResult {
 // InstallSteps returns the guided setup steps for a CLI runtime. The steps
 // walk the user from install to signed-in, with a copyable command per step
 // and a doc link pointing at the runtime's canonical install page (reused
+
+// verifyDisplayNames maps prereq binaries to the labels the runtime cards
+// show. FailedStep must match the InstallSteps titles exactly for the FE to
+// highlight the failed step, and hints must speak the product name, not the
+// binary (2026-08-16 first-run audit).
+var verifyDisplayNames = map[string]string{
+	"claude":   "Claude Code",
+	"codex":    "Codex",
+	"opencode": "opencode",
+	"cursor":   "Cursor",
+}
+
+// verifyInstallStepTitles maps binaries to their InstallSteps install-step
+// title; sign-in titles diverge per runtime too.
+var verifyInstallStepTitles = map[string]string{
+	"claude":   "Install Claude Code",
+	"codex":    "Install Codex",
+	"opencode": "Install opencode",
+	"cursor":   "Install Cursor",
+}
+
+var verifySignInStepTitles = map[string]string{
+	"claude":   "Sign in to Claude",
+	"codex":    "Sign in to Codex",
+	"opencode": "Add a provider credential",
+	"cursor":   "Sign in inside Cursor",
+}
+
+func verifyDisplayName(name string) string {
+	if label, ok := verifyDisplayNames[name]; ok {
+		return label
+	}
+	return name
+}
+
+func verifyStepTitle(m map[string]string, name, fallback string) string {
+	if t, ok := m[name]; ok {
+		return t
+	}
+	return fallback
+}
+
 // from prereqSpecs). Returns nil only for unknown names. node and git are
 // prerequisites rather than pickable runtimes, but they are present in
 // prereqSpecs, so they still yield a generic step rather than nil.

--- a/internal/onboarding/verify.go
+++ b/internal/onboarding/verify.go
@@ -145,10 +145,6 @@ func VerifyRuntime(ctx context.Context, name string) VerifyResult {
 	return res
 }
 
-// InstallSteps returns the guided setup steps for a CLI runtime. The steps
-// walk the user from install to signed-in, with a copyable command per step
-// and a doc link pointing at the runtime's canonical install page (reused
-
 // verifyDisplayNames maps prereq binaries to the labels the runtime cards
 // show. FailedStep must match the InstallSteps titles exactly for the FE to
 // highlight the failed step, and hints must speak the product name, not the
@@ -190,6 +186,9 @@ func verifyStepTitle(m map[string]string, name, fallback string) string {
 	return fallback
 }
 
+// InstallSteps returns the guided setup steps for a CLI runtime. The steps
+// walk the user from install to signed-in, with a copyable command per step
+// and a doc link pointing at the runtime's canonical install page (reused
 // from prereqSpecs). Returns nil only for unknown names. node and git are
 // prerequisites rather than pickable runtimes, but they are present in
 // prereqSpecs, so they still yield a generic step rather than nil.

--- a/internal/team/broker_apps_scaffold.go
+++ b/internal/team/broker_apps_scaffold.go
@@ -14,6 +14,7 @@ package team
 
 import (
 	"fmt"
+	"log"
 	"regexp"
 	"strings"
 	"time"
@@ -76,7 +77,11 @@ func (b *Broker) maybePrescaffoldAppForCreate(action, channel string, body TaskP
 		actor = appBuilderSlug
 	}
 	if _, err := b.appStore().Scaffold(id, name, "", actor, time.Now()); err != nil {
-		// Pre-scaffold is an enhancement; never block task creation on it.
+		// Pre-scaffold is an enhancement; never block task creation on it —
+		// but never swallow it either: without the scaffold there is no
+		// instant preview, no stable app id in the brief, and no edit
+		// channel, which silently degrades the whole first build.
+		log.Printf("apps: pre-scaffold %s failed (build continues without instant preview): %v", id, err)
 		return body
 	}
 

--- a/internal/team/broker_task_stall.go
+++ b/internal/team/broker_task_stall.go
@@ -176,7 +176,7 @@ func (b *Broker) markSilentRunningTasksLocked(now time.Time, threshold time.Dura
 			From:    "system",
 			Channel: channel,
 			Kind:    taskStalledMessageKind,
-			Content: fmt.Sprintf("%s has produced no visible activity on %s for %s — investigating or stalled.", ownerRef, task.ID, silentFor),
+			Content: fmt.Sprintf("%s has gone quiet on “%s” for about %d minutes. It may still be working — if nothing lands soon, restart it from the task.", ownerRef, strings.TrimSpace(task.Title), int(silentFor.Minutes())),
 			// Stamp with the watchdog's now (not wall clock) so a
 			// fixture-clock eval produces a consistent record.
 			Timestamp: now.UTC().Format(time.RFC3339),

--- a/internal/team/custom_app.go
+++ b/internal/team/custom_app.go
@@ -59,6 +59,11 @@ const (
 	// "ready" (back-compat with manifests written before this field existed).
 	customAppStatusBuilding = "building"
 	customAppStatusReady    = "ready"
+	// customAppStatusFailed marks a pre-scaffolded app whose build task
+	// terminally blocked. Stamped by the broker so the FE reads failure off
+	// the wire instead of inferring it from a stale createdAt; a later
+	// successful register_app flips it back to ready.
+	customAppStatusFailed = "failed"
 )
 
 // customAppPreservedSrcDirs are top-level entries under src/ that a publish must
@@ -512,6 +517,35 @@ func (s *customAppStore) SetEditChannel(id, channel string) error {
 		return nil
 	}
 	app.EditChannel = channel
+	manifestBytes, err := json.MarshalIndent(app, "", "  ")
+	if err != nil {
+		return fmt.Errorf("app: marshal manifest: %w", err)
+	}
+	manifestBytes = append(manifestBytes, '\n')
+	if err := writeFileAtomic(filepath.Join(s.appDir(id), customAppManifestFile), manifestBytes, 0o600); err != nil {
+		return fmt.Errorf("app: write manifest: %w", err)
+	}
+	return nil
+}
+
+// MarkBuildFailed flips a still-building app to "failed" — the broker calls
+// it when the build task terminally blocks, so the operator sees an honest
+// failed state instead of "Building" forever (2026-08-16 first-run audit).
+// A ready app is left untouched: a blocked REFINE does not un-ready an app.
+func (s *customAppStore) MarkBuildFailed(id string) error {
+	if err := validateCustomAppID(id); err != nil {
+		return err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	app, err := s.readManifestLocked(id)
+	if err != nil {
+		return newCustomAppCallerError("app: %s not found", id)
+	}
+	if app.Status != customAppStatusBuilding {
+		return nil
+	}
+	app.Status = customAppStatusFailed
 	manifestBytes, err := json.MarshalIndent(app, "", "  ")
 	if err != nil {
 		return fmt.Errorf("app: marshal manifest: %w", err)

--- a/internal/team/headless_codex_queue.go
+++ b/internal/team/headless_codex_queue.go
@@ -96,10 +96,18 @@ func (l *Launcher) enqueueHeadlessCodexTurn(slug string, prompt string, channel 
 	if slug == "" || prompt == "" {
 		return
 	}
+	taskID := headlessCodexTaskID(prompt)
+	if taskID == "" && strings.HasPrefix(ch, "task-") {
+		// A per-task channel names its task ("task-VANCE-2"): dispatches
+		// whose prompt carries no #task- marker (e.g. direct app improves)
+		// still get labeled, so their events attach to the right task
+		// instead of an empty scope (2026-08-16 first-run audit).
+		taskID = strings.TrimPrefix(ch, "task-")
+	}
 	l.enqueueHeadlessCodexTurnRecord(slug, headlessCodexTurn{
 		Prompt:     prompt,
 		Channel:    ch,
-		TaskID:     headlessCodexTaskID(prompt),
+		TaskID:     taskID,
 		EnqueuedAt: time.Now(),
 	})
 }

--- a/internal/team/headless_codex_recovery.go
+++ b/internal/team/headless_codex_recovery.go
@@ -84,7 +84,7 @@ func (l *Launcher) headlessTurnCompletedDurably(slug string, active *headlessCod
 	// was judged by office-agent evidence (task writes, channel posts) the
 	// App Builder never produces, got "blocked", and burned a retry turn —
 	// observed on every build in the 2026-08-15 QA pass.
-	if isAppBuilderSlug(slug) && l.appRegistryTouchedSince(active.StartedAt) {
+	if isAppBuilderSlug(slug) && l.appRegistryTouchedSince(active.StartedAt, task) {
 		return true, ""
 	}
 	if l.agentPostedSubstantiveMessageSince(slug, active.StartedAt) {
@@ -384,13 +384,61 @@ func (l *Launcher) recoverTimedOutHeadlessTurn(slug string, turn headlessCodexTu
 		l.enqueueHeadlessCodexTurnRecord(slug, retryTurn)
 		return
 	}
-	reason := fmt.Sprintf("Automatic timeout recovery: @%s timed out after %s before posting a substantive update. Requeue, retry, or reassign from here.", slug, timeout)
+	reason := fmt.Sprintf("@%s ran out of time (about %d minutes) without finishing. Restart it from here, or hand it to another agent.", slug, int(timeout.Round(time.Minute).Minutes()))
 	if _, changed, err := l.broker.BlockTask(task.ID, slug, reason, ""); err != nil {
 		appendHeadlessCodexLog(slug, fmt.Sprintf("timeout-recovery-error: could not block %s: %v", task.ID, err))
 		return
 	} else if changed {
 		appendHeadlessCodexLog(slug, fmt.Sprintf("timeout-recovery: blocked %s after empty timeout", task.ID))
+		if isAppBuilderSlug(slug) {
+			l.markAppBuildFailedForTask(task)
+		}
 		_, _, _ = l.requestSelfHealing(slug, task.ID, agent.EscalationStuck, reason)
+	}
+}
+
+// markAppBuildFailedForTask flips the app behind a blocked BUILD task to
+// "failed" so the operator-facing surfaces stop saying "Building". The app
+// is found by its edit channel (task-<ID>); refines of ready apps no-op
+// inside MarkBuildFailed.
+func (l *Launcher) markAppBuildFailedForTask(task *teamTask) {
+	if l == nil || l.broker == nil || task == nil {
+		return
+	}
+	channel := strings.TrimSpace(task.Channel)
+	if channel == "" {
+		return
+	}
+	apps, err := l.broker.appStore().List()
+	if err != nil {
+		return
+	}
+	for i := range apps {
+		if strings.EqualFold(apps[i].EditChannel, channel) {
+			if err := l.broker.appStore().MarkBuildFailed(apps[i].ID); err == nil {
+				appendHeadlessCodexLog(appBuilderSlug, "recovery: marked "+apps[i].ID+" failed after terminal block")
+			}
+			return
+		}
+	}
+}
+
+// classifyFailureForOperator maps a raw turn-failure detail onto a plain
+// phrase for operator-facing copy. The raw text goes to the headless log.
+func classifyFailureForOperator(detail string) string {
+	switch {
+	case isTransientProviderErrorText(detail):
+		return "the AI provider connection dropped"
+	case strings.Contains(detail, "signal: killed"):
+		return "the run was stopped"
+	case strings.Contains(strings.ToLower(detail), "at capacity") ||
+		strings.Contains(strings.ToLower(detail), "overloaded") ||
+		strings.Contains(strings.ToLower(detail), "rate limit"):
+		return "the AI provider was overloaded"
+	case isDurabilityFailure(detail):
+		return "it finished without saving its work"
+	default:
+		return "something went wrong while it worked"
 	}
 }
 
@@ -417,7 +465,13 @@ func (l *Launcher) recoverFailedHeadlessTurn(slug string, turn headlessCodexTurn
 	// Only the detail string survives to this layer, so classify transience
 	// from it — same marker set the queue's fast path uses on the error.
 	transient := isTransientProviderErrorText(detail)
-	if shouldRetryHeadlessTurn(task, turn, transient) && !isDurabilityFailure(detail) {
+	// Builds get the same resume carve-out as the timeout path: a first
+	// build that dies on a NON-transient error (tool crash, bad exit)
+	// otherwise had zero retries and blocked straight into self-heal.
+	buildRetry := isAppBuilderSlug(slug) &&
+		turn.Attempts < headlessCodexLocalWorktreeRetryLimit &&
+		!isDurabilityFailure(detail)
+	if (shouldRetryHeadlessTurn(task, turn, transient) || buildRetry) && !isDurabilityFailure(detail) {
 		retryTurn := turn
 		retryTurn.Attempts++
 		retryTurn.EnqueuedAt = time.Now()
@@ -436,12 +490,18 @@ func (l *Launcher) recoverFailedHeadlessTurn(slug string, turn headlessCodexTurn
 	if trimmed == "" {
 		trimmed = "unknown headless codex failure"
 	}
-	reason := fmt.Sprintf("Automatic error recovery: @%s failed before a durable task handoff. Last error: %s. Requeue, retry, or reassign from here.", slug, truncate(trimmed, 220))
+	// The reason reaches the operator (task details + incident body): plain
+	// language, classified cause, no raw stderr — that goes to the log.
+	appendHeadlessCodexLog(slug, "error-recovery: raw failure detail: "+truncate(trimmed, 400))
+	reason := fmt.Sprintf("@%s hit an error and stopped after retrying (%s). Restart it from here, or hand it to another agent.", slug, classifyFailureForOperator(trimmed))
 	if _, changed, err := l.broker.BlockTask(task.ID, slug, reason, ""); err != nil {
 		appendHeadlessCodexLog(slug, fmt.Sprintf("error-recovery-error: could not block %s: %v", task.ID, err))
 		return
 	} else if changed {
 		appendHeadlessCodexLog(slug, fmt.Sprintf("error-recovery: blocked %s after failed turn", task.ID))
+		if isAppBuilderSlug(slug) {
+			l.markAppBuildFailedForTask(task)
+		}
 		_, _, _ = l.requestSelfHealing(slug, task.ID, agent.EscalationMaxRetries, reason)
 	}
 }
@@ -471,7 +531,7 @@ func (l *Launcher) timedOutTurnAlreadyRecovered(task *teamTask, slug string, sta
 // appRegistryTouchedSince reports whether any custom app's manifest was
 // created or updated at/after t — the App Builder's durable-completion
 // evidence. Manifest stamps are RFC3339; unparseable stamps are skipped.
-func (l *Launcher) appRegistryTouchedSince(t time.Time) bool {
+func (l *Launcher) appRegistryTouchedSince(t time.Time, task *teamTask) bool {
 	if l == nil || l.broker == nil || t.IsZero() {
 		return false
 	}
@@ -479,7 +539,18 @@ func (l *Launcher) appRegistryTouchedSince(t time.Time) bool {
 	if err != nil {
 		return false
 	}
+	// When the turn's task is known, only ITS app counts as evidence — a
+	// concurrent build touching some other manifest must not vouch for this
+	// turn (2026-08-16 first-run audit). With no task (defensive), any
+	// registry write still counts, preserving the pre-audit behavior.
+	taskChannel := ""
+	if task != nil {
+		taskChannel = strings.TrimSpace(task.Channel)
+	}
 	for _, app := range apps {
+		if taskChannel != "" && !strings.EqualFold(strings.TrimSpace(app.EditChannel), taskChannel) {
+			continue
+		}
 		for _, stamp := range []string{app.UpdatedAt, app.CreatedAt} {
 			ts, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(stamp))
 			if err != nil {

--- a/internal/team/headless_codex_recovery_test.go
+++ b/internal/team/headless_codex_recovery_test.go
@@ -40,11 +40,19 @@ func waitForTurnError(t *testing.T, ch <-chan error) error {
 // keywords, so neither the durability guard nor the external-action rules
 // interfere with the queue behavior under test.
 func newOfficeModeTaskForTest(t *testing.T, b *Broker) teamTask {
+	return newOfficeModeTaskForTestWithOwner(t, b, "app-builder")
+}
+
+// newOfficeModeTaskForTestWithOwner lets GENERIC office-contract tests pick a
+// non-builder owner: the App Builder now has its own retry carve-out
+// (resume-requeue on failure/timeout), so tests pinning the generic
+// block-on-failure contract must not run under its slug.
+func newOfficeModeTaskForTestWithOwner(t *testing.T, b *Broker, owner string) teamTask {
 	t.Helper()
 	task, reused, err := b.EnsurePlannedTask(plannedTaskInput{
 		Channel:       "general",
 		Title:         "Refresh the weekly metrics summary layout",
-		Owner:         "app-builder",
+		Owner:         owner,
 		CreatedBy:     "ceo",
 		TaskType:      "feature",
 		ExecutionMode: "office",
@@ -156,13 +164,13 @@ func TestHeadlessQueueDoesNotRetryOfficeTurnAfterNonTransientError(t *testing.T)
 	t.Setenv("HOME", t.TempDir())
 
 	b := newTestBroker(t)
-	task := newOfficeModeTaskForTest(t, b)
+	task := newOfficeModeTaskForTestWithOwner(t, b, "cmo")
 
 	var mu sync.Mutex
 	calls := 0
 	turnDone := make(chan error, 4)
 	setHeadlessCodexRunTurnForTest(t, func(_ *Launcher, _ context.Context, slug, _ string, _ ...string) error {
-		if slug != "app-builder" {
+		if slug != "cmo" {
 			return nil
 		}
 		mu.Lock()
@@ -176,7 +184,7 @@ func TestHeadlessQueueDoesNotRetryOfficeTurnAfterNonTransientError(t *testing.T)
 	l := newHeadlessLauncherForTest(t)
 	l.broker = b
 
-	l.enqueueHeadlessCodexTurnRecord("app-builder", headlessCodexTurn{
+	l.enqueueHeadlessCodexTurnRecord("cmo", headlessCodexTurn{
 		Prompt:  "Work the office build for #" + task.ID,
 		Channel: task.Channel,
 		TaskID:  task.ID,
@@ -199,7 +207,7 @@ func TestHeadlessQueueDoesNotRetryOfficeTurnAfterNonTransientError(t *testing.T)
 		t.Fatalf("expected non-transient failure to keep the BlockTask recovery path, got status=%s blocked=%v", updated.Status(), updated.Blocked())
 	}
 
-	for _, line := range b.AgentStream("app-builder").recentTask(task.ID) {
+	for _, line := range b.AgentStream("cmo").recentTask(task.ID) {
 		if strings.Contains(line, `"type":"reconnecting"`) {
 			t.Fatalf("expected no reconnecting event for a non-transient failure, got %q", line)
 		}
@@ -326,7 +334,7 @@ func TestRecoverFailedHeadlessTurnRetriesOfficeTaskOnceOnTransientFailure(t *tes
 	t.Setenv("HOME", t.TempDir())
 
 	b := newTestBroker(t)
-	task := newOfficeModeTaskForTest(t, b)
+	task := newOfficeModeTaskForTestWithOwner(t, b, "cmo")
 
 	l := newHeadlessLauncherForTest(t)
 	l.broker = b
@@ -336,13 +344,13 @@ func TestRecoverFailedHeadlessTurnRetriesOfficeTaskOnceOnTransientFailure(t *tes
 		Channel: task.Channel,
 		TaskID:  task.ID,
 	}
-	lane := l.laneForTurn("app-builder", turn)
+	lane := l.laneForTurn("cmo", turn)
 	l.headless.mu.Lock()
 	l.headless.workers[lane] = true // keep the queue inspectable: no worker spawns
 	l.headless.mu.Unlock()
 
 	detail := "exit status 1: read tcp 10.0.0.5:52344->104.18.2.1:443: read: connection reset by peer"
-	l.recoverFailedHeadlessTurn("app-builder", turn, time.Now().UTC().Add(-2*time.Second), detail)
+	l.recoverFailedHeadlessTurn("cmo", turn, time.Now().UTC().Add(-2*time.Second), detail)
 
 	l.headless.mu.Lock()
 	queued := append([]headlessCodexTurn(nil), l.headless.queues[lane]...)
@@ -354,7 +362,7 @@ func TestRecoverFailedHeadlessTurnRetriesOfficeTaskOnceOnTransientFailure(t *tes
 	if retry.Attempts != 1 {
 		t.Fatalf("expected recovery retry attempt 1, got %+v", retry)
 	}
-	if !strings.Contains(retry.Prompt, "Previous attempt by @app-builder failed") {
+	if !strings.Contains(retry.Prompt, "Previous attempt by @cmo failed") {
 		t.Fatalf("expected retry prompt note, got %q", retry.Prompt)
 	}
 
@@ -365,7 +373,7 @@ func TestRecoverFailedHeadlessTurnRetriesOfficeTaskOnceOnTransientFailure(t *tes
 
 	// Second transient failure of the recovery retry: the one-retry budget is
 	// spent, so the old BlockTask path takes over.
-	l.recoverFailedHeadlessTurn("app-builder", retry, time.Now().UTC().Add(-1*time.Second), detail)
+	l.recoverFailedHeadlessTurn("cmo", retry, time.Now().UTC().Add(-1*time.Second), detail)
 	updated = taskByIDForTest(t, b, task.ID)
 	if !updated.Blocked() && updated.Status() != "blocked" {
 		t.Fatalf("expected the second transient failure to block the task, got status=%s blocked=%v", updated.Status(), updated.Blocked())

--- a/internal/team/headless_codex_test.go
+++ b/internal/team/headless_codex_test.go
@@ -1435,7 +1435,7 @@ func TestRecoverTimedOutHeadlessTurnBlocksTaskWithoutSubstantiveReply(t *testing
 	if updated.Status() != "blocked" || !updated.Blocked() {
 		t.Fatalf("expected task to be blocked after empty timeout, got %+v", updated)
 	}
-	if !strings.Contains(updated.Details, "timed out") {
+	if !strings.Contains(updated.Details, "ran out of time") {
 		t.Fatalf("expected timeout detail appended, got %+v", updated)
 	}
 }
@@ -1808,8 +1808,10 @@ func TestRecoverFailedHeadlessTurnBlocksLocalWorktreeAfterRetryExhausted(t *test
 	if updated.Status() != "blocked" || !updated.Blocked() {
 		t.Fatalf("expected task to be blocked after retry budget exhausted, got %+v", updated)
 	}
-	if !strings.Contains(updated.Details, "Selected model is at capacity") {
-		t.Fatalf("expected failure detail appended, got %+v", updated)
+	// The block reason is operator-voice now: the raw provider text goes to
+	// the headless log; the reason carries the classified cause.
+	if !strings.Contains(updated.Details, "the AI provider was overloaded") {
+		t.Fatalf("expected classified failure detail appended, got %+v", updated)
 	}
 	var healTask teamTask
 	for _, candidate := range b.AllTasks() {

--- a/internal/team/office_eval_jobs_platform_honesty.go
+++ b/internal/team/office_eval_jobs_platform_honesty.go
@@ -89,8 +89,8 @@ func evalJobPlatformHonesty(fx *officeEvalFixture, r *OfficeEvalReport) error {
 	notes := fx.channelMessagesByKind(stalled.Channel, taskStalledMessageKind)
 	lineOK := len(notes) == 1 &&
 		strings.Contains(notes[0].Content, "@eng") &&
-		strings.Contains(notes[0].Content, "no visible activity") &&
-		strings.Contains(notes[0].Content, taskID)
+		strings.Contains(notes[0].Content, "gone quiet") &&
+		strings.Contains(notes[0].Content, stalled.Title)
 	detail := fmt.Sprintf("lines=%d", len(notes))
 	if len(notes) > 0 {
 		detail += " first=" + truncate(notes[0].Content, 120)

--- a/web/src/api/apps.ts
+++ b/web/src/api/apps.ts
@@ -18,7 +18,7 @@ export interface CustomApp {
    * "building" = a pre-scaffolded app awaiting its first published build
    * (shown as a building row, not a clickable app). Absent/"ready" = published.
    */
-  status?: "building" | "ready";
+  status?: "building" | "ready" | "failed";
   /**
    * Slug of the app's persistent edit thread — the channel of the App Builder
    * task that created/improves it (`task-<id>`). The app view binds its

--- a/web/src/components/apps/AppLivePreview.tsx
+++ b/web/src/components/apps/AppLivePreview.tsx
@@ -81,9 +81,16 @@ export function AppLivePreview({
         <p className="app-build-preview__state-title">
           Preview failed to start
         </p>
-        <pre className="app-build-preview__bootlog-text">
-          {data.boot_log || data.error}
-        </pre>
+        <p className="app-build-preview__state-detail">
+          The agent's page could not boot. Ask the agent to fix it in chat, or
+          check the detail below.
+        </p>
+        <details className="app-build-preview__bootlog" open={false}>
+          <summary>Show technical detail</summary>
+          <pre className="app-build-preview__bootlog-text">
+            {data.boot_log || data.error}
+          </pre>
+        </details>
       </div>
     );
   }

--- a/web/src/components/apps/buildActivity.ts
+++ b/web/src/components/apps/buildActivity.ts
@@ -144,6 +144,25 @@ function bashVerb(command: string): string {
   return "Running a setup step";
 }
 
+/** Heuristic error sniff on a tool_result payload: explicit error envelopes
+ * and the classic crash prefixes. Conservative on purpose — a false checkmark
+ * hides failures, a false ✗ cries wolf. */
+function looksLikeToolError(text: string): boolean {
+  const t = text.trim();
+  if (!t) return false;
+  try {
+    const parsed: unknown = JSON.parse(t);
+    if (parsed && typeof parsed === "object") {
+      const o = parsed as { is_error?: unknown; error?: unknown };
+      if (o.is_error === true) return true;
+      if (typeof o.error === "string" && o.error.trim()) return true;
+    }
+  } catch {
+    // plain text — fall through
+  }
+  return /^(error|fatal|panic):/i.test(t);
+}
+
 /** Condense a tool_result payload into a short one-line note. */
 export function summarizeResult(text: string): string {
   const t = text.trim();
@@ -229,9 +248,12 @@ export function reduceBuildActivity(
       case "tool_result": {
         const q = open.get(key);
         const note = summarizeResult(ev.text);
+        // An error payload must not render as a checkmark (2026-08-16
+        // audit: the feed could literally never show a failure).
+        const failed = looksLikeToolError(ev.text);
         if (q && q.length > 0) {
           const idx = q.shift() as number;
-          items[idx].status = "done";
+          items[idx].status = failed ? "error" : "done";
           if (note) items[idx].note = note;
         } else {
           const { verb, target } = humanizeToolEvent(ev.toolName, "");
@@ -239,7 +261,7 @@ export function reduceBuildActivity(
             id: `${ev.turnId}:${ev.toolName}:${seq++}`,
             verb,
             target,
-            status: "done",
+            status: failed ? "error" : "done",
             note: note || undefined,
             turn: ev.turnId,
           });

--- a/web/src/components/onboarding/LocalProviderPicker.tsx
+++ b/web/src/components/onboarding/LocalProviderPicker.tsx
@@ -63,10 +63,9 @@ export function LocalProviderPicker({
           className="pre-pick-local-error"
           data-testid="pre-pick-local-fetch-error"
         >
-          Could not reach the broker to check installed runtimes:{" "}
-          <code>{fetchError}</code>. You can still pick providers — install
-          commands are in <strong>Settings &rarr; Local LLMs</strong> after
-          onboarding.
+          We could not check which local models are installed just now. You can
+          still pick one — we verify it after setup, and install commands live
+          in <strong>Settings &rarr; Local LLMs</strong>.
         </div>
       ) : null}
       {!loading ? (

--- a/web/src/components/onboarding/PrePickScreen.test.tsx
+++ b/web/src/components/onboarding/PrePickScreen.test.tsx
@@ -399,11 +399,6 @@ describe("config sections collapse", () => {
       toggle: "pre-pick-local-toggle",
       body: "pre-pick-local-body",
     },
-    {
-      name: "Custom endpoint",
-      toggle: "pre-pick-oai-toggle",
-      body: "pre-pick-oai-body",
-    },
   ];
 
   for (const section of SECTIONS) {
@@ -593,88 +588,11 @@ describe("local provider picker", () => {
   });
 });
 
-describe("OpenAI-compatible endpoint", () => {
-  it("renders the OAI-compatible section", async () => {
-    mockPrereqs({});
-    render(<PrePickScreen onComplete={vi.fn()} />);
-    await screen.findByTestId("pre-pick-oai-section");
-    expect(screen.getByTestId("pre-pick-oai-compat")).toBeInTheDocument();
-  });
-
-  it("does not show submit button when only an invalid URL is entered", async () => {
-    mockPrereqs({});
-    render(<PrePickScreen onComplete={vi.fn()} />);
-    await screen.findByTestId("pre-pick-oai-url");
-
-    fireEvent.change(screen.getByTestId("pre-pick-oai-url"), {
-      target: { value: "not-a-url" },
-    });
-
-    // URL error message should appear
-    expect(
-      await screen.findByTestId("pre-pick-oai-url-error"),
-    ).toBeInTheDocument();
-    // Submit button must NOT appear
-    expect(screen.queryByTestId("pre-pick-form-submit")).toBeNull();
-  });
-
-  it("shows submit button and posts provider_endpoints when a valid URL is entered", async () => {
-    mockPrereqs({});
-    const onComplete = vi.fn();
-    render(<PrePickScreen onComplete={onComplete} />);
-    await screen.findByTestId("pre-pick-oai-url");
-
-    fireEvent.change(screen.getByTestId("pre-pick-oai-url"), {
-      target: { value: "https://my-server.example.com/v1" },
-    });
-
-    const submitBtn = await screen.findByTestId("pre-pick-form-submit");
-    fireEvent.click(submitBtn);
-
-    await waitFor(() => expect(onComplete).toHaveBeenCalledTimes(1));
-    expect(postMock).toHaveBeenCalledWith(
-      "/config",
-      expect.objectContaining({
-        provider_endpoints: expect.objectContaining({
-          "openai-compatible": expect.objectContaining({
-            base_url: "https://my-server.example.com/v1",
-          }),
-        }),
-      }),
-    );
-  });
-
-  it("does not conflate the OAI-compat endpoint with OpenClaw config", async () => {
-    // Filling the Custom endpoint section writes only to provider_endpoints.
-    // OpenClaw is a gateway managed through Integrations, not a runtime.
-    mockPrereqs({});
-    const onComplete = vi.fn();
-    render(<PrePickScreen onComplete={onComplete} />);
-    await screen.findByTestId("pre-pick-oai-url");
-
-    fireEvent.change(screen.getByTestId("pre-pick-oai-url"), {
-      target: { value: "https://example.com/v1" },
-    });
-    fireEvent.change(screen.getByTestId("pre-pick-oai-key"), {
-      target: { value: "tok-secret" },
-    });
-
-    const submitBtn = await screen.findByTestId("pre-pick-form-submit");
-    fireEvent.click(submitBtn);
-
-    await waitFor(() => expect(onComplete).toHaveBeenCalledTimes(1));
-    const calledPayload = postMock.mock.calls[0]?.[1] as Record<
-      string,
-      unknown
-    >;
-    expect(calledPayload.openclaw_token).toBeUndefined();
-    expect(calledPayload.openclaw_gateway_url).toBeUndefined();
-    expect(calledPayload.provider_endpoints).toMatchObject({
-      "openai-compatible": { base_url: "https://example.com/v1" },
-    });
-  });
-});
-
+// The "Custom endpoint" section was REMOVED (2026-08-16 audit): the FE
+// posted provider_endpoints keyed "openai-compatible", a kind no provider
+// registers, so the path 400'd on every submit — a setup flow that could
+// never succeed. A working custom-endpoint runtime can return as its own
+// feature with a registered provider kind.
 describe("canContinue predicate", () => {
   it("does not show form submit button when no form section is filled", async () => {
     mockPrereqs({});

--- a/web/src/components/onboarding/PrePickScreen.tsx
+++ b/web/src/components/onboarding/PrePickScreen.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from "react";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import type { LLMRuntimeKind } from "../../api/client";
 import { get, post } from "../../api/client";
@@ -56,6 +56,7 @@ interface RuntimeCardState {
 interface RuntimeCardProps {
   state: RuntimeCardState;
   prereqsLoaded: boolean;
+  prereqsFailed: boolean;
   isSubmitting: boolean;
   anySubmitting: boolean;
   expanded: boolean;
@@ -68,16 +69,19 @@ interface RuntimeCardProps {
 
 function cardStatusLabel({
   prereqsLoaded,
+  prereqsFailed,
   available,
   version,
   signedIn,
 }: {
   prereqsLoaded: boolean;
+  prereqsFailed: boolean;
   available: boolean;
   version: string | undefined;
   signedIn: boolean | undefined;
 }): string {
   if (!prereqsLoaded) return "Checking…";
+  if (prereqsFailed) return "Could not check — verify below";
   if (!available) return "Not installed";
   // Issue #932: when the runtime supports a session probe and we got a
   // definite "not signed in", surface that as the primary status. The user
@@ -95,6 +99,7 @@ function cardStatusLabel({
 function RuntimeCard({
   state,
   prereqsLoaded,
+  prereqsFailed,
   isSubmitting,
   anySubmitting,
   expanded,
@@ -109,6 +114,7 @@ function RuntimeCard({
     ? "Starting your office…"
     : cardStatusLabel({
         prereqsLoaded,
+        prereqsFailed,
         available,
         version: detected?.version,
         signedIn,
@@ -210,11 +216,6 @@ const DISPATCHABLE_RUNTIMES = RUNTIMES.filter((r) => r.provider !== null);
 // Empty initial state for the API-key map.
 const EMPTY_API_KEYS: Record<string, string> = {};
 
-/** Returns true when the OAI-compatible endpoint URL+key pair is usable. */
-function oaiCompatFilled(url: string): boolean {
-  return url.trim().length > 0 && isValidUrl(url);
-}
-
 /** Returns true when at least one API key has been pasted. */
 function anyApiKeyFilled(keys: Record<string, string>): boolean {
   return API_KEY_FIELDS.some((f) => (keys[f.key] ?? "").trim().length > 0);
@@ -234,15 +235,9 @@ function isCliProvider(provider: RuntimeSpec["provider"] | string): boolean {
 function hasConfigContent(
   isCliRuntime: boolean,
   localProviders: readonly LLMRuntimeKind[],
-  oaiUrl: string,
   apiKeys: Record<string, string>,
 ): boolean {
-  return (
-    isCliRuntime ||
-    localProviders.length > 0 ||
-    oaiCompatFilled(oaiUrl) ||
-    anyApiKeyFilled(apiKeys)
-  );
+  return isCliRuntime || localProviders.length > 0 || anyApiKeyFilled(apiKeys);
 }
 
 type ConfigPayload = {
@@ -263,14 +258,6 @@ type ConfigPayload = {
 function buildConfigPayload(
   selectedProviders: LLMRuntimeKind[],
   localProviders: LLMRuntimeKind[],
-  oaiUrl: string,
-  // _oaiKey is intentionally unused on the current write path: the OAI-
-  // compatible endpoint section writes only to provider_endpoints, never
-  // to openclaw_* (gateway config) or to an Anthropic/OpenAI key row.
-  // Kept in the signature so the call site can stay 1:1 with form
-  // state — renaming the parameter to _oaiKey marks the intent for
-  // TypeScript-aware linters without forcing a 4-argument call shape.
-  _oaiKey: string,
   apiKeys: Record<string, string>,
 ): ConfigPayload {
   const payload: ConfigPayload = { memory_backend: "markdown" };
@@ -285,17 +272,6 @@ function buildConfigPayload(
   if (providerPriority.length > 0) {
     payload.llm_provider = providerPriority[0];
     payload.llm_provider_priority = providerPriority;
-  } else if (oaiCompatFilled(oaiUrl)) {
-    // Custom OAI-compatible endpoint goes into provider_endpoints. We do
-    // NOT write to openclaw_* here — that conflated OpenClaw (a gateway
-    // for importing existing agents) with generic OpenAI-compatible HTTP
-    // runtimes. OpenClaw is configured through the Integrations app, not
-    // through this onboarding step. The _oaiKey parameter is intentionally
-    // unused on this path; users wanting to pair an API key with the
-    // endpoint should paste it in the OpenAI API key row above.
-    payload.provider_endpoints = {
-      "openai-compatible": { base_url: sanitizeConfigString(oaiUrl) },
-    };
   }
 
   for (const f of API_KEY_FIELDS) {
@@ -332,14 +308,14 @@ function VerifyClipFigure() {
           src="/media/onboarding/provider-verify.gif"
           width={808}
           height={600}
-          alt="A runtime being verified: Claude Code is checked for an installed binary, an active sign-in, and a reachable model, then resolves to Connected."
+          alt="A runtime being verified: Claude Code is checked for an install and an active sign-in, then resolves to Ready."
           loading="lazy"
           decoding="async"
         />
       </picture>
       <figcaption className="pre-pick-clip-caption">
-        "Set up &amp; verify" checks the binary, your sign-in, and that the
-        model is reachable before you continue.
+        "Set up &amp; verify" checks the install and your sign-in before you
+        continue.
       </figcaption>
     </figure>
   );
@@ -463,55 +439,14 @@ function LocalModelSection({
       sectionTestId="pre-pick-local-section"
       idBase="pre-pick-local"
       title="Local model"
-      toggleHint="Optional — run inference on this machine"
+      toggleHint="Optional — run a model on this computer"
       open={open}
       onToggle={onToggle}
     >
       <p className="pre-pick-section-hint">
-        Run inference on this machine. No cloud key required.
+        Run a model on this computer. No cloud account needed.
       </p>
       <LocalProviderPicker selected={selected} onToggle={onToggleProvider} />
-    </CollapsibleConfigSection>
-  );
-}
-
-interface CustomEndpointSectionProps {
-  open: boolean;
-  onToggle: () => void;
-  oaiUrl: string;
-  oaiKey: string;
-  onChangeUrl: (value: string) => void;
-  onChangeKey: (value: string) => void;
-}
-
-function CustomEndpointSection({
-  open,
-  onToggle,
-  oaiUrl,
-  oaiKey,
-  onChangeUrl,
-  onChangeKey,
-}: CustomEndpointSectionProps) {
-  return (
-    <CollapsibleConfigSection
-      sectionTestId="pre-pick-oai-section"
-      idBase="pre-pick-oai"
-      title="Custom endpoint"
-      toggleHint="Optional — OpenAI-compatible server"
-      open={open}
-      onToggle={onToggle}
-    >
-      <p className="pre-pick-section-hint">
-        Any server that speaks the OpenAI REST protocol (LiteLLM, vLLM,
-        llama.cpp server, etc.). For OpenClaw or Hermes, use the Integrations
-        app after onboarding.
-      </p>
-      <OpenAICompatibleInput
-        endpointUrl={oaiUrl}
-        apiKey={oaiKey}
-        onChangeUrl={onChangeUrl}
-        onChangeKey={onChangeKey}
-      />
     </CollapsibleConfigSection>
   );
 }
@@ -519,6 +454,7 @@ function CustomEndpointSection({
 export function PrePickScreen({ onComplete }: PrePickScreenProps) {
   const [prereqs, setPrereqs] = useState<PrereqResult[]>([]);
   const [prereqsLoaded, setPrereqsLoaded] = useState(false);
+  const [prereqsFailed, setPrereqsFailed] = useState(false);
   const [submitting, setSubmitting] = useState<string | null>(null);
   const [submitError, setSubmitError] = useState<string>("");
   const [selectedProviders, setSelectedProviders] = useState<LLMRuntimeKind[]>(
@@ -534,13 +470,10 @@ export function PrePickScreen({ onComplete }: PrePickScreenProps) {
   // (hidden) when closed so in-progress field state survives a collapse.
   const [apiKeysOpen, setApiKeysOpen] = useState(false);
   const [localOpen, setLocalOpen] = useState(false);
-  const [oaiOpen, setOaiOpen] = useState(false);
 
   const [localProviders, setLocalProviders] = useState<LLMRuntimeKind[]>([]);
 
   // OpenAI-compatible custom endpoint
-  const [oaiUrl, setOaiUrl] = useState<string>("");
-  const [oaiKey, setOaiKey] = useState<string>("");
 
   // Guided-setup + verify state (spec section B). At most one runtime's guide
   // is expanded at a time. `verifiedReady` records the runtimes a live verify
@@ -559,8 +492,11 @@ export function PrePickScreen({ onComplete }: PrePickScreenProps) {
         setPrereqs(prereqsFromPayload(data));
       })
       .catch(() => {
-        // Prereqs unreachable -- render runtime cards in "Not installed" state
-        // so the user can proceed via another path (API key / local / skip).
+        // Probe unreachable is UNKNOWN, not "Not installed" — a failed check
+        // must not present as a detected fact (2026-08-16 audit). Cards show
+        // an honest could-not-check state; other paths (API key / local /
+        // skip) stay available.
+        if (!cancelled) setPrereqsFailed(true);
       })
       .finally(() => {
         if (!cancelled) setPrereqsLoaded(true);
@@ -599,8 +535,7 @@ export function PrePickScreen({ onComplete }: PrePickScreenProps) {
   const canContinueFromForm =
     selectedProviders.length > 0 ||
     anyApiKeyFilled(apiKeys) ||
-    localProviders.length > 0 ||
-    oaiCompatFilled(oaiUrl);
+    localProviders.length > 0;
 
   function handleApiKeyChange(key: string, value: string): void {
     setApiKeys((prev) => ({ ...prev, [key]: value }));
@@ -629,6 +564,23 @@ export function PrePickScreen({ onComplete }: PrePickScreenProps) {
 
   // True once any runtime has verified ready — drives the primary CTA copy.
   const anyRuntimeReady = Object.values(verifiedReady).some(Boolean);
+  // The runtime that verified ready (first wins): Next commits THIS one,
+  // not whichever guide happens to be expanded — collapsing the guide used
+  // to make the advance button vanish (2026-08-16 audit).
+  const readyRuntime = runtimes.find((r) => verifiedReady[r.spec.binary]);
+
+  // Sensible default: exactly one runtime is already signed in — open its
+  // guide (autoVerify turns it into live checkmarks) so the first screen
+  // leads with the working path instead of three equal cards.
+  const autoExpandedRef = useRef(false);
+  useEffect(() => {
+    if (!prereqsLoaded || autoExpandedRef.current || expandedGuide) return;
+    const signedIn = runtimes.filter((r) => r.signedIn === true);
+    if (signedIn.length === 1) {
+      autoExpandedRef.current = true;
+      setExpandedGuide(signedIn[0].spec.binary);
+    }
+  }, [prereqsLoaded, expandedGuide, runtimes]);
 
   // Issue #979 guard: best-effort probe of /onboarding/state at click time.
   // If the broker reports phase=complete, the SPA is in a session-loss
@@ -675,14 +627,12 @@ export function PrePickScreen({ onComplete }: PrePickScreenProps) {
       const configPayload = buildConfigPayload(
         selected,
         localProviders,
-        oaiUrl,
-        oaiKey,
         apiKeys,
       );
       if (
         !isSkipChoice &&
         (selected.length > 0 ||
-          hasConfigContent(isCli, localProviders, oaiUrl, apiKeys))
+          hasConfigContent(isCli, localProviders, apiKeys))
       ) {
         await post("/config", configPayload);
       }
@@ -779,6 +729,7 @@ export function PrePickScreen({ onComplete }: PrePickScreenProps) {
                     key={state.spec.label}
                     state={state}
                     prereqsLoaded={prereqsLoaded}
+                    prereqsFailed={prereqsFailed}
                     isSubmitting={submitting === state.spec.label}
                     anySubmitting={anySubmitting}
                     expanded={expandedGuide === state.spec.binary}
@@ -808,7 +759,7 @@ export function PrePickScreen({ onComplete }: PrePickScreenProps) {
               ) : null}
 
               {/* ── Advance when a runtime has verified ready ───────────── */}
-              {anyRuntimeReady && expandedRuntime ? (
+              {readyRuntime ? (
                 <div className="pre-pick-secondary-row">
                   <button
                     type="button"
@@ -817,14 +768,14 @@ export function PrePickScreen({ onComplete }: PrePickScreenProps) {
                     disabled={anySubmitting}
                     onClick={() =>
                       void commitChoice(
-                        expandedRuntime.spec.provider,
-                        expandedRuntime.spec.label,
+                        readyRuntime.spec.provider,
+                        readyRuntime.spec.label,
                       )
                     }
                   >
-                    {submitting === expandedRuntime.spec.label
-                      ? "Opening your office…"
-                      : "Next  →"}
+                    {submitting === readyRuntime.spec.label
+                      ? "Opening your workspace…"
+                      : `Next with ${readyRuntime.spec.label}  →`}
                   </button>
                 </div>
               ) : null}
@@ -844,14 +795,6 @@ export function PrePickScreen({ onComplete }: PrePickScreenProps) {
                 selected={localProviders}
                 onToggleProvider={toggleLocalProvider}
               />
-              <CustomEndpointSection
-                open={oaiOpen}
-                onToggle={() => setOaiOpen((open) => !open)}
-                oaiUrl={oaiUrl}
-                oaiKey={oaiKey}
-                onChangeUrl={setOaiUrl}
-                onChangeKey={setOaiKey}
-              />
             </div>
 
             {/* ── Submit from form sections ──────────────────────────────── */}
@@ -859,13 +802,13 @@ export function PrePickScreen({ onComplete }: PrePickScreenProps) {
               <div className="pre-pick-secondary-row">
                 <button
                   type="button"
-                  className="btn btn-primary pre-pick-form-submit"
+                  className={`btn ${readyRuntime ? "" : "btn-primary "}pre-pick-form-submit`}
                   data-testid="pre-pick-form-submit"
                   disabled={anySubmitting}
                   onClick={() => void commitChoice("form", "form")}
                 >
                   {submitting === "form"
-                    ? "Opening your office…"
+                    ? "Opening your workspace…"
                     : "Continue  →"}
                 </button>
                 {selectedProviderLabels.length > 0 ? (
@@ -886,7 +829,7 @@ export function PrePickScreen({ onComplete }: PrePickScreenProps) {
                 onClick={() => void commitChoice(null, "skip")}
               >
                 {submitting === "skip"
-                  ? "Opening your office…"
+                  ? "Opening your workspace…"
                   : "I will add one later  →"}
               </button>
             </div>

--- a/web/src/components/onboarding/wizard/EmbeddingChoice.tsx
+++ b/web/src/components/onboarding/wizard/EmbeddingChoice.tsx
@@ -31,7 +31,27 @@ import { ONBOARDING_EMBEDDING_COPY as COPY } from "./wizardSteps";
 /** How often to re-read the options while an install is running. */
 const INSTALL_POLL_MS = 2_000;
 /** Hard ceiling on the poll so a wedged install never loops forever (~6 min). */
-const INSTALL_POLL_CAP_MS = 6 * 60 * 1_000;
+// Must OUTLAST the broker's install budget (12 minutes, installTimeout in
+// broker_knowledge.go) — a shorter cap fabricated a client-side failure
+// while the real install was still running (2026-08-16 audit).
+/** The backend streams BOTH curated step headlines ("Installing Bun...")
+ * and raw installer stdout through the same progress field. Only the
+ * curated lines belong in the headline slot — raw bootstrap output reads
+ * as developer exhaust to a first-run operator (2026-08-16 audit). */
+function curatedProgressLine(progress: string): string {
+  const line = progress.trim();
+  if (!line) return "";
+  if (
+    /^(Installing|Applying|Preparing|Starting|Checking|Downloading|Setting up|Finishing)\b/.test(
+      line,
+    )
+  ) {
+    return line;
+  }
+  return "";
+}
+
+const INSTALL_POLL_CAP_MS = 13 * 60 * 1_000;
 
 interface EmbeddingChoiceViewProps {
   /** The current embedding options (drives every state). */
@@ -123,8 +143,14 @@ function InstallPanel({
             className="onboarding-embedding-install-progress"
             data-testid="onboarding-embedding-install-progress"
           >
-            {progress.trim() || COPY.install.progressPending}
+            {curatedProgressLine(progress) || COPY.install.progressPending}
           </p>
+          {progress.trim() && !curatedProgressLine(progress) ? (
+            <details className="onboarding-embedding-install-raw">
+              <summary>Show technical detail</summary>
+              <pre>{progress.trim()}</pre>
+            </details>
+          ) : null}
           <p className="onboarding-embedding-install-hint">
             {COPY.install.installingHint}
           </p>
@@ -159,8 +185,14 @@ function InstallPanel({
             role="alert"
             data-testid="onboarding-embedding-install-error"
           >
-            {error.trim() || COPY.install.errorFallback}
+            {COPY.install.errorFallback}
           </p>
+          {error.trim() ? (
+            <details className="onboarding-embedding-install-raw">
+              <summary>Show technical detail</summary>
+              <pre>{error.trim()}</pre>
+            </details>
+          ) : null}
           <p className="onboarding-embedding-install-hint">
             {COPY.install.keywordFallback}
           </p>

--- a/web/src/components/onboarding/wizard/useOnboardingWizard.ts
+++ b/web/src/components/onboarding/wizard/useOnboardingWizard.ts
@@ -46,10 +46,10 @@ import {
 import { OPERATOR_FIRST_WORKFLOW_SEED_KEY } from "../../../operator/firstWorkflowSeed";
 import { HOME_COMPOSER_DRAFT_CHANNEL, useAppStore } from "../../../stores/app";
 import {
-  pickFirstIssueExample,
   ONBOARDING_WIZARD_STEP_IDS,
   type OnboardingAnswers,
   type OnboardingWizardStepId,
+  pickFirstIssueExample,
 } from "./wizardSteps";
 
 /**

--- a/web/src/components/onboarding/wizard/wizardSteps.ts
+++ b/web/src/components/onboarding/wizard/wizardSteps.ts
@@ -105,7 +105,8 @@ export const ONBOARDING_FIRST_ISSUE_EXAMPLES: readonly string[] = [
 ];
 
 /** Back-compat: the canonical example (tests and the tour handoff pin it). */
-export const ONBOARDING_FIRST_ISSUE_EXAMPLE = ONBOARDING_FIRST_ISSUE_EXAMPLES[0];
+export const ONBOARDING_FIRST_ISSUE_EXAMPLE =
+  ONBOARDING_FIRST_ISSUE_EXAMPLES[0];
 
 /** Pick the prefill for this visit. */
 export function pickFirstIssueExample(): string {

--- a/web/src/operator/apps/useOperatorApps.test.ts
+++ b/web/src/operator/apps/useOperatorApps.test.ts
@@ -79,9 +79,24 @@ describe("appBuildState", () => {
     expect(appBuildState(a, now)).toBe("building");
   });
 
-  it("reports failed for a build stalled past the timeout", () => {
-    const a = app({ status: "building", createdAt: "2026-06-29T11:40:00Z" });
+  it("reports failed for a build stalled past the backstop window", () => {
+    // The backstop is 80 minutes now (the broker stamps real failures on the
+    // wire); a build 90 minutes old with no status flip means the broker died.
+    const a = app({ status: "building", createdAt: "2026-06-29T10:35:00Z" });
     expect(appBuildState(a, now)).toBe("failed");
+  });
+
+  it("reads a broker-stamped failed status straight off the wire", () => {
+    const a = app({ status: "failed", createdAt: "2026-06-29T12:04:00Z" });
+    expect(appBuildState(a, now)).toBe("failed");
+  });
+
+  it("keeps a 20-minute-old build honest — still building, not failed", () => {
+    // Regression (2026-08-16 audit): the old 10-minute window declared
+    // legitimately-running first builds failed while the broker's own
+    // budget was 25 minutes.
+    const a = app({ status: "building", createdAt: "2026-06-29T11:45:00Z" });
+    expect(appBuildState(a, now)).toBe("building");
   });
 });
 

--- a/web/src/operator/apps/useOperatorApps.ts
+++ b/web/src/operator/apps/useOperatorApps.ts
@@ -28,7 +28,11 @@ const APPS_POLL_MS = 4000;
  * agent stalled — so the operator should see a failure it can clear, not a
  * forever-spinning "building" row.
  */
-const BUILD_STALL_MS = 10 * 60 * 1000;
+// The broker's build budget is 25 minutes per attempt with up to two
+// resume-requeues (WUPHF_BUILD_TIMEOUT + the recovery carve-out), and a
+// terminally failed build is stamped status="failed" on the wire now — this
+// client-side window is only the backstop for a broker that died mid-build.
+const BUILD_STALL_MS = 80 * 60 * 1000;
 
 /** App ids carry an `app_<hex>` prefix; the operator uses it to tell a real
  * built app apart from a mock tool id. */
@@ -49,6 +53,7 @@ export function appBuildState(
   app: CustomApp,
   now: number = Date.now(),
 ): AppBuildState {
+  if (app.status === "failed") return "failed";
   if (app.status !== "building") return "ready";
   const created = Date.parse(app.createdAt ?? "");
   if (Number.isFinite(created) && now - created > BUILD_STALL_MS) {
@@ -177,17 +182,17 @@ const AGENT_ROLES: ReadonlyArray<[RegExp, string]> = [
   ],
   // Nouns accept plurals; bare verbs ("score", "route", "inbound") are gone —
   // they collide with every other domain ("score a task", "inbound tickets").
-  [
-    /\b(leads?|lead routing|demo requests?)\b/i,
-    "Lead Routing Agent",
-  ],
+  [/\b(leads?|lead routing|demo requests?)\b/i, "Lead Routing Agent"],
   [/\b(pipelines?|deals?|forecasts?)\b/i, "Pipeline Agent"],
   [/\b(sales|quotas?|outreach|prospects?)\b/i, "Sales Agent"],
   [/\b(support|tickets?|escalations?|incidents?)\b/i, "Support Triage Agent"],
   [/\b(invoices?|billing|receivables?|dunning)\b/i, "Invoice Agent"],
   [/\b(expenses?|reimburse|spend)\b/i, "Expense Agent"],
   [/\b(email|inbox|follow[- ]?ups?|replies|nurture)\b/i, "Follow-up Agent"],
-  [/\b(reports?|summar|digests?|dashboards?|recaps?|kpis?|metrics?)\b/i, "Reporting Agent"],
+  [
+    /\b(reports?|summar|digests?|dashboards?|recaps?|kpis?|metrics?)\b/i,
+    "Reporting Agent",
+  ],
   [/\b(onboard|welcome|signups?|sign-ups?)\b/i, "Onboarding Agent"],
 ];
 

--- a/web/src/operator/surfaces/AppBuilderChat.tsx
+++ b/web/src/operator/surfaces/AppBuilderChat.tsx
@@ -11,10 +11,7 @@ import { ArrowRight, Check, Send, X } from "lucide-react";
 
 import { type CustomApp, listApps, submitAppEdit } from "../../api/apps";
 import { AppActivity } from "../../components/apps/AppActivity";
-import {
-  tryCreateRoutine,
-  tryListRoutines,
-} from "../agents/agentStateClient";
+import { tryCreateRoutine, tryListRoutines } from "../agents/agentStateClient";
 import { capturePromptSeed, type DemoCapture } from "../apps/demoCapture";
 import {
   appBuildState,
@@ -136,6 +133,10 @@ export function AppBuilderChat({
   });
   const [appName, setAppName] = useState(editApp?.name ?? "");
   const [newAppId, setNewAppId] = useState<string | null>(null);
+  // The finish card must never claim success for a failed build
+  // (2026-08-16 audit: a failed build rendered a green check + "Ready to
+  // use" + "Open the agent").
+  const [buildFailed, setBuildFailed] = useState(false);
   // The app currently building/refining, used to stream its live activity
   // (thinking + tool calls) by APP ID alone via <AppActivity/>. Known
   // immediately for a refine; resolved from the pre-scaffolded app for a new
@@ -268,6 +269,7 @@ export function AppBuilderChat({
     setNewAppId(candidate.id);
     setPhase("done");
     const failed = state === "failed";
+    setBuildFailed(failed);
     // First-build ceremony: the BROKER mints the starter routine at
     // registration (durable — this chat used to own the create and lost it
     // whenever it unmounted mid-build, 2026-08-16 QA). The chat only
@@ -296,7 +298,43 @@ export function AppBuilderChat({
             : `“${appName}” is ready. Tell me any change to refine it, or open it.`,
       },
     ]);
-  }, [appsQuery.data, phase, appName, onBuildingApp, demo]);
+    // dataUpdatedAt keeps the effect firing on every poll even when React
+    // Query's structural sharing returns a referentially-identical `data` —
+    // without it the 15s terminal-grace acceptance below could literally
+    // never fire for a build that published between two polls (2026-08-16
+    // audit).
+  }, [
+    appsQuery.data,
+    appsQuery.dataUpdatedAt,
+    phase,
+    appName,
+    onBuildingApp,
+    demo,
+  ]);
+
+  // Refine honesty backstop: the edit path completes only on a version bump,
+  // so a failed edit turn (blocked task, no bump) used to spin forever with a
+  // disabled composer (2026-08-16 audit). After 30 minutes with no bump, stop
+  // waiting and say so — the operator can re-send or check the agent.
+  useEffect(() => {
+    if (!(phase === "building" && activeRefineRef.current)) return;
+    const timer = window.setTimeout(
+      () => {
+        setPhase("done");
+        setBuildFailed(true);
+        setMessages((prev) => [
+          ...prev,
+          {
+            id: `ai-${seqRef.current++}`,
+            from: "ai",
+            body: `That update is taking far longer than it should — it may not have gone through. Tell me the change again, or check “${appName}” directly.`,
+          },
+        ]);
+      },
+      30 * 60 * 1000,
+    );
+    return () => window.clearTimeout(timer);
+  }, [phase, appName]);
 
   const lastMsgId = messages[messages.length - 1]?.id;
   // biome-ignore lint/correctness/useExhaustiveDependencies: scroll on each new message
@@ -671,7 +709,7 @@ export function AppBuilderChat({
                         // nothing typed is lost while they go connect.
                         setDraft(gate.description);
                         say(
-                          "Holding off. Connect it from any agent's Integrations tab (connections are shared across the office) — your description is still in the composer for when you are back.",
+                          "Holding off. Connect it from any agent's Integrations tab (connections are shared across your workspace) — your description is still in the composer for when you are back.",
                         );
                       }}
                     >
@@ -703,29 +741,53 @@ export function AppBuilderChat({
           ) : null}
 
           {phase === "done" && newAppId ? (
-            <div className="opr-finish-card">
+            <div
+              className={`opr-finish-card${buildFailed ? " is-failed" : ""}`}
+            >
               <div className="opr-finish-row">
                 <span className="opr-finish-glyph" aria-hidden={true}>
-                  <Check size={15} strokeWidth={2.2} />
+                  {buildFailed ? (
+                    <X size={15} strokeWidth={2.2} />
+                  ) : (
+                    <Check size={15} strokeWidth={2.2} />
+                  )}
                 </span>
                 <div style={{ flex: 1, minWidth: 0 }}>
                   <div className="opr-finish-name">{appName}</div>
                   <div className="opr-finish-sub">
                     <span>
-                      {editApp ? "New version published" : "Ready to use"}
+                      {buildFailed
+                        ? "The build stopped before it finished"
+                        : editApp
+                          ? "New version published"
+                          : "Ready to use"}
                     </span>
                   </div>
                 </div>
               </div>
               <div className="opr-finish-actions">
-                <button
-                  type="button"
-                  className="opr-btn opr-btn-primary opr-btn-sm"
-                  onClick={() => onFinish(newAppId)}
-                >
-                  Open the agent
-                  <ArrowRight size={13} strokeWidth={1.9} aria-hidden={true} />
-                </button>
+                {buildFailed ? (
+                  <button
+                    type="button"
+                    className="opr-btn opr-btn-ghost opr-btn-sm"
+                    onClick={() => onFinish(newAppId)}
+                  >
+                    Open it anyway
+                  </button>
+                ) : (
+                  <button
+                    type="button"
+                    className="opr-btn opr-btn-primary opr-btn-sm"
+                    onClick={() => onFinish(newAppId)}
+                  >
+                    Open the agent
+                    <ArrowRight
+                      size={13}
+                      strokeWidth={1.9}
+                      aria-hidden={true}
+                    />
+                  </button>
+                )}
               </div>
             </div>
           ) : null}

--- a/web/src/operator/surfaces/OperatorAppDetail.tsx
+++ b/web/src/operator/surfaces/OperatorAppDetail.tsx
@@ -101,7 +101,9 @@ export function OperatorAppDetail({
 
   const detail = query.data;
   const app = detail?.app;
-  const state = app ? appBuildState(app) : "building";
+  // No app record yet means UNKNOWN, not "Building" — an erroring detail
+  // query must not stamp a confident build state (2026-08-16 audit).
+  const state = app ? appBuildState(app) : null;
   const failed = state === "failed";
   const ready = state === "ready" && !!detail?.html;
 
@@ -226,7 +228,13 @@ export function OperatorAppDetail({
                           : "opr-led-draft"
                     }`}
                   />
-                  {failed ? "Failed" : ready ? "Live" : "Building"}
+                  {failed
+                    ? "Stopped"
+                    : ready
+                      ? "Live"
+                      : state === "building"
+                        ? "Building"
+                        : "Loading…"}
                 </span>
                 {app ? (
                   <span className="opr-meta-dot">v{app.version}</span>
@@ -315,9 +323,13 @@ export function OperatorAppDetail({
           </div>
         </div>
 
-        {/* Ask AI — floating bubble + docked drawer, openable from any tab. During
-          the build experience the build chat is already docked, so suppress it. */}
-        {app && ready && !buildWalk ? (
+        {/* Ask AI — floating bubble + docked drawer, openable from any tab.
+          During the build experience the build chat is already docked, so the
+          floating bubble stays suppressed — but an EXPLICIT open (the header
+          button, "Teach a tool in chat", a routine's "Open its chat") must
+          still work: those buttons silently no-opped during the walk
+          (2026-08-16 audit). */}
+        {app && ready && (!buildWalk || chatOpen) ? (
           <AskAiDock
             app={app}
             open={chatOpen}

--- a/web/src/styles/operator-shell.css
+++ b/web/src/styles/operator-shell.css
@@ -5003,3 +5003,11 @@
   white-space: pre-wrap;
   overflow-wrap: anywhere;
 }
+
+/* Failed finish card: honest red framing, no green success glyph. */
+.opr-finish-card.is-failed {
+  border-color: color-mix(in srgb, var(--t-red, #e5534b) 45%, var(--t-line));
+}
+.opr-finish-card.is-failed .opr-finish-glyph {
+  color: var(--t-red, #e5534b);
+}


### PR DESCRIPTION
## What

Round 2 of the fresh-workspace pass: a 45-agent adversarially-verified audit of the onboarding + first-build path confirmed **38 findings**. This lands all the code fixes. Two product-shape items are deliberately NOT changed here and flagged for a founder call (see bottom).

### Build failures become honest, end to end
- A terminally blocked build **stamps the app `failed`** on the wire (new `MarkBuildFailed`); the FE stops guessing from timestamps (old 10-min client guess called legitimately-running 25-min builds failed — now an 80-min backstop only).
- The finish card can no longer show a green check + "Ready to use" + "Open the agent" **for a failed build**.
- Failed (not just timed-out) build turns get the resume-requeue carve-out; generic office turns keep their old block-on-failure contract (re-pinned under a non-builder slug).
- BlockTask reasons are operator language with a classified cause; raw stderr goes to the log. The stall line names the task title, not `VANCE-2 for 21m0s`.
- The activity feed can show ✗ now; failed previews explain themselves (raw boot log behind a disclosure); a stuck refine stops spinning after 30 min and says so; durable-completion evidence is scoped to the turn's own app; app improves get task-labeled events.

### The runtime picker's dead paths work or are gone
- "Next →" commits the runtime that **verified**, not whichever guide is expanded; single signed-in runtime auto-expands into live verification; one primary CTA at a time.
- **"Custom endpoint" removed** — it posted a provider kind the broker never registers (400 on every submit, a setup path that could never succeed).
- Failed probes read "Could not check", never a definitive "Not installed"; the opencode probe no longer reads "10 credentials" as "0 credentials"; verify hints speak product names and FailedStep matches step titles.

### Company-brain install
Curated step headlines only — raw curl/bun output behind "Show technical detail"; the failure headline is always plain; the FE poll cap (13m) outlasts the broker's 12-minute budget instead of fabricating a failure at 6.

## Founder calls (not changed here)
1. **Wizard step 2 (company brain) surfaces an embeddings choice before any value is shown** — activation-principle tension with a designed step. Option: default keyword-on with the whole choice collapsed behind "Improve recall (optional)".
2. **Email capture + 3 consent checkboxes bracket the wizard** — growth ceremony before the hero moment; your call to slim or keep.

## Test plan
- [x] Go: `./internal/team` (147s, uncached) + `./internal/onboarding` green; build + vet + fmt
- [x] Web: 2396 tests green (263 files) + tsc + biome on touched files
- [x] Live: three-persona pass on the fresh workspace (invoice chasing incl. send-gate veto/approve, applicant screening scored 100/100 with criteria chips, Zendesk gate both paths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V9n6uZhopKDdZoXQ37ry17

## Screenshots (live pass)

**Recruiting Agent scoring a real pasted application** — 100/100, criteria chips, shortlist, CSV export:
![recruiting](https://raw.githubusercontent.com/najmuzzaman-mohammad/wuphf/screenshots/pr-1191/01-recruiting-scored.png)

**Ask-before-building gate on Zendesk** (honest text fallback; both paths verified):
![gate](https://raw.githubusercontent.com/najmuzzaman-mohammad/wuphf/screenshots/pr-1191/02-zendesk-gate.png)