### PR TITLE
feat(operator): the delight pass — the product rises to its emotional beats

### DIFF
--- a/internal/team/broker_apps_scaffold.go
+++ b/internal/team/broker_apps_scaffold.go
@@ -71,6 +71,23 @@ func (b *Broker) maybePrescaffoldAppForCreate(action, channel string, body TaskP
 		slug = "app"
 	}
 	id := customAppID(slug, name, channel)
+	// A PUBLISHED agent must never be handed to a new build. Identity is
+	// (name, channel) and channel is still "general" at create time, so a
+	// second workflow whose derived name matches an existing agent would be
+	// told to publish OVER it (2026-08-16 VP-RevOps QA: the discount-desk
+	// build was briefed to republish the live Pipeline Agent). Salt the id
+	// until it is free or points at a resumable building leftover — that
+	// keeps retry-of-the-same-build semantics without the hijack.
+	for n := 2; ; n++ {
+		existing, _, err := b.appStore().Get(id)
+		if err != nil {
+			break // id free
+		}
+		if existing.Status == customAppStatusBuilding {
+			break // an unpublished leftover of this same build — resume it
+		}
+		id = customAppID(slug, name, fmt.Sprintf("%s#%d", channel, n))
+	}
 
 	actor := strings.TrimSpace(body.CreatedBy)
 	if actor == "" {

--- a/internal/team/broker_apps_starter_routine_test.go
+++ b/internal/team/broker_apps_starter_routine_test.go
@@ -97,3 +97,57 @@ func TestMintStarterRoutineForFirstBuild(t *testing.T) {
 		t.Errorf("expected no additional routines, got %d -> %d", before, len(b.scheduler))
 	}
 }
+
+// 2026-08-16 VP-RevOps QA regression: a second build whose derived name
+// matches a PUBLISHED agent must get a fresh app id — the old identity
+// (name, "general") briefed the new build to republish over the live agent.
+func TestPrescaffoldNeverReusesAPublishedAgentsID(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	b := newTestBroker(t)
+
+	first := b.maybePrescaffoldAppForCreate("create", "general", TaskPostRequest{
+		Title:     "Build app: Pipeline Agent",
+		Owner:     appBuilderSlug,
+		CreatedBy: "human",
+		Details:   "What it should do:\nMonday brief.",
+	})
+	firstID, _ := parseAppBuilderTaskAppID(first.Details)
+	if firstID == "" {
+		t.Fatalf("expected a scaffolded app id in the first brief, got %q", first.Details)
+	}
+
+	// Publish the first app (register flips it ready).
+	if _, err := b.appStore().Save(CustomAppWriteRequest{
+		ID:    firstID,
+		Name:  "Pipeline Agent",
+		HTML:  "<html><body>brief</body></html>",
+		Actor: appBuilderSlug,
+	}, time.Now()); err != nil {
+		t.Fatalf("publish first app: %v", err)
+	}
+
+	second := b.maybePrescaffoldAppForCreate("create", "general", TaskPostRequest{
+		Title:     "Build app: Pipeline Agent",
+		Owner:     appBuilderSlug,
+		CreatedBy: "human",
+		Details:   "What it should do:\nDiscount approvals.",
+	})
+	secondID, _ := parseAppBuilderTaskAppID(second.Details)
+	if secondID == "" {
+		t.Fatalf("expected a scaffolded app id in the second brief, got %q", second.Details)
+	}
+	if secondID == firstID {
+		t.Fatalf("second build was handed the PUBLISHED agent's id %s — republish hijack", firstID)
+	}
+
+	// A retry of an UNPUBLISHED build keeps continuing its own scaffold.
+	third := b.maybePrescaffoldAppForCreate("create", "general", TaskPostRequest{
+		Title:     "Build app: Pipeline Agent",
+		Owner:     appBuilderSlug,
+		CreatedBy: "human",
+		Details:   "What it should do:\nAnother take.",
+	})
+	if got, _ := parseAppBuilderTaskAppID(third.Details); got != secondID {
+		t.Fatalf("expected the building leftover %s to be resumed, got %s", secondID, got)
+	}
+}

--- a/templates/app-scaffold/AI_RULES.md
+++ b/templates/app-scaffold/AI_RULES.md
@@ -459,3 +459,11 @@ your app). NEVER invent navigation like "Settings → Integrations" — those
 surfaces are the host's, they move, and wrong directions strand the
 operator. Good: "Gmail is not connected yet — use the Connect button
 above." Bad: "Connect Gmail in Settings → Integrations."
+
+## After a mutating action, the UI reflects it immediately
+
+When a button mutates state (approve, escalate, archive, send), update the
+affected row/counters in the same interaction — optimistic update or refetch,
+either works. An operator who clicks "Escalate" and still sees PENDING with
+the same button assumes the click failed and clicks again. Every action's
+outcome must be visible where the operator is looking, immediately.

--- a/templates/app-scaffold/DESIGN.md
+++ b/templates/app-scaffold/DESIGN.md
@@ -132,8 +132,12 @@ reveals. If it doesn't clarify state, leave it out.
 The empty / loading / error / not-connected states are not afterthoughts — they're
 what the human sees first and most often. The worked example in `App.tsx` shows all
 four; match that bar. An empty state is a `<Text c="dimmed">` that says what will
-appear and why, not a blank screen. A not-connected integration renders a calm
-connect-state, not a red error. Every guarded bridge call gets a designed fallback.
+appear and why and ends by naming the next action ("Connect Gmail from the WUPHF
+Integrations tab", "Run the weekly routine to fill this"), never a bare "No items
+yet." A not-connected integration renders a calm connect-state, not a red error.
+Every guarded bridge call gets a designed fallback. Copy in these states is plain
+and warm, never jokey — the app belongs to the operator's company, not to WUPHF,
+so the host's personality stays in the host.
 
 ## Anti-patterns — if you ship one of these, it looks AI-made
 
@@ -141,8 +145,9 @@ connect-state, not a red error. Every guarded bridge call gets a designed fallba
 - A `<Title>` "Dashboard" + dimmed subtitle hero over a single table. (Generic
   SaaS hero.)
 - A grid of identical `<Card>`s where a `<Table>` or row list belongs. (Card pile.)
-- Placeholder copy: "Welcome", "Dashboard", "Items", "Data". Name the actual thing
-  ("Unread by sender", "Tasks blocked 3+ days").
+- Placeholder copy: "Welcome", "Dashboard", "Items", "Data", or a bare "No items
+  yet." empty state. Name the actual thing ("Unread by sender", "Tasks blocked
+  3+ days").
 - Five font sizes / five badge colors / mixed radii — no decided scale.
 - Centered single column when the content has a clear primary + secondary region.
 - Gradient text, glassmorphism, drop shadows on everything, animated reveals.
@@ -163,6 +168,8 @@ connect-state, not a red error. Every guarded bridge call gets a designed fallba
 - [ ] Layout fits the content — asymmetric split when there's a primary+secondary
       region, not a reflexive centered column.
 - [ ] Real, specific copy — no "Dashboard"/"Welcome"/"Items" placeholders.
+- [ ] Empty states end with a next action; copy is plain — no jokes, no host-brand
+      voice.
 - [ ] Empty / loading / error / not-connected states are all present and designed.
 - [ ] If the app COMPUTES or CURATES anything, its model is persisted to the app
       `db` (defineTable + upsert) and rendered from `db.query` — not recomputed on

--- a/templates/app-scaffold/src/App.tsx
+++ b/templates/app-scaffold/src/App.tsx
@@ -17,10 +17,10 @@ export function App() {
     <Center mih="100vh" p="xl">
       <Stack align="center" gap="sm" maw={380}>
         <Loader size="sm" />
-        <Title order={3}>Building your app…</Title>
+        <Title order={3}>Building your agent…</Title>
         <Text c="dimmed" size="sm" ta="center">
-          Your AI is writing this tool now. It will take shape right here, live,
-          as each part comes together.
+          Your AI is writing it now. The page takes shape right here, live, as
+          each part comes together.
         </Text>
       </Stack>
     </Center>

--- a/web/src/components/apps/AppActivity.tsx
+++ b/web/src/components/apps/AppActivity.tsx
@@ -51,6 +51,24 @@ export function AppActivity({ appId }: AppActivityProps) {
   );
   const running = items.some((i) => i.status === "running");
 
+  // The builder's streamed prose is the STORY of the build — the verb rows
+  // alone read as a wall of "Working ×14" (2026-08-16 delight audit). Show
+  // the latest narration line while the build runs.
+  const narration = useMemo(() => {
+    for (let i = lines.length - 1; i >= 0; i--) {
+      const p = lines[i].parsed;
+      if (
+        p?.kind === "headless_event" &&
+        p.type === "text" &&
+        typeof p.text === "string" &&
+        p.text.trim()
+      ) {
+        return p.text.replace(/\s+/g, " ").trim().slice(0, 140);
+      }
+    }
+    return null;
+  }, [lines]);
+
   const lastId = items[items.length - 1]?.id;
   // biome-ignore lint/correctness/useExhaustiveDependencies: scroll on each new row
   useEffect(() => {
@@ -85,6 +103,9 @@ export function AppActivity({ appId }: AppActivityProps) {
         />
         <span className="app-build-activity__count">{items.length}</span>
       </button>
+      {narration && running ? (
+        <div className="app-build-activity__now">{narration}</div>
+      ) : null}
       {open ? (
         <div className="app-build-activity__list" ref={scrollRef}>
           {collapseRepeats(items).map(({ item, repeats }) => (

--- a/web/src/components/apps/OfficeOverviewApp.test.tsx
+++ b/web/src/components/apps/OfficeOverviewApp.test.tsx
@@ -289,7 +289,9 @@ describe("OfficeOverviewApp", () => {
 
       render(wrap(<OfficeOverviewApp />));
 
-      expect(await screen.findByText("1 provider connected")).toBeInTheDocument();
+      expect(
+        await screen.findByText("1 provider connected"),
+      ).toBeInTheDocument();
       expect(screen.getByText("Exo")).toBeInTheDocument();
       expect(await screen.findByText("Settings")).toBeInTheDocument();
       expect(screen.getByText("Provider Doctor")).toBeInTheDocument();
@@ -327,7 +329,6 @@ describe("OfficeOverviewApp", () => {
       await screen.findByText("Active runs");
       expect(screen.queryByText(/provider.*connected/)).not.toBeInTheDocument();
     });
-
   });
 
   describe("section links", () => {

--- a/web/src/components/apps/RoutinesApp.tsx
+++ b/web/src/components/apps/RoutinesApp.tsx
@@ -337,9 +337,9 @@ function EmptyState({ hiddenSystemCount, onShowSystem }: EmptyStateProps) {
           </>
         ) : (
           <>
-            Scheduled tasks run on a schedule, assigned to an agent. They appear here
-            once an agent registers a cron job, a workflow gets a schedule, or a
-            system loop publishes a heartbeat.
+            Scheduled tasks run on a schedule, assigned to an agent. They appear
+            here once an agent registers a cron job, a workflow gets a schedule,
+            or a system loop publishes a heartbeat.
           </>
         )}
       </div>

--- a/web/src/components/apps/integrations/ActionGrantsPanel.test.tsx
+++ b/web/src/components/apps/integrations/ActionGrantsPanel.test.tsx
@@ -8,10 +8,9 @@ import type { ActionGrant } from "../../../api/client";
 const getGrants = vi.fn();
 const revoke = vi.fn();
 vi.mock("../../../api/client", async () => {
-  const actual =
-    await vi.importActual<typeof import("../../../api/client")>(
-      "../../../api/client",
-    );
+  const actual = await vi.importActual<typeof import("../../../api/client")>(
+    "../../../api/client",
+  );
   return {
     ...actual,
     getActionGrants: () => getGrants(),
@@ -70,7 +69,9 @@ describe("<ActionGrantsPanel>", () => {
 
   it("revokes a grant by id", async () => {
     getGrants.mockResolvedValue({ grants: [grant()] });
-    revoke.mockResolvedValue({ grant: grant({ revoked_at: "2026-06-09T00:00:00Z" }) });
+    revoke.mockResolvedValue({
+      grant: grant({ revoked_at: "2026-06-09T00:00:00Z" }),
+    });
     render(wrap(<ActionGrantsPanel />));
     fireEvent.click(await screen.findByRole("button", { name: "Revoke" }));
     await waitFor(() => expect(revoke).toHaveBeenCalledWith("grant-1"));

--- a/web/src/components/apps/integrations/ActionGrantsPanel.tsx
+++ b/web/src/components/apps/integrations/ActionGrantsPanel.tsx
@@ -82,7 +82,10 @@ export function ActionGrantsPanel() {
   const revokeMutation = useMutation({
     mutationFn: (id: string) => revokeActionGrant(id),
     onSuccess: () => {
-      showNotice("Grant revoked. That action will ask again next time.", "info");
+      showNotice(
+        "Grant revoked. That action will ask again next time.",
+        "info",
+      );
       void queryClient.invalidateQueries({ queryKey: ["action-grants"] });
     },
     onError: (err: unknown) => {
@@ -97,12 +100,15 @@ export function ActionGrantsPanel() {
   if (grantsQuery.isLoading || grants.length === 0) return null;
 
   return (
-    <section className="op-category grants-panel" aria-label="Always-allowed actions">
+    <section
+      className="op-category grants-panel"
+      aria-label="Always-allowed actions"
+    >
       <div className="grants-panel-head">
         <h3 className="grants-panel-title">Always-allowed actions</h3>
         <p className="grants-panel-sub">
-          Actions approved to run without asking again. Revoke any to restore the
-          approval prompt.
+          Actions approved to run without asking again. Revoke any to restore
+          the approval prompt.
         </p>
       </div>
       <ul className="grant-list">

--- a/web/src/components/apps/integrations/CardShell.tsx
+++ b/web/src/components/apps/integrations/CardShell.tsx
@@ -1,5 +1,5 @@
-import { NavArrowLeft, NavArrowRight } from "iconoir-react";
 import type { ReactElement, ReactNode } from "react";
+import { NavArrowLeft, NavArrowRight } from "iconoir-react";
 
 import type { IntegrationStatus, IntegrationStatusTone } from "./types";
 
@@ -18,13 +18,15 @@ import type { IntegrationStatus, IntegrationStatusTone } from "./types";
 //   warning     → amber LED · ATTENTION
 //   unconfigured → grey LED · NOT CONFIGURED
 
-const TONE_CLASS: Record<IntegrationStatusTone, "on" | "warn" | "off" | "info"> =
-  {
-    connected: "on",
-    available: "info",
-    warning: "warn",
-    unconfigured: "off",
-  };
+const TONE_CLASS: Record<
+  IntegrationStatusTone,
+  "on" | "warn" | "off" | "info"
+> = {
+  connected: "on",
+  available: "info",
+  warning: "warn",
+  unconfigured: "off",
+};
 
 function StatusPill({ status }: { status: IntegrationStatus }) {
   const tone = TONE_CLASS[status.tone];

--- a/web/src/components/apps/integrations/ComposioOnboarding.stories.tsx
+++ b/web/src/components/apps/integrations/ComposioOnboarding.stories.tsx
@@ -1,5 +1,5 @@
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 import { ComposioOnboarding } from "./ComposioOnboarding";
 

--- a/web/src/components/apps/integrations/registry.tsx
+++ b/web/src/components/apps/integrations/registry.tsx
@@ -1,9 +1,5 @@
 import { HermesDetail, hermesStatus } from "./HermesCard";
-import {
-  HermesLogo,
-  OpenClawLogo,
-  TelegramLogo,
-} from "./IntegrationLogos";
+import { HermesLogo, OpenClawLogo, TelegramLogo } from "./IntegrationLogos";
 import { OpenClawDetail, openClawStatus } from "./OpenClawCard";
 import { TelegramDetail, telegramStatus } from "./TelegramCard";
 import type { IntegrationContext, IntegrationDescriptor } from "./types";

--- a/web/src/components/apps/integrations/types.ts
+++ b/web/src/components/apps/integrations/types.ts
@@ -1,9 +1,6 @@
 import type { ReactElement, ReactNode } from "react";
 
-import type {
-  ConfigSnapshot,
-  LocalProviderStatus,
-} from "../../../api/client";
+import type { ConfigSnapshot, LocalProviderStatus } from "../../../api/client";
 
 // IntegrationCategory groups cards by the role they play in the team. The
 // app renders each category as a labelled section. Add a new category only

--- a/web/src/components/apps/routines/RoutineComposer.tsx
+++ b/web/src/components/apps/routines/RoutineComposer.tsx
@@ -139,8 +139,8 @@ export function RoutineComposer() {
             fontSize: "var(--text-sm)",
           }}
         >
-          Scheduled tasks fire on a schedule and run as a specific agent. Webhook and
-          context-change triggers are coming soon.
+          Scheduled tasks fire on a schedule and run as a specific agent.
+          Webhook and context-change triggers are coming soon.
         </p>
       </header>
 
@@ -201,7 +201,8 @@ export function RoutineComposer() {
                 marginTop: 4,
               }}
             >
-              No agents available. Add a teammate before creating a scheduled task.
+              No agents available. Add a teammate before creating a scheduled
+              task.
             </span>
           )}
         </FormField>

--- a/web/src/components/apps/routines/routineModel.test.ts
+++ b/web/src/components/apps/routines/routineModel.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+
 import type { SchedulerJob } from "../../../api/client";
 import { routineOwner } from "./routineModel";
 

--- a/web/src/components/onboarding/wizard/wizardSteps.ts
+++ b/web/src/components/onboarding/wizard/wizardSteps.ts
@@ -102,6 +102,7 @@ export const ONBOARDING_FIRST_ISSUE_EXAMPLES: readonly string[] = [
   "Audit our CRM for duplicate accounts, deals missing an owner, and opportunities with no activity in 30 days, then propose a cleanup plan",
   "Chase our unpaid invoices: find anything past its due date, draft a polite reminder for each customer, and flag 30+ days overdue for my review",
   "Screen inbound job applications against our role requirements, keep a shortlist of strong candidates, and draft a friendly note for the rest",
+  "Prep my Monday pipeline review: every deal closing this quarter that has gone quiet for two weeks, plus a one-line ask for each owner",
 ];
 
 /** Back-compat: the canonical example (tests and the tour handoff pin it). */
@@ -266,6 +267,12 @@ export const ONBOARDING_WIZARD_LABELS = {
    * the wizard (no Esc, no skip-all).
    */
   firstIssueSkip: "Skip and look around first",
-  /** Shown while the broker seeds the office after Finish. */
-  seeding: "Setting up your office…",
+  /**
+   * Shown while the broker seeds the office after Finish. Renders as the
+   * primary button label, so it must stay SHORTER than the resting finish
+   * label to keep the button geometry stable. The mock-office metaphor from
+   * StepMeet carries the wink; the disabled state plus ellipsis keeps it
+   * unambiguously a progress message.
+   */
+  seeding: "Moving the desks in…",
 } as const;

--- a/web/src/operator/OperatorSidebar.tsx
+++ b/web/src/operator/OperatorSidebar.tsx
@@ -76,7 +76,10 @@ export function OperatorSidebar({
         <PixelAvatar slug={a.id} size={18} className="opr-agent-rail-avatar" />
         <span className="opr-agent-rail-name">{a.name}</span>
         {a.building ? (
-          <span className="opr-led opr-led-draft" title="Building" />
+          <span
+            className="opr-led opr-led-building"
+            title="Building. I keep working while you look around"
+          />
         ) : null}
       </button>
     );
@@ -174,7 +177,7 @@ export function OperatorSidebar({
           <div className="opr-user-name">
             {officeName?.trim() || "Your office"}
           </div>
-          <div className="opr-user-role">your workspace</div>
+          <div className="opr-user-role">regional headquarters</div>
         </div>
       </div>
     </aside>

--- a/web/src/operator/agents/agentStateClient.ts
+++ b/web/src/operator/agents/agentStateClient.ts
@@ -14,7 +14,11 @@
 // null on ANY failure so callers can fall back to the local seeded state and
 // the FE keeps working offline. All agent POST bodies carry schema_version.
 
-import { get as brokerGet, patch as brokerPatch, post as brokerPost } from "../../api/client";
+import {
+  get as brokerGet,
+  patch as brokerPatch,
+  post as brokerPost,
+} from "../../api/client";
 
 const SCHEMA_VERSION = 1;
 const READ_TIMEOUT_MS = 10_000;
@@ -235,7 +239,8 @@ export async function patchRoutine(
   if (input.enabled !== undefined) body.enabled = input.enabled;
   if (input.prompt !== undefined) {
     body.payload = input.prompt;
-    body.change_note = input.changeNote || "Prompt updated from the Routines tab";
+    body.change_note =
+      input.changeNote || "Prompt updated from the Routines tab";
   }
   const data = await brokerPatch<{ job: BrokerSchedulerJob }>(
     `/scheduler/${encodeURIComponent(id)}`,

--- a/web/src/operator/apps/useOperatorApps.test.ts
+++ b/web/src/operator/apps/useOperatorApps.test.ts
@@ -8,6 +8,7 @@ import {
   deriveAppName,
   isRealAppId,
   resolveNewAppId,
+  uniquifyAppName,
 } from "./useOperatorApps";
 
 function app(over: Partial<CustomApp>): CustomApp {
@@ -100,6 +101,21 @@ describe("appBuildState", () => {
   });
 });
 
+describe("uniquifyAppName", () => {
+  it("appends a counter when the roster already has the name", () => {
+    expect(
+      uniquifyAppName("Pipeline Agent", [{ name: "Pipeline Agent" }]),
+    ).toBe("Pipeline Agent 2");
+    expect(
+      uniquifyAppName("Pipeline Agent", [
+        { name: "Pipeline Agent" },
+        { name: "Pipeline Agent 2" },
+      ]),
+    ).toBe("Pipeline Agent 3");
+    expect(uniquifyAppName("Deal Desk Agent", [])).toBe("Deal Desk Agent");
+  });
+});
+
 describe("deriveAppName", () => {
   it("names an agent for its role when the domain is recognizable", () => {
     expect(deriveAppName("score inbound leads and route hot ones")).toBe(
@@ -153,6 +169,25 @@ describe("deriveAppName", () => {
   // 2026-08-16 fresh-workspace QA: "Chase our unpaid invoices" was named
   // "Chase Agent" (plural nouns missed the role table), and a recruiting
   // description using scoring verbs was claimed by Lead Routing.
+  it("names forecast-accuracy tracking Forecast Agent", () => {
+    expect(
+      deriveAppName(
+        "Track rep forecast accuracy: compare each commit against pipeline coverage",
+      ),
+    ).toBe("Forecast Agent");
+  });
+
+  it("names a discount approval workflow Deal Desk, not Pipeline", () => {
+    // 2026-08-16 VP-RevOps QA: "deal desk" hit the pipeline row and collided
+    // with an existing Pipeline Agent — briefing the build to republish over
+    // the live agent.
+    expect(
+      deriveAppName(
+        "Run our deal desk discount approvals: apply our rules and draft escalation notes",
+      ),
+    ).toBe("Deal Desk Agent");
+  });
+
   it("names invoice chasing and applicant screening by their nouns", () => {
     expect(
       deriveAppName(

--- a/web/src/operator/apps/useOperatorApps.ts
+++ b/web/src/operator/apps/useOperatorApps.ts
@@ -62,6 +62,23 @@ export function appBuildState(
   return "building";
 }
 
+/** Uniquify a derived agent name against the existing roster: a second
+ * workflow that derives the same name must not LOOK like the same agent —
+ * and the broker refuses to hand a published agent's id to a new build
+ * (2026-08-16 VP-RevOps QA). "Pipeline Agent" -> "Pipeline Agent 2". */
+export function uniquifyAppName(
+  name: string,
+  existing: readonly { name: string }[],
+): string {
+  const taken = new Set(existing.map((a) => a.name.trim().toLowerCase()));
+  if (!taken.has(name.trim().toLowerCase())) return name;
+  for (let n = 2; n <= 20; n++) {
+    const candidate = `${name} ${n}`;
+    if (!taken.has(candidate.toLowerCase())) return candidate;
+  }
+  return name;
+}
+
 /**
  * List the workspace's built apps. Polls while any app is GENUINELY building
  * (not stalled/failed) so a freshly-published app appears without a reload, then
@@ -174,6 +191,11 @@ const AGENT_ROLES: ReadonlyArray<[RegExp, string]> = [
     /\b(hygiene|dedupe|duplicate|clean[- ]?up|data quality)\b/i,
     "CRM Hygiene Agent",
   ],
+  // Deal desk outranks pipeline: approval workflows mention deals constantly
+  // ("deal desk", "discount approvals") but they are not pipeline reporting.
+  // Bare "approval(s)" is too generic (a "refund-approval form" is a form
+  // app, not a deal desk) — the desk needs its own nouns.
+  [/\b(deal desk|discounts?)\b/i, "Deal Desk Agent"],
   // Recruiting outranks lead routing: hiring language ("score fit", "inbound
   // applicants") reuses scoring/routing verbs, so the noun cues must win.
   [
@@ -183,7 +205,10 @@ const AGENT_ROLES: ReadonlyArray<[RegExp, string]> = [
   // Nouns accept plurals; bare verbs ("score", "route", "inbound") are gone —
   // they collide with every other domain ("score a task", "inbound tickets").
   [/\b(leads?|lead routing|demo requests?)\b/i, "Lead Routing Agent"],
-  [/\b(pipelines?|deals?|forecasts?)\b/i, "Pipeline Agent"],
+  // Forecast discipline is its own job — commits, quota, accuracy — not
+  // pipeline reporting.
+  [/\b(forecasts?|commits?|quotas?)\b/i, "Forecast Agent"],
+  [/\b(pipelines?|deals?)\b/i, "Pipeline Agent"],
   [/\b(sales|quotas?|outreach|prospects?)\b/i, "Sales Agent"],
   [/\b(support|tickets?|escalations?|incidents?)\b/i, "Support Triage Agent"],
   [/\b(invoices?|billing|receivables?|dunning)\b/i, "Invoice Agent"],

--- a/web/src/operator/artifacts/ArtifactsTab.test.tsx
+++ b/web/src/operator/artifacts/ArtifactsTab.test.tsx
@@ -116,6 +116,8 @@ describe("ArtifactsTab", () => {
     const { getByText } = render(
       <ArtifactsTab agentName="Pipeline Agent" artifacts={[]} />,
     );
-    expect(getByText(/Nothing yet/)).toBeTruthy();
+    expect(
+      getByText(/The out-tray stays empty until the first run/),
+    ).toBeTruthy();
   });
 });

--- a/web/src/operator/artifacts/ArtifactsTab.tsx
+++ b/web/src/operator/artifacts/ArtifactsTab.tsx
@@ -24,7 +24,7 @@ export function ArtifactsTab({ agentName, artifacts }: ArtifactsTabProps) {
     return (
       <div className="opr-empty-hint">
         Everything {agentName} produces collects here — apps, PDFs, pages, docs.
-        Nothing yet.
+        The out-tray stays empty until the first run.
       </div>
     );
   }

--- a/web/src/operator/components/ApprovalPrompt.tsx
+++ b/web/src/operator/components/ApprovalPrompt.tsx
@@ -3,6 +3,7 @@
 // modal asking the operator to Approve or Reject. The human approves; the agent
 // never self-approves. Mounted globally in the operator shell.
 
+import { useEffect, useState } from "react";
 import { ShieldCheck, X } from "lucide-react";
 
 import { useOperatorApprovals } from "../approvals/useOperatorApprovals";
@@ -11,7 +12,26 @@ import { Eyebrow } from "./primitives";
 export function ApprovalPrompt() {
   const { pending, approve, reject, answering } = useOperatorApprovals();
   const req = pending[0];
-  if (!req) return null;
+  // The trust beat: after the LAST pending approval clears via Approve, hold
+  // a 2.4s confirmation in the card's place — the modal used to just vanish
+  // (2026-08-16 delight audit). Straight copy; this is a safety surface.
+  const [confirming, setConfirming] = useState(false);
+  useEffect(() => {
+    if (!(confirming && !req)) return;
+    const t = window.setTimeout(() => setConfirming(false), 2400);
+    return () => window.clearTimeout(t);
+  }, [confirming, req]);
+  if (!req) {
+    if (!confirming) return null;
+    return (
+      <div className="opr-approval-prompt opr-approval-sent" role="status">
+        <span className="opr-approval-prompt-glyph" aria-hidden={true}>
+          <ShieldCheck size={16} strokeWidth={1.8} />
+        </span>
+        <span>Sent. Nothing leaves the office without you.</span>
+      </div>
+    );
+  }
 
   const more = pending.length - 1;
 
@@ -51,7 +71,10 @@ export function ApprovalPrompt() {
         <button
           type="button"
           className="opr-btn opr-btn-primary opr-btn-sm"
-          onClick={() => approve(req.id)}
+          onClick={() => {
+            approve(req.id);
+            setConfirming(true);
+          }}
           disabled={answering}
         >
           {answering ? "Approving…" : "Approve & send"}

--- a/web/src/operator/components/primitives.test.tsx
+++ b/web/src/operator/components/primitives.test.tsx
@@ -1,0 +1,80 @@
+import { useState } from "react";
+import { fireEvent, render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { type TabDef, Tabs } from "./primitives";
+
+type Id = "ui" | "data" | "knowledge";
+
+const TABS: readonly TabDef<Id>[] = [
+  { id: "ui", label: "UI" },
+  { id: "data", label: "Data" },
+  { id: "knowledge", label: "Knowledge" },
+];
+
+// Stateful harness: selection follows focus, as in the real consumers.
+function Harness({ initial = "ui" as Id }: { initial?: Id }) {
+  const [active, setActive] = useState<Id>(initial);
+  return <Tabs tabs={TABS} active={active} onSelect={setActive} />;
+}
+
+describe("Tabs keyboard contract (ARIA tablist)", () => {
+  it("gives the strip ONE Tab stop via roving tabindex", () => {
+    const { getByRole } = render(<Harness initial="data" />);
+    expect(getByRole("tab", { name: "Data" }).tabIndex).toBe(0);
+    expect(getByRole("tab", { name: "UI" }).tabIndex).toBe(-1);
+    expect(getByRole("tab", { name: "Knowledge" }).tabIndex).toBe(-1);
+  });
+
+  it("moves selection AND focus with ArrowRight/ArrowLeft, wrapping", () => {
+    const { getByRole } = render(<Harness initial="ui" />);
+    fireEvent.keyDown(getByRole("tab", { name: "UI" }), { key: "ArrowRight" });
+    const data = getByRole("tab", { name: "Data" });
+    expect(data.getAttribute("aria-selected")).toBe("true");
+    expect(document.activeElement).toBe(data);
+    // ArrowLeft from the FIRST tab wraps to the last.
+    fireEvent.keyDown(data, { key: "ArrowLeft" });
+    fireEvent.keyDown(getByRole("tab", { name: "UI" }), { key: "ArrowLeft" });
+    const knowledge = getByRole("tab", { name: "Knowledge" });
+    expect(knowledge.getAttribute("aria-selected")).toBe("true");
+    expect(document.activeElement).toBe(knowledge);
+  });
+
+  it("jumps to the first/last tab with Home/End", () => {
+    const { getByRole } = render(<Harness initial="data" />);
+    fireEvent.keyDown(getByRole("tab", { name: "Data" }), { key: "End" });
+    expect(
+      getByRole("tab", { name: "Knowledge" }).getAttribute("aria-selected"),
+    ).toBe("true");
+    fireEvent.keyDown(getByRole("tab", { name: "Knowledge" }), {
+      key: "Home",
+    });
+    expect(getByRole("tab", { name: "UI" }).getAttribute("aria-selected")).toBe(
+      "true",
+    );
+    expect(document.activeElement).toBe(getByRole("tab", { name: "UI" }));
+  });
+
+  it("leaves other keys alone (no hijacked typing or Tab)", () => {
+    const onSelect = vi.fn();
+    const { getByRole } = render(
+      <Tabs tabs={TABS} active="ui" onSelect={onSelect} />,
+    );
+    fireEvent.keyDown(getByRole("tab", { name: "UI" }), { key: "Tab" });
+    fireEvent.keyDown(getByRole("tab", { name: "UI" }), { key: "a" });
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it("keeps the strip reachable when the active id is stale", () => {
+    const onSelect = vi.fn();
+    const { getByRole } = render(
+      // A stale id no tab owns: the first tab takes the Tab stop.
+      <Tabs tabs={TABS} active={"gone" as Id} onSelect={onSelect} />,
+    );
+    const first = getByRole("tab", { name: "UI" });
+    expect(first.tabIndex).toBe(0);
+    // Arrow keys still work, falling back to index 0 as the origin.
+    fireEvent.keyDown(first, { key: "ArrowRight" });
+    expect(onSelect).toHaveBeenCalledWith("data");
+  });
+});

--- a/web/src/operator/components/primitives.tsx
+++ b/web/src/operator/components/primitives.tsx
@@ -1,7 +1,7 @@
 // Shared visual primitives for the operator shell. Token-driven, presentational
 // only — no data fetching. See operator-shell.css for the matching styles.
 
-import type { ReactNode } from "react";
+import { type KeyboardEvent, type ReactNode, useRef } from "react";
 
 import type {
   IntegrationStatus,
@@ -113,9 +113,42 @@ export function Tabs<T extends string>({
   onSelect,
   hint,
 }: TabsProps<T>) {
+  const listRef = useRef<HTMLDivElement>(null);
+  // Roving tabindex per the ARIA tabs contract: the strip is ONE Tab stop;
+  // ArrowLeft/ArrowRight (wrapping) and Home/End move selection and focus.
+  // Selection follows focus: every panel renders local data, so switching is
+  // free. A stale `active` id falls back to the first tab so the strip never
+  // becomes keyboard-unreachable.
+  const activeIndex = tabs.findIndex((t) => t.id === active);
+
+  function moveTo(next: TabDef<T> | undefined) {
+    if (!next) return;
+    onSelect(next.id);
+    // Scoped lookup (not document-global): generic ids like "data" would
+    // collide if two Tabs instances ever mount at once.
+    listRef.current
+      ?.querySelector<HTMLButtonElement>(`#${CSS.escape(`opr-tab-${next.id}`)}`)
+      ?.focus();
+  }
+
+  function onTabKeyDown(e: KeyboardEvent<HTMLButtonElement>) {
+    if (e.key === "ArrowRight" || e.key === "ArrowLeft") {
+      e.preventDefault();
+      const dir = e.key === "ArrowRight" ? 1 : -1;
+      const from = activeIndex === -1 ? 0 : activeIndex;
+      moveTo(tabs[(from + dir + tabs.length) % tabs.length]);
+    } else if (e.key === "Home") {
+      e.preventDefault();
+      moveTo(tabs[0]);
+    } else if (e.key === "End") {
+      e.preventDefault();
+      moveTo(tabs[tabs.length - 1]);
+    }
+  }
+
   return (
-    <div className="opr-tabs" role="tablist">
-      {tabs.map((t) => (
+    <div className="opr-tabs" role="tablist" ref={listRef}>
+      {tabs.map((t, i) => (
         <button
           key={t.id}
           type="button"
@@ -123,8 +156,10 @@ export function Tabs<T extends string>({
           id={`opr-tab-${t.id}`}
           aria-controls={`opr-panel-${t.id}`}
           aria-selected={t.id === active}
+          tabIndex={t.id === active || (activeIndex === -1 && i === 0) ? 0 : -1}
           className={`opr-tab${t.id === active ? " is-active" : ""}`}
           onClick={() => onSelect(t.id)}
+          onKeyDown={onTabKeyDown}
         >
           {t.label}
         </button>

--- a/web/src/operator/firstWorkflowSeed.ts
+++ b/web/src/operator/firstWorkflowSeed.ts
@@ -7,7 +7,8 @@
 // their first agent being assembled. localStorage (not the app store) because
 // completing onboarding remounts the tree.
 
-export const OPERATOR_FIRST_WORKFLOW_SEED_KEY = "wuphf.operator.firstWorkflowSeed";
+export const OPERATOR_FIRST_WORKFLOW_SEED_KEY =
+  "wuphf.operator.firstWorkflowSeed";
 
 /** Read + clear the pending seed. Returns null when there is none. */
 export function consumeFirstWorkflowSeed(): string | null {

--- a/web/src/operator/routines/RoutinesTab.test.tsx
+++ b/web/src/operator/routines/RoutinesTab.test.tsx
@@ -1,4 +1,10 @@
-import { fireEvent, render, waitFor } from "@testing-library/react";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { RoutinesTab } from "./RoutinesTab";
@@ -73,6 +79,56 @@ describe("RoutinesTab", () => {
   });
 });
 
+// Raw broker scheduler job as GET /api/scheduler returns it.
+function job(over: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    slug: "routine-live-recap",
+    label: "Live recap",
+    target_type: "agent",
+    target_id: "app_x",
+    schedule_expr: "0 9 * * 1",
+    payload: "Summarize the pipeline",
+    enabled: true,
+    status: "scheduled",
+    ...over,
+  };
+}
+
+function ok(data: unknown) {
+  return { ok: true, json: async () => data };
+}
+
+/** Routes the broker endpoints the routine view touches. */
+function brokerFetch(overrides: {
+  onPatch?: () => unknown;
+  onCreate?: () => unknown;
+  jobs?: () => unknown[];
+  runs?: () => unknown[];
+}) {
+  return vi.fn(async (url: string, init?: RequestInit) => {
+    if (init?.method === "PATCH") {
+      return ok({ job: overrides.onPatch?.() ?? job() });
+    }
+    if (url === "/api/scheduler/routines" && init?.method === "POST") {
+      return ok({ job: overrides.onCreate?.() ?? job() });
+    }
+    if (url.endsWith("/run") && init?.method === "POST") {
+      return ok({ job: job() });
+    }
+    if (url.endsWith("/revisions")) {
+      return ok({
+        revisions: [
+          { version: 2, created_at: "", label: "Live recap", enabled: true },
+        ],
+      });
+    }
+    if (url.endsWith("/runs")) {
+      return ok({ runs: overrides.runs?.() ?? [] });
+    }
+    return ok({ jobs: overrides.jobs?.() ?? [job()] });
+  });
+}
+
 // With a REAL agent id a routine IS a broker scheduler job (via /api): cron,
 // enable/disable, revisions (versioning), and run history live there. When the
 // broker is unreachable the tab says so — it never fabricates rows.
@@ -80,56 +136,6 @@ describe("RoutinesTab (live broker scheduler)", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
   });
-
-  // Raw broker scheduler job as GET /api/scheduler returns it.
-  function job(over: Record<string, unknown> = {}): Record<string, unknown> {
-    return {
-      slug: "routine-live-recap",
-      label: "Live recap",
-      target_type: "agent",
-      target_id: "app_x",
-      schedule_expr: "0 9 * * 1",
-      payload: "Summarize the pipeline",
-      enabled: true,
-      status: "scheduled",
-      ...over,
-    };
-  }
-
-  function ok(data: unknown) {
-    return { ok: true, json: async () => data };
-  }
-
-  /** Routes the broker endpoints the routine view touches. */
-  function brokerFetch(overrides: {
-    onPatch?: () => unknown;
-    onCreate?: () => unknown;
-    jobs?: () => unknown[];
-    runs?: () => unknown[];
-  }) {
-    return vi.fn(async (url: string, init?: RequestInit) => {
-      if (init?.method === "PATCH") {
-        return ok({ job: overrides.onPatch?.() ?? job() });
-      }
-      if (url === "/api/scheduler/routines" && init?.method === "POST") {
-        return ok({ job: overrides.onCreate?.() ?? job() });
-      }
-      if (url.endsWith("/run") && init?.method === "POST") {
-        return ok({ job: job() });
-      }
-      if (url.endsWith("/revisions")) {
-        return ok({
-          revisions: [
-            { version: 2, created_at: "", label: "Live recap", enabled: true },
-          ],
-        });
-      }
-      if (url.endsWith("/runs")) {
-        return ok({ runs: overrides.runs?.() ?? [] });
-      }
-      return ok({ jobs: overrides.jobs?.() ?? [job()] });
-    });
-  }
 
   it("loads routines from the broker scheduler for a real agent id", async () => {
     const fetchMock = brokerFetch({});
@@ -200,7 +206,7 @@ describe("RoutinesTab (live broker scheduler)", () => {
     });
   });
 
-  it("Run now queues a broker fire and says so", async () => {
+  it("Run now queues a broker fire, points at the chat, and opens the receipts", async () => {
     const fetchMock = brokerFetch({});
     vi.stubGlobal("fetch", fetchMock);
     const { findByText, getByText } = render(
@@ -208,11 +214,21 @@ describe("RoutinesTab (live broker scheduler)", () => {
     );
     await findByText("Live recap"); // hydration replaced the seeds
     fireEvent.click(getByText("Run now"));
-    expect(await findByText("queued — starting in a moment")).toBeTruthy();
+    expect(
+      await findByText("queued — watch the play-by-play in its chat"),
+    ).toBeTruthy();
     const runCall = fetchMock.mock.calls.find(([url]) =>
       String(url).endsWith("/run"),
     );
     expect(runCall?.[0]).toBe("/api/scheduler/routine-live-recap/run");
+    // The receipts opened on their own so the run lands somewhere visible.
+    expect(
+      screen.getByRole("status", { name: "Loading recent runs" }),
+    ).toBeTruthy();
+    // And the next step is lit: Open its chat swaps ghost for primary.
+    const openChat = getByText("Open its chat").closest("button");
+    expect(openChat?.className).toContain("opr-btn-primary");
+    expect(openChat?.className).not.toContain("opr-btn-ghost");
   });
 
   it("Add routine registers a scheduler routine (purpose + cron + owner)", async () => {
@@ -275,5 +291,136 @@ describe("RoutinesTab (live broker scheduler)", () => {
       String(url).endsWith("/runs"),
     );
     expect(runsCall?.[0]).toBe("/api/scheduler/routine-live-recap/runs");
+  });
+});
+
+// The watch that follows a live Run now: the header label walks queued →
+// running → the landed stamp while the opened Recent runs list refreshes.
+// Fake timers drive the bounded poll; findByText/waitFor would hang under
+// them, so the helpers settle promise chains by hand.
+describe("RoutinesTab (run-now watch)", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  /** Settle pending microtask chains (mocked fetch → json → setState). */
+  async function flushLive(): Promise<void> {
+    await act(async () => {
+      for (let i = 0; i < 20; i += 1) {
+        await Promise.resolve();
+      }
+    });
+  }
+
+  /** Advance fake time and settle the fired poll tick's promise chain. */
+  async function tick(ms: number): Promise<void> {
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(ms);
+      for (let i = 0; i < 20; i += 1) {
+        await Promise.resolve();
+      }
+    });
+  }
+
+  function useWatchTimers(): void {
+    vi.useFakeTimers({
+      toFake: [
+        "setTimeout",
+        "setInterval",
+        "clearTimeout",
+        "clearInterval",
+        "Date",
+      ],
+    });
+    vi.setSystemTime(new Date("2026-08-16T10:00:00Z"));
+  }
+
+  it("watches the queued run: pending flips the label, terminal lands the stamp", async () => {
+    useWatchTimers();
+    let runs: Record<string, unknown>[] = [];
+    const fetchMock = brokerFetch({ runs: () => runs });
+    vi.stubGlobal("fetch", fetchMock);
+    const utils = render(
+      <RoutinesTab agentName="Pipeline Agent" agentId="app_x" />,
+    );
+    await flushLive();
+    fireEvent.click(utils.getByText("Run now"));
+    await flushLive();
+    expect(
+      utils.getByText("queued — watch the play-by-play in its chat"),
+    ).toBeTruthy();
+
+    // First poll tick: the queued run shows up, still in flight.
+    runs = [
+      {
+        slug: "routine-live-recap",
+        started_at: "2026-08-16T10:00:05Z",
+        status: "running",
+      },
+    ];
+    await tick(2000);
+    expect(utils.getByText("running now…")).toBeTruthy();
+
+    // Next tick: it landed — the header falls back to the real run stamp and
+    // the opened receipts list the outcome.
+    runs = [
+      {
+        slug: "routine-live-recap",
+        started_at: "2026-08-16T10:00:05Z",
+        status: "ok",
+        output_summary: "Recap saved to Artifacts.",
+      },
+    ];
+    await tick(2000);
+    expect(utils.getByText(/last ran/)).toBeTruthy();
+    expect(utils.getByText("Recap saved to Artifacts.")).toBeTruthy();
+    expect(
+      utils.queryByText("queued — watch the play-by-play in its chat"),
+    ).toBeNull();
+    // The watch is over: no further polling.
+    const runsCalls = fetchMock.mock.calls.filter(([url]) =>
+      String(url).endsWith("/runs"),
+    ).length;
+    await tick(10_000);
+    expect(
+      fetchMock.mock.calls.filter(([url]) => String(url).endsWith("/runs"))
+        .length,
+    ).toBe(runsCalls);
+  });
+
+  it("gives up quietly when the run history is unreachable mid-watch", async () => {
+    useWatchTimers();
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      if (String(url).endsWith("/runs")) throw new Error("broker away");
+      if (String(url).endsWith("/run") && init?.method === "POST") {
+        return ok({ job: job() });
+      }
+      if (String(url).endsWith("/revisions")) return ok({ revisions: [] });
+      return ok({ jobs: [job()] });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const utils = render(
+      <RoutinesTab agentName="Pipeline Agent" agentId="app_x" />,
+    );
+    await flushLive();
+    fireEvent.click(utils.getByText("Run now"));
+    await flushLive();
+    expect(
+      utils.getByText("queued — watch the play-by-play in its chat"),
+    ).toBeTruthy();
+    const runsCalls = () =>
+      fetchMock.mock.calls.filter(([url]) => String(url).endsWith("/runs"))
+        .length;
+    await tick(2000);
+    expect(runsCalls()).toBe(1);
+    // The poll stopped silently — no retry spam, the honest label stays, and
+    // the opened receipts settle on the honest empty note.
+    await tick(10_000);
+    expect(runsCalls()).toBe(1);
+    expect(
+      utils.getByText("queued — watch the play-by-play in its chat"),
+    ).toBeTruthy();
+    expect(utils.getByText("No runs recorded yet.")).toBeTruthy();
   });
 });

--- a/web/src/operator/routines/RoutinesTab.tsx
+++ b/web/src/operator/routines/RoutinesTab.tsx
@@ -12,7 +12,13 @@
 // seeded state so the FE keeps working offline.
 // See docs/specs/operator-agent-routines.md.
 
-import { useEffect, useState } from "react";
+import {
+  type Dispatch,
+  type SetStateAction,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 import {
   CalendarClock,
   CheckCircle2,
@@ -65,6 +71,117 @@ function firstLine(text: string): string {
   );
 }
 
+// A live "Run now" watch: which routine queued, the client clock at queue time
+// (runs started after it are the queued one), and the phase the header label
+// renders. Cleared when the watched run reaches a terminal status.
+interface RunWatch {
+  id: string;
+  queuedAt: number;
+  phase: "queued" | "running" | "overtime";
+}
+
+// Watch cadence: the broker watchdog fires within one tick (~20s), so a 2s
+// poll bounded at 60s sees most runs start and land.
+const RUN_WATCH_INTERVAL_MS = 2_000;
+const RUN_WATCH_CAP_MS = 60_000;
+
+// Header labels per watch phase. Wayfinding, not decoration: "queued" points
+// at where the outcome lands, and past the cap the label degrades honestly
+// instead of freezing on "running now…".
+const RUN_WATCH_LABELS: Record<RunWatch["phase"], string> = {
+  queued: "queued — watch the play-by-play in its chat",
+  running: "running now…",
+  overtime: "running — open its chat to watch",
+};
+
+// The queued run's fate in a run listing: `landed` once a run started after
+// queue time reached a terminal status; `running` while one is still pending.
+function watchedOutcome(
+  runs: WireRoutineRun[],
+  queuedAt: number,
+): { landed: WireRoutineRun | undefined; running: boolean } {
+  const ours = runs.filter((run) => Date.parse(run.started_at) > queuedAt);
+  return {
+    landed: ours.find((run) => runStatusClass(run.status) !== "is-pending"),
+    running: ours.length > 0,
+  };
+}
+
+interface StartRunWatchOptions {
+  id: string;
+  queuedAt: number;
+  /** Owns the active interval; the watch clears it when it ends. */
+  pollRef: { current: ReturnType<typeof setInterval> | null };
+  setRunWatch: Dispatch<SetStateAction<RunWatch | null>>;
+  setRunsById: Dispatch<
+    SetStateAction<Record<string, WireRoutineRun[] | null>>
+  >;
+  /** Land the run on the routine row (lastRun := the run's started_at). */
+  landRun: (id: string, startedAt: string) => void;
+}
+
+// Watch a queued run land: poll the run ring, mirror it into the opened Recent
+// runs list, flip the header "queued" → "running" once the queued run starts,
+// and stop at a terminal status — lastRun then carries the run's real stamp
+// through the normal formatLastRun path. Bounded: past the cap a still-running
+// run points at the chat instead of pretending, and an unreachable broker
+// stops the poll without inventing progress.
+function startRunWatch(opts: StartRunWatchOptions): void {
+  const { id, queuedAt, pollRef, setRunWatch, setRunsById, landRun } = opts;
+  const watchedFrom = Date.now();
+  const stop = (handle: ReturnType<typeof setInterval>) => {
+    clearInterval(handle);
+    if (pollRef.current === handle) pollRef.current = null;
+  };
+  const timer = setInterval(() => {
+    if (Date.now() - watchedFrom >= RUN_WATCH_CAP_MS) {
+      stop(timer);
+      setRunWatch((prev) =>
+        prev && prev.id === id && prev.phase === "running"
+          ? { ...prev, phase: "overtime" }
+          : prev,
+      );
+      return;
+    }
+    void tryListRoutineRuns(id).then((runs) => {
+      if (pollRef.current !== timer) return; // superseded or stopped
+      if (!runs) {
+        // Offline mid-watch: settle the opened list on the honest empty
+        // note and give up quietly.
+        setRunsById((prev) => ({ ...prev, [id]: null }));
+        stop(timer);
+        return;
+      }
+      setRunsById((prev) => ({ ...prev, [id]: runs }));
+      const { landed, running } = watchedOutcome(runs, queuedAt);
+      if (landed) {
+        stop(timer);
+        landRun(id, landed.started_at);
+        setRunWatch((prev) => (prev && prev.id === id ? null : prev));
+        return;
+      }
+      if (running) {
+        setRunWatch((prev) =>
+          prev && prev.id === id && prev.phase === "queued"
+            ? { ...prev, phase: "running" }
+            : prev,
+        );
+      }
+    });
+  }, RUN_WATCH_INTERVAL_MS);
+  pollRef.current = timer;
+}
+
+// The row's status line: an active watch wins; otherwise the honest last-ran
+// stamp (or paused).
+function headerLabel(r: Routine, runWatch: RunWatch | null): string {
+  if (runWatch && runWatch.id === r.id) {
+    return RUN_WATCH_LABELS[runWatch.phase];
+  }
+  if (!r.enabled) return "paused";
+  return r.lastRun ? `last ran ${formatLastRun(r.lastRun)}` : "not run yet";
+}
+
 interface RoutinesTabProps {
   agentName: string;
   /** Real agent id (app_…). When set, routines live in the broker's scheduler
@@ -107,9 +224,14 @@ export function RoutinesTab({
   const [name, setName] = useState("");
   const [prompt, setPrompt] = useState("");
   const [schedule, setSchedule] = useState(SCHEDULE_PRESETS[0].expr);
-  // Run-now feedback: which routine is mid-queue, and which just queued/ran.
+  // Run-now feedback: which routine is mid-queue, plus the watch that follows
+  // a successful live queue (see startRunWatch) — one phase state drives the
+  // header label and clears when the watched run lands.
   const [runningId, setRunningId] = useState<string | null>(null);
-  const [ranJustNowId, setRanJustNowId] = useState<string | null>(null);
+  const [runWatch, setRunWatch] = useState<RunWatch | null>(null);
+  // The active watch poll — one at a time; dies on unmount and when a new
+  // Run now supersedes it.
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
   // Recent-runs disclosure: which routine cards are expanded, and their loaded
   // run history (undefined = not fetched yet, null = fetched but unavailable).
   const [expandedRuns, setExpandedRuns] = useState<Set<string>>(new Set());
@@ -141,6 +263,20 @@ export function RoutinesTab({
   function patch(id: string, up: (r: Routine) => Routine) {
     setRoutines((prev) => prev.map((r) => (r.id === id ? up(r) : r)));
   }
+
+  function stopWatchPoll() {
+    if (pollRef.current !== null) {
+      clearInterval(pollRef.current);
+      pollRef.current = null;
+    }
+  }
+
+  // The watch poll must not outlive the component.
+  useEffect(() => {
+    return () => {
+      if (pollRef.current !== null) clearInterval(pollRef.current);
+    };
+  }, []);
 
   // Expand/collapse a routine's run history; load it lazily on first expand
   // (the broker keeps a per-slug run ring). Offline/mock agents just resolve
@@ -209,29 +345,42 @@ export function RoutinesTab({
 
   // Run now — queues a fire at the broker; the watchdog runs the prompt
   // through the agent (gated server-side) within one tick. The outcome lands
-  // in the routine's chat session + run history, not in this response.
+  // in the routine's chat session + run history — so a successful queue opens
+  // the Recent runs receipts and watches them until the run lands.
   async function runNow(r: Routine) {
     if (runningId) return;
     setRunningId(r.id);
-    setRanJustNowId(null);
+    stopWatchPoll();
+    setRunWatch(null);
     try {
       if (live && realId) {
+        const queuedAt = Date.now();
         const queued = await tryRunRoutineNow(r.id);
         if (queued) {
           setNotice(null);
-          setRanJustNowId(r.id);
+          setRunWatch({ id: r.id, queuedAt, phase: "queued" });
+          setExpandedRuns((prev) => new Set(prev).add(r.id));
+          startRunWatch({
+            id: r.id,
+            queuedAt,
+            pollRef,
+            setRunWatch,
+            setRunsById,
+            landRun: (rid, startedAt) =>
+              patch(rid, (x) => ({ ...x, lastRun: startedAt })),
+          });
         } else {
           // The queue call failed: nothing will run — do not fabricate
-          // "ran just now".
+          // progress.
           setNotice(
             `Could not queue “${r.name}” — the workspace may be offline. Try again.`,
           );
         }
         return;
       }
-      // Mock agent: record the run locally so the row reflects it.
+      // Mock agent: record the run locally so the row reflects it ("last ran
+      // just now" through the normal lastRun path).
       patch(r.id, (x) => ({ ...x, lastRun: "just now" }));
-      setRanJustNowId(r.id);
     } finally {
       setRunningId(null);
     }
@@ -292,118 +441,31 @@ export function RoutinesTab({
         </p>
       ) : routines.length === 0 ? (
         <p className="opr-scoped-note">
-          No routines yet. Create the first one below — a good starter is a
-          Monday morning recap of the week ahead.
+          No routines yet. A good first one is a Monday 9:00 recap of the week
+          ahead — the status meeting that no longer needs the meeting. Create it
+          below.
         </p>
       ) : null}
 
       <div className="opr-routine-list">
         {routines.map((r) => (
-          <div
+          <RoutineCard
             key={r.id}
-            className={`opr-routine${r.enabled ? "" : " is-disabled"}`}
-          >
-            <div className="opr-routine-head">
-              <span className="opr-routine-name">{r.name}</span>
-              <span className="opr-routine-version">
-                v{r.version}
-                {r.draft ? " · draft" : ""}
-              </span>
-              <span className="opr-routine-schedule">
-                <CalendarClock size={11} strokeWidth={2} aria-hidden={true} />
-                {humanSchedule(r.schedule)}
-              </span>
-              <span className="opr-routine-lastrun">
-                {ranJustNowId === r.id
-                  ? live
-                    ? "queued — starting in a moment"
-                    : "ran just now"
-                  : r.enabled
-                    ? r.lastRun
-                      ? `last ran ${formatLastRun(r.lastRun)}`
-                      : "not run yet"
-                    : "paused"}
-              </span>
-            </div>
-
-            <textarea
-              className="opr-routine-prompt"
-              aria-label={`Prompt for ${r.name}`}
-              value={r.prompt}
-              rows={2}
-              onChange={(e) =>
-                patch(r.id, (x) => ({
-                  ...x,
-                  prompt: e.target.value,
-                  draft: true,
-                }))
-              }
-            />
-
-            <div className="opr-routine-actions">
-              <button
-                type="button"
-                className="opr-btn opr-btn-sm"
-                onClick={() => toggleEnabled(r)}
-              >
-                <Power size={12} strokeWidth={2} aria-hidden={true} />
-                {r.enabled ? "Disable" : "Enable"}
-              </button>
-              <button
-                type="button"
-                className="opr-btn opr-btn-primary opr-btn-sm"
-                disabled={!r.draft}
-                title={
-                  r.draft
-                    ? "Freeze the edited prompt as the next version"
-                    : "No changes since the last publish"
-                }
-                onClick={() => publish(r)}
-              >
-                <CheckCircle2 size={12} strokeWidth={2} aria-hidden={true} />
-                Publish new version
-              </button>
-              <button
-                type="button"
-                className="opr-btn opr-btn-sm"
-                disabled={runningId !== null}
-                title="Run this routine's prompt through the agent now"
-                onClick={() => void runNow(r)}
-              >
-                <Play size={12} strokeWidth={2} aria-hidden={true} />
-                {runningId === r.id ? "Queueing…" : "Run now"}
-              </button>
-              <button
-                type="button"
-                className="opr-btn opr-btn-ghost opr-btn-sm"
-                onClick={() => onOpenSession?.(routineSessionKey(r), r.name)}
-              >
-                <MessageSquareText
-                  size={12}
-                  strokeWidth={2}
-                  aria-hidden={true}
-                />
-                Open its chat
-              </button>
-            </div>
-
-            <div className="opr-routine-runs">
-              <button
-                type="button"
-                className={`opr-routine-runs-toggle${
-                  expandedRuns.has(r.id) ? " is-open" : ""
-                }`}
-                aria-expanded={expandedRuns.has(r.id)}
-                onClick={() => toggleRuns(r)}
-              >
-                <ChevronRight size={11} strokeWidth={2} aria-hidden={true} />
-                Recent runs
-              </button>
-              {expandedRuns.has(r.id) ? (
-                <RecentRuns runs={runsById[r.id]} />
-              ) : null}
-            </div>
-          </div>
+            r={r}
+            runWatch={runWatch}
+            queueing={runningId === r.id}
+            runDisabled={runningId !== null}
+            expanded={expandedRuns.has(r.id)}
+            runs={runsById[r.id]}
+            onToggleEnabled={() => toggleEnabled(r)}
+            onPublish={() => publish(r)}
+            onRunNow={() => void runNow(r)}
+            onToggleRuns={() => toggleRuns(r)}
+            onEditPrompt={(value) =>
+              patch(r.id, (x) => ({ ...x, prompt: value, draft: true }))
+            }
+            onOpenChat={() => onOpenSession?.(routineSessionKey(r), r.name)}
+          />
         ))}
       </div>
 
@@ -458,32 +520,172 @@ export function RoutinesTab({
   );
 }
 
+// One routine card: name/version/schedule/status header, the editable prompt,
+// the action row, and the Recent runs disclosure. While a Run now watch is
+// live the Open its chat button swaps ghost for primary — the play-by-play is
+// one click away.
+function RoutineCard({
+  r,
+  runWatch,
+  queueing,
+  runDisabled,
+  expanded,
+  runs,
+  onToggleEnabled,
+  onPublish,
+  onRunNow,
+  onToggleRuns,
+  onEditPrompt,
+  onOpenChat,
+}: {
+  r: Routine;
+  runWatch: RunWatch | null;
+  queueing: boolean;
+  runDisabled: boolean;
+  expanded: boolean;
+  runs: WireRoutineRun[] | null | undefined;
+  onToggleEnabled: () => void;
+  onPublish: () => void;
+  onRunNow: () => void;
+  onToggleRuns: () => void;
+  onEditPrompt: (value: string) => void;
+  onOpenChat: () => void;
+}) {
+  const watching = runWatch !== null && runWatch.id === r.id;
+  return (
+    <div className={`opr-routine${r.enabled ? "" : " is-disabled"}`}>
+      <div className="opr-routine-head">
+        <span className="opr-routine-name">{r.name}</span>
+        <span className="opr-routine-version">
+          v{r.version}
+          {r.draft ? " · draft" : ""}
+        </span>
+        <span className="opr-routine-schedule">
+          <CalendarClock size={11} strokeWidth={2} aria-hidden={true} />
+          {humanSchedule(r.schedule)}
+        </span>
+        <span className="opr-routine-lastrun">{headerLabel(r, runWatch)}</span>
+      </div>
+
+      <textarea
+        className="opr-routine-prompt"
+        aria-label={`Prompt for ${r.name}`}
+        value={r.prompt}
+        rows={2}
+        onChange={(e) => onEditPrompt(e.target.value)}
+      />
+
+      <div className="opr-routine-actions">
+        <button
+          type="button"
+          className="opr-btn opr-btn-sm"
+          onClick={onToggleEnabled}
+        >
+          <Power size={12} strokeWidth={2} aria-hidden={true} />
+          {r.enabled ? "Disable" : "Enable"}
+        </button>
+        <button
+          type="button"
+          className="opr-btn opr-btn-primary opr-btn-sm"
+          disabled={!r.draft}
+          title={
+            r.draft
+              ? "Freeze the edited prompt as the next version"
+              : "No changes since the last publish"
+          }
+          onClick={onPublish}
+        >
+          <CheckCircle2 size={12} strokeWidth={2} aria-hidden={true} />
+          Publish new version
+        </button>
+        <button
+          type="button"
+          className="opr-btn opr-btn-sm"
+          disabled={runDisabled}
+          title="Run this routine's prompt through the agent now"
+          onClick={onRunNow}
+        >
+          <Play size={12} strokeWidth={2} aria-hidden={true} />
+          {queueing ? "Queueing…" : "Run now"}
+        </button>
+        <button
+          type="button"
+          className={`opr-btn ${
+            watching ? "opr-btn-primary" : "opr-btn-ghost"
+          } opr-btn-sm`}
+          onClick={onOpenChat}
+        >
+          <MessageSquareText size={12} strokeWidth={2} aria-hidden={true} />
+          Open its chat
+        </button>
+      </div>
+
+      <div className="opr-routine-runs">
+        <button
+          type="button"
+          className={`opr-routine-runs-toggle${expanded ? " is-open" : ""}`}
+          aria-expanded={expanded}
+          onClick={onToggleRuns}
+        >
+          <ChevronRight size={11} strokeWidth={2} aria-hidden={true} />
+          Recent runs
+        </button>
+        {expanded ? (
+          <RecentRuns
+            runs={runs}
+            watchFrom={watching && runWatch ? runWatch.queuedAt : undefined}
+          />
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
 // The routine's recent runs from the broker's per-slug run ring: status dot,
 // when it ran (humanized), and the first line of its outcome. `undefined` while
-// loading; `null`/empty shows the honest empty note.
-function RecentRuns({ runs }: { runs: WireRoutineRun[] | null | undefined }) {
+// loading; `null`/empty shows the honest empty note. During a Run now watch
+// the queued run (started after `watchFrom`, still pending) blinks with the
+// existing live LED class.
+function RecentRuns({
+  runs,
+  watchFrom,
+}: {
+  runs: WireRoutineRun[] | null | undefined;
+  watchFrom?: number;
+}) {
   if (runs === undefined) {
-    return <p className="opr-scoped-note">Loading recent runs…</p>;
+    return (
+      <div role="status" aria-label="Loading recent runs">
+        <div className="opr-skeleton opr-skel-row" />
+      </div>
+    );
   }
   if (!runs || runs.length === 0) {
     return <p className="opr-scoped-note">No runs recorded yet.</p>;
   }
   return (
     <ul className="opr-routine-runs-list">
-      {runs.slice(0, 5).map((run, i) => (
-        <li className="opr-routine-run" key={`${run.started_at}-${i}`}>
-          <span
-            className={`opr-run-led ${runStatusClass(run.status)}`}
-            aria-hidden={true}
-          />
-          <span className="opr-routine-run-when">
-            {formatStamp(run.started_at)}
-          </span>
-          <span className="opr-routine-run-summary">
-            {firstLine(run.output_summary || run.message || "") || run.status}
-          </span>
-        </li>
-      ))}
+      {runs.slice(0, 5).map((run, i) => {
+        const status = runStatusClass(run.status);
+        const isLive =
+          watchFrom !== undefined &&
+          status === "is-pending" &&
+          Date.parse(run.started_at) > watchFrom;
+        return (
+          <li className="opr-routine-run" key={`${run.started_at}-${i}`}>
+            <span
+              className={`opr-run-led ${status}${isLive ? " opr-led-live" : ""}`}
+              aria-hidden={true}
+            />
+            <span className="opr-routine-run-when">
+              {formatStamp(run.started_at)}
+            </span>
+            <span className="opr-routine-run-summary">
+              {firstLine(run.output_summary || run.message || "") || run.status}
+            </span>
+          </li>
+        );
+      })}
     </ul>
   );
 }

--- a/web/src/operator/surfaces/AppBuilderChat.test.tsx
+++ b/web/src/operator/surfaces/AppBuilderChat.test.tsx
@@ -21,6 +21,7 @@ const buildMutateMock = vi.fn(
 vi.mock("../apps/useOperatorApps", () => ({
   useBuildApp: () => ({ mutateAsync: buildMutateMock }),
   deriveAppName: () => "Pipeline Agent",
+  uniquifyAppName: (name: string) => name,
   resolveNewAppId: (before: ReadonlySet<string>, apps: { id: string }[]) =>
     apps.find((a) => !before.has(a.id))?.id ?? null,
   appBuildState: (app: { status?: string }) =>

--- a/web/src/operator/surfaces/AppBuilderChat.tsx
+++ b/web/src/operator/surfaces/AppBuilderChat.tsx
@@ -11,12 +11,16 @@ import { ArrowRight, Check, Send, X } from "lucide-react";
 
 import { type CustomApp, listApps, submitAppEdit } from "../../api/apps";
 import { AppActivity } from "../../components/apps/AppActivity";
+import { PixelAvatar } from "../../components/ui/PixelAvatar";
+import { useCyclingPhrase } from "../../hooks/useCyclingPhrase";
+import { OFFICE_LOADING_PHRASES } from "../../lib/officeLoadingPhrases";
 import { tryCreateRoutine, tryListRoutines } from "../agents/agentStateClient";
 import { capturePromptSeed, type DemoCapture } from "../apps/demoCapture";
 import {
   appBuildState,
   deriveAppName,
   resolveNewAppId,
+  uniquifyAppName,
   useBuildApp,
 } from "../apps/useOperatorApps";
 import {
@@ -45,9 +49,10 @@ interface ChatMessage {
 }
 
 const STARTERS: readonly string[] = [
-  "A dashboard of our open tasks with their status",
+  "A pipeline review board: every deal with no next step, grouped by owner",
+  "A renewals radar: contracts up in 90 days, flagged when a support ticket is open",
   "A refund-approval form that posts to Slack",
-  "A weekly pipeline summary I can glance at",
+  "A Friday close-out digest: what shipped, what slipped, and who is blocked",
 ];
 
 // A per-app chat transcript, persisted across the build chat -> app detail ->
@@ -177,6 +182,13 @@ export function AppBuilderChat({
   // polls, so after a short grace window of the candidate staying terminal we
   // accept it rather than waiting forever (see the guard below).
   const terminalSinceRef = useRef<{ id: string; at: number } | null>(null);
+  // The longest wait in the product gets the shell's cycling Office gerund
+  // (the same delight system WorkflowBuilder uses for its 15s wait).
+  const workPhrase = useCyclingPhrase(
+    OFFICE_LOADING_PHRASES,
+    2400,
+    phase === "building" && !editApp,
+  );
 
   const build = useBuildApp();
   const queryClient = useQueryClient();
@@ -239,6 +251,13 @@ export function AppBuilderChat({
       reportedBuildingRef.current = candidate.id;
       onBuildingApp?.(candidate.id);
       void setupDemoExtras(candidate.id);
+      // A useful head start beats an empty wait: the operator can prep the
+      // delivery side while the build runs (2026-08-16 delight audit).
+      if (!demo) {
+        say(
+          "While it builds, a head start: connect the systems it will deliver to on the Integrations tab, and think about the next workflow you would hand off. I will keep working either way.",
+        );
+      }
     }
 
     const state = appBuildState(candidate);
@@ -536,9 +555,13 @@ export function AppBuilderChat({
     // follow-up REFINES that app instead of starting a brand-new build — so a
     // second message like "also handle event signups" amends the same app.
     const refineId = editApp?.id ?? newAppId;
+    // New builds uniquify against the roster: "Pipeline Agent" twice would
+    // read as the same agent (and the broker refuses to reuse a published
+    // agent's id, so the names MUST diverge too — 2026-08-16 VP-RevOps QA).
+    const roster = refineId || demo ? [] : await listApps().catch(() => []);
     const name = refineId
       ? appName || deriveAppName(description)
-      : deriveAppName(description);
+      : uniquifyAppName(deriveAppName(description), roster);
     activeRefineRef.current = refineId;
     // A brand-new build remembers its description so the completion hook can
     // mint the starter routine from it (the workflow IS the recurring job).
@@ -558,7 +581,7 @@ export function AppBuilderChat({
         from: "ai",
         body: refineId
           ? `On it — refining “${name}”. You can watch it update below.`
-          : `On it — building “${name}”. You can watch it come together below.`,
+          : `On it — building “${name}”. A first build usually runs 10 to 20 minutes, and every step shows below. You do not have to watch: the sidebar keeps a pulse on it, and the finish card lands right here.`,
       },
     ]);
     try {
@@ -624,7 +647,21 @@ export function AppBuilderChat({
 
         <div className="opr-builder-scroll" ref={scrollRef}>
           {messages.map((m) => (
-            <div key={m.id} className="opr-edit-msgwrap">
+            <div
+              key={m.id}
+              className={`opr-edit-msgwrap${m.from === "ai" ? " opr-msgwrap-ai" : ""}`}
+            >
+              {m.from === "ai" ? (
+                <span
+                  className="opr-msg-face opr-portrait-frame"
+                  aria-hidden={true}
+                >
+                  <PixelAvatar
+                    slug={editApp?.id ?? newAppId ?? "nex"}
+                    size={20}
+                  />
+                </span>
+              ) : null}
               <div
                 className={`opr-msg ${
                   m.from === "ai" ? "opr-msg-ai" : "opr-msg-you"
@@ -727,15 +764,27 @@ export function AppBuilderChat({
                   nothing until the first event arrives, so the working
                   indicator below carries the initial seconds. */}
               <AppActivity appId={buildingAppId} />
-              <div className="opr-act-working" aria-label="Building your agent">
+              <div
+                className="opr-act-working"
+                role="status"
+                aria-label="Building your agent"
+              >
                 <span className="opr-work-dots" aria-hidden={true}>
                   <span />
                   <span />
                   <span />
                 </span>
-                <span className="opr-work-phrase">
-                  {editApp ? "Applying your change…" : "Building your agent…"}
-                </span>
+                {editApp ? (
+                  <span className="opr-work-phrase">Applying your change…</span>
+                ) : (
+                  <span
+                    key={workPhrase}
+                    className="opr-work-phrase"
+                    aria-hidden={true}
+                  >
+                    {workPhrase ? `${workPhrase}…` : "Building your agent…"}
+                  </span>
+                )}
               </div>
             </div>
           ) : null}
@@ -745,11 +794,14 @@ export function AppBuilderChat({
               className={`opr-finish-card${buildFailed ? " is-failed" : ""}`}
             >
               <div className="opr-finish-row">
-                <span className="opr-finish-glyph" aria-hidden={true}>
+                <span
+                  className={`opr-finish-glyph${buildFailed ? "" : " opr-portrait-frame"}`}
+                  aria-hidden={true}
+                >
                   {buildFailed ? (
                     <X size={15} strokeWidth={2.2} />
                   ) : (
-                    <Check size={15} strokeWidth={2.2} />
+                    <PixelAvatar slug={newAppId} size={22} />
                   )}
                 </span>
                 <div style={{ flex: 1, minWidth: 0 }}>
@@ -760,7 +812,7 @@ export function AppBuilderChat({
                         ? "The build stopped before it finished"
                         : editApp
                           ? "New version published"
-                          : "Ready to use"}
+                          : "Hired. It starts now, no orientation needed."}
                     </span>
                   </div>
                 </div>
@@ -815,7 +867,7 @@ export function AppBuilderChat({
             aria-label="Describe what this agent should do"
             placeholder={
               phase === "building"
-                ? `One build at a time — “${appName || "this agent"}” is almost ready`
+                ? `One build at a time — “${appName || "this agent"}” is on the bench, back shortly`
                 : "Describe what this agent should do…"
             }
             value={draft}

--- a/web/src/operator/surfaces/AppDataTab.test.tsx
+++ b/web/src/operator/surfaces/AppDataTab.test.tsx
@@ -67,6 +67,22 @@ describe("AppDataTab", () => {
     expect(getByText("2 rows")).toBeTruthy();
   });
 
+  it("frames the populated view as the agent's own exportable database", async () => {
+    get.mockResolvedValue({
+      tables: [
+        {
+          name: "Emails",
+          columns: [{ name: "sender", type: "string" }],
+          rows: [{ sender: "a@b.com" }],
+        },
+      ],
+    });
+    const { getByText } = wrap(<AppDataTab appId="app_abc" />);
+    await waitFor(() => expect(getByText("Emails")).toBeTruthy());
+    expect(getByText("This agent’s database")).toBeTruthy();
+    expect(getByText(/no export ticket/i)).toBeTruthy();
+  });
+
   it("shows a defined-but-empty note for a table with no rows", async () => {
     get.mockResolvedValue({
       tables: [

--- a/web/src/operator/surfaces/AppDataTab.tsx
+++ b/web/src/operator/surfaces/AppDataTab.tsx
@@ -13,6 +13,7 @@ import { useQuery } from "@tanstack/react-query";
 
 import { get } from "../../api/client";
 import { EmptyState } from "../components/EmptyState";
+import { Eyebrow } from "../components/primitives";
 
 interface AppDataTabProps {
   appId: string;
@@ -83,14 +84,13 @@ export function AppDataTab({ appId }: AppDataTabProps) {
   });
 
   if (dbQuery.isLoading) {
+    // Table-shaped skeleton, not a 320px void: the wait previews the shape
+    // of what loads (2026-08-16 delight audit).
     return (
-      <div className="opr-app-building" role="status">
-        <span className="opr-work-dots" aria-hidden={true}>
-          <span />
-          <span />
-          <span />
-        </span>
-        <div className="opr-empty-title">Reading this app’s data…</div>
+      <div className="opr-tool-scoped" role="status" aria-label="Loading data">
+        <div className="opr-skeleton opr-skel-row" />
+        <div className="opr-skeleton opr-skel-row" style={{ marginTop: 8 }} />
+        <div className="opr-skeleton opr-skel-row" style={{ marginTop: 8 }} />
       </div>
     );
   }
@@ -112,13 +112,21 @@ export function AppDataTab({ appId }: AppDataTabProps) {
         glyph="▦"
         portraitSlug={appId}
         title="No data yet"
-        hint="This agent has not written to its database yet. As it derives and saves its data model — the tables that power it — they appear here."
+        hint="Nothing saved yet. After its first run, everything this agent records lands here as tables you own: browse every row, export any table as CSV or JSON. No BI ticket required."
       />
     );
   }
 
   return (
     <div className="opr-tool-scoped opr-app-data">
+      <div className="opr-data-intro">
+        <Eyebrow>This agent’s database</Eyebrow>
+        <p className="opr-scoped-note">
+          The tables this agent derived and saved, read straight from its own
+          database. Nothing reconstructed. Every table exports as CSV or JSON:
+          your data, no export ticket.
+        </p>
+      </div>
       {tables.map((t, i) => (
         // Name+index key: parseTables falls back to "Table" for a half-written
         // table, so bare names can collide and misapply reconciliation.

--- a/web/src/operator/surfaces/AppKnowledgeTab.test.tsx
+++ b/web/src/operator/surfaces/AppKnowledgeTab.test.tsx
@@ -1,0 +1,45 @@
+import type { ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { AppKnowledgeTab } from "./AppKnowledgeTab";
+
+// vi.mock is hoisted above this file's const declarations, so the mock handle
+// must be hoisted too or the factory hits the TDZ.
+const { fetchCatalog, fetchArticle } = vi.hoisted(() => ({
+  fetchCatalog: vi.fn(),
+  fetchArticle: vi.fn(),
+}));
+vi.mock("../../api/wiki", () => ({ fetchCatalog, fetchArticle }));
+
+function wrap(node: ReactNode) {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(<QueryClientProvider client={qc}>{node}</QueryClientProvider>);
+}
+
+describe("AppKnowledgeTab", () => {
+  beforeEach(() => {
+    fetchCatalog.mockReset();
+    fetchArticle.mockReset();
+  });
+
+  it("names concrete pages in the empty state, not just the mechanism", async () => {
+    fetchCatalog.mockResolvedValue([]);
+    const { getByText } = wrap(<AppKnowledgeTab />);
+    await waitFor(() => expect(getByText(/No knowledge yet/)).toBeTruthy());
+    // The promise stays concrete: pages a revenue leader would recognize,
+    // mirroring the onboarding wizard's own examples.
+    expect(getByText(/how you route a lead/)).toBeTruthy();
+    expect(getByText(/stale deal/)).toBeTruthy();
+  });
+
+  it("keeps the offline state straight, with no example copy", async () => {
+    fetchCatalog.mockRejectedValue(new Error("down"));
+    const { getByText, queryByText } = wrap(<AppKnowledgeTab />);
+    await waitFor(() => expect(getByText(/Knowledge is offline/)).toBeTruthy());
+    expect(queryByText(/stale deal/)).toBeNull();
+  });
+});

--- a/web/src/operator/surfaces/AppKnowledgeTab.tsx
+++ b/web/src/operator/surfaces/AppKnowledgeTab.tsx
@@ -65,7 +65,7 @@ export function AppKnowledgeTab() {
       <EmptyState
         glyph="✦"
         title="No knowledge yet"
-        hint="As your team works, the company brain fills with pages your agents can draw on. None have been written yet."
+        hint="As your agents work, pages land here with citations: how you tier accounts, how you route a lead, what counts as a stale deal. Write a rule once, and every agent reads it before acting."
       />
     );
   }

--- a/web/src/operator/surfaces/AppToolsChat.test.tsx
+++ b/web/src/operator/surfaces/AppToolsChat.test.tsx
@@ -85,6 +85,45 @@ describe("AppToolsChat + Tools tab (slice 2)", () => {
     );
   });
 
+  it("the first tool ever taught gets the milestone reply; the second does not", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValueOnce(
+          builtTool("draftFollowup", "Draft a follow-up email"),
+        )
+        .mockResolvedValueOnce(builtTool("weeklyRecap", "Weekly recap")),
+    );
+    // Product-shaped start: agents begin with NO tools.
+    const { getByLabelText, findByText } = render(
+      <ToolsProvider appName="Pipeline" initialTools={[]}>
+        <AppToolsChat appName="Pipeline" />
+      </ToolsProvider>,
+    );
+    const input = getByLabelText(
+      "Describe a task for Nex to build a tool for",
+    ) as HTMLInputElement;
+
+    fireEvent.change(input, {
+      target: { value: "Draft a follow-up email for a stalled deal" },
+    });
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(
+      await findByText(/“Draft a follow-up email”, this agent's first tool/),
+    ).toBeTruthy();
+
+    await waitFor(() => expect(input.disabled).toBe(false));
+    fireEvent.change(input, {
+      target: { value: "Recap the pipeline every week" },
+    });
+    fireEvent.keyDown(input, { key: "Enter" });
+    // The second teach is routine: plain reply, no milestone.
+    expect(
+      await findByText(/“Weekly recap”\. It is in your Tools now/),
+    ).toBeTruthy();
+  });
+
   // 2026-08-15 QA regression: a teach that the service could not really author
   // must never mint a tool — not from the offline mock, not from the service's
   // canned stub. The chat says what happened instead.
@@ -331,7 +370,9 @@ describe("AppToolsChat calls tools (slice 5)", () => {
     fireEvent.change(input, { target: { value: "Globex renewal" } });
     fireEvent.keyDown(input, { key: "Enter" });
 
-    expect((await findAllByText("drafted the follow-up")).length).toBeGreaterThan(0);
+    expect(
+      (await findAllByText("drafted the follow-up")).length,
+    ).toBeGreaterThan(0);
     const body = JSON.parse(fetchMock.mock.calls[0][1].body as string);
     expect(body.args).toEqual({ lead: "Globex renewal" });
   });
@@ -357,7 +398,7 @@ describe("AppToolsChat calls tools (slice 5)", () => {
 
     fireEvent.click(await findByText("Not now"));
     expect(
-      await findByText("Okay — I didn't send it. Nothing left this agent."),
+      await findByText("Okay — I did not send it. Nothing left this agent."),
     ).toBeTruthy();
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });

--- a/web/src/operator/surfaces/AppToolsChat.tsx
+++ b/web/src/operator/surfaces/AppToolsChat.tsx
@@ -12,6 +12,8 @@
 import { useEffect, useRef, useState } from "react";
 import { Send, Terminal } from "lucide-react";
 
+import { PixelAvatar } from "../../components/ui/PixelAvatar";
+import { useCyclingPhrase } from "../../hooks/useCyclingPhrase";
 import type { Tool, ToolCall } from "../tools/mockTools";
 import {
   buildToolFromChat,
@@ -55,6 +57,16 @@ function nextId(): string {
   uid += 1;
   return `tc_${uid}`;
 }
+
+// Sentinel for the tool-authoring wait. The working row swaps it for the
+// cycling phrases below at render time — raw internal identifiers like
+// create_tool are developer material, not operator narration.
+const AUTHORING_STATUS = "__authoring__";
+const AUTHORING_PHRASES = [
+  "Writing it up as a tool",
+  "Wiring the steps in order",
+  "Giving it a name",
+] as const;
 
 // The create_tool call the chat shows, with the args the agent passed.
 function callSignature(tool: Tool): string {
@@ -122,9 +134,11 @@ function extractArgs(
 ): { args: Record<string, string>; missing: string[] } {
   const args: Record<string, string> = {};
   const named = new Map(
-    [...text.matchAll(/([A-Za-z][\w]*)\s*[:=]\s*("[^"]+"|“[^”]+”|'[^']+'|\S+)/g)].map(
-      (m) => [m[1].toLowerCase(), m[2].replace(/^["“']|["”']$/g, "")],
-    ),
+    [
+      ...text.matchAll(
+        /([A-Za-z][\w]*)\s*[:=]\s*("[^"]+"|“[^”]+”|'[^']+'|\S+)/g,
+      ),
+    ].map((m) => [m[1].toLowerCase(), m[2].replace(/^["“']|["”']$/g, "")]),
   );
   const quoted = [...text.matchAll(/["“”']([^"“”']+)["“”']/g)].map((m) => m[1]);
   let qi = 0;
@@ -147,9 +161,10 @@ function extractArgs(
  * (TypeError etc.) rides after it, truncated, as diagnostic detail. */
 function frameRunError(detail: string | undefined): string {
   if (!detail) return "Something went wrong — nothing was sent.";
-  const technical = /is not a function|is not defined|undefined is not|TypeError|ReferenceError|SyntaxError|Cannot read/.test(
-    detail,
-  );
+  const technical =
+    /is not a function|is not defined|undefined is not|TypeError|ReferenceError|SyntaxError|Cannot read/.test(
+      detail,
+    );
   if (!technical) return detail;
   return `The tool hit a bug while running — nothing was sent. Ask me to rebuild it if this keeps happening. (${detail.slice(0, 140)})`;
 }
@@ -161,6 +176,12 @@ export function AppToolsChat({
   onTurn,
 }: AppToolsChatProps) {
   const { tools, addTool, logCall, agentId } = useAppTools();
+  // Read at teach time through a ref: the seeded hand-off path fires send() on
+  // mount while the persisted toolbox hydrates async, so a render-time closure
+  // would still see the empty mount-time array (and announce a "first tool"
+  // for an agent that already has some).
+  const toolsRef = useRef(tools);
+  toolsRef.current = tools;
   const [items, setItems] = useState<ChatItem[]>(() =>
     initialTranscript
       ? initialTranscript.map((m) => ({
@@ -174,7 +195,7 @@ export function AppToolsChat({
             kind: "text",
             id: nextId(),
             from: "nex",
-            body: `Tell me a repeatable task you do in ${appName} and I'll build it a tool you can call. Anything I make shows up under Tools — ask me to run one any time.`,
+            body: `Tell me a job you still do by hand (the Monday-morning one counts) and I will teach ${appName} a tool for it. It lands under Tools, and you can ask me to run it any time.`,
           },
         ],
   );
@@ -189,6 +210,11 @@ export function AppToolsChat({
   } | null>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
   const seededRef = useRef(false);
+  const authoringPhrase = useCyclingPhrase(
+    AUTHORING_PHRASES,
+    2400,
+    working === AUTHORING_STATUS,
+  );
 
   function scrollDown() {
     requestAnimationFrame(() => {
@@ -237,7 +263,7 @@ export function AppToolsChat({
   }
 
   async function invokeTool(tool: Tool, args: Record<string, string>) {
-    setWorking(`Nex is calling ${tool.name}…`);
+    setWorking(`Running “${tool.title}”…`);
     scrollDown();
     try {
       const outcome = await callToolViaAgent(tool, args, false);
@@ -263,7 +289,7 @@ export function AppToolsChat({
   async function approvePending() {
     const p = pending;
     if (!p || working) return;
-    setWorking(`Nex is calling ${p.tool.name}…`);
+    setWorking(`Running “${p.tool.title}”…`);
     try {
       // Clear the pending approval only on a successful outcome: a failure
       // keeps the card actionable instead of losing the approval context.
@@ -287,7 +313,7 @@ export function AppToolsChat({
         kind: "text",
         id: nextId(),
         from: "nex",
-        body: "Okay — I didn't send it. Nothing left this agent.",
+        body: "Okay — I did not send it. Nothing left this agent.",
       },
     ]);
     scrollDown();
@@ -371,7 +397,7 @@ export function AppToolsChat({
     // tool (2026-08-15 audit). Say what this chat can do instead.
     if (looksLikeQuestion(body)) {
       const reply =
-        'This chat is where you teach me tools and run them. Describe a workflow ("score each new lead and route hot ones") and I\'ll build it as a tool, or say "run <tool name>" to use one.';
+        'This chat is where you teach me tools and run them. Describe a workflow ("score each new lead and route hot ones") and I will build it as a tool, or say "run <tool name>" to use one.';
       setItems((prev) => [
         ...prev,
         { kind: "text", id: nextId(), from: "nex", body: reply },
@@ -380,7 +406,7 @@ export function AppToolsChat({
       scrollDown();
       return;
     }
-    setWorking("Nex is calling create_tool…");
+    setWorking(AUTHORING_STATUS);
     scrollDown();
     try {
       // The pi-mono chat agent decides to make a tool and calls create_tool; we
@@ -410,7 +436,7 @@ export function AppToolsChat({
         // instead of pretending the service was down.
         const reply =
           narration ||
-          "I could not turn that into a tool. Describe the workflow step by step and I'll try again.";
+          "I could not turn that into a tool. Describe the workflow step by step and I will try again.";
         setItems((prev) => [
           ...prev,
           { kind: "text", id: nextId(), from: "nex", body: reply },
@@ -424,7 +450,7 @@ export function AppToolsChat({
         // operator's workflow is worse than nothing (2026-08-15 QA pass), so
         // say what's missing instead of minting it into Tools.
         const reply =
-          "I can't author tools on this computer yet — there's no AI model connected for me to write them with. Connect Claude Code, an Anthropic API key, or Ollama, then teach me again.";
+          "I cannot author tools on this computer yet — there is no AI model connected for me to write them with. Connect Claude Code, an Anthropic API key, or Ollama, then teach me again.";
         setItems((prev) => [
           ...prev,
           { kind: "text", id: nextId(), from: "nex", body: reply },
@@ -432,8 +458,13 @@ export function AppToolsChat({
         onTurn?.("nex", reply);
         return;
       }
+      // The first tool ever taught is a milestone in the operator's mental
+      // model (the agent can now DO something on its own) — notice it.
+      const isFirstTool = toolsRef.current.length === 0;
       addTool(tool);
-      const reply = `Done — I built “${tool.title}”. It's in your Tools now, and I'll call it when you need it.`;
+      const reply = isFirstTool
+        ? `Done — I built “${tool.title}”, this agent's first tool. It is in Tools now, and I will reach for it whenever the job calls for it.`
+        : `Done — I built “${tool.title}”. It is in your Tools now, and I will call it when you need it.`;
       setItems((prev) => [
         ...prev,
         { kind: "call", id: nextId(), tool },
@@ -463,7 +494,18 @@ export function AppToolsChat({
           {items.map((item) => {
             if (item.kind === "text") {
               return (
-                <div key={item.id} className="opr-edit-msgwrap">
+                <div
+                  key={item.id}
+                  className={`opr-edit-msgwrap${item.from === "nex" ? " opr-msgwrap-ai" : ""}`}
+                >
+                  {item.from === "nex" ? (
+                    <span
+                      className="opr-msg-face opr-portrait-frame"
+                      aria-hidden={true}
+                    >
+                      <PixelAvatar slug={agentId ?? appName} size={20} />
+                    </span>
+                  ) : null}
                   <div
                     className={`opr-msg ${item.from === "nex" ? "opr-msg-ai" : "opr-msg-you"}`}
                   >
@@ -554,7 +596,9 @@ export function AppToolsChat({
                 <span />
                 <span />
               </span>
-              <span className="opr-work-phrase">{working}</span>
+              <span className="opr-work-phrase">
+                {working === AUTHORING_STATUS ? `${authoringPhrase}…` : working}
+              </span>
             </div>
           ) : null}
         </div>

--- a/web/src/operator/surfaces/InternalToolDetail.tsx
+++ b/web/src/operator/surfaces/InternalToolDetail.tsx
@@ -199,7 +199,11 @@ export function InternalToolDetail({
             tabs={TABS}
             active={tab}
             onSelect={setTab}
-            hint={tab === "workflow" ? "same steps every run · every run logged" : undefined}
+            hint={
+              tab === "workflow"
+                ? "same steps every run · every run logged"
+                : undefined
+            }
           />
 
           <div

--- a/web/src/operator/surfaces/OperatorAppDetail.test.tsx
+++ b/web/src/operator/surfaces/OperatorAppDetail.test.tsx
@@ -1,6 +1,6 @@
 import type { ReactElement } from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { fireEvent, render as rtlRender } from "@testing-library/react";
+import { act, fireEvent, render as rtlRender } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { CustomAppDetail } from "../../api/apps";
@@ -58,7 +58,10 @@ vi.mock("./ToolIntegrations", () => ({
 }));
 vi.mock("./AppToolsChat", () => ({
   AppToolsChat: ({ appName }: { appName: string }) => (
-    <div data-testid="ask-ai-chat">tools:{appName}</div>
+    <div data-testid="ask-ai-chat">
+      tools:{appName}
+      <input data-testid="chat-input" />
+    </div>
   ),
 }));
 
@@ -234,6 +237,126 @@ describe("OperatorAppDetail", () => {
     expect(getByTestId("ask-ai-chat").textContent).toContain(
       "tools:Open Tasks",
     );
+  });
+
+  it("moves focus into the Ask Agent panel on open and closes it on Escape", () => {
+    useOperatorAppMock.mockReturnValue({
+      data: detail({ status: "ready" }, "<html>hi</html>"),
+      isError: false,
+    });
+    const { container, getByRole, queryByTestId } = render(
+      <OperatorAppDetail appId="app_abc" onBack={() => {}} />,
+    );
+    fireEvent.click(
+      getByRole("button", { name: /ask agent about open tasks/i }),
+    );
+    // The panel takes focus on open (overlay keyboard grammar, as CallModal).
+    const panel = container.querySelector(".opr-ask-panel");
+    expect(panel).toBeTruthy();
+    expect(document.activeElement).toBe(panel);
+    // Escape anywhere outside the composer closes the drawer.
+    fireEvent.keyDown(document.body, { key: "Escape" });
+    expect(queryByTestId("ask-ai-chat")).toBeNull();
+    // The floating bubble is back.
+    expect(
+      getByRole("button", { name: /ask agent about open tasks/i }),
+    ).toBeTruthy();
+  });
+
+  it("ignores Escape pressed inside the chat composer (draft protection)", () => {
+    useOperatorAppMock.mockReturnValue({
+      data: detail({ status: "ready" }, "<html>hi</html>"),
+      isError: false,
+    });
+    const { getByRole, getByTestId, queryByTestId } = render(
+      <OperatorAppDetail appId="app_abc" onBack={() => {}} />,
+    );
+    fireEvent.click(
+      getByRole("button", { name: /ask agent about open tasks/i }),
+    );
+    // Escape from the composer input (e.g. cancelling IME composition or an
+    // autocomplete) must NOT unmount the chat and discard the draft.
+    fireEvent.keyDown(getByTestId("chat-input"), { key: "Escape" });
+    expect(queryByTestId("ask-ai-chat")).not.toBeNull();
+    // Escape outside the composer still closes.
+    fireEvent.keyDown(document.body, { key: "Escape" });
+    expect(queryByTestId("ask-ai-chat")).toBeNull();
+  });
+});
+
+describe("OperatorAppDetail build walk narration", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  function renderWalk() {
+    useOperatorAppMock.mockReturnValue({
+      data: detail({ status: "ready" }, "<html>hi</html>"),
+      isError: false,
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({ ok: false, status: 404, json: async () => ({}) })),
+    );
+    return render(
+      <OperatorAppDetail appId="app_abc" onBack={() => {}} buildWalk={true} />,
+    );
+  }
+
+  it("captions each walked tab, then falls silent when the walk settles", () => {
+    vi.useFakeTimers();
+    const { getByText, queryByText } = renderWalk();
+    // Before the walk starts: no caption.
+    expect(queryByText(/Its routines/)).toBeNull();
+    act(() => {
+      vi.advanceTimersByTime(900);
+    });
+    expect(
+      getByText("Its routines: the schedule it runs your workflow on."),
+    ).toBeTruthy();
+    act(() => {
+      vi.advanceTimersByTime(2300);
+    });
+    expect(
+      getByText("Its own database. It fills up as it works."),
+    ).toBeTruthy();
+    act(() => {
+      vi.advanceTimersByTime(2300);
+    });
+    expect(
+      getByText("What it learns, written down with citations."),
+    ).toBeTruthy();
+    // The walk settles back on the UI tab and the narration goes away.
+    act(() => {
+      vi.advanceTimersByTime(2500);
+    });
+    expect(
+      queryByText(/Its routines|Its own database|What it learns/),
+    ).toBeNull();
+  });
+
+  it("clears the caption the moment the operator clicks a tab themselves", () => {
+    vi.useFakeTimers();
+    const { getByRole, getByText, queryByText } = renderWalk();
+    act(() => {
+      vi.advanceTimersByTime(900);
+    });
+    expect(
+      getByText("Its routines: the schedule it runs your workflow on."),
+    ).toBeTruthy();
+    // A manual click cancels the walk AND its narration.
+    fireEvent.click(getByRole("tab", { name: "Data" }));
+    expect(
+      queryByText(/Its routines|Its own database|What it learns/),
+    ).toBeNull();
+    // The cancelled timers never resurrect a caption.
+    act(() => {
+      vi.advanceTimersByTime(10000);
+    });
+    expect(
+      queryByText(/Its routines|Its own database|What it learns/),
+    ).toBeNull();
   });
 });
 

--- a/web/src/operator/surfaces/OperatorAppDetail.tsx
+++ b/web/src/operator/surfaces/OperatorAppDetail.tsx
@@ -154,16 +154,35 @@ export function OperatorAppDetail({
   // the operator sees the workflow, data, and knowledge get hooked up.
   const walkedRef = useRef(false);
   const walkTimersRef = useRef<number[]>([]);
+  // One caption line under the tabs narrating the walk, so the auto-advance
+  // reads as a guided tour instead of the UI flipping between empty states.
+  const [walkNote, setWalkNote] = useState<string | null>(null);
   useEffect(() => {
     if (!(buildWalk && ready) || walkedRef.current) return;
     walkedRef.current = true;
     walkTimersRef.current = [
-      window.setTimeout(() => setTab("workflow"), 900),
-      window.setTimeout(() => setTab("data"), 3200),
-      window.setTimeout(() => setTab("knowledge"), 5500),
-      window.setTimeout(() => setTab("ui"), 8000),
+      window.setTimeout(() => {
+        setTab("workflow");
+        setWalkNote("Its routines: the schedule it runs your workflow on.");
+      }, 900),
+      window.setTimeout(() => {
+        setTab("data");
+        setWalkNote("Its own database. It fills up as it works.");
+      }, 3200),
+      window.setTimeout(() => {
+        setTab("knowledge");
+        setWalkNote("What it learns, written down with citations.");
+      }, 5500),
+      window.setTimeout(() => {
+        setTab("ui");
+        setWalkNote(null);
+      }, 8000),
     ];
-    return () => walkTimersRef.current.forEach((t) => window.clearTimeout(t));
+    return () => {
+      walkTimersRef.current.forEach((t) => window.clearTimeout(t));
+      // A mid-walk unmount must not resurrect a stale caption on re-entry.
+      setWalkNote(null);
+    };
   }, [buildWalk, ready]);
 
   // A manual tab click cancels the walk (the documented contract) — the tour
@@ -171,6 +190,7 @@ export function OperatorAppDetail({
   function selectTab(next: AppTab) {
     walkTimersRef.current.forEach((t) => window.clearTimeout(t));
     walkTimersRef.current = [];
+    setWalkNote(null);
     setTab(next);
   }
 
@@ -280,6 +300,11 @@ export function OperatorAppDetail({
           <AgentPurpose summary={app?.summary} />
 
           <Tabs tabs={TABS} active={tab} onSelect={selectTab} />
+          {walkNote ? (
+            <p className="opr-scoped-note" aria-hidden={true}>
+              {walkNote}
+            </p>
+          ) : null}
 
           <div
             role="tabpanel"
@@ -361,6 +386,37 @@ function AskAiDock({
   onSizeChange: (next: (s: PanelSize) => PanelSize) => void;
   requestedSessionId?: string | null;
 }) {
+  const panelRef = useRef<HTMLElement>(null);
+
+  // a11y: close on Escape, move focus into the panel on open, and restore it
+  // on close, matching the shell's overlay keyboard grammar (see CallModal).
+  // Escape originating inside the chat composer (input/textarea/
+  // contentEditable) is left alone: closing unmounts the composer, and a
+  // mid-composition Escape must never destroy an un-sent draft.
+  useEffect(() => {
+    if (!open) return;
+    const prev = document.activeElement as HTMLElement | null;
+    panelRef.current?.focus();
+    function onKey(e: KeyboardEvent) {
+      if (e.key !== "Escape" || e.defaultPrevented) return;
+      const target = e.target as HTMLElement | null;
+      if (
+        target &&
+        (target.tagName === "INPUT" ||
+          target.tagName === "TEXTAREA" ||
+          target.isContentEditable)
+      ) {
+        return;
+      }
+      onOpenChange(false);
+    }
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("keydown", onKey);
+      prev?.focus();
+    };
+  }, [open, onOpenChange]);
+
   if (!open) {
     return (
       <button
@@ -385,6 +441,8 @@ function AskAiDock({
         />
       ) : null}
       <aside
+        ref={panelRef}
+        tabIndex={-1}
         className={`opr-ask-panel is-${size}`}
         aria-label={`Ask Agent about ${app.name}`}
       >

--- a/web/src/operator/surfaces/ToolIntegrations.tsx
+++ b/web/src/operator/surfaces/ToolIntegrations.tsx
@@ -130,7 +130,10 @@ export function ToolIntegrations({
       />
 
       {cfgQuery.isLoading || query.isLoading ? (
-        <p className="opr-scoped-note">Loading your integrations…</p>
+        <div role="status" aria-label="Loading your integrations">
+          <div className="opr-skeleton opr-skel-row" />
+          <div className="opr-skeleton opr-skel-row" style={{ marginTop: 8 }} />
+        </div>
       ) : query.isError ? (
         <p className="opr-scoped-note">
           Could not load integrations right now.

--- a/web/src/styles/apps.css
+++ b/web/src/styles/apps.css
@@ -1099,3 +1099,15 @@
 .app-build-preview__bootlog[open] > summary {
   margin-bottom: 6px;
 }
+
+/* The latest streamed narration line — the build telling its own story. */
+.app-build-activity__now {
+  padding: 4px 10px 6px;
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--text-secondary);
+  border-bottom: 1px solid var(--border);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}

--- a/web/src/styles/operator-shell.css
+++ b/web/src/styles/operator-shell.css
@@ -71,6 +71,11 @@
   --t-tint-2: color-mix(in srgb, var(--t-accent-2) 12%, transparent);
   --t-r: var(--radius);
   --t-r-sm: 4px;
+  /* Aliases referenced by later sections — previously undefined: secondary
+     text lost its muted tone and md-radius cards rendered square. */
+  --t-text: var(--t-ink);
+  --t-text-2: var(--t-dim);
+  --t-r-md: var(--t-r);
 
   position: fixed;
   inset: 0;
@@ -460,6 +465,20 @@
 .opr-led-warn {
   background: var(--t-accent);
 }
+.opr-led-building {
+  background: transparent;
+  box-shadow: inset 0 0 0 1.5px var(--t-accent-2);
+  animation: opr-led-breathe 2.4s ease-in-out infinite;
+}
+@keyframes opr-led-breathe {
+  0%,
+  100% {
+    opacity: 0.4;
+  }
+  50% {
+    opacity: 1;
+  }
+}
 .opr-led-draft {
   background: transparent;
   box-shadow: inset 0 0 0 1.5px var(--t-faint);
@@ -536,6 +555,22 @@
 }
 /* The live tool leads the page as an open block, set off by weight and space,
    not a box. */
+.opr-card-hero {
+  transition: background var(--duration-fast) ease;
+}
+.opr-card-hero:hover {
+  background: color-mix(in srgb, var(--t-accent-2) 5%, transparent);
+}
+.opr-card-hero:hover .opr-btn {
+  border-color: var(--t-accent);
+  color: var(--t-accent);
+}
+.opr-card-hero .opr-btn svg {
+  transition: transform var(--duration-fast) ease;
+}
+.opr-card-hero:hover .opr-btn svg {
+  transform: translateX(2px);
+}
 .opr-card-hero {
   border: none;
   border-bottom: 1px dotted var(--t-line-2);
@@ -1241,6 +1276,33 @@
   align-self: flex-start;
   background: color-mix(in srgb, var(--t-surface) 86%, transparent);
 }
+.opr-builder-scroll .opr-edit-msgwrap,
+.opr-chat-scroll .opr-msg {
+  animation: opr-step-in var(--duration-base) cubic-bezier(0.22, 1, 0.36, 1);
+}
+@media (prefers-reduced-motion: no-preference) {
+  .opr-builder-scroll,
+  .opr-chat-scroll,
+  .opr-call-transcript {
+    scroll-behavior: smooth;
+  }
+}
+/* AI bubbles carry the agent's face — "Every agent has a face" extends into
+   the conversation itself (2026-08-16 delight audit). The portrait replaces
+   the mono "Nex" label; both at once would double-identify. */
+.opr-msgwrap-ai .opr-msg-ai::before {
+  display: none;
+}
+.opr-msgwrap-ai {
+  display: flex;
+  flex-direction: row;
+  align-items: flex-end;
+  gap: var(--space-2);
+}
+.opr-msg-face {
+  flex: 0 0 auto;
+  margin-bottom: 2px;
+}
 .opr-msg-ai::before {
   content: "Nex";
   display: block;
@@ -1290,6 +1352,19 @@
 
 /* ───────────────────────────── Call modal */
 
+@keyframes opr-rise-in {
+  from {
+    opacity: 0;
+    transform: translateY(8px) scale(0.99);
+  }
+}
+.opr-modal-scrim {
+  animation: opr-fade-in 140ms ease both;
+}
+.opr-call,
+.opr-exec {
+  animation: opr-rise-in 200ms cubic-bezier(0.2, 0.7, 0.2, 1) both;
+}
 .opr-modal-scrim {
   position: fixed;
   inset: 0;
@@ -2784,6 +2859,9 @@
 
 /* Finish card — the draft tool handed off in the conversation */
 .opr-finish-card {
+  animation: opr-rise-in 0.28s cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+.opr-finish-card {
   border: 1px solid color-mix(in srgb, var(--t-green) 40%, var(--t-line-2));
   border-radius: var(--t-r-sm);
   background: color-mix(in srgb, var(--t-green) 7%, var(--t-surface));
@@ -2995,6 +3073,50 @@
 .opr-step-reveal {
   animation: opr-step-in var(--duration-base) cubic-bezier(0.22, 1, 0.36, 1);
 }
+/* Small interactive elements share the shell's fast ease — no snapping
+   (2026-08-16 delight audit: the left rail mixed six snap-vs-ease materials). */
+.opr-agent-rail-item,
+.opr-session-chip,
+.opr-artifact-chip,
+.opr-kn-item,
+.opr-back,
+.opr-nav-caret,
+.opr-routine-runs-toggle,
+.opr-tool-code-toggle {
+  transition:
+    background var(--duration-fast) ease,
+    color var(--duration-fast) ease,
+    border-color var(--duration-fast) ease;
+}
+
+.opr-skeleton {
+  position: relative;
+  overflow: hidden;
+  border-radius: var(--t-r-sm);
+  background: color-mix(in srgb, var(--t-ink) 7%, transparent);
+}
+.opr-skeleton::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  transform: translateX(-100%);
+  background: linear-gradient(
+    90deg,
+    transparent,
+    color-mix(in srgb, var(--t-ink) 6%, transparent),
+    transparent
+  );
+  animation: opr-shimmer 1.4s ease infinite;
+}
+@keyframes opr-shimmer {
+  to {
+    transform: translateX(100%);
+  }
+}
+.opr-skel-row {
+  height: 34px;
+}
+
 @keyframes opr-step-in {
   from {
     opacity: 0;
@@ -3731,6 +3853,28 @@
 /* ── Auto-surfaced approval prompt (human-in-the-loop for app actions) ─────── */
 /* A prominent but NON-blocking card pinned bottom-right: it asks for the human's
    sign-off without freezing the rest of the operator behind a modal backdrop. */
+.opr-approval-sent {
+  flex-direction: row;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: 12.5px;
+  color: var(--t-dim);
+  animation: opr-sent-fade 2.4s ease both;
+}
+@keyframes opr-sent-fade {
+  0% {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+  8%,
+  82% {
+    opacity: 1;
+    transform: translateY(0);
+  }
+  100% {
+    opacity: 0;
+  }
+}
 .opr-approval-prompt {
   position: fixed;
   right: var(--space-4);
@@ -4067,6 +4211,12 @@
   display: flex;
 }
 /* Live phase: app detail fills the main area, chat docks to the right. */
+.opr-build-exp.is-live .opr-build-exp-main {
+  animation: opr-fade-in 0.35s ease-out;
+}
+.opr-build-exp.is-live .opr-build-exp-chat {
+  animation: opr-slide-in-right 0.3s ease-out;
+}
 .opr-build-exp.is-live .opr-build-exp-main {
   flex: 1;
   min-width: 0;
@@ -4460,6 +4610,19 @@
   gap: 1px;
   margin: var(--space-1) 0 var(--space-2);
   padding-left: var(--space-4);
+}
+.opr-agent-rail-item {
+  animation: opr-rail-arrive 0.3s steps(3, end) both;
+}
+@keyframes opr-rail-arrive {
+  from {
+    opacity: 0;
+    transform: translateX(-5px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
 }
 .opr-agent-rail-item {
   display: flex;
@@ -5007,7 +5170,27 @@
 /* Failed finish card: honest red framing, no green success glyph. */
 .opr-finish-card.is-failed {
   border-color: color-mix(in srgb, var(--t-red, #e5534b) 45%, var(--t-line));
+  background: color-mix(in srgb, var(--t-red, #e5534b) 6%, var(--t-surface));
 }
 .opr-finish-card.is-failed .opr-finish-glyph {
   color: var(--t-red, #e5534b);
+  background: color-mix(in srgb, var(--t-red, #e5534b) 14%, var(--t-surface));
+}
+
+/* 2026-08-16 delight additions all degrade to their resting state. */
+@media (prefers-reduced-motion: reduce) {
+  .opr-modal-scrim,
+  .opr-call,
+  .opr-exec,
+  .opr-finish-card,
+  .opr-build-exp.is-live .opr-build-exp-main,
+  .opr-build-exp.is-live .opr-build-exp-chat,
+  .opr-agent-rail-item,
+  .opr-led-building,
+  .opr-approval-sent,
+  .opr-skeleton::after,
+  .opr-builder-scroll .opr-edit-msgwrap,
+  .opr-chat-scroll .opr-msg {
+    animation: none;
+  }
 }


### PR DESCRIPTION
## What

Third fresh-workspace pass, this time as **a VP of RevOps** with the bar set at *delight*, not just honesty. Three new agents built and genuinely used (Monday pipeline brief, deal-desk discount approvals with a CFO escalation note drafted by the real AI bridge, rep forecast accuracy with live variance math), plus a 45-agent delight audit — 5 lenses, every proposal adversarially judged for taste/risk — confirming **37 worth-it fixes**. All landed.

### The emotional beats now land
- **Birth:** the finish card shows the new agent's pixel **face** with a rise-in and hiring copy ("Hired. It starts now, no orientation needed."). Failed state loses its green chrome (real bug: red ✗ on a green chip).
- **The wait:** cycling Office gerunds + the builder's own streamed narration under the feed — the build tells its story instead of "Working ×14". Honest 10-20 min expectation up front; a useful head-start suggestion; no more "almost ready" at minute 0.
- **Trust:** Approve & send earns a held confirmation — "Sent. Nothing leaves the office without you."
- **Identity:** agents keep their face in the conversation (AI bubbles carry the portrait), rail arrivals step in sprite-style, and a *building* agent breathes (previously indistinguishable from *disabled*).

### Craft + fit
- Three used-but-undefined tokens defined (`--t-text`, `--t-text-2`, `--t-r-md` — secondary text + radii were silently broken); modal/build-layout entrances; hero-card hover; shared transitions on six snapping rail elements; skeletons over voids; Escape+focus for the Ask dock; ARIA roving tabindex for Tabs. All compositor-only, reduced-motion-guarded, token-pure.
- RevOps-fluent: starter chips name real revenue workflows, wizard gains a pipeline-review prefill, Data/Knowledge/Artifacts empty states sell the payoff.

### Safety net found live
The pass caught a **republish hijack**: a second build deriving the same name ("deal desk" → Pipeline Agent) was briefed to publish OVER the live agent. Fixed three ways: FE name uniquify ("Pipeline Agent 2" — verified live), new Deal Desk/Forecast roles, and the broker now refuses to hand a published agent's id to a new build (regression-tested).

## Test plan
- [x] Web: 2414 tests green (265 files, 16 net-new incl. new primitives + AppKnowledgeTab suites) + tsc + biome
- [x] Go: hijack regression + starter-routine suites green
- [x] Live: all three agents built + used end-to-end; CFO escalation note fact-perfect; variance math correct (-39.4% → SANDBAGGING); all three routines server-minted at Monday 9:00

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V9n6uZhopKDdZoXQ37ry17

## Screenshots (live VP-RevOps pass)

**Deal Desk: CFO escalation note drafted by the real AI bridge** (editable before send):
![escalation](https://raw.githubusercontent.com/najmuzzaman-mohammad/wuphf/screenshots/pr-1192/01-escalation-note.png)

**The rules became UI** — 25% multi-year auto-classified CFO REQUIRED:
![queue](https://raw.githubusercontent.com/najmuzzaman-mohammad/wuphf/screenshots/pr-1192/02-dealdesk-queue.png)

**Forecast accuracy board** — live variance math, SANDBAGGING flag, per-rep score:
![forecast](https://raw.githubusercontent.com/najmuzzaman-mohammad/wuphf/screenshots/pr-1192/03-forecast-board.png)

**Monday pipeline brief** — moved/stuck/risks structure from the described workflow:
![brief](https://raw.githubusercontent.com/najmuzzaman-mohammad/wuphf/screenshots/pr-1192/04-monday-brief.png)