### PR TITLE
fix: follow-ups + EM-pass findings — seed lifecycle, gate fail-ask, roles, slimmer wizard

### DIFF
--- a/internal/team/broker_apps_starter_routine.go
+++ b/internal/team/broker_apps_starter_routine.go
@@ -39,6 +39,9 @@ var starterScheduleRules = []struct {
 	{regexp.MustCompile(`(?i)\b(every|each)\s+week\b|\bweekly\b`), "0 9 * * 1", "Weekly"},
 }
 
+// starterRoutineCounterRe strips a trailing dedupe counter from an app name.
+var starterRoutineCounterRe = regexp.MustCompile(`\s+\d+$`)
+
 // deriveStarterSchedule reads the operator's own cadence out of the build
 // description. Returns the cron expr and a human label prefix.
 func deriveStarterSchedule(description string) (expr, prefix string) {
@@ -95,7 +98,11 @@ func (b *Broker) mintStarterRoutineForFirstBuild(app CustomApp) {
 	now := time.Now().UTC()
 	nextRun := sched.Next(now).Format(time.RFC3339)
 
-	base := strings.TrimSpace(strings.TrimSuffix(strings.TrimSpace(app.Name), "Agent"))
+	// "Pipeline Agent 2" -> "Pipeline": the dedupe counter and the Agent
+	// suffix are roster bookkeeping, not routine vocabulary.
+	base := strings.TrimSpace(app.Name)
+	base = strings.TrimSpace(starterRoutineCounterRe.ReplaceAllString(base, ""))
+	base = strings.TrimSpace(strings.TrimSuffix(base, "Agent"))
 	if base == "" {
 		base = app.Name
 	}

--- a/internal/team/broker_apps_starter_routine_test.go
+++ b/internal/team/broker_apps_starter_routine_test.go
@@ -81,6 +81,38 @@ func TestMintStarterRoutineForFirstBuild(t *testing.T) {
 		t.Errorf("next run is not RFC3339: %v", err)
 	}
 
+	// The label strips the dedupe counter: "Chase Agent 2" -> "Weekday Chase
+	// run". NOTE the lock discipline: b.mu is HELD here (taken above with a
+	// deferred unlock), so the task append rides the held lock, the mint runs
+	// unlocked, and the read re-takes the lock to stay balanced with the
+	// idempotency section below.
+	b.tasks = append(b.tasks, teamTask{
+		ID:      "VANCE-9",
+		Channel: "task-VANCE-9",
+		Title:   "Build app: Chase Agent 2",
+		Details: "What it should do:\nChase invoices. Every weekday morning, remind people.",
+		Owner:   appBuilderSlug,
+	})
+	b.mu.Unlock()
+	numbered := CustomApp{
+		ID:          "app_00000000000000aa",
+		Name:        "Chase Agent 2",
+		Version:     1,
+		CreatedBy:   "human",
+		EditChannel: "task-VANCE-9",
+	}
+	b.mintStarterRoutineForFirstBuild(numbered)
+	b.mu.Lock()
+	var labeled string
+	for i := range b.scheduler {
+		if b.scheduler[i].TargetID == numbered.ID {
+			labeled = b.scheduler[i].Label
+		}
+	}
+	if labeled != "Weekday Chase run" {
+		t.Errorf("expected the counter stripped from the label, got %q", labeled)
+	}
+
 	// Idempotent: a republish (version 2) and a re-mint both no-op.
 	before := len(b.scheduler)
 	b.mu.Unlock()

--- a/templates/app-scaffold/AI_RULES.md
+++ b/templates/app-scaffold/AI_RULES.md
@@ -467,3 +467,12 @@ affected row/counters in the same interaction — optimistic update or refetch,
 either works. An operator who clicks "Escalate" and still sees PENDING with
 the same button assumes the click failed and clicks again. Every action's
 outcome must be visible where the operator is looking, immediately.
+
+## Bridge action failures are told, never swallowed
+
+`createTask`, `integration`, and other bridge calls can be refused (a
+confirmation is already pending), cancelled, or time out. NEVER swallow the
+rejection in an empty catch: tell the operator what happened where they are
+looking ("The confirmation was still open — finish it and try again", "That
+did not go through — try again"), and leave the row/state unchanged so the
+retry is obvious. A silent failure reads as a broken button.

--- a/web/src/components/onboarding/wizard/EmbeddingChoice.stories.tsx
+++ b/web/src/components/onboarding/wizard/EmbeddingChoice.stories.tsx
@@ -56,6 +56,8 @@ function Harness({
         saving={saving}
         saveError={saveError}
         ollamaChosen={chosen}
+        expanded={true}
+        onExpand={() => undefined}
         onChooseOllama={() => setChosen(true)}
         installBusy={installBusy}
         onInstallGbrain={() => undefined}

--- a/web/src/components/onboarding/wizard/EmbeddingChoice.tsx
+++ b/web/src/components/onboarding/wizard/EmbeddingChoice.tsx
@@ -74,6 +74,11 @@ interface EmbeddingChoiceViewProps {
   installBusy: boolean;
   /** Kick off (or retry) the gbrain install. */
   onInstallGbrain: () => void;
+  /** The optional upgrade machinery is unfolded (auto-unfolds when it
+   * already matters: key saved, local path picked, install active). */
+  expanded: boolean;
+  /** Unfold the upgrade machinery. */
+  onExpand: () => void;
 }
 
 /** The Ollama setup command, using the broker's model id when it gave one. */
@@ -321,6 +326,8 @@ export function EmbeddingChoiceView({
   onChooseOllama,
   installBusy,
   onInstallGbrain,
+  expanded,
+  onExpand,
 }: EmbeddingChoiceViewProps) {
   const resolved = resolveEmbedder(options);
   const keySet = resolved === "openai";
@@ -330,6 +337,12 @@ export function EmbeddingChoiceView({
       : resolved === "ollama"
         ? COPY.statusOllama
         : COPY.statusKeyword;
+
+  // Auto-unfold when the choice already matters: a key is saved, the local
+  // path was picked, or an install is running/errored (its progress must
+  // never hide).
+  const showBody =
+    expanded || keySet || ollamaChosen || options.install_state !== "idle";
 
   const onSubmit = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -370,9 +383,24 @@ export function EmbeddingChoiceView({
         </p>
       </div>
 
-      <p className="onboarding-embedding-note">{COPY.note}</p>
+      {showBody ? (
+        <p className="onboarding-embedding-note">{COPY.note}</p>
+      ) : (
+        // Activation default: keyword search is ON and stated in the status
+        // line above. The upgrade machinery only unfolds on request — a
+        // fresh operator should not weigh embedders before seeing anything
+        // work (2026-08-16 audit, founder-approved).
+        <button
+          type="button"
+          className="onboarding-embedding-expand"
+          onClick={onExpand}
+          data-testid="onboarding-embedding-expand"
+        >
+          Improve recall (optional)
+        </button>
+      )}
 
-      {keySet ? (
+      {showBody && keySet ? (
         <p
           className="onboarding-embedding-success"
           data-testid="onboarding-embedding-success"
@@ -380,7 +408,8 @@ export function EmbeddingChoiceView({
           <CheckMark />
           {COPY.openaiSet}
         </p>
-      ) : (
+      ) : null}
+      {showBody && !keySet ? (
         <>
           <form className="onboarding-embedding-key" onSubmit={onSubmit}>
             <div className="onboarding-embedding-key-head">
@@ -444,7 +473,7 @@ export function EmbeddingChoiceView({
             />
           ) : null}
         </>
-      )}
+      ) : null}
     </section>
   );
 }
@@ -461,6 +490,7 @@ export function EmbeddingChoice() {
     EMBEDDING_OPTIONS_FALLBACK,
   );
   const [keyValue, setKeyValue] = useState("");
+  const [expanded, setExpanded] = useState(false);
   const [saving, setSaving] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
   const [ollamaChosen, setOllamaChosen] = useState(false);
@@ -550,6 +580,8 @@ export function EmbeddingChoice() {
       onChooseOllama={onChooseOllama}
       installBusy={installBusy}
       onInstallGbrain={onInstallGbrain}
+      expanded={expanded}
+      onExpand={() => setExpanded(true)}
     />
   );
 }

--- a/web/src/components/onboarding/wizard/steps/StepFirstIssue.tsx
+++ b/web/src/components/onboarding/wizard/steps/StepFirstIssue.tsx
@@ -94,56 +94,28 @@ export function StepFirstIssue({
           </p>
         </div>
 
-        {answers.email.trim() ? (
-          <label className="onboarding-keep-in-touch">
-            <input
-              type="checkbox"
-              className="onboarding-keep-in-touch-box"
-              checked={answers.keepInTouch}
-              onChange={(event) =>
-                setAnswers({ keepInTouch: event.target.checked })
-              }
-              data-testid="onboarding-keep-in-touch"
-            />
-            <span className="onboarding-keep-in-touch-copy">
-              {ONBOARDING_EMAIL_COPY.consent}
-            </span>
-          </label>
-        ) : null}
-
+        {/* Typing an email IS the keep-in-touch opt-in — the field's own hint
+            makes the promise, so no second checkbox restates it
+            (2026-08-16 ceremony slim, founder-approved). */}
         <div
           className="onboarding-analytics-consent"
           data-testid="onboarding-analytics-consent"
         >
-          <p className="onboarding-analytics-consent-heading">
-            {ONBOARDING_ANALYTICS_CONSENT_COPY.heading}
-          </p>
           <label className="onboarding-keep-in-touch">
             <input
               type="checkbox"
               className="onboarding-keep-in-touch-box"
-              checked={answers.telemetryConsent}
+              checked={answers.telemetryConsent && answers.recordingConsent}
               onChange={(event) =>
-                setAnswers({ telemetryConsent: event.target.checked })
+                setAnswers({
+                  telemetryConsent: event.target.checked,
+                  recordingConsent: event.target.checked,
+                })
               }
-              data-testid="onboarding-consent-telemetry"
+              data-testid="onboarding-consent-analytics"
             />
             <span className="onboarding-keep-in-touch-copy">
-              {ONBOARDING_ANALYTICS_CONSENT_COPY.telemetryLabel}
-            </span>
-          </label>
-          <label className="onboarding-keep-in-touch">
-            <input
-              type="checkbox"
-              className="onboarding-keep-in-touch-box"
-              checked={answers.recordingConsent}
-              onChange={(event) =>
-                setAnswers({ recordingConsent: event.target.checked })
-              }
-              data-testid="onboarding-consent-recording"
-            />
-            <span className="onboarding-keep-in-touch-copy">
-              {ONBOARDING_ANALYTICS_CONSENT_COPY.recordingLabel}
+              {ONBOARDING_ANALYTICS_CONSENT_COPY.combinedLabel}
             </span>
           </label>
           <p className="onboarding-analytics-consent-note">

--- a/web/src/components/onboarding/wizard/wizardSteps.ts
+++ b/web/src/components/onboarding/wizard/wizardSteps.ts
@@ -180,11 +180,12 @@ export const ONBOARDING_EMAIL_COPY = {
  */
 export const ONBOARDING_ANALYTICS_CONSENT_COPY = {
   heading: "Help improve WUPHF",
-  note: "Both are optional, on by default, and easy to change anytime in Settings. Analytics never collects your content, and recordings mask everything you type.",
-  telemetryLabel:
-    "Share anonymous product analytics. Counts and shapes of what you do, never the content.",
-  recordingLabel:
-    "Allow session recordings. We mask everything you type — passwords, keys, form fields — and capture layout, clicks, and navigation to fix rough edges.",
+  // One consent, honestly described (2026-08-16: the three-checkbox stack
+  // bracketed the hero moment; founder approved slimming it). It drives both
+  // the analytics and the masked-replay flags together.
+  combinedLabel:
+    "Share anonymous product analytics and masked session replays. Counts, clicks, and layout only: never your content, and everything you type is masked.",
+  note: "Optional, on by default, easy to change any time in Settings.",
 } as const;
 
 /**

--- a/web/src/operator/OperatorApp.tsx
+++ b/web/src/operator/OperatorApp.tsx
@@ -69,7 +69,12 @@ export function OperatorApp() {
   // the shell opens straight into the build flow with the text already sent —
   // the user lands on their first agent being assembled, which is what the
   // "Start your first workflow" CTA promised.
-  const [firstWorkflow] = useState<string | null>(() =>
+  // Consumed ONCE: cleared the moment the first build experience closes —
+  // holding it in state re-auto-sent the onboarding workflow on EVERY later
+  // "Build an agent" mount, burning a duplicate build (2026-08-16 EM pass:
+  // "Support Triage Agent 2" built itself while the operator typed a
+  // different description into a dead composer).
+  const [firstWorkflow, setFirstWorkflow] = useState<string | null>(() =>
     consumeFirstWorkflowSeed(),
   );
   const [appBuildingInit] = useState<boolean>(() => firstWorkflow !== null);
@@ -121,6 +126,7 @@ export function OperatorApp() {
   }));
 
   function resetSubState() {
+    setFirstWorkflow(null);
     setSelectedId(null);
     setAppBuilding(false);
     setEditingApp(null);
@@ -233,8 +239,12 @@ export function OperatorApp() {
             onClose={() => {
               setAppBuilding(false);
               setEditingApp(null);
+              setFirstWorkflow(null);
             }}
-            onFinish={finishApp}
+            onFinish={(id) => {
+              setFirstWorkflow(null);
+              finishApp(id);
+            }}
           />
         ) : building ? (
           <WorkflowBuilder

--- a/web/src/operator/apps/useOperatorApps.test.ts
+++ b/web/src/operator/apps/useOperatorApps.test.ts
@@ -169,6 +169,23 @@ describe("deriveAppName", () => {
   // 2026-08-16 fresh-workspace QA: "Chase our unpaid invoices" was named
   // "Chase Agent" (plural nouns missed the role table), and a recruiting
   // description using scoring verbs was claimed by Lead Routing.
+  it("names engineering rituals by their own nouns", () => {
+    expect(deriveAppName("Prep our standup every weekday at 9")).toBe(
+      "Standup Agent",
+    );
+    expect(
+      deriveAppName("Plan sprint capacity against historical velocity"),
+    ).toBe("Sprint Planning Agent");
+  });
+
+  it("names incident tracking Incident Agent, not Support Triage", () => {
+    expect(
+      deriveAppName(
+        "Track our incidents with severity and owners, nag for postmortems, keep MTTR stats",
+      ),
+    ).toBe("Incident Agent");
+  });
+
   it("names forecast-accuracy tracking Forecast Agent", () => {
     expect(
       deriveAppName(

--- a/web/src/operator/apps/useOperatorApps.ts
+++ b/web/src/operator/apps/useOperatorApps.ts
@@ -210,7 +210,13 @@ const AGENT_ROLES: ReadonlyArray<[RegExp, string]> = [
   [/\b(forecasts?|commits?|quotas?)\b/i, "Forecast Agent"],
   [/\b(pipelines?|deals?)\b/i, "Pipeline Agent"],
   [/\b(sales|quotas?|outreach|prospects?)\b/i, "Sales Agent"],
-  [/\b(support|tickets?|escalations?|incidents?)\b/i, "Support Triage Agent"],
+  // Engineering-team rituals get their own names, not a generic bucket.
+  [/\b(stand-?ups?)\b/i, "Standup Agent"],
+  [/\b(sprints?|velocity|story points?)\b/i, "Sprint Planning Agent"],
+  [/\b(retros?|retrospectives?)\b/i, "Retro Agent"],
+  // Incident management (SRE vocabulary) is not support triage.
+  [/\b(incidents?|postmortems?|outages?|on-call|mttr)\b/i, "Incident Agent"],
+  [/\b(support|tickets?|escalations?)\b/i, "Support Triage Agent"],
   [/\b(invoices?|billing|receivables?|dunning)\b/i, "Invoice Agent"],
   [/\b(expenses?|reimburse|spend)\b/i, "Expense Agent"],
   [/\b(email|inbox|follow[- ]?ups?|replies|nurture)\b/i, "Follow-up Agent"],

--- a/web/src/operator/builder/describedIntegrations.ts
+++ b/web/src/operator/builder/describedIntegrations.ts
@@ -114,7 +114,10 @@ export async function missingIntegrations(
       (r) => !r.platforms.some((p) => connected.has(p.toLowerCase())),
     );
   } catch {
-    return [];
+    // The check itself failed — treat the described systems as unverified
+    // and ASK. Silently skipping the gate on a transient error contradicts
+    // the ask-before-building decision (2026-08-16 EM pass).
+    return refs;
   }
 }
 


### PR DESCRIPTION
## What

The approved follow-ups plus what a fourth fresh-workspace pass — this time as an **engineering manager** — surfaced.

### The bug that mattered
The onboarding first-workflow seed lived in state forever and **re-auto-sent itself on every later 'Build an agent' mount**: a duplicate agent built itself while the operator's own description died silently against the building-guard. (The #1192 name-uniquifier turned what would have been a republish hijack into a mere duplicate — this PR removes the duplicate too.) Seed now clears on close/finish/any navigation.

### Follow-ups (founder-approved)
- **Wizard step 2**: embeddings choice collapses behind "Improve recall (optional)" — keyword on by default, status stated up front, auto-unfolds when a key/local path/install already matters.
- **One consent**: analytics + masked replay as a single honest checkbox; typing an email IS the keep-in-touch opt-in.
- **Routine labels** strip the dedupe counter ("Chase Agent 2" → "Weekday Chase run").
- Live Deal Desk row-refresh fixed via the product's own improve flow (dogfooded; also surfaced that a silent create_task refusal from the anti-fatigue lock reads as a broken button → new scaffold rule: bridge failures are told, never swallowed).

### EM-pass findings
- The pre-build gate now **asks when the connected-check itself fails** instead of silently skipping (a transient catalog error was bypassing ask-before-building).
- deriveAppName learns engineering vocabulary: incidents/postmortems/MTTR → Incident Agent; standup → Standup Agent; sprint/velocity → Sprint Planning Agent; ambiguous "on-call" cue removed.

## Live verification (Scranton Platform Eng workspace)
- Incident tracker: logged a P2, resolved it, MTTR computed, 48-hour postmortem clock explained in the dialog.
- Standup prep: GitHub gate fired **with connect rows**, built honestly against workspace data, app copy follows the no-invented-navigation rule.
- Sprint planner: out→0 / on-call→half live math; "Committed 45 exceeds real capacity 36 by 9 pts" warning exactly as described.
- Delight beats all render: cycling gerunds ("Setting the stapler in gelatin…"), faces on bubbles, finish-card hire moment, server-minted routine announced in chat, collapsed step-2 + single consent live.

## Test plan
- [x] Web: 2416 tests green (265 files) + tsc; Go: build + vet + starter-routine suite (incl. a lock-discipline regression that briefly deadlocked)
- [x] All three EM agents built + used end-to-end on the fresh workspace

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V9n6uZhopKDdZoXQ37ry17

## Screenshots (live EM pass)

**The hire moment** — face on the finish card, routine announced, faces on every bubble:
![hire](https://raw.githubusercontent.com/najmuzzaman-mohammad/wuphf/screenshots/pr-1193/01-hire-moment.png)

**Incident tracker in use** — P2 resolved, MTTR, postmortem clock:
![incident](https://raw.githubusercontent.com/najmuzzaman-mohammad/wuphf/screenshots/pr-1193/02-incident-tracker.png)

**GitHub gate with connect rows** on the standup build:
![gate](https://raw.githubusercontent.com/najmuzzaman-mohammad/wuphf/screenshots/pr-1193/03-github-gate.png)

**Sprint capacity** — live out/on-call math + over-capacity warning:
![sprint](https://raw.githubusercontent.com/najmuzzaman-mohammad/wuphf/screenshots/pr-1193/04-sprint-capacity.png)