### PR TITLE
fix: strip builder machinery from the minted operator playbook

### DIFF
--- a/internal/team/broker_apps_starter_routine.go
+++ b/internal/team/broker_apps_starter_routine.go
@@ -72,6 +72,18 @@ func (b *Broker) buildDescriptionForApp(app CustomApp) string {
 		if idx := strings.Index(details, "What it should do:"); idx >= 0 {
 			details = details[idx+len("What it should do:"):]
 		}
+		// The task description is the operator's words PLUS machinery appended
+		// for the builder (register_app instructions, the workspace brief with
+		// filesystem paths). Cut at the first machinery marker so operator-facing
+		// pages (the playbook) never quote internal plumbing back at the human.
+		for _, marker := range []string{
+			"When the build passes, register it with register_app",
+			"App workspace ready:",
+		} {
+			if idx := strings.Index(details, marker); idx >= 0 {
+				details = details[:idx]
+			}
+		}
 		return strings.TrimSpace(details)
 	}
 	return ""

--- a/internal/team/broker_apps_starter_routine_test.go
+++ b/internal/team/broker_apps_starter_routine_test.go
@@ -240,6 +240,22 @@ func TestMintOperatorPlaybookForFirstBuild(t *testing.T) {
 	}
 }
 
+func TestBuildDescriptionStripsBuilderMachinery(t *testing.T) {
+	b := newTestBroker(t)
+	b.mu.Lock()
+	b.tasks = append(b.tasks, teamTask{
+		ID: "LAKES-2",
+		Details: "What it should do: Chase missing scorecards and apply our rule.\n\n" +
+			"When the build passes, register it with register_app so it appears under Apps.\n\n" +
+			"App workspace ready: source lives at /tmp/x/apps/app_1/src",
+	})
+	b.mu.Unlock()
+	got := b.buildDescriptionForApp(CustomApp{EditChannel: "task-LAKES-2"})
+	if got != "Chase missing scorecards and apply our rule." {
+		t.Fatalf("machinery leaked into the operator description: %q", got)
+	}
+}
+
 func TestPublishOddity(t *testing.T) {
 	big := strings.Repeat("<div>real interface</div>", 2000)
 	if got := publishOddity(big); got != "" {


### PR DESCRIPTION
## What

Found live on the eval7 re-score pass (fresh workspace, Head of Talent persona): the first-build playbook mint (#1194) captures the operator's workflow verbatim into `team/playbooks/<slug>.md` — but `buildDescriptionForApp` returns the full build-task description, so the page also quoted the `register_app` instruction and the workspace brief, including a filesystem path:

> App workspace ready: … The project source lives at `/tmp/…/apps/app_xxxx/src` — work there directly …

Operator-facing pages must never quote internal plumbing back at the human. The description now cuts at the first machinery marker ("When the build passes, register it with register_app" / "App workspace ready:"), both of which are appended deterministically by the broker.

## Test plan
- [x] New `TestBuildDescriptionStripsBuilderMachinery` (fails pre-fix)
- [x] `go test ./internal/team/` focused run green; `golangci-lint` 0 issues
- [x] Verified live: eval7's minted playbook contained the leak; the strip boundary removes exactly the appended machinery

No UI change — screenshots N/A (broker-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V9n6uZhopKDdZoXQ37ry17