### PR TITLE
fix: honest diagnosis when tool authoring fails on a configured model

### DIFF
--- a/agent/src/service.ts
+++ b/agent/src/service.ts
@@ -171,10 +171,16 @@ export function createServer(opts: ServerOptions = {}) {
 				// the operator's Tools list as if it were their workflow was the worst
 				// finding of the 2026-08-15 QA pass. The stub still rides the response
 				// (labeled) so harness callers keep a deterministic shape.
+				// `via` tells the caller WHY a stub came back: "none" means nothing
+				// is configured (connect-a-model copy is right); anything else means
+				// the model was tried and failed (retry copy is right). Conflating
+				// the two told operators to "connect Claude Code" on machines where
+				// it was already connected (2026-08-17 eval8 finding).
+				const via = authoring?.via ?? "none";
 				if (app && outcome.tool && outcome.authored_by === "model") {
-					return json({ ...outcome, tool: store.upsertTool(app, outcome.tool) });
+					return json({ ...outcome, via, tool: store.upsertTool(app, outcome.tool) });
 				}
-				return json(outcome);
+				return json({ ...outcome, via });
 			}
 
 			if (req.method === "GET" && pathname === "/tools") {

--- a/agent/src/serviceRoutines.test.ts
+++ b/agent/src/serviceRoutines.test.ts
@@ -114,6 +114,16 @@ test("POST /tools/build with app persists the tool; same name bumps version", as
 	expect(((await (await fetch(`${base}/tools?agent=sales`)).json()) as { tools: StoredTool[] }).tools).toHaveLength(1);
 });
 
+test("POST /tools/build reports the resolved authoring route as via", async () => {
+	// The FE branches its stub copy on this: via "none" means nothing is
+	// configured; a real route with a stub result means the model attempt
+	// failed and the operator should retry, not reconfigure.
+	const r = (await (await post("/tools/build", { schema_version: 1, message: "summarize open invoices" })).json()) as {
+		via: string;
+	};
+	expect(r.via).toBe("api_key");
+});
+
 test("POST /routines/run (a broker fire) lands transcript + artifact and reports back", async () => {
 	const res = await post("/routines/run", {
 		schema_version: 1,

--- a/web/src/operator/apps/useOperatorApps.test.ts
+++ b/web/src/operator/apps/useOperatorApps.test.ts
@@ -178,6 +178,14 @@ describe("deriveAppName", () => {
     ).toBe("Sprint Planning Agent");
   });
 
+  it("names tenant maintenance dispatch Maintenance Agent, not a verb fallback", () => {
+    expect(
+      deriveAppName(
+        "Handle our tenant maintenance requests: classify urgency, match to the right vendor, track response time",
+      ),
+    ).toBe("Maintenance Agent");
+  });
+
   it("names a renewals radar Renewals Agent, not Follow-up", () => {
     expect(
       deriveAppName(

--- a/web/src/operator/apps/useOperatorApps.ts
+++ b/web/src/operator/apps/useOperatorApps.ts
@@ -214,6 +214,12 @@ const AGENT_ROLES: ReadonlyArray<[RegExp, string]> = [
   [/\b(stand-?ups?)\b/i, "Standup Agent"],
   [/\b(sprints?|velocity|story points?)\b/i, "Sprint Planning Agent"],
   [/\b(retros?|retrospectives?)\b/i, "Retro Agent"],
+  // Facilities vocabulary ("tenant maintenance requests") reuses request/
+  // ticket verbs, so its nouns must outrank support triage.
+  [
+    /\b(maintenance|tenants?|work orders?|facilities)\b/i,
+    "Maintenance Agent",
+  ],
   // Incident management (SRE vocabulary) is not support triage.
   // "on-call" deliberately absent: rotation staffing shows up in sprint
   // planning too, and the strong nouns below carry incident management.

--- a/web/src/operator/surfaces/AppToolsChat.test.tsx
+++ b/web/src/operator/surfaces/AppToolsChat.test.tsx
@@ -176,6 +176,42 @@ describe("AppToolsChat + Tools tab (slice 2)", () => {
     expect(queryByText("Draft a board update")).toBeNull();
   });
 
+  it("stub with a configured route reads as a failed attempt, not missing setup", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          tool: {
+            name: "vendorResponseSummary",
+            title: "Vendor response summary",
+            purpose: "canned",
+            inputs: [],
+            code: "function vendorResponseSummary() {}",
+          },
+          narration: "Built Vendor response summary.",
+          authored_by: "stub",
+          via: "claude_cli",
+        }),
+      }),
+    );
+    const { getByLabelText, findByText, queryByText } = renderApp();
+    const input = getByLabelText(
+      "Describe a task for Nex to build a tool for",
+    ) as HTMLInputElement;
+    fireEvent.change(input, {
+      target: { value: "summarize vendor response times" },
+    });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    // A model IS connected; the attempt failed. Telling the operator to
+    // "connect Claude Code" here was the eval8 misdiagnosis.
+    expect(await findByText(/model call failed/i)).toBeTruthy();
+    expect(queryByText(/no AI model connected/i)).toBeNull();
+    // The canned stub tool still must not land in Tools.
+    expect(queryByText("Vendor response summary")).toBeNull();
+  });
+
   it("re-teaching the same workflow updates the tool in place (no duplicate)", async () => {
     vi.stubGlobal(
       "fetch",

--- a/web/src/operator/surfaces/AppToolsChat.tsx
+++ b/web/src/operator/surfaces/AppToolsChat.tsx
@@ -413,7 +413,8 @@ export function AppToolsChat({
       // render that call and drop the tool into the shared Tools state. The
       // `app` field carries the REAL agent id when the provider has one, so the
       // service persists the tool per-agent.
-      const { tool, offline, authoredBy, narration } = await buildToolFromChat(
+      const { tool, offline, authoredBy, narration, modelTriedAndFailed } =
+        await buildToolFromChat(
         body,
         agentId ?? appName,
       );
@@ -445,12 +446,14 @@ export function AppToolsChat({
         return;
       }
       if (authoredBy === "stub") {
-        // The service answered, but with its canned template — no model is
-        // connected on that machine. A template pretending to be the
-        // operator's workflow is worse than nothing (2026-08-15 QA pass), so
-        // say what's missing instead of minting it into Tools.
-        const reply =
-          "I cannot author tools on this computer yet — there is no AI model connected for me to write them with. Connect Claude Code, an Anthropic API key, or Ollama, then teach me again.";
+        // The service answered, but with its canned template. Two very
+        // different states end here: no model configured (setup copy), or a
+        // configured model whose attempt failed (retry copy). Telling an
+        // operator to "connect Claude Code" on a machine where it is already
+        // connected was the eval8 finding — diagnose honestly.
+        const reply = modelTriedAndFailed
+          ? "I hit an error writing that tool — the model call failed mid-draft. Nothing was saved. Teach me again and I will take another run at it."
+          : "I cannot author tools on this computer yet — there is no AI model connected for me to write them with. Connect Claude Code, an Anthropic API key, or Ollama, then teach me again.";
         setItems((prev) => [
           ...prev,
           { kind: "text", id: nextId(), from: "nex", body: reply },

--- a/web/src/operator/tools/toolAgentClient.ts
+++ b/web/src/operator/tools/toolAgentClient.ts
@@ -25,6 +25,10 @@ interface ToolBuildResult {
   /** How the agent authored it: a real model, or the deterministic stub the
    * service falls back to when no model is available on that machine. */
   authored_by?: "model" | "stub";
+  /** Which authoring route the service resolved. "none" = nothing configured;
+   * any other value with authored_by "stub" means the model was tried and
+   * the attempt failed (a retryable state, not a setup problem). */
+  via?: string;
 }
 
 let seq = 0;
@@ -56,6 +60,9 @@ export interface BuiltTool {
   /** "stub" when the service answered with its canned template because no
    * model is connected — callers must NOT present that as a built tool. */
   authoredBy: "model" | "stub";
+  /** True when a model IS configured but this authoring attempt failed —
+   * the right copy is "try again", not "connect a model". */
+  modelTriedAndFailed: boolean;
 }
 
 /**
@@ -87,6 +94,10 @@ export async function buildToolFromChat(
       offline: false,
       // Older services omit the field; they only ever stub-authored.
       authoredBy: data.authored_by ?? "stub",
+      modelTriedAndFailed:
+        (data.authored_by ?? "stub") === "stub" &&
+        data.via != null &&
+        data.via !== "none",
     };
   } catch {
     const tool = authorToolFromDescription(message);
@@ -95,6 +106,7 @@ export async function buildToolFromChat(
       narration: `Built ${tool.title}.`,
       offline: true,
       authoredBy: "stub",
+      modelTriedAndFailed: false,
     };
   }
 }


### PR DESCRIPTION
## What

Two findings from the eval8 tool-authoring judgment pass (property-manager persona, fresh workspace on merged main):

1. **Wrong diagnosis on transient authoring failure.** A model call failed mid-authoring, the service fell back to its stub, and the chat told the operator *"no AI model connected — connect Claude Code, an Anthropic API key, or Ollama"* — on a machine where Claude Code was connected and had just finished building the app. Configured-but-failed and not-configured are different states and now get different copy:
   - `/tools/build` responses carry `via` (the resolved authoring route; `"none"` when nothing is configured).
   - The Tools chat branches on it: a stub with a real route reads *"the model call failed — teach me again"* (retryable); only `via: "none"` keeps the connect-a-model setup copy. Stub tools still never land in Tools either way.
2. **Verb-fallback agent name.** "Handle our tenant maintenance requests…" derived **"Handle Agent"**. Facilities vocabulary gets its own role row (`maintenance | tenants | work orders | facilities` → **Maintenance Agent**), placed above support triage since maintenance requests reuse ticket verbs.

## Test plan
- [x] agent: `bun test` — 114 pass (new: `/tools/build` reports `via`)
- [x] web: `AppToolsChat.test.tsx` 11 pass (new: configured-route stub shows retry copy, never setup copy; canned tool still kept out of Tools), `useOperatorApps.test.ts` 28 pass (new: Maintenance Agent row)
- [x] `bunx tsc --noEmit` clean
- [x] Live: re-taught the same workflow on the restarted service — authored for real (`vendorResponseTimeReport`, structured returns, input guards, no Date.parse on human strings), first-tool milestone copy shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V9n6uZhopKDdZoXQ37ry17

## Screenshots

**Eval8 (property manager):** the misdiagnosed refusal followed by the real authoring after the fix (create_tool call card + first-tool milestone copy):

![tool built](https://raw.githubusercontent.com/najmuzzaman-mohammad/wuphf/screenshots/pr-1196/eval8-tool-built.png)

**Build kickoff for the same pass** (note "Handle Agent" — the verb-fallback name this PR's role row fixes):

![kickoff](https://raw.githubusercontent.com/najmuzzaman-mohammad/wuphf/screenshots/pr-1196/eval8-kickoff.png)
