### PR TITLE
feat(operator): data tab reaches a usable 8 — search, sort, pagination, typed cells

### DIFF
--- a/web/src/operator/surfaces/AppDataTab.test.tsx
+++ b/web/src/operator/surfaces/AppDataTab.test.tsx
@@ -1,9 +1,9 @@
 import type { ReactNode } from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, waitFor } from "@testing-library/react";
+import { fireEvent, render, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { AppDataTab } from "./AppDataTab";
+import { AppDataTab, compareByColumn, rowMatchesQuery } from "./AppDataTab";
 
 // vi.mock is hoisted above this file's const declarations, so the mock handle
 // must be hoisted too or the factory hits the TDZ.
@@ -134,5 +134,129 @@ describe("AppDataTab", () => {
     await waitFor(() =>
       expect(getByText(/could not read this agent’s data/i)).toBeTruthy(),
     );
+  });
+
+  it("renders numbers grouped and right-aligned, booleans as a badge", async () => {
+    get.mockResolvedValue({
+      tables: [
+        {
+          name: "Products",
+          columns: [
+            { name: "stock", type: "number" },
+            { name: "perishable", type: "string" },
+          ],
+          rows: [{ stock: 8400, perishable: true }],
+        },
+      ],
+    });
+    const { getByText } = wrap(<AppDataTab appId="app_abc" />);
+    await waitFor(() => expect(getByText("Products")).toBeTruthy());
+    // 8400 -> grouped "8,400" (locale-dependent separator, but the digits group)
+    expect(getByText(/8.400/)).toBeTruthy();
+    // boolean renders as a Yes badge, not raw "true"
+    expect(getByText("Yes")).toBeTruthy();
+  });
+
+  it("filters visible rows by the search box", async () => {
+    get.mockResolvedValue({
+      tables: [
+        {
+          name: "Accounts",
+          columns: [{ name: "name", type: "string" }],
+          // >8 rows so the search toolbar renders.
+          rows: Array.from({ length: 10 }, (_, i) => ({
+            name: i === 3 ? "Meridian Health" : `Filler ${i}`,
+          })),
+        },
+      ],
+    });
+    const { getByText, getByLabelText, queryByText } = wrap(
+      <AppDataTab appId="app_abc" />,
+    );
+    await waitFor(() => expect(getByText("Meridian Health")).toBeTruthy());
+    fireEvent.change(getByLabelText("Search Accounts"), {
+      target: { value: "meridian" },
+    });
+    await waitFor(() => expect(queryByText("Filler 0")).toBeNull());
+    expect(getByText("Meridian Health")).toBeTruthy();
+    expect(getByText("1 of 10 rows")).toBeTruthy();
+  });
+
+  it("paginates a large table and advances pages", async () => {
+    get.mockResolvedValue({
+      tables: [
+        {
+          name: "Rows",
+          columns: [{ name: "n", type: "number" }],
+          rows: Array.from({ length: 30 }, (_, i) => ({ n: i })),
+        },
+      ],
+    });
+    const { getByText, queryByText } = wrap(<AppDataTab appId="app_abc" />);
+    await waitFor(() => expect(getByText("Showing 1–25 of 30")).toBeTruthy());
+    // Row 25 (0-indexed) is on page 2, not shown yet.
+    expect(queryByText("25")).toBeNull();
+    fireEvent.click(getByText("Next"));
+    await waitFor(() => expect(getByText("Showing 26–30 of 30")).toBeTruthy());
+    expect(getByText("25")).toBeTruthy();
+  });
+});
+
+describe("compareByColumn", () => {
+  const numCol = { name: "n", type: "number" };
+  const strCol = { name: "s", type: "string" };
+  const dateCol = { name: "d", type: "date" };
+
+  it("orders a number column numerically, not lexically", () => {
+    const rows = [{ n: 10 }, { n: 9 }, { n: 2 }];
+    const asc = [...rows].sort((a, b) => compareByColumn(a, b, numCol, "asc"));
+    expect(asc.map((r) => r.n)).toEqual([2, 9, 10]);
+  });
+
+  it("orders a date column chronologically", () => {
+    const rows = [
+      { d: "2026-09-16" },
+      { d: "2026-01-02" },
+      { d: "2026-05-01" },
+    ];
+    const asc = [...rows].sort((a, b) => compareByColumn(a, b, dateCol, "asc"));
+    expect(asc.map((r) => r.d)).toEqual([
+      "2026-01-02",
+      "2026-05-01",
+      "2026-09-16",
+    ]);
+  });
+
+  it("sorts empty values last regardless of direction", () => {
+    const rows = [{ s: "" }, { s: "beta" }, { s: "alpha" }];
+    const asc = [...rows].sort((a, b) => compareByColumn(a, b, strCol, "asc"));
+    expect(asc.map((r) => r.s)).toEqual(["alpha", "beta", ""]);
+    const desc = [...rows].sort((a, b) =>
+      compareByColumn(a, b, strCol, "desc"),
+    );
+    expect(desc[desc.length - 1].s).toBe("");
+  });
+});
+
+describe("rowMatchesQuery", () => {
+  const cols = [
+    { name: "name", type: "string" },
+    { name: "meta", type: "string" },
+  ];
+  it("matches a case-insensitive substring across columns", () => {
+    expect(
+      rowMatchesQuery({ name: "Meridian Health", meta: {} }, cols, "meridian"),
+    ).toBe(true);
+    expect(rowMatchesQuery({ name: "Acme", meta: {} }, cols, "zzz")).toBe(
+      false,
+    );
+  });
+  it("searches inside nested JSON cells", () => {
+    expect(
+      rowMatchesQuery({ name: "X", meta: { owner: "Priya" } }, cols, "priya"),
+    ).toBe(true);
+  });
+  it("empty query matches everything", () => {
+    expect(rowMatchesQuery({ name: "anything" }, cols, "  ")).toBe(true);
   });
 });

--- a/web/src/operator/surfaces/AppDataTab.tsx
+++ b/web/src/operator/surfaces/AppDataTab.tsx
@@ -8,7 +8,7 @@
 // reconstruction, no re-fetch of the source — what the app persisted is what
 // shows here, so the two never drift.
 
-import { Fragment, useState } from "react";
+import { Fragment, useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 
 import { get } from "../../api/client";
@@ -151,6 +151,8 @@ export function AppDataTab({ appId }: AppDataTabProps) {
 type Parsed =
   | { kind: "empty" }
   | { kind: "scalar"; text: string }
+  | { kind: "number"; text: string; value: number }
+  | { kind: "bool"; value: boolean }
   | { kind: "date"; text: string; full: string }
   | { kind: "list"; items: unknown[] }
   | { kind: "record"; value: Record<string, unknown> };
@@ -182,8 +184,20 @@ function humanizeDate(iso: string): string {
   });
 }
 
+function formatNumber(n: number): string {
+  // Group digits so "$8400" reads as "8,400"; keep up to 2 decimals without
+  // forcing trailing zeros on whole numbers.
+  return n.toLocaleString(undefined, { maximumFractionDigits: 2 });
+}
+
 function parseValue(v: unknown, colType: string): Parsed {
   if (v == null || v === "") return { kind: "empty" };
+  if (typeof v === "boolean") return { kind: "bool", value: v };
+  if (typeof v === "number") {
+    return Number.isFinite(v)
+      ? { kind: "number", text: formatNumber(v), value: v }
+      : { kind: "scalar", text: String(v) };
+  }
   if (typeof v === "string") {
     const t = v.trim();
     if (
@@ -191,6 +205,16 @@ function parseValue(v: unknown, colType: string): Parsed {
       !Number.isNaN(Date.parse(t))
     ) {
       return { kind: "date", text: humanizeDate(t), full: t };
+    }
+    // A number column whose value arrived as a string ("8400") still renders
+    // as a grouped number — but only when the column is typed number, so a
+    // ZIP code or SKU in a string column is never mangled into "12,345".
+    if (colType === "number" && t !== "" && !Number.isNaN(Number(t))) {
+      return {
+        kind: "number",
+        text: formatNumber(Number(t)),
+        value: Number(t),
+      };
     }
     if (t.startsWith("[") || t.startsWith("{")) {
       try {
@@ -210,11 +234,73 @@ function parseValue(v: unknown, colType: string): Parsed {
   return { kind: "scalar", text: String(v) };
 }
 
+// ── Filter + sort: pure helpers, unit-tested ────────────────────────────────
+
+/** Flatten any cell value to a lowercased searchable string (nested JSON too). */
+function cellSearchText(v: unknown): string {
+  if (v == null) return "";
+  if (typeof v === "object") {
+    try {
+      return JSON.stringify(v).toLowerCase();
+    } catch {
+      return "";
+    }
+  }
+  return String(v).toLowerCase();
+}
+
+/** Case-insensitive substring match across every column of a row. */
+export function rowMatchesQuery(
+  row: Record<string, unknown>,
+  columns: ModelColumn[],
+  query: string,
+): boolean {
+  const q = query.trim().toLowerCase();
+  if (q === "") return true;
+  return columns.some((c) => cellSearchText(row[c.name]).includes(q));
+}
+
+/**
+ * Type-aware comparator for a column. Numbers compare numerically ("10" after
+ * "9"), dates by timestamp, everything else by locale string. Empty values sort
+ * last regardless of direction so blanks never crowd the top.
+ */
+export function compareByColumn(
+  a: Record<string, unknown>,
+  b: Record<string, unknown>,
+  col: ModelColumn,
+  dir: "asc" | "desc",
+): number {
+  const av = a[col.name];
+  const bv = b[col.name];
+  const aEmpty = av == null || av === "";
+  const bEmpty = bv == null || bv === "";
+  if (aEmpty && bEmpty) return 0;
+  if (aEmpty) return 1;
+  if (bEmpty) return -1;
+  const sign = dir === "asc" ? 1 : -1;
+  if (col.type === "number") {
+    return (Number(av) - Number(bv)) * sign;
+  }
+  if (col.type === "date") {
+    return (Date.parse(String(av)) - Date.parse(String(bv))) * sign;
+  }
+  return String(av).localeCompare(String(bv)) * sign;
+}
+
 /** Short inline summary for a cell; the row expansion carries the detail. */
 function CellSummary({ parsed }: { parsed: Parsed }) {
   switch (parsed.kind) {
     case "empty":
       return <span className="opr-data-none">none</span>;
+    case "number":
+      return <span className="opr-data-num">{parsed.text}</span>;
+    case "bool":
+      return (
+        <span className={`opr-data-bool${parsed.value ? " is-yes" : " is-no"}`}>
+          {parsed.value ? "Yes" : "No"}
+        </span>
+      );
     case "date":
       return <span title={parsed.full}>{parsed.text}</span>;
     case "list": {
@@ -251,6 +337,14 @@ function ValueDetail({ parsed }: { parsed: Parsed }) {
   switch (parsed.kind) {
     case "empty":
       return <span className="opr-data-none">none</span>;
+    case "number":
+      return <span className="opr-data-num">{parsed.text}</span>;
+    case "bool":
+      return (
+        <span className={`opr-data-bool${parsed.value ? " is-yes" : " is-no"}`}>
+          {parsed.value ? "Yes" : "No"}
+        </span>
+      );
     case "date":
       return (
         <span>
@@ -325,7 +419,10 @@ function downloadBlob(filename: string, mime: string, content: string) {
 }
 
 function csvEscape(v: unknown): string {
-  const s = v == null ? "" : String(v);
+  // Objects/arrays serialize to JSON (matching the JSON export), never the
+  // useless "[object Object]" String() would produce.
+  const s =
+    v == null ? "" : typeof v === "object" ? JSON.stringify(v) : String(v);
   return /[",\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
 }
 
@@ -346,16 +443,63 @@ function exportTable(table: ModelTable, format: "csv" | "json") {
   downloadBlob(`${table.name}.csv`, "text/csv", lines.join("\n"));
 }
 
+const PAGE_SIZE = 25;
+
+interface SortState {
+  col: string;
+  dir: "asc" | "desc";
+}
+
 function ModelTableView({ table }: { table: ModelTable }) {
-  const [openRow, setOpenRow] = useState<number | null>(null);
+  // Expansion is keyed on the row OBJECT, not an index: filtering, sorting, and
+  // paging all reorder the visible rows, so an index would open the wrong row.
+  const [openRow, setOpenRow] = useState<Record<string, unknown> | null>(null);
+  const [query, setQuery] = useState("");
+  const [sort, setSort] = useState<SortState | null>(null);
+  const [page, setPage] = useState(0);
+
+  const filtered = useMemo(
+    () => table.rows.filter((r) => rowMatchesQuery(r, table.columns, query)),
+    [table.rows, table.columns, query],
+  );
+
+  const sorted = useMemo(() => {
+    if (!sort) return filtered;
+    const col = table.columns.find((c) => c.name === sort.col);
+    if (!col) return filtered;
+    // Copy before sort: never mutate the query cache's row array in place.
+    return [...filtered].sort((a, b) => compareByColumn(a, b, col, sort.dir));
+  }, [filtered, sort, table.columns]);
+
+  // Clamp the page whenever the result set shrinks (a query narrowing past the
+  // current page must not leave the operator staring at an empty slice).
+  const pageCount = Math.max(1, Math.ceil(sorted.length / PAGE_SIZE));
+  const safePage = Math.min(page, pageCount - 1);
+  const start = safePage * PAGE_SIZE;
+  const paged = sorted.slice(start, start + PAGE_SIZE);
+
+  const total = table.rows.length;
+  const filteredOut = query.trim() !== "" && filtered.length !== total;
+
+  function toggleSort(colName: string) {
+    setPage(0);
+    setSort((prev) =>
+      prev?.col === colName
+        ? { col: colName, dir: prev.dir === "asc" ? "desc" : "asc" }
+        : { col: colName, dir: "asc" },
+    );
+  }
+
   return (
     <div className="opr-data-block">
       <div className="opr-data-block-head">
         {table.name}
         <span className="opr-data-block-sub">
-          {table.rows.length} {table.rows.length === 1 ? "row" : "rows"}
+          {filteredOut
+            ? `${filtered.length} of ${total} rows`
+            : `${total} ${total === 1 ? "row" : "rows"}`}
         </span>
-        {table.rows.length > 0 ? (
+        {total > 0 ? (
           <span className="opr-data-export">
             <button
               type="button"
@@ -374,61 +518,134 @@ function ModelTableView({ table }: { table: ModelTable }) {
           </span>
         ) : null}
       </div>
-      {table.rows.length === 0 ? (
+      {total === 0 ? (
         <div className="opr-data-empty">
           Defined, no rows yet — the agent has declared this table but not
           written to it.
         </div>
       ) : (
-        <table className="opr-data-table">
-          <thead>
-            <tr>
-              {table.columns.map((c) => (
-                <th key={c.name}>
-                  <span className="opr-data-col-name">{c.name}</span>
-                  <span className="opr-data-col-type">{c.type}</span>
-                </th>
-              ))}
-            </tr>
-          </thead>
-          <tbody>
-            {table.rows.map((row, i) => {
-              const open = openRow === i;
-              return (
-                <Fragment key={`row-${i}`}>
-                  <tr
-                    className={`opr-data-row${open ? " is-open" : ""}`}
-                    onClick={() => setOpenRow(open ? null : i)}
-                  >
-                    {table.columns.map((c) => (
-                      <td key={c.name}>
-                        <CellSummary parsed={parseValue(row[c.name], c.type)} />
-                      </td>
-                    ))}
-                  </tr>
-                  {open ? (
-                    <tr className="opr-data-detail-row">
-                      <td colSpan={table.columns.length}>
-                        <dl className="opr-data-kv">
-                          {table.columns.map((c) => (
-                            <div className="opr-data-kv-row" key={c.name}>
-                              <dt>{c.name}</dt>
-                              <dd>
-                                <ValueDetail
-                                  parsed={parseValue(row[c.name], c.type)}
-                                />
-                              </dd>
-                            </div>
-                          ))}
-                        </dl>
-                      </td>
-                    </tr>
-                  ) : null}
-                </Fragment>
-              );
-            })}
-          </tbody>
-        </table>
+        <>
+          {total > 8 ? (
+            <div className="opr-data-toolbar">
+              <input
+                type="search"
+                className="opr-data-search"
+                placeholder={`Search ${table.name.toLowerCase()}…`}
+                aria-label={`Search ${table.name}`}
+                value={query}
+                onChange={(e) => {
+                  setQuery(e.target.value);
+                  setPage(0);
+                }}
+              />
+            </div>
+          ) : null}
+          {filtered.length === 0 ? (
+            <div className="opr-data-empty">
+              No rows match “{query.trim()}”.
+            </div>
+          ) : (
+            <table className="opr-data-table">
+              <thead>
+                <tr>
+                  {table.columns.map((c) => {
+                    const active = sort?.col === c.name;
+                    const ariaSort = active
+                      ? sort?.dir === "asc"
+                        ? "ascending"
+                        : "descending"
+                      : "none";
+                    return (
+                      <th
+                        key={c.name}
+                        aria-sort={ariaSort}
+                        className="opr-data-th-sortable"
+                      >
+                        <button
+                          type="button"
+                          className="opr-data-sort-btn"
+                          onClick={() => toggleSort(c.name)}
+                        >
+                          <span className="opr-data-col-name">{c.name}</span>
+                          <span className="opr-data-col-type">{c.type}</span>
+                          <span
+                            className="opr-data-sort-caret"
+                            aria-hidden={true}
+                          >
+                            {active ? (sort?.dir === "asc" ? "▲" : "▼") : "↕"}
+                          </span>
+                        </button>
+                      </th>
+                    );
+                  })}
+                </tr>
+              </thead>
+              <tbody>
+                {paged.map((row, i) => {
+                  const open = openRow === row;
+                  return (
+                    <Fragment key={`row-${start + i}`}>
+                      <tr
+                        className={`opr-data-row${open ? " is-open" : ""}`}
+                        onClick={() => setOpenRow(open ? null : row)}
+                      >
+                        {table.columns.map((c) => (
+                          <td key={c.name}>
+                            <CellSummary
+                              parsed={parseValue(row[c.name], c.type)}
+                            />
+                          </td>
+                        ))}
+                      </tr>
+                      {open ? (
+                        <tr className="opr-data-detail-row">
+                          <td colSpan={table.columns.length}>
+                            <dl className="opr-data-kv">
+                              {table.columns.map((c) => (
+                                <div className="opr-data-kv-row" key={c.name}>
+                                  <dt>{c.name}</dt>
+                                  <dd>
+                                    <ValueDetail
+                                      parsed={parseValue(row[c.name], c.type)}
+                                    />
+                                  </dd>
+                                </div>
+                              ))}
+                            </dl>
+                          </td>
+                        </tr>
+                      ) : null}
+                    </Fragment>
+                  );
+                })}
+              </tbody>
+            </table>
+          )}
+          {sorted.length > PAGE_SIZE ? (
+            <div className="opr-data-pager">
+              <button
+                type="button"
+                className="opr-btn opr-btn-sm"
+                disabled={safePage === 0}
+                onClick={() => setPage(safePage - 1)}
+              >
+                Prev
+              </button>
+              <span className="opr-data-pager-label">
+                Showing {start + 1}–{Math.min(start + PAGE_SIZE, sorted.length)}{" "}
+                of {sorted.length}
+              </span>
+              <button
+                type="button"
+                className="opr-btn opr-btn-sm"
+                disabled={safePage >= pageCount - 1}
+                onClick={() => setPage(safePage + 1)}
+              >
+                Next
+              </button>
+            </div>
+          ) : null}
+        </>
       )}
     </div>
   );

--- a/web/src/styles/operator-shell.css
+++ b/web/src/styles/operator-shell.css
@@ -5166,6 +5166,92 @@
   white-space: pre-wrap;
   overflow-wrap: anywhere;
 }
+/* Typed cells: numbers right-align and group, booleans read as a badge. */
+.opr-data-num {
+  font-family: var(--font-mono);
+  font-variant-numeric: tabular-nums;
+  display: block;
+  text-align: right;
+}
+.opr-data-bool {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  border-radius: 999px;
+  padding: 1px 8px;
+  white-space: nowrap;
+  border: 1px solid transparent;
+}
+.opr-data-bool.is-yes {
+  color: var(--t-accent-3);
+  border-color: color-mix(in srgb, var(--t-accent-3) 45%, transparent);
+}
+.opr-data-bool.is-no {
+  color: var(--t-faint);
+  border-color: color-mix(in srgb, var(--t-faint) 40%, transparent);
+}
+/* Search + sort + pagination controls. */
+.opr-data-toolbar {
+  margin: 8px 0 4px;
+}
+.opr-data-search {
+  width: 100%;
+  max-width: 320px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--t-ink);
+  background: var(--t-figure-bg);
+  border: 1px solid var(--t-line);
+  border-radius: var(--radius-sm, 6px);
+  padding: 6px 10px;
+}
+.opr-data-search:focus-visible {
+  outline: 2px solid var(--t-accent-2);
+  outline-offset: 1px;
+}
+.opr-data-th-sortable {
+  padding: 0;
+}
+.opr-data-sort-btn {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 6px;
+  width: 100%;
+  background: none;
+  border: 0;
+  cursor: pointer;
+  text-align: left;
+  padding: 8px 10px;
+  color: inherit;
+  font: inherit;
+}
+.opr-data-sort-btn:hover {
+  background: var(--t-tint-accent);
+}
+.opr-data-sort-btn:focus-visible {
+  outline: 2px solid var(--t-accent-2);
+  outline-offset: -2px;
+}
+.opr-data-sort-caret {
+  margin-left: auto;
+  font-size: 9px;
+  color: var(--t-faint);
+}
+th[aria-sort="ascending"] .opr-data-sort-caret,
+th[aria-sort="descending"] .opr-data-sort-caret {
+  color: var(--t-accent-3);
+}
+.opr-data-pager {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-top: 10px;
+}
+.opr-data-pager-label {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--t-dim);
+  font-variant-numeric: tabular-nums;
+}
 
 /* Failed finish card: honest red framing, no green success glyph. */
 .opr-finish-card.is-failed {


### PR DESCRIPTION
Part of the "8/10 on every quality axis" program. This lifts the **data-tab** axis (was 5/10) to a genuine 8 by turning the correct-but-static table dump into a navigable data surface. Every change is behavior the operator can use on their own data.

## What
- **Search** — per-table case-insensitive box (searches nested JSON cells too), appears once a table passes 8 rows; header shows "N of M rows" when filtered.
- **Type-aware sortable columns** — numbers sort numerically ("10" after "9"), dates chronologically, else locale; empty values sort last; `<th aria-sort>` + keyboard-reachable sort button.
- **Pagination** — 25/page, "Showing a–b of M" + Prev/Next; resets on query/sort change; clamps when the set shrinks.
- **Typed cells** — numbers grouped + right-aligned (`tabular-nums`); booleans as a Yes/No badge, not raw `true`.
- **CSV fidelity** — object/array cells serialize to JSON (matching JSON export), not `[object Object]`.
- Row expansion keyed on the row object, so it survives filter/sort/paging.

## Test plan
- [x] `AppDataTab.test.tsx` 17 pass — new: number/bool rendering, search filter, pagination advance, and pure `compareByColumn` (numeric/date/empty-last) + `rowMatchesQuery` (nested JSON, case-insensitive) unit tests.
- [x] `bunx tsc --noEmit` clean, biome clean.

Screenshots to follow on a fresh build in the re-verification pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V9n6uZhopKDdZoXQ37ry17