### PR TITLE
feat(apps): the publish advisory reaches the operator, and catches more

### DIFF
--- a/internal/team/broker_app_eval.go
+++ b/internal/team/broker_app_eval.go
@@ -44,7 +44,11 @@ const (
 	// appScaffoldSentinel is a distinctive instruction comment from the starter
 	// App.tsx (templates/app-scaffold/src/App.tsx) that no real app would keep.
 	// Its presence means the agent never replaced the template.
-	appScaffoldSentinel = "Replace the columns + resource to build a different tool"
+	// A distinctive line from the current starter App.tsx doc comment
+	// (templates/app-scaffold/src/App.tsx). A real build REPLACES App.tsx, so
+	// this string surviving means the scaffold shipped unmodified. Keep this in
+	// sync with the scaffold if that comment is reworded.
+	appScaffoldSentinel = "The App Builder REPLACES this file with the real tool"
 )
 
 // sweepStalledAppBuildsLocked returns the App Builder build tasks that have gone

--- a/internal/team/broker_app_eval_test.go
+++ b/internal/team/broker_app_eval_test.go
@@ -430,3 +430,20 @@ func TestAppAcceptanceReopensWhenNoAppRegistered(t *testing.T) {
 		t.Fatalf("want 1 acceptance-fail notice, got %d", countMessagesOfKind(b, ch, appAcceptanceFailKind))
 	}
 }
+
+// The scaffold-source gap check only works if appScaffoldSentinel is a string
+// that actually appears in the current starter App.tsx — otherwise it silently
+// matches nothing (the 2026-08-17 build-pipeline audit found exactly this drift:
+// the sentinel referenced a comment that no longer existed). Guard against it
+// recurring: the sentinel MUST be present in the live scaffold.
+func TestScaffoldSentinelMatchesTemplate(t *testing.T) {
+	// The test binary runs from the package dir; the scaffold lives at repo root.
+	path := filepath.Join("..", "..", "templates", "app-scaffold", "src", "App.tsx")
+	src, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read scaffold App.tsx: %v", err)
+	}
+	if !strings.Contains(string(src), appScaffoldSentinel) {
+		t.Fatalf("appScaffoldSentinel %q is not present in the current scaffold %s — the scaffold-source gap check is a silent no-op; update the sentinel", appScaffoldSentinel, path)
+	}
+}

--- a/internal/team/broker_apps_starter_routine.go
+++ b/internal/team/broker_apps_starter_routine.go
@@ -94,29 +94,42 @@ func (b *Broker) buildDescriptionForApp(app CustomApp) string {
 // on purpose: no model call, no false authority — just the two failure shapes
 // the quality audits actually observed (scaffold placeholder shipped as the
 // final app; a bundle too small to hold the refine+Mantine stack).
-func publishOddity(html string) string {
-	switch {
-	case strings.Contains(html, "Building your agent…"):
-		return "the published page still shows the scaffold placeholder — the build may not have replaced the starter screen"
-	case len(html) < 20_000:
-		return "the published bundle is unusually small — the page may be missing its real interface"
+// publishOddity translates the deterministic gap list into ONE operator-facing
+// heads-up line, or "" when the publish looked healthy. It reuses
+// deterministicAppGaps (broker_app_eval.go) — the richer, unit-tested check
+// (ready/version grounding, content-hash-vs-bytes integrity, min-bundle, and
+// the scaffold-source sentinel) — instead of the two hard-coded shapes it used
+// before, so a corrupt or partial publish is caught too.
+func (b *Broker) publishOddity(app CustomApp) string {
+	gaps := b.deterministicAppGaps(app)
+	if len(gaps) == 0 {
+		return ""
 	}
-	return ""
+	// Lead with the first gap (they are ordered non-delivery → integrity →
+	// scaffold); a single clear line beats a wall of them in the finish card.
+	return gaps[0]
 }
 
 // advisePublishOddities is the deterministic "look at your own output once"
 // check (2026-08-17 quality audit: every area's worst defect traced to the
 // system never inspecting what it produced; the old LLM acceptance gate was
 // removed for wedging tasks — this one is advisory, cheap, and never blocks
-// or reopens anything). On a suspicious publish it posts ONE honest line to
-// the app's edit channel.
+// or reopens anything). On a suspicious publish it (1) STAMPS the advisory on
+// the manifest so the finish card can downgrade its green "ready", and (2)
+// posts ONE honest line to the app's edit channel. On a healthy publish it
+// clears any stale advisory from a prior build.
 func (b *Broker) advisePublishOddities(app CustomApp) {
-	fresh, html, err := b.appStore().Get(app.ID)
+	fresh, _, err := b.appStore().Get(app.ID)
 	if err != nil {
 		return
 	}
 	app = fresh
-	oddity := publishOddity(html)
+	oddity := b.publishOddity(app)
+	// Stamp (or clear) the manifest first so the finish card is honest even if
+	// there is no edit channel to post into.
+	if err := b.appStore().SetAdvisory(app.ID, oddity); err != nil {
+		log.Printf("publish-advisory: stamp %s: %v", app.ID, err)
+	}
 	if oddity == "" || strings.TrimSpace(app.EditChannel) == "" {
 		return
 	}

--- a/internal/team/broker_apps_starter_routine_test.go
+++ b/internal/team/broker_apps_starter_routine_test.go
@@ -256,15 +256,38 @@ func TestBuildDescriptionStripsBuilderMachinery(t *testing.T) {
 	}
 }
 
-func TestPublishOddity(t *testing.T) {
-	big := strings.Repeat("<div>real interface</div>", 2000)
-	if got := publishOddity(big); got != "" {
+func TestPublishOddityAndAdvisoryStamp(t *testing.T) {
+	t.Setenv("WUPHF_RUNTIME_HOME", t.TempDir())
+	b := newTestBroker(t)
+
+	// A healthy publish (ready, versioned, big bundle, real source): no oddity,
+	// and advisePublishOddities leaves the manifest advisory empty.
+	seedAcceptanceApp(t, "app_0000000000000ea1", "task-x-2", 8000, "ready", 1)
+	healthy, _, err := b.appStore().Get("app_0000000000000ea1")
+	if err != nil {
+		t.Fatalf("get healthy: %v", err)
+	}
+	if got := b.publishOddity(healthy); got != "" {
 		t.Fatalf("healthy publish flagged: %q", got)
 	}
-	if got := publishOddity("Building your agent…" + big); !strings.Contains(got, "placeholder") {
-		t.Fatalf("placeholder publish not flagged: %q", got)
+	b.advisePublishOddities(healthy)
+	if after, _, _ := b.appStore().Get("app_0000000000000ea1"); after.Advisory != "" {
+		t.Fatalf("healthy publish stamped an advisory: %q", after.Advisory)
 	}
-	if got := publishOddity("<html>tiny</html>"); !strings.Contains(got, "unusually small") {
-		t.Fatalf("tiny publish not flagged: %q", got)
+
+	// A trivially small bundle: publishOddity flags it and advisePublishOddities
+	// stamps the advisory onto the manifest so the finish card can read it.
+	seedAcceptanceApp(t, "app_0000000000000ea2", "task-x-3", 100, "ready", 1)
+	tiny, _, err := b.appStore().Get("app_0000000000000ea2")
+	if err != nil {
+		t.Fatalf("get tiny: %v", err)
+	}
+	if got := b.publishOddity(tiny); got == "" {
+		t.Fatal("tiny bundle was not flagged")
+	}
+	b.advisePublishOddities(tiny)
+	after, _, _ := b.appStore().Get("app_0000000000000ea2")
+	if after.Advisory == "" {
+		t.Fatal("tiny publish did not stamp a manifest advisory")
 	}
 }

--- a/internal/team/custom_app.go
+++ b/internal/team/custom_app.go
@@ -106,6 +106,13 @@ type CustomApp struct {
 	CreatedAt   string `json:"createdAt"`
 	UpdatedAt   string `json:"updatedAt"`
 	ContentHash string `json:"contentHash"`
+	// Advisory is a deterministic, non-blocking heads-up about the LAST publish
+	// (scaffold placeholder shipped, bundle too small, corrupt/partial publish).
+	// Empty when the publish looked healthy. Stamped by advisePublishOddities so
+	// the finish card can downgrade a green "ready" to an honest "built, but this
+	// looks off" — the advisory previously only reached a channel the build UI
+	// never read (2026-08-17 build-pipeline audit).
+	Advisory string `json:"advisory,omitempty"`
 }
 
 // CustomAppWriteRequest is the create/update payload. An empty ID creates a new
@@ -507,6 +514,35 @@ const scaffoldPlaceholderHTML = `<!doctype html><html lang="en"><head><meta char
 // retried create) so it never churns the manifest or bumps anything.
 //
 // Unknown id → caller error (404 upstream). Never touches Version/Status/bytes.
+// SetAdvisory stamps (or clears, with "") the post-publish advisory on the
+// manifest. Idempotent: a no-op when unchanged so a healthy republish does not
+// rewrite the manifest just to write the same empty string.
+func (s *customAppStore) SetAdvisory(id, advisory string) error {
+	if err := validateCustomAppID(id); err != nil {
+		return err
+	}
+	advisory = strings.TrimSpace(advisory)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	app, err := s.readManifestLocked(id)
+	if err != nil {
+		return newCustomAppCallerError("app: %s not found", id)
+	}
+	if app.Advisory == advisory {
+		return nil
+	}
+	app.Advisory = advisory
+	manifestBytes, err := json.MarshalIndent(app, "", "  ")
+	if err != nil {
+		return fmt.Errorf("app: marshal manifest: %w", err)
+	}
+	manifestBytes = append(manifestBytes, '\n')
+	if err := writeFileAtomic(filepath.Join(s.appDir(id), customAppManifestFile), manifestBytes, 0o600); err != nil {
+		return fmt.Errorf("app: write manifest: %w", err)
+	}
+	return nil
+}
+
 func (s *customAppStore) SetEditChannel(id, channel string) error {
 	if err := validateCustomAppID(id); err != nil {
 		return err

--- a/web/src/api/apps.ts
+++ b/web/src/api/apps.ts
@@ -32,6 +32,13 @@ export interface CustomApp {
   createdAt: string;
   updatedAt: string;
   contentHash: string;
+  /**
+   * A deterministic, non-blocking heads-up about the last publish (scaffold
+   * placeholder shipped, bundle too small, corrupt publish). Empty when the
+   * publish looked healthy. The finish card downgrades a green "ready" to an
+   * honest "built, but this looks off" when this is set.
+   */
+  advisory?: string;
 }
 
 export interface CustomAppDetail {

--- a/web/src/operator/surfaces/AppBuilderChat.tsx
+++ b/web/src/operator/surfaces/AppBuilderChat.tsx
@@ -142,6 +142,11 @@ export function AppBuilderChat({
   // (2026-08-16 audit: a failed build rendered a green check + "Ready to
   // use" + "Open the agent").
   const [buildFailed, setBuildFailed] = useState(false);
+  // A deterministic non-blocking heads-up about the publish (scaffold placeholder
+  // shipped, bundle too small). The broker stamps it on the manifest AFTER the
+  // build resolves, so we re-read once shortly after "done" to catch it and
+  // downgrade the finish card's green "ready" to an honest line.
+  const [finishAdvisory, setFinishAdvisory] = useState<string | null>(null);
   // The app currently building/refining, used to stream its live activity
   // (thinking + tool calls) by APP ID alone via <AppActivity/>. Known
   // immediately for a refine; resolved from the pre-scaffolded app for a new
@@ -216,6 +221,29 @@ export function AppBuilderChat({
     }, BUILD_POLL_MS);
     return () => window.clearInterval(tick);
   }, [phase, queryClient]);
+
+  // Catch the publish advisory: the broker stamps it on the manifest in a
+  // goroutine right after the build resolves, which the completion poll (that
+  // stops polling the instant it sees "done") systematically misses. One
+  // delayed re-read closes that race so a scaffold-placeholder publish never
+  // shows a clean green "ready".
+  useEffect(() => {
+    if (phase !== "done" || !newAppId || buildFailed) return;
+    let alive = true;
+    const t = window.setTimeout(async () => {
+      try {
+        const apps = await listApps();
+        const built = apps.find((a) => a.id === newAppId);
+        if (alive) setFinishAdvisory(built?.advisory?.trim() || null);
+      } catch {
+        // Best-effort: a missed advisory is not worth surfacing an error.
+      }
+    }, 1500);
+    return () => {
+      alive = false;
+      window.clearTimeout(t);
+    };
+  }, [phase, newAppId, buildFailed]);
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: say/setupDemoExtras are instance functions; completion re-evaluates on poll data and phase
   useEffect(() => {
@@ -810,11 +838,16 @@ export function AppBuilderChat({
                     <span>
                       {buildFailed
                         ? "The build stopped before it finished"
-                        : editApp
-                          ? "New version published"
-                          : "Hired. It starts now, no orientation needed."}
+                        : finishAdvisory
+                          ? "Built — but this looks off"
+                          : editApp
+                            ? "New version published"
+                            : "Hired. It starts now, no orientation needed."}
                     </span>
                   </div>
+                  {!buildFailed && finishAdvisory ? (
+                    <div className="opr-finish-advisory">{finishAdvisory}</div>
+                  ) : null}
                 </div>
               </div>
               <div className="opr-finish-actions">

--- a/web/src/styles/operator-shell.css
+++ b/web/src/styles/operator-shell.css
@@ -2896,6 +2896,14 @@
   font-size: 11px;
   color: var(--t-faint);
 }
+.opr-finish-advisory {
+  margin-top: 5px;
+  font-size: 11px;
+  line-height: 1.4;
+  color: var(--t-warn, #d9a04b);
+  border-left: 2px solid var(--t-warn, #d9a04b);
+  padding-left: 8px;
+}
 .opr-finish-actions {
   display: flex;
   gap: var(--space-2);


### PR DESCRIPTION
Part of the 8/10-on-every-axis program. Lifts the **build-pipeline** axis (was 5/10) by closing the honesty gap: the build could say **ready** while detecting the publish was the scaffold placeholder or a too-small bundle — the advisory posted to a channel the build UI never reads.

- Stamp the advisory on the CustomApp manifest (new `Advisory` field + `SetAdvisory`); the finish card re-reads ~1.5s after 'done' and downgrades the green 'Hired' to **'Built — but this looks off: <reason>'**.
- Route it through `deterministicAppGaps` (richer, unit-tested) so corrupt/partial publishes are caught too.
- Fix the STALE `appScaffoldSentinel` (silent no-op) + `TestScaffoldSentinelMatchesTemplate` guard.

Advisory-only: never blocks/reopens/retries.

## Test plan
- [x] go test ./internal/team new tests; acceptance green; go build/vet, golangci-lint 0, tsc/biome clean; useOperatorApps (30) + AppBuilderChat (4) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V9n6uZhopKDdZoXQ37ry17