### PR TITLE
feat(tools): domain-neutral capability catalog + smoke reference check

### DIFF
--- a/agent/src/capabilities.test.ts
+++ b/agent/src/capabilities.test.ts
@@ -56,11 +56,12 @@ test("capabilityConfigFromEnv threads TOOL_CALL_TIMEOUT_MS into callTimeoutMs", 
 });
 
 test("GATED_CAPABILITIES lists every mutating capability the send-gate must hold", () => {
-	// toolRuntime.ts default-allows anything NOT in this set — these three paths
-	// disappearing from it would silently un-gate external mutations.
-	expect(GATED_CAPABILITIES.has("crm.assign")).toBe(true);
+	// toolRuntime.ts default-allows anything NOT in this set — these outbound
+	// paths disappearing from it would silently un-gate external mutations.
 	expect(GATED_CAPABILITIES.has("nex.send")).toBe(true);
 	expect(GATED_CAPABILITIES.has("nex.browser")).toBe(true);
+	// The catalog is domain-neutral now: no crm.* capability exists to gate.
+	expect(GATED_CAPABILITIES.has("crm.assign")).toBe(false);
 });
 
 // --- simulated fallbacks (empty input honesty) ----------------------------------

--- a/agent/src/capabilities.ts
+++ b/agent/src/capabilities.ts
@@ -18,9 +18,11 @@
 //                                 GATED at the agent layer (browser control needs
 //                                 the operator's in-chat approval, mirroring the
 //                                 browser-step reframe).
-//   nex.send / crm.*              Still simulated (real sends/CRM go through
-//                                 integrations.call); nex.send stays gated so the
-//                                 approval flow is exercised end to end.
+//   nex.send / data.*             Still simulated. nex.send stays gated so the
+//                                 approval flow is exercised end to end; data.* is
+//                                 the domain-neutral store surface (list/get/upsert)
+//                                 an authored tool uses to read/write the app's own
+//                                 records — simulated as an empty store on this host.
 //
 // Secrets discipline: the broker token comes from the agent's OWN environment and
 // goes out only as an Authorization header to the configured broker — never to
@@ -40,7 +42,7 @@ import type { CapabilityFn, CapabilityTree } from "./toolRuntime.js";
 // ungated. Kept next to the capability definitions on purpose.
 // (integrations.call is intentionally absent: the broker classifies
 // read-vs-mutate server-side and raises its own approval card for mutations.)
-export const GATED_CAPABILITIES: ReadonlySet<string> = new Set(["crm.assign", "nex.send", "nex.browser"]);
+export const GATED_CAPABILITIES: ReadonlySet<string> = new Set(["nex.send", "nex.browser"]);
 
 export interface CapabilityConfig {
 	/** Broker base URL (e.g. http://127.0.0.1:7893) for integrations + browser. */
@@ -96,13 +98,6 @@ function hashScore(subject: unknown): number {
 	return 55 + (h % 41);
 }
 
-const DEALS = [
-	{ name: "Globex", stage: "Negotiation", amount: 120_000, stageChanged: true },
-	{ name: "Initech", stage: "Discovery", amount: 45_000, stageChanged: false },
-	{ name: "Acme", stage: "Proposal", amount: 80_000, stageChanged: true },
-	{ name: "Umbrella", stage: "Closed Won", amount: 96_000, stageChanged: true },
-] as const;
-
 function simSummarize(items: unknown): string {
 	const list = Array.isArray(items) ? items : [items];
 	const names = list.map(labelOf).slice(0, 3).join(", ");
@@ -138,16 +133,17 @@ export function simulatedCapabilities(): CapabilityTree {
 			send: (target: unknown) => `Sent to ${labelOf(target)} (simulated).`,
 			browser: (goal: unknown) => `Would drive the browser: ${labelOf(goal)} (browser engine not configured).`,
 		},
-		crm: {
-			deals: () => DEALS.map((d) => ({ ...d })),
-			dealContext: (deal: unknown) => ({
-				deal: labelOf(deal),
-				stage: "Negotiation",
-				lastTouch: "9 days ago",
-				owner: "Priya (AE)",
-			}),
-			ownerFor: () => ({ name: "Priya (AE)" }),
-			assign: (lead: unknown, ae: unknown) => `Assigned ${labelOf(lead)} to ${labelOf(ae)} (simulated).`,
+		// Domain-neutral store surface: an authored tool reads and writes the
+		// app's OWN records, whatever the domain (deals, tickets, candidates,
+		// products). Simulated here as an empty store — HONEST: nothing is
+		// connected yet, so list returns [] and get returns null rather than
+		// fabricating rows (a CRM-shaped fake was the reason non-sales workflows
+		// authored garbage, 2026-08-17 tools audit). On a real host this is
+		// overlaid with the app's db.* store.
+		data: {
+			list: () => [] as unknown[],
+			get: () => null,
+			upsert: (record: unknown) => `Saved ${labelOf(record)} (simulated — no data store connected).`,
 		},
 	};
 }

--- a/agent/src/routineRunner.test.ts
+++ b/agent/src/routineRunner.test.ts
@@ -116,7 +116,7 @@ test("default authoring path (buildTool stub) stays offline and persists", async
 	const { store, sessions } = tmpDeps();
 	const r = await runRoutine("a1", fired("Recap", "Summarize last week's pipeline movement"), { store, sessions });
 	expect(r.status).toBe("ok");
-	expect(store.listTools("a1").map((t) => t.name)).toEqual(["weeklyPipelineSummary"]);
+	expect(store.listTools("a1").map((t) => t.name)).toEqual(["weeklySummary"]);
 });
 
 test("SEND-GATE: a gated routine records needs_approval — it never auto-sends", async () => {

--- a/agent/src/serviceRoutines.test.ts
+++ b/agent/src/serviceRoutines.test.ts
@@ -95,7 +95,7 @@ test("POST /tools/build with app persists the tool; same name bumps version", as
 	const r1 = (await (await post("/tools/build", { schema_version: 1, message: "summarize the weekly pipeline", app: "sales" })).json()) as {
 		tool: StoredTool;
 	};
-	expect(r1.tool.name).toBe("weeklyPipelineSummary");
+	expect(r1.tool.name).toBe("weeklySummary");
 	expect(r1.tool.version).toBe(1);
 	const r2 = (await (await post("/tools/build", { schema_version: 1, message: "weekly pipeline digest", app: "sales" })).json()) as {
 		tool: StoredTool;
@@ -109,7 +109,7 @@ test("POST /tools/build with app persists the tool; same name bumps version", as
 	const r3 = (await (await post("/tools/build", { schema_version: 1, message: "draft a follow-up email" })).json()) as {
 		tool: StoredTool;
 	};
-	expect(r3.tool.name).toBe("draftFollowup");
+	expect(r3.tool.name).toBe("draftMessage");
 	expect(r3.tool.version).toBeUndefined();
 	expect(((await (await fetch(`${base}/tools?agent=sales`)).json()) as { tools: StoredTool[] }).tools).toHaveLength(1);
 });
@@ -147,7 +147,7 @@ test("POST /routines/run (a broker fire) lands transcript + artifact and reports
 	expect(session.messages[0].body).toBe("(scheduled) Summarize last week's pipeline movement");
 	// The authored tool was persisted, and the run artifact saved.
 	const tools = (await (await fetch(`${base}/tools?agent=runner`)).json()) as { tools: StoredTool[] };
-	expect(tools.tools.map((t) => t.name)).toEqual(["weeklyPipelineSummary"]);
+	expect(tools.tools.map((t) => t.name)).toEqual(["weeklySummary"]);
 	const arts = (await (await fetch(`${base}/artifacts?agent=runner`)).json()) as { artifacts: StoredArtifact[] };
 	expect(arts.artifacts).toEqual([expect.objectContaining({ type: "md", title: "recap-run-1.md", producedBy: "Recap" })]);
 

--- a/agent/src/toolRuntime.test.ts
+++ b/agent/src/toolRuntime.test.ts
@@ -17,10 +17,9 @@ function makeTool(code: string, inputs: Tool["inputs"] = [], name = "t"): Tool {
 
 const READ_TOOL = makeTool(
 	[
-		"async function weeklyPipelineSummary() {",
-		"  const deals = await crm.deals({ since: '7d' });",
-		"  const moved = deals.filter((d) => d.stageChanged);",
-		"  return nex.ai.summarize(moved, { style: 'exec recap' });",
+		"async function weeklySummary() {",
+		"  const records = await data.list('records', { since: '7d' });",
+		"  return nex.ai.summarize(records, { style: 'concise recap' });",
 		"}",
 	].join("\n"),
 	[],
@@ -29,40 +28,37 @@ const READ_TOOL = makeTool(
 
 const GATED_TOOL = makeTool(
 	[
-		"async function routeLead(lead) {",
-		"  const ae = await crm.ownerFor(lead);",
-		"  await crm.assign(lead, ae);",
-		"  return `routed ${lead} to ${ae.name}`;",
+		"async function notifyOwner(record) {",
+		"  const result = await nex.send(record, 'heads up');",
+		"  return `notified ${record}: ${result}`;",
 		"}",
 	].join("\n"),
-	[{ name: "lead", type: "string" }],
+	[{ name: "record", type: "string" }],
 	"gated_tool",
 );
 
-test("a read tool (crm.deals + summarize) runs ok with actions recorded", async () => {
+test("a read tool (data.list + summarize) runs ok with actions recorded", async () => {
 	const r = await runTool(READ_TOOL, {});
 	expect(r.status).toBe("ok");
 	if (r.status !== "ok") throw new Error("unreachable");
-	expect(r.result).toContain("simulated recap");
-	expect(r.actions.some((a) => a.startsWith("crm.deals("))).toBe(true);
+	// data.list returns [] in the sim, summarize records "0 items" honestly.
+	expect(r.actions.some((a) => a.startsWith("data.list("))).toBe(true);
 	expect(r.actions.some((a) => a.startsWith("nex.ai.summarize("))).toBe(true);
 });
 
-test("crm.assign halts needs_approval by default (default deny)", async () => {
-	const r = await runTool(GATED_TOOL, { lead: "Acme" });
+test("a gated write (nex.send) halts needs_approval by default (default deny)", async () => {
+	const r = await runTool(GATED_TOOL, { record: "Acme" });
 	expect(r.status).toBe("needs_approval");
 	if (r.status !== "needs_approval") throw new Error("unreachable");
-	expect(r.gate.capability).toBe("crm.assign");
+	expect(r.gate.capability).toBe("nex.send");
 	expect(r.gate.detail).toContain("Acme");
-	expect(r.gate.detail).toContain("Priya (AE)");
 });
 
-test("the same call with approved: true completes", async () => {
-	const r = await runTool(GATED_TOOL, { lead: "Acme" }, { approved: true });
+test("the same gated call with approved: true completes", async () => {
+	const r = await runTool(GATED_TOOL, { record: "Acme" }, { approved: true });
 	expect(r.status).toBe("ok");
 	if (r.status !== "ok") throw new Error("unreachable");
-	expect(r.result).toBe("routed Acme to Priya (AE)");
-	expect(r.actions.some((a) => a.startsWith("crm.assign("))).toBe(true);
+	expect(r.actions.some((a) => a.startsWith("nex.send("))).toBe(true);
 });
 
 test("nex.send is gated too", async () => {
@@ -76,12 +72,12 @@ test("nex.send is gated too", async () => {
 });
 
 test("a thrown error -> status error (with prior actions kept)", async () => {
-	const t = makeTool('async function boom() { await crm.deals(); throw new Error("kaput"); }');
+	const t = makeTool('async function boom() { await data.list("records"); throw new Error("kaput"); }');
 	const r = await runTool(t, {});
 	expect(r.status).toBe("error");
 	if (r.status !== "error") throw new Error("unreachable");
 	expect(r.detail).toContain("kaput");
-	expect(r.actions.some((a) => a.startsWith("crm.deals("))).toBe(true);
+	expect(r.actions.some((a) => a.startsWith("data.list("))).toBe(true);
 });
 
 test("the code scan rejects import (dynamic and static) and eval", async () => {
@@ -177,25 +173,27 @@ test("nex.browser is gated: default deny with the browser-control detail", async
 test("injected capabilities are used AND recorded (and stay gated)", async () => {
 	const seen: string[] = [];
 	const capabilities: CapabilityTree = {
-		crm: {
-			deals: () => {
-				seen.push("deals");
-				return [{ name: "OnlyDeal", stageChanged: true }];
+		data: {
+			list: () => {
+				seen.push("list");
+				return [{ name: "OnlyRecord" }];
 			},
-			assign: () => "assigned",
 		},
-		nex: { ai: { summarize: (items: unknown) => `got ${(items as unknown[]).length}` } },
+		nex: {
+			ai: { summarize: (items: unknown) => `got ${(items as unknown[]).length}` },
+			send: () => "sent",
+		},
 	};
-	const read = makeTool("async function t() { const d = await crm.deals({ since: '7d' }); return nex.ai.summarize(d); }");
+	const read = makeTool("async function t() { const d = await data.list('records', { since: '7d' }); return nex.ai.summarize(d); }");
 	const r = await runTool(read, {}, { capabilities });
 	expect(r.status).toBe("ok");
 	if (r.status !== "ok") throw new Error("unreachable");
 	expect(r.result).toBe("got 1");
-	expect(seen).toEqual(["deals"]);
-	expect(r.actions[0]).toBe('crm.deals({"since":"7d"})');
+	expect(seen).toEqual(["list"]);
+	expect(r.actions[0]).toBe('data.list("records", {"since":"7d"})');
 	// The gate is enforced at the instrumentation layer, so an injected
-	// crm.assign is still default-deny.
-	const gated = makeTool('async function t() { return crm.assign("Acme", "Priya"); }');
+	// nex.send is still default-deny.
+	const gated = makeTool('async function t() { return nex.send("Acme", "hi"); }');
 	const g = await runTool(gated, {}, { capabilities });
 	expect(g.status).toBe("needs_approval");
 });
@@ -252,11 +250,11 @@ test("POST /tools/call runs a read tool ok", async () => {
 });
 
 test("POST /tools/call halts needs_approval, then completes with approved: true", async () => {
-	const r1 = (await (await post({ schema_version: 1, agent: APP, name: "gated_tool", args: { lead: "Acme" } })).json()) as ToolCallResult;
+	const r1 = (await (await post({ schema_version: 1, agent: APP, name: "gated_tool", args: { record: "Acme" } })).json()) as ToolCallResult;
 	expect(r1.status).toBe("needs_approval");
-	expect(r1.gate?.capability).toBe("crm.assign");
+	expect(r1.gate?.capability).toBe("nex.send");
 	const r2 = (await (
-		await post({ schema_version: 1, agent: APP, name: "gated_tool", args: { lead: "Acme" }, approved: true })
+		await post({ schema_version: 1, agent: APP, name: "gated_tool", args: { record: "Acme" }, approved: true })
 	).json()) as ToolCallResult;
 	expect(r2.status).toBe("ok");
 });

--- a/agent/src/toolRuntime.ts
+++ b/agent/src/toolRuntime.ts
@@ -15,7 +15,7 @@
 //     by strict-mode parameter shadowing + a code scan (import/eval rejected).
 //     TODO(security): a permissioned runtime for full authority stripping.
 //
-// SEND-GATE (CQ1, default deny): gated capabilities (`crm.assign`, `nex.send`,
+// SEND-GATE (CQ1, default deny): gated capabilities (`nex.send`,
 // `nex.browser`) halt the run with status="needs_approval" unless the run carries
 // approved=true — the FE renders the human approval card in the chat.
 
@@ -23,7 +23,7 @@ import { buildCapabilities, GATED_CAPABILITIES } from "./capabilities.js";
 import { withRunSignal } from "./runContext.js";
 import type { Tool, ToolCallGate } from "./wire.js";
 
-/** One callable capability (e.g. crm.deals). Args/return are untyped on purpose:
+/** One callable capability (e.g. data.list). Args/return are untyped on purpose:
  * tool code is agent-authored JS, not a typed consumer. */
 export type CapabilityFn = (...args: unknown[]) => unknown;
 
@@ -107,7 +107,6 @@ function labelOf(v: unknown): string {
 
 /** Human-readable gate copy for the approval card ("This will <detail>."). */
 function gateDetail(path: string, args: unknown[]): string {
-	if (path === "crm.assign") return `assign ${labelOf(args[0])} to ${labelOf(args[1])}`;
 	if (path === "nex.send") return `send ${labelOf(args[1])} to ${labelOf(args[0])}`;
 	if (path === "nex.browser") return `control your browser to ${labelOf(args[0])}`;
 	return `run ${path}`;

--- a/agent/src/tools.test.ts
+++ b/agent/src/tools.test.ts
@@ -24,11 +24,11 @@ const MODEL_TOOL_JSON = JSON.stringify({
 // --- deterministic (stub) path ---------------------------------------------
 
 test("authorTool matches a known workflow shape", () => {
-	const t = authorTool("score its fit and route hot leads to the AE");
-	expect(t.name).toBe("scoreAndRouteLead");
-	expect(t.title).toBe("Score & route a lead");
-	expect(t.inputs.map((i) => i.name)).toEqual(["lead"]);
-	expect(t.code).toContain("async function scoreAndRouteLead(lead)");
+	const t = authorTool("score and triage each record by risk");
+	expect(t.name).toBe("scoreAndFlag");
+	expect(t.title).toBe("Score & flag records");
+	expect(t.inputs.map((i) => i.name)).toEqual(["rubric"]);
+	expect(t.code).toContain("async function scoreAndFlag(rubric)");
 });
 
 test("authorTool honors an explicit leading name over a keyword-hijacked shape", () => {
@@ -44,16 +44,16 @@ test("authorTool honors an explicit leading name over a keyword-hijacked shape",
 });
 
 test("authorTool still uses a shape when the explicit name AGREES with it", () => {
-	const t = authorTool("scoreAndRouteLead — Score a lead's fit and route hot ones to the right AE.");
-	expect(t.name).toBe("scoreAndRouteLead");
-	expect(t.title).toBe("Score & route a lead");
+	const t = authorTool("scoreAndFlag — Score and flag records that need attention.");
+	expect(t.name).toBe("scoreAndFlag");
+	expect(t.title).toBe("Score & flag records");
 	expect(t.code).toContain("nex.ai.score");
 });
 
 test("authorTool does not read prose with a dash as an explicit name", () => {
 	// No interior capital → not camelCase → not a name; shape matching applies.
-	const t = authorTool("okay — score its fit and route hot leads to the AE");
-	expect(t.name).toBe("scoreAndRouteLead");
+	const t = authorTool("okay — score and triage each record by risk");
+	expect(t.name).toBe("scoreAndFlag");
 });
 
 test("authorTool synthesizes a name + plain title for an unknown workflow", () => {
@@ -94,7 +94,7 @@ test("authorTool keeps a multi-line description inside the scripted-from comment
 
 test("buildTool returns the tool + a narration (stub by default)", async () => {
 	const r = await buildTool("draft a follow-up for a stalled deal");
-	expect(r.tool?.name).toBe("draftFollowup");
+	expect(r.tool?.name).toBe("draftMessage");
 	expect(r.narration).toContain("Built");
 	expect(r.authored_by).toBe("stub");
 });
@@ -124,7 +124,7 @@ test("buildTool falls back to the stub on a garbage model reply", async () => {
 		complete: fakeComplete("sorry, I cannot help with that"),
 	});
 	expect(r.authored_by).toBe("stub");
-	expect(r.tool?.name).toBe("draftFollowup"); // the deterministic shape, not the model's
+	expect(r.tool?.name).toBe("draftMessage"); // the deterministic shape, not the model's
 });
 
 test("buildTool falls back to the stub when the model call throws", async () => {
@@ -133,7 +133,27 @@ test("buildTool falls back to the stub when the model call throws", async () => 
 	}) as unknown as CompleteFn;
 	const r = await buildTool("draft a follow-up for a stalled deal", { tryModel: true, complete: throwing });
 	expect(r.authored_by).toBe("stub");
-	expect(r.tool?.name).toBe("draftFollowup");
+	expect(r.tool?.name).toBe("draftMessage");
+});
+
+test("buildTool rejects a model tool that calls a capability not in the catalog", async () => {
+	// The model authored valid JS, but against crm.deals — a capability the
+	// domain-neutral catalog no longer exposes. The smoke run's static reference
+	// check must catch it (the single placeholder run might never reach the call)
+	// and fall back to the stub rather than ship a tool that cannot run here.
+	const bogus = JSON.stringify({
+		name: "oldSalesTool",
+		title: "Old sales tool",
+		purpose: "uses a removed capability",
+		inputs: [],
+		code: "async function oldSalesTool() { const d = await crm.deals({ since: '7d' }); return d.length; }",
+	});
+	const r = await buildTool("summarize the deals", {
+		tryModel: true,
+		complete: fakeComplete(bogus),
+	});
+	expect(r.authored_by).toBe("stub");
+	expect(r.tool?.code).not.toContain("crm.deals");
 });
 
 test("buildTool falls back to the stub when the model tool fails validation", async () => {
@@ -200,8 +220,8 @@ test("POST /tools/build creates a tool", async () => {
 	});
 	expect(res.status).toBe(200);
 	const body = await res.json();
-	expect(body.tool.name).toBe("draftFollowup");
-	expect(body.tool.inputs.map((i: { name: string }) => i.name)).toEqual(["deal"]);
+	expect(body.tool.name).toBe("draftMessage");
+	expect(body.tool.inputs.map((i: { name: string }) => i.name)).toEqual(["recordId"]);
 	expect(body.narration).toContain("Built");
 	expect(body.authored_by).toBe("stub");
 });

--- a/agent/src/tools.ts
+++ b/agent/src/tools.ts
@@ -14,6 +14,7 @@
 import { complete, type Context, type Model, type StreamOptions } from "@mariozechner/pi-ai";
 import { apiKeyFor, resolveModel } from "./model.js";
 import { asError, deadlineSignal, textOf } from "./modelCall.js";
+import { buildCapabilities } from "./capabilities.js";
 import { runTool } from "./toolRuntime.js";
 import { extractJson, type Tool, type ToolBuildResult, type ToolInput } from "./wire.js";
 
@@ -29,49 +30,59 @@ interface Shape {
 // Keyword -> tool shape (first match wins). Kept in sync with the FE
 // web/src/operator/tools/mockTools.ts SHAPES so a taught workflow yields the same
 // recognizable tool everywhere.
+// Domain-neutral fallback shapes: keyed on generic workflow verbs (score,
+// summarize, draft) and built on data.* + nex.ai.* so a taught workflow in ANY
+// domain — deals, tickets, candidates, inventory — yields a plausible tool.
+// The prior shapes were sales-only (scoreAndRouteLead/weeklyPipelineSummary/
+// draftFollowup on crm.*), so the no-model fallback minted a CRM tool for every
+// operator (2026-08-17 tools audit). Kept in sync with the FE mirror
+// web/src/operator/tools/mockTools.ts.
 const SHAPES: readonly Shape[] = [
 	{
-		test: /\b(score|fit|route|lead|assign)\b/i,
-		name: "scoreAndRouteLead",
-		title: "Score & route a lead",
-		purpose: "Score a lead's fit and route hot ones to the right AE.",
-		inputs: ["lead"],
+		test: /\b(score|scor|rank|prioriti[sz]e|risk|rate|triage)\b/i,
+		name: "scoreAndFlag",
+		title: "Score & flag records",
+		purpose: "Score each record against a rubric and flag the ones that need attention.",
+		inputs: ["rubric"],
 		code: [
-			"async function scoreAndRouteLead(lead) {",
-			"  const fit = await nex.ai.score(lead, { rubric: 'ICP fit' });",
-			"  if (fit >= 75) {",
-			"    const ae = await crm.ownerFor(lead);",
-			"    await crm.assign(lead, ae);",
-			"    return `Fit ${fit} -> routed to ${ae.name}`;",
+			"async function scoreAndFlag(rubric) {",
+			"  const records = await data.list('records');",
+			"  const scored = [];",
+			"  for (const r of records) {",
+			"    const score = await nex.ai.score(r, { rubric: rubric || 'priority' });",
+			"    scored.push({ record: r, score, flagged: score >= 75 });",
 			"  }",
-			"  return `Fit ${fit} -> left in the queue`;",
+			"  return { count: scored.length, flagged: scored.filter((s) => s.flagged) };",
 			"}",
 		].join("\n"),
 	},
 	{
-		test: /\b(summary|summar|pipeline|digest|weekly|report|recap)\b/i,
-		name: "weeklyPipelineSummary",
-		title: "Weekly pipeline summary",
-		purpose: "Summarize last week's pipeline movement into a glanceable recap.",
-		inputs: [],
+		test: /\b(summar\w*|digest|weekly|report|recap|roll.?up|overview)\b/i,
+		name: "weeklySummary",
+		title: "Weekly summary",
+		purpose: "Summarize this period's records into a glanceable recap.",
+		inputs: ["since"],
 		code: [
-			"async function weeklyPipelineSummary() {",
-			"  const deals = await crm.deals({ since: '7d' });",
-			"  const moved = deals.filter((d) => d.stageChanged);",
-			"  return nex.ai.summarize(moved, { style: 'exec recap' });",
+			"async function weeklySummary(since) {",
+			"  const records = await data.list('records', { since });",
+			"  if (records.length === 0) return { count: 0, summary: 'No records in this period.' };",
+			"  const summary = await nex.ai.summarize(records, { style: 'concise recap' });",
+			"  return { count: records.length, summary };",
 			"}",
 		].join("\n"),
 	},
 	{
-		test: /\b(draft|follow.?up|email|reply|outreach|nudge|stall)\b/i,
-		name: "draftFollowup",
-		title: "Draft a follow-up email",
-		purpose: "Draft a follow-up email for a stalled deal in the rep's voice.",
-		inputs: ["deal"],
+		test: /\b(draft|write|compose|follow.?up|email|reply|outreach|nudge|message|reminder)\b/i,
+		name: "draftMessage",
+		title: "Draft a message",
+		purpose: "Draft a message about a record for your review before it goes out.",
+		inputs: ["recordId"],
 		code: [
-			"async function draftFollowup(deal) {",
-			"  const ctx = await crm.dealContext(deal);",
-			"  return nex.ai.write('follow-up email', { context: ctx, tone: 'warm, brief' });",
+			"async function draftMessage(recordId) {",
+			"  const record = await data.get('records', recordId);",
+			"  if (!record) return { error: `No record found for ${recordId}.` };",
+			"  const draft = await nex.ai.write('message', { context: record, tone: 'warm, brief' });",
+			"  return { recordId, draft, status: 'draft — review before sending' };",
 			"}",
 		].join("\n"),
 	},
@@ -190,26 +201,31 @@ export const TOOL_SCHEMA_PROMPT = `You are the create_tool author for an operato
 
 {"name": str, "title": str, "purpose": str, "inputs": [str], "code": str}
 
-- name: a camelCase callable id, e.g. "scoreAndRouteLead".
-- title: plain language for a non-technical operator, e.g. "Score & route a lead".
+- name: a camelCase callable id, e.g. "scoreAndFlag".
+- title: plain language for a non-technical operator, e.g. "Score & flag records".
 - purpose: one line — what running it does.
 - inputs: the argument names the tool takes (may be empty).
 - code: a complete async JavaScript function named exactly like "name", taking the inputs as parameters, that performs the workflow.
 
-The code runs against these capabilities (use them; do not invent others). All are async — await every call:
+The code runs against these capabilities (use them; do NOT invent others — a call to a capability not listed here will be rejected). All are async — await every call:
+- data.list(collection, { filter, since }) -> array of the app's OWN records (whatever the app persists: deals, tickets, candidates, products). Returns [] when nothing is stored yet.
+- data.get(collection, id) -> one record by id, or null if absent
+- data.upsert(collection, record) -> saves a record to the app's store (confirmation string)
 - nex.ai.score(subject, { rubric }) -> number 0-100
 - nex.ai.summarize(items, { style }) -> string
 - nex.ai.write(kind, { context, tone }) -> string
-- nex.run(input) -> opaque fallback for ONE genuinely un-decomposable step inside a larger flow
 - integrations.call(platform, action, params) -> call a connected integration (e.g. integrations.call("gmail", "GMAIL_FETCH_EMAILS", { max_results: 10 })); reads return data, writes are held for human approval
 - nex.browser(goal) -> drive the operator's browser to accomplish a goal when no integration exists (needs the operator's approval)
 - nex.send(target, content) -> external send (needs the operator's approval)
-- crm.deals({ since }) -> array of deal objects; crm.ownerFor(lead) -> { name }; crm.assign(lead, owner) -> confirmation string; crm.dealContext(deal) -> { deal, stage, lastTouch, owner } (lastTouch is a HUMAN string like "9 days ago", not a date — do not Date.parse it)
+- nex.run(input) -> opaque fallback for ONE genuinely un-decomposable step inside a larger flow
+
+The tool operates on the app's OWN records via data.*: read what the app persists, compute over it, and either return the result or (with approval) send it. There is no built-in CRM — a "deal", "ticket", or "candidate" is just a record in data.list, keyed by whatever the app stores.
 
 Runtime facts your code must respect:
 - Every input parameter arrives as a STRING (the chat binds arguments as text). Parse numbers with Number(...) and guard NaN; JSON.parse only when the operator is told to paste JSON.
 - There is no reliable wall clock in the sandbox — compute "days since" from fields the data provides, never from Date.now().
 - nex.ai.* return plain strings/numbers; do not JSON.parse them.
+- data.list returns records whose fields are whatever the app stored; read fields defensively (a field may be absent) and never assume a fixed schema.
 
 Quality bar (the operator will read and rely on this code):
 - NEVER write a tool whose body is just nex.run(input) — that is not a tool, it is a shrug. Decompose the workflow into real steps with the specific capabilities above; if the workflow genuinely cannot be decomposed, still express the parts you can (validation, shaping, summary) around the one opaque step.
@@ -293,14 +309,73 @@ export async function authorToolWithModel(message: string, opts: ToolAuthorOptio
 }
 
 // ---------------------------------------------------------------------------
+
+/** Flatten the capability tree to the set of valid dotted leaf paths
+ * ("nex.ai.score", "data.list", ...). A capability the catalog does not expose
+ * is a hallucination the single smoke run may never reach (a branch behind a
+ * condition), so we reject it statically too. */
+function catalogPaths(): Set<string> {
+	const paths = new Set<string>();
+	const walk = (node: unknown, prefix: string) => {
+		if (typeof node === "function") {
+			paths.add(prefix);
+			return;
+		}
+		if (node && typeof node === "object") {
+			for (const [k, v] of Object.entries(node)) {
+				walk(v, prefix ? `${prefix}.${k}` : k);
+			}
+		}
+	};
+	walk(buildCapabilities(), "");
+	return paths;
+}
+
+const CATALOG_ROOTS = new Set(["nex", "data", "integrations"]);
+
+/** Scan tool code for `root.a.b(...)` capability calls and return the first that
+ * is not in the catalog, or "" if all referenced capabilities exist. Only chains
+ * rooted at a known capability namespace are checked, so ordinary JS
+ * (`records.filter`, `Math.max`, `JSON.parse`) is never flagged. */
+function unknownCapabilityRef(code: string, valid: Set<string>): string {
+	// root.seg.seg( — a called member chain rooted at a capability namespace.
+	const re = /\b(nex|data|integrations)((?:\.[a-zA-Z_$][\w$]*)+)\s*\(/g;
+	for (let m = re.exec(code); m !== null; m = re.exec(code)) {
+		const path = m[1] + m[2];
+		if (CATALOG_ROOTS.has(m[1]) && !valid.has(path)) return path;
+	}
+	return "";
+}
+
+/** A realistic placeholder for an input, derived from its name, so branches that
+ * inspect the value actually run during the smoke test (a bare "42" made every
+ * email/date branch dead code). */
+function placeholderArg(name: string): string {
+	const n = name.toLowerCase();
+	if (/email|recipient|to\b/.test(n)) return "sample@example.com";
+	if (/date|day|when|since|deadline|due/.test(n)) return "2026-01-15";
+	if (/count|amount|total|qty|quantity|number|score|threshold|price|cost|stock/.test(n)) return "10";
+	if (/id$|_id|^id/.test(n)) return "rec-1";
+	if (/name|title|subject/.test(n)) return "Sample Record";
+	if (/rubric|style|tone|kind/.test(n)) return "priority";
+	return "sample";
+}
+
 /** Execute the freshly-authored tool once in the SIMULATED sandbox with
- * placeholder string args. Returns the crash detail for hard failures
- * (undefined-property crashes, syntax-level issues), or "" when the run
- * completed or failed only in expected gated/simulated ways. */
+ * type-aware placeholder args, AND statically reject references to capabilities
+ * the catalog does not expose. Returns the failure detail for hard failures
+ * (unknown capability, undefined-property crashes, syntax issues), or "" when
+ * the run completed or failed only in expected gated/simulated ways. */
 async function smokeRunTool(tool: Tool): Promise<string> {
+	// Static pass first: a hallucinated capability ("crm.deals" now that the
+	// catalog is data.*) is caught even when it sits behind an unreached branch.
+	const missing = unknownCapabilityRef(tool.code, catalogPaths());
+	if (missing) {
+		return `references a capability that does not exist here: ${missing}`;
+	}
 	try {
 		const args: Record<string, string> = {};
-		for (const input of tool.inputs) args[input.name] = "42";
+		for (const input of tool.inputs) args[input.name] = placeholderArg(input.name);
 		const res = await runTool(tool, args, { timeoutMs: 8_000 });
 		if (res.status === "error" && res.detail) {
 			const d = res.detail;

--- a/web/src/operator/apps/realtimeClient.ts
+++ b/web/src/operator/apps/realtimeClient.ts
@@ -140,7 +140,7 @@ const DRAFT_TOOL = {
           properties: {
             name: {
               type: "string",
-              description: "camelCase tool name, e.g. scoreAndRouteLead.",
+              description: "camelCase tool name, e.g. scoreAndFlag.",
             },
             purpose: {
               type: "string",

--- a/web/src/operator/tools/mockTools.test.ts
+++ b/web/src/operator/tools/mockTools.test.ts
@@ -8,15 +8,15 @@ import {
 } from "./mockTools";
 
 describe("authorToolFromDescription", () => {
-  it("recognizes the score-and-route workflow with a plain title", () => {
+  it("recognizes the score-and-flag workflow with a plain title", () => {
     const t = authorToolFromDescription(
-      "When a new lead comes in, score its fit and route hot ones to the AE",
+      "When a new record comes in, score and triage it by risk",
     );
-    expect(t.name).toBe("scoreAndRouteLead");
-    expect(t.title).toBe("Score & route a lead");
-    expect(t.inputs.map((i) => i.name)).toEqual(["lead"]);
-    expect(t.script).toContain("async function scoreAndRouteLead(lead)");
-    expect(t.createdFrom).toContain("score its fit");
+    expect(t.name).toBe("scoreAndFlag");
+    expect(t.title).toBe("Score & flag records");
+    expect(t.inputs.map((i) => i.name)).toEqual(["rubric"]);
+    expect(t.script).toContain("async function scoreAndFlag(rubric)");
+    expect(t.createdFrom).toContain("score and triage");
   });
 
   it("derives a plain-language title for an unknown workflow", () => {
@@ -27,18 +27,18 @@ describe("authorToolFromDescription", () => {
     expect(t.title).toBe("File it in the folder");
   });
 
-  it("recognizes the weekly summary workflow (no inputs)", () => {
-    const t = authorToolFromDescription("Every Monday summarize the pipeline");
-    expect(t.name).toBe("weeklyPipelineSummary");
-    expect(t.inputs).toEqual([]);
+  it("recognizes the weekly summary workflow", () => {
+    const t = authorToolFromDescription("Every Monday summarize the week");
+    expect(t.name).toBe("weeklySummary");
+    expect(t.inputs.map((i) => i.name)).toEqual(["since"]);
   });
 
-  it("recognizes the follow-up draft workflow", () => {
+  it("recognizes the message-draft workflow", () => {
     const t = authorToolFromDescription(
-      "Draft a follow-up email for a stalled deal",
+      "Draft a follow-up message for a record",
     );
-    expect(t.name).toBe("draftFollowup");
-    expect(t.inputs.map((i) => i.name)).toEqual(["deal"]);
+    expect(t.name).toBe("draftMessage");
+    expect(t.inputs.map((i) => i.name)).toEqual(["recordId"]);
   });
 
   it("synthesizes a camelCase name for an unknown workflow", () => {
@@ -57,10 +57,10 @@ describe("authorToolFromDescription", () => {
 
 describe("callTool", () => {
   it("returns the known shape's canned result", () => {
-    const t = authorToolFromDescription("score and route the lead");
+    const t = authorToolFromDescription("score and triage each record");
     const call = callTool(t, sampleArgsFor(t));
-    expect(call.args).toEqual({ lead: "Acme" });
-    expect(call.result).toMatch(/routed to/i);
+    expect(call.args).toEqual({ rubric: "priority" });
+    expect(call.result).toMatch(/flagged/i);
   });
 
   it("echoes args for an unknown tool", () => {

--- a/web/src/operator/tools/mockTools.ts
+++ b/web/src/operator/tools/mockTools.ts
@@ -20,7 +20,7 @@ export interface Tool {
   id: string;
   /** Plain-language title for a non-technical reader, e.g. "Score & route a lead". */
   title: string;
-  /** Callable identifier the agent invokes, e.g. scoreAndRouteLead. */
+  /** Callable identifier the agent invokes, e.g. scoreAndFlag. */
   name: string;
   /** One line: what running this tool does. */
   purpose: string;
@@ -45,54 +45,58 @@ const SHAPES: ReadonlyArray<{
   sampleResult: string;
 }> = [
   {
-    test: /\b(score|fit|route|lead|assign)\b/i,
-    name: "scoreAndRouteLead",
-    title: "Score & route a lead",
-    purpose: "Score a lead's fit and route hot ones to the right AE.",
-    inputs: [{ name: "lead", type: "string" }],
+    test: /\b(score|scor|rank|prioriti[sz]e|risk|rate|triage)\b/i,
+    name: "scoreAndFlag",
+    title: "Score & flag records",
+    purpose:
+      "Score each record against a rubric and flag the ones that need attention.",
+    inputs: [{ name: "rubric", type: "string" }],
     body: [
-      "const fit = await nex.ai.score(lead, { rubric: 'ICP fit' });",
-      "if (fit >= 75) {",
-      "  const ae = await crm.ownerFor(lead);",
-      "  await crm.assign(lead, ae);",
-      "  return `Fit ${fit} → routed to ${ae.name}`;",
+      "const records = await data.list('records');",
+      "const scored = [];",
+      "for (const r of records) {",
+      "  const score = await nex.ai.score(r, { rubric: rubric || 'priority' });",
+      "  scored.push({ record: r, score, flagged: score >= 75 });",
       "}",
-      "return `Fit ${fit} → left in the queue`;",
+      "return { count: scored.length, flagged: scored.filter((s) => s.flagged) };",
     ].join("\n"),
-    sampleArg: { lead: "Acme" },
-    sampleResult: "Fit 82 → routed to Priya (AE)",
+    sampleArg: { rubric: "priority" },
+    sampleResult: "12 records scored · 3 flagged for attention.",
   },
   {
-    test: /\b(summary|summar|pipeline|digest|weekly|report|recap)\b/i,
-    name: "weeklyPipelineSummary",
-    title: "Weekly pipeline summary",
-    purpose: "Summarize last week's pipeline movement into a glanceable recap.",
-    inputs: [],
+    test: /\b(summar\w*|digest|weekly|report|recap|roll.?up|overview)\b/i,
+    name: "weeklySummary",
+    title: "Weekly summary",
+    purpose: "Summarize this period's records into a glanceable recap.",
+    inputs: [{ name: "since", type: "string" }],
     body: [
-      "const deals = await crm.deals({ since: '7d' });",
-      "const moved = deals.filter((d) => d.stageChanged);",
-      "return nex.ai.summarize(moved, { style: 'exec recap' });",
+      "const records = await data.list('records', { since });",
+      "if (records.length === 0) return { count: 0, summary: 'No records in this period.' };",
+      "const summary = await nex.ai.summarize(records, { style: 'concise recap' });",
+      "return { count: records.length, summary };",
     ].join("\n"),
-    sampleArg: {},
-    sampleResult:
-      "6 deals moved · $420k created · 2 slipped. Biggest: Globex → Negotiation.",
+    sampleArg: { since: "7d" },
+    sampleResult: "18 records this week · summarized into a 3-line recap.",
   },
   {
-    test: /\b(draft|follow.?up|email|reply|outreach|nudge|stall)\b/i,
-    name: "draftFollowup",
-    title: "Draft a follow-up email",
-    purpose: "Draft a follow-up email for a stalled deal in the rep's voice.",
-    inputs: [{ name: "deal", type: "string" }],
+    test: /\b(draft|write|compose|follow.?up|email|reply|outreach|nudge|message|reminder)\b/i,
+    name: "draftMessage",
+    title: "Draft a message",
+    purpose:
+      "Draft a message about a record for your review before it goes out.",
+    inputs: [{ name: "recordId", type: "string" }],
     body: [
-      "const ctx = await crm.dealContext(deal);",
-      "return nex.ai.write('follow-up email', {",
-      "  context: ctx,",
+      "const record = await data.get('records', recordId);",
+      "if (!record) return { error: `No record found for ${recordId}.` };",
+      "const draft = await nex.ai.write('message', {",
+      "  context: record,",
       "  tone: 'warm, brief',",
       "});",
+      "return { recordId, draft, status: 'draft — review before sending' };",
     ].join("\n"),
-    sampleArg: { deal: "Globex" },
+    sampleArg: { recordId: "rec-1" },
     sampleResult:
-      "Subject: Quick nudge on Globex — drafted a 3-line check-in ready to send.",
+      "Drafted a warm, brief message — ready to review before sending.",
   },
 ];
 

--- a/web/src/operator/tools/toolAgentClient.ts
+++ b/web/src/operator/tools/toolAgentClient.ts
@@ -125,7 +125,7 @@ export interface ToolCallOutcome {
   result?: string;
   detail?: string;
   gate?: ToolCallGate;
-  /** Every capability call the tool made, e.g. crm.deals({"since":"7d"}). */
+  /** Every capability call the tool made, e.g. data.list("records", {"since":"7d"}). */
   actions: string[];
 }
 


### PR DESCRIPTION
Part of the 8/10-on-every-axis program. Lifts the **generated-tools** axis (was 3/10) by removing the CRM-shaped steering that made non-sales workflows author garbage.

## The problem
The only store surface authored tools could call was a fabricated sales CRM — `crm.deals/dealContext/ownerFor/assign` returning Globex/Initech/Priya (AE). The prompt documented those shapes as first-class (with a `lastTouch is a HUMAN string, do not Date.parse it` band-aid that only existed because the shape was CRM-specific), and the no-model fallback minted `scoreAndRouteLead`/`weeklyPipelineSummary`/`draftFollowup` for **every** operator. A facilities or inventory workflow had nothing honest to call, so it adapted itself through `crm.deals`.

## What
- **Domain-neutral `data.*` store surface** (list/get/upsert) an authored tool uses to read/write the app's OWN records — deals, tickets, candidates, products. Simulated as an *empty* store (honest: nothing connected), never fabricated rows.
- **Rewrote `TOOL_SCHEMA_PROMPT`** to document only `data.*` + `nex.ai.*`/integrations/browser/send; dropped the CRM lines and the Date.parse band-aid.
- **Re-keyed the fallback shapes** (and the FE `mockTools` mirror in lockstep): `scoreAndFlag` / `weeklySummary` / `draftMessage`, built on `data.*` + `nex.ai.*`.
- **Un-gated the app's own store** (dropped `crm.assign` from the send-gate — writing your own records is not a confused-deputy risk); `nex.send` + `nex.browser` stay gated.
- **Hardened `smokeRunTool`**: a static pass rejects any tool referencing a capability the catalog does not expose (caught even behind an unreached branch — the single placeholder run misses those), and placeholder args are type-aware (email/date/count/id) so realistic branches actually run.

Gets authored tools domain-honest for every persona. A genuine app-data binding (`db.*` routed to the app's real store) is the follow-up for tools that operate on live rows.

## Test plan
- [x] `agent bun test` 115 pass — new: catalog-reference rejection falls back to stub; toolRuntime fixtures rewritten to data.*/nex.send; capabilities gate assertions updated.
- [x] web mockTools (9) + AppToolsChat suites pass; `bunx tsc --noEmit` clean both; biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V9n6uZhopKDdZoXQ37ry17