### PR TITLE
feat(scaffold): mount Notifications, add statusColor, resolve rule contradictions

### DIFF
--- a/internal/team/scaffold_invariants_test.go
+++ b/internal/team/scaffold_invariants_test.go
@@ -1,0 +1,44 @@
+package team
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The scaffold is a template the App Builder copies and edits, so its
+// invariants cannot be unit-tested per app — guard them here against silent
+// drift. These are the exact regressions the 2026-08-17 app-quality audit found.
+
+func scaffoldFile(t *testing.T, rel string) string {
+	t.Helper()
+	path := filepath.Join("..", "..", "templates", "app-scaffold", rel)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read scaffold %s: %v", rel, err)
+	}
+	return string(data)
+}
+
+func TestScaffoldMountsNotifications(t *testing.T) {
+	// AI_RULES mandates "every user-triggered write gets visible feedback" via
+	// @mantine/notifications, but notifications.show() renders NOTHING unless
+	// <Notifications /> is mounted — the rule silently no-oped without it.
+	main := scaffoldFile(t, "src/main.tsx")
+	if !strings.Contains(main, "<Notifications") {
+		t.Fatal("scaffold main.tsx does not mount <Notifications /> — notifications.show() will silently no-op")
+	}
+	if !strings.Contains(main, "@mantine/notifications/styles.css") {
+		t.Fatal("scaffold main.tsx does not import @mantine/notifications styles — notifications render unstyled")
+	}
+}
+
+func TestScaffoldHasStatusColorHelper(t *testing.T) {
+	// DESIGN.md points at src/statusColor.ts as "the scaffold's pattern"; it must
+	// actually exist so the reference is not a dangling promise.
+	src := scaffoldFile(t, "src/statusColor.ts")
+	if !strings.Contains(src, "export function statusColor") {
+		t.Fatal("scaffold statusColor.ts missing the exported helper DESIGN.md references")
+	}
+}

--- a/templates/app-scaffold/AI_RULES.md
+++ b/templates/app-scaffold/AI_RULES.md
@@ -477,18 +477,24 @@ looking ("The confirmation was still open — finish it and try again", "That
 did not go through — try again"), and leave the row/state unchanged so the
 retry is obvious. A silent failure reads as a broken button.
 
-## Data provenance is sacred — no invented rows, no Meta tables
+## Data provenance is sacred — no invented DATA rows
 
-Every persisted row must trace to a bridge source (integration, office data)
-or something the operator typed. NEVER seed placeholder records ("Engineer 1"
-… "Engineer 6", sample deals) into the database — placeholders in the DB are
-indistinguishable from facts and poison every number computed from them.
-When a source is empty, render the honest empty state and let the operator
-add the first real record. If the workspace itself is the only data (no
-integration connected), never persist AI analysis OF THE WORKSPACE'S OWN
-SCAFFOLDING (your build task is not a deal). And no `*Meta` tables holding a
-single "initialized" sentinel — derive first-run from whether the real
-tables are empty.
+Every persisted **data** row must trace to a bridge source (integration, office
+data) or something the operator typed. NEVER seed placeholder records ("Engineer
+1" … "Engineer 6", sample deals) into a data table — placeholders are
+indistinguishable from facts and poison every number computed from them. When a
+source is empty, render the honest empty state and let the operator add the
+first real record. If the workspace itself is the only data (no integration
+connected), never persist AI analysis OF THE WORKSPACE'S OWN SCAFFOLDING (your
+build task is not a deal).
+
+The one legitimate non-source row is the **derive marker** (the `Meta` /
+`initialized` sentinel in the useTable pattern above): it is app-owned CONTROL
+state, not data, and it never appears in a data table or a computed number. Use
+it exactly as shown — a `rows.length` check cannot tell "never derived" from
+"derived, and the honest answer was zero rows", so the explicit marker is
+required. That is the ONLY sentinel allowed; it is not a license for placeholder
+data.
 
 ## Every user-triggered write gets visible feedback
 
@@ -506,3 +512,19 @@ inbox" or point at any surface you have not seen in the host. The honest
 line is: "Submitted — the team picked it up. You will be pinged in the agent
 chat when it needs your sign-off." Copy that sends the operator hunting for
 a page that does not exist reads as a bug even when the write succeeded.
+
+## No half-built tabs, and reach every control by keyboard
+
+Every tab, section, and button you render must be fully wired. NEVER ship a
+tab that shows "Coming soon", a placeholder, or an empty shell you did not
+intend as an honest empty state — if a surface is not built, do not render its
+tab. A dead tab reads as a broken app even when the rest works.
+
+Accessibility minimums (they are also how the operator's keyboard and the
+live-preview inspector reach your UI):
+- Every icon-only button gets an `aria-label` naming its action.
+- Every input has a visible `<label>` or an `aria-label`.
+- Every action is reachable and triggerable by keyboard (a clickable `<div>`
+  is not — use `<button>`).
+- Status reads as more than color: pair a color with text or a shape (use
+  `src/statusColor.ts` for the color, and always render the status word too).

--- a/templates/app-scaffold/src/main.tsx
+++ b/templates/app-scaffold/src/main.tsx
@@ -1,7 +1,9 @@
 import "@mantine/core/styles.css";
+import "@mantine/notifications/styles.css";
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { createTheme, MantineProvider } from "@mantine/core";
+import { Notifications } from "@mantine/notifications";
 import { Refine } from "@refinedev/core";
 
 import { App } from "./App";
@@ -41,6 +43,10 @@ if (root) {
   createRoot(root).render(
     <StrictMode>
       <MantineProvider theme={appTheme} forceColorScheme="dark">
+        {/* Mounted so notifications.show() actually renders — the AI_RULES
+            "every user-triggered write gets visible feedback" rule silently
+            no-ops without this. Keep it. */}
+        <Notifications position="top-right" />
         <Refine
           dataProvider={bridgeDataProvider}
           resources={[

--- a/templates/app-scaffold/src/statusColor.ts
+++ b/templates/app-scaffold/src/statusColor.ts
@@ -1,0 +1,38 @@
+// statusColor — map a workflow status/severity to a Mantine color name, so
+// state reads at a glance (a chip, a badge, a dot) instead of as plain text.
+// DESIGN.md §7 points at this as the pattern; use it for every status you
+// render rather than hardcoding colors per component.
+//
+// Extend the map for your domain's own states — the point is ONE place that
+// decides "approved is green, blocked is red", not a scatter of inline colors.
+
+const STATUS_COLORS: Record<string, string> = {
+  // good / done
+  approved: "green",
+  done: "green",
+  complete: "green",
+  active: "green",
+  paid: "green",
+  ready: "green",
+  // attention / in-progress
+  pending: "yellow",
+  review: "yellow",
+  waiting: "yellow",
+  "in progress": "blue",
+  building: "blue",
+  // bad / blocked
+  rejected: "red",
+  blocked: "red",
+  failed: "red",
+  overdue: "red",
+  churn: "red",
+  // neutral
+  draft: "gray",
+  archived: "gray",
+  inactive: "gray",
+};
+
+export function statusColor(status: string | null | undefined): string {
+  const key = (status ?? "").trim().toLowerCase();
+  return STATUS_COLORS[key] ?? "gray";
+}


### PR DESCRIPTION
Part of the 8/10-on-every-axis program. **App-quality** fixes: the scaffold is where the model copies its patterns, so fixing the scaffold lifts every generated app.

- **Mount `<Notifications />`** (+ its stylesheet) in `main.tsx`. `@mantine/notifications` was already a dependency and AI_RULES mandated *every user-triggered write gets visible feedback* — but `notifications.show()` renders **nothing** without the mount, so the rule silently no-oped. `TestScaffoldMountsNotifications` guards it.
- **Add `src/statusColor.ts`** — the status→color helper DESIGN.md already cites as *the scaffold's pattern* but which did not exist. Guarded by a test.
- **Resolve the AI_RULES self-contradiction**: the `useTable` worked example uses a `Meta`/`initialized` derive marker, while *Data provenance is sacred* forbade exactly that. Reworded to forbid placeholder **data** rows while explicitly allowing the derive marker as app-owned **control** state (a `rows.length` check cannot tell 'never derived' from 'derived, zero rows').
- **Add anti-half-built-tab + accessibility rules** (aria-label on icon buttons, labels on inputs, keyboard-reachable actions, status as more than color).

## Test plan
- [x] `go test ./internal/team` — new scaffold-invariant guards (Notifications mounted + styled, statusColor exists) pass.
- [x] `go build ./...`, `go vet`, gofmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V9n6uZhopKDdZoXQ37ry17