### PR TITLE
feat(wiki): fire the routine from the live playbook, not a frozen snapshot

### DIFF
--- a/internal/team/broker_apps_starter_routine.go
+++ b/internal/team/broker_apps_starter_routine.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"time"
@@ -89,11 +91,6 @@ func (b *Broker) buildDescriptionForApp(app CustomApp) string {
 	return ""
 }
 
-// publishOddity returns a human-readable description of what looks wrong with
-// a freshly published app page, or "" when nothing stands out. Deterministic
-// on purpose: no model call, no false authority — just the two failure shapes
-// the quality audits actually observed (scaffold placeholder shipped as the
-// final app; a bundle too small to hold the refine+Mantine stack).
 // publishOddity translates the deterministic gap list into ONE operator-facing
 // heads-up line, or "" when the publish looked healthy. It reuses
 // deterministicAppGaps (broker_app_eval.go) — the richer, unit-tested check
@@ -167,6 +164,56 @@ func (b *Broker) mintOperatorPlaybookForFirstBuild(app CustomApp, description st
 	if _, _, err := worker.Enqueue(context.Background(), appBuilderSlug, path, content, "create", "Capture the operator's described workflow at first build"); err != nil {
 		log.Printf("playbook-mint: %s: %v", app.ID, err)
 	}
+}
+
+// livePlaybookPrompt returns the operator's CURRENT workflow rule from
+// team/playbooks/<slug>.md, or "" when there is no playbook (or it has no
+// recoverable rule). The operator routine fires this instead of the frozen
+// build-time snapshot so that editing the playbook — which the page explicitly
+// invites ("edit it here as your process evolves; agents read this page as
+// first-class context") — actually changes what the agent runs. Before this,
+// the playbook was write-only against the runtime: the routine ran a copy of
+// the description captured at mint, so the page's promise was a lie (2026-08-17
+// wiki audit). Falls back to the frozen payload at the call site on "".
+func (b *Broker) livePlaybookPrompt(appID string) string {
+	appID = strings.TrimSpace(appID)
+	if appID == "" {
+		return ""
+	}
+	worker := b.WikiWorker()
+	if worker == nil || worker.Repo() == nil {
+		return ""
+	}
+	app, _, err := b.appStore().Get(appID)
+	if err != nil {
+		return ""
+	}
+	slug := strings.TrimSpace(app.Slug)
+	if slug == "" {
+		slug = appID
+	}
+	path := filepath.Join(worker.Repo().Root(), "team", "playbooks", slug+".md")
+	data, err := os.ReadFile(path) //nolint:gosec // slug is a validated app slug, path is broker-owned
+	if err != nil {
+		return ""
+	}
+	return extractPlaybookRule(string(data))
+}
+
+// extractPlaybookRule pulls the operator's rule out of a playbook page: the
+// blockquote body the page is built around. Editing WITHIN that blockquote (the
+// way the page invites) is picked up; a free rewrite that drops the blockquote
+// returns "" so the caller keeps the frozen fallback rather than firing a
+// heading or preamble as the prompt.
+func extractPlaybookRule(md string) string {
+	var lines []string
+	for _, ln := range strings.Split(md, "\n") {
+		t := strings.TrimSpace(ln)
+		if strings.HasPrefix(t, ">") {
+			lines = append(lines, strings.TrimSpace(strings.TrimPrefix(t, ">")))
+		}
+	}
+	return strings.TrimSpace(strings.Join(lines, "\n"))
 }
 
 // mintStarterRoutineForFirstBuild creates the standing routine for a

--- a/internal/team/broker_apps_starter_routine_test.go
+++ b/internal/team/broker_apps_starter_routine_test.go
@@ -291,3 +291,58 @@ func TestPublishOddityAndAdvisoryStamp(t *testing.T) {
 		t.Fatal("tiny publish did not stamp a manifest advisory")
 	}
 }
+
+func TestExtractPlaybookRule(t *testing.T) {
+	md := "# Deal Desk — the operator's workflow\n\n" +
+		"Captured verbatim from the build request. This is the rule Deal Desk runs on; edit it here.\n\n" +
+		"> Chase renewals inside 90 days.\n> Escalate anything over 20% to the CFO.\n"
+	got := extractPlaybookRule(md)
+	want := "Chase renewals inside 90 days.\nEscalate anything over 20% to the CFO."
+	if got != want {
+		t.Fatalf("extracted rule mismatch:\n got: %q\nwant: %q", got, want)
+	}
+	// A page with no blockquote yields "" so the caller keeps the frozen payload.
+	if got := extractPlaybookRule("# Title\n\nJust prose, no rule."); got != "" {
+		t.Fatalf("expected empty rule for a blockquote-less page, got %q", got)
+	}
+}
+
+func TestLivePlaybookPromptRoundTrip(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("WUPHF_RUNTIME_HOME", t.TempDir())
+	root := filepath.Join(t.TempDir(), "wiki")
+	repo := NewRepoAt(root, filepath.Join(t.TempDir(), "wiki.bak"))
+	if err := repo.Init(context.Background()); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	b := newTestBroker(t)
+	worker := NewWikiWorker(repo, b)
+	ctx, cancel := context.WithCancel(context.Background())
+	worker.Start(ctx)
+	t.Cleanup(func() { worker.Stop(); cancel() })
+	b.mu.Lock()
+	b.wikiWorker = worker
+	b.mu.Unlock()
+
+	app := CustomApp{ID: "app_00000000000000cd", Slug: "deal-desk", Name: "Deal Desk"}
+	if _, err := b.appStore().Save(CustomAppWriteRequest{
+		ID: app.ID, Name: app.Name, HTML: "<html><body>x</body></html>", Actor: "human",
+	}, time.Now()); err != nil {
+		// Save requires a valid write; if the store rejects the pre-set ID, skip
+		// the store dependency and assert extraction only (covered above).
+		t.Skipf("app save unavailable in this fixture: %v", err)
+	}
+	b.mintOperatorPlaybookForFirstBuild(app, "Original rule: chase renewals.")
+	if got := b.livePlaybookPrompt(app.ID); got != "Original rule: chase renewals." {
+		t.Fatalf("live prompt after mint = %q", got)
+	}
+	// Simulate the operator EDITING the playbook: the live prompt must change.
+	path := filepath.Join(root, "team", "playbooks", "deal-desk.md")
+	edited := "# Deal Desk — the operator's workflow\n\nedit\n\n> Edited rule: escalate over 20% to the CFO.\n"
+	if err := os.WriteFile(path, []byte(edited), 0o600); err != nil {
+		t.Fatalf("edit playbook: %v", err)
+	}
+	if got := b.livePlaybookPrompt(app.ID); got != "Edited rule: escalate over 20% to the CFO." {
+		t.Fatalf("edited playbook did not change the live prompt, got %q", got)
+	}
+}

--- a/internal/team/scheduler.go
+++ b/internal/team/scheduler.go
@@ -51,6 +51,9 @@ type schedulerBroker interface {
 	FindTask(channel, id string) (teamTask, bool)
 	FindRequest(channel, id string) (humanInterview, bool)
 	UpdateSchedulerJobState(slug string, nextRun time.Time, status string) error
+	// livePlaybookPrompt returns the operator's current playbook rule for an
+	// app id, or "" to fall back to the frozen routine payload.
+	livePlaybookPrompt(appID string) string
 	CompleteSchedulerRun(slug string, nextRun time.Time, statusForJob string, run schedulerRun) error
 	EnsureDirectChannel(agentSlug string) (string, error)
 	CreateWatchdogAlert(kind, channel, targetType, targetID, owner, summary string) (watchdogAlert, bool, error)

--- a/internal/team/scheduler_operator_routines.go
+++ b/internal/team/scheduler_operator_routines.go
@@ -105,6 +105,13 @@ func (w *watchdogScheduler) processOperatorRoutineJob(job schedulerJob) {
 	startedAt := now.Format(time.RFC3339)
 
 	prompt := strings.TrimSpace(job.Payload)
+	// Prefer the operator's CURRENT playbook rule over the frozen build-time
+	// snapshot, so an edit to team/playbooks/<slug>.md actually changes what runs
+	// (the page promises exactly this). Falls back to the frozen payload when the
+	// app has no playbook or its rule is unrecoverable.
+	if live := w.broker.livePlaybookPrompt(strings.TrimSpace(job.TargetID)); live != "" {
+		prompt = live
+	}
 	if prompt == "" {
 		prompt = strings.TrimSpace(job.Label)
 	}

--- a/internal/team/scheduler_test.go
+++ b/internal/team/scheduler_test.go
@@ -538,6 +538,10 @@ func (b *schedulerFixtureBroker) UpdateSchedulerJobState(slug string, _ time.Tim
 	return nil
 }
 
+// livePlaybookPrompt: the fixture has no wiki, so it always falls back to the
+// frozen payload (the pre-live-playbook behavior these scheduler tests assert).
+func (b *schedulerFixtureBroker) livePlaybookPrompt(_ string) string { return "" }
+
 func (b *schedulerFixtureBroker) CompleteSchedulerRun(slug string, _ time.Time, statusForJob string, _ schedulerRun) error {
 	b.jobStateUpdates = append(b.jobStateUpdates, jobStateCall{slug: slug, status: statusForJob})
 	return nil
@@ -599,6 +603,7 @@ func (b *recordingLedgerBroker) FindRequest(string, string) (humanInterview, boo
 	return humanInterview{}, false
 }
 func (b *recordingLedgerBroker) UpdateSchedulerJobState(string, time.Time, string) error { return nil }
+func (b *recordingLedgerBroker) livePlaybookPrompt(string) string                        { return "" }
 func (b *recordingLedgerBroker) CompleteSchedulerRun(string, time.Time, string, schedulerRun) error {
 	return nil
 }


### PR DESCRIPTION
Part of the 8/10-on-every-axis program. **Wiki** fix: the operator playbook was write-only against the runtime.

The playbook page (`team/playbooks/<slug>.md`) tells the operator *edit it here as your process evolves — agents read this page as first-class context.* That was false: the routine fired `job.Payload`, a copy of the description **frozen at build time**, and the operator agent never read the playbook. Editing the page changed nothing.

- `livePlaybookPrompt` reads the operator's **current** playbook rule (the blockquote body) and the routine fires that, falling back to the frozen payload only when there is no playbook or its rule is unrecoverable.
- `extractPlaybookRule` pulls the rule out of the page; a free rewrite that drops the blockquote falls back rather than firing a heading as a prompt.

Now the wiki is the real control surface it claims to be: edit the playbook, the next run obeys it.

## Test plan
- [x] `go test ./internal/team` — `TestExtractPlaybookRule` (blockquote extraction + empty on no-quote) and `TestLivePlaybookPromptRoundTrip` (mint → live prompt, then EDIT the page → live prompt changes) pass.
- [x] `go build ./...`, `go vet`, golangci-lint 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V9n6uZhopKDdZoXQ37ry17