### PR TITLE
feat(operator): the build finish lands, and edits get personality too

### DIFF
--- a/web/src/operator/surfaces/AppBuilderChat.tsx
+++ b/web/src/operator/surfaces/AppBuilderChat.tsx
@@ -189,10 +189,13 @@ export function AppBuilderChat({
   const terminalSinceRef = useRef<{ id: string; at: number } | null>(null);
   // The longest wait in the product gets the shell's cycling Office gerund
   // (the same delight system WorkflowBuilder uses for its 15s wait).
+  // Cycle the Office loading phrases during ANY build wait — including an edit
+  // (a refine can also take a minute). The edit path used to sit on a flat
+  // "Applying your change…" with no personality (2026-08-17 delight audit).
   const workPhrase = useCyclingPhrase(
     OFFICE_LOADING_PHRASES,
     2400,
-    phase === "building" && !editApp,
+    phase === "building",
   );
 
   const build = useBuildApp();
@@ -802,17 +805,17 @@ export function AppBuilderChat({
                   <span />
                   <span />
                 </span>
-                {editApp ? (
-                  <span className="opr-work-phrase">Applying your change…</span>
-                ) : (
-                  <span
-                    key={workPhrase}
-                    className="opr-work-phrase"
-                    aria-hidden={true}
-                  >
-                    {workPhrase ? `${workPhrase}…` : "Building your agent…"}
-                  </span>
-                )}
+                <span
+                  key={workPhrase}
+                  className="opr-work-phrase"
+                  aria-hidden={true}
+                >
+                  {workPhrase
+                    ? `${workPhrase}…`
+                    : editApp
+                      ? "Reworking your agent…"
+                      : "Building your agent…"}
+                </span>
               </div>
             </div>
           ) : null}

--- a/web/src/styles/operator-shell.css
+++ b/web/src/styles/operator-shell.css
@@ -5271,6 +5271,35 @@ th[aria-sort="descending"] .opr-data-sort-caret {
   background: color-mix(in srgb, var(--t-red, #e5534b) 14%, var(--t-surface));
 }
 
+/* The finish card is the emotional beat of the whole build — the agent arrives.
+   A single non-looping scale-in with a green ring that pulses once makes
+   "Hired" land instead of just appearing. Plays once (~460ms); success only —
+   a failed build must not celebrate — and the reduce block below stills it. */
+@keyframes opr-finish-arrive {
+  0% {
+    transform: scale(0.82);
+  }
+  60% {
+    transform: scale(1.04);
+  }
+  100% {
+    transform: scale(1);
+  }
+}
+@keyframes opr-finish-ring {
+  0% {
+    box-shadow: 0 0 0 0 color-mix(in srgb, var(--t-green) 55%, transparent);
+  }
+  100% {
+    box-shadow: 0 0 0 10px transparent;
+  }
+}
+.opr-finish-card:not(.is-failed) .opr-finish-glyph {
+  animation:
+    opr-finish-arrive 460ms cubic-bezier(0.22, 1, 0.36, 1) both,
+    opr-finish-ring 720ms ease-out both;
+}
+
 /* 2026-08-16 delight additions all degrade to their resting state. */
 @media (prefers-reduced-motion: reduce) {
   .opr-modal-scrim,
@@ -5284,7 +5313,8 @@ th[aria-sort="descending"] .opr-data-sort-caret {
   .opr-approval-sent,
   .opr-skeleton::after,
   .opr-builder-scroll .opr-edit-msgwrap,
-  .opr-chat-scroll .opr-msg {
+  .opr-chat-scroll .opr-msg,
+  .opr-finish-card:not(.is-failed) .opr-finish-glyph {
     animation: none;
   }
 }


### PR DESCRIPTION
Part of the 8/10-on-every-axis program. **Delight** fixes for the build experience.

- **The finish lands.** The success avatar on the finish card scales in once with a green ring that pulses once (~460ms, spring ease), so *Hired. It starts now, no orientation needed.* actually **lands** instead of just appearing — the emotional beat of the whole build. Success only (a failed build must not celebrate), and it degrades to its resting state under `prefers-reduced-motion`.
- **Edits get personality too.** The Office loading phrases now cycle during a refine (they were gated to first builds only), so an edit no longer sits on a flat *Applying your change…*; the static fallback reads *Reworking your agent…*.

No gratuitous motion — one played-once beat, reduced-motion-safe.

## Test plan
- [x] AppBuilderChat suite (4) pass; `bunx tsc --noEmit` clean; biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V9n6uZhopKDdZoXQ37ry17