### PR TITLE
feat(wiki): record each routine fire into the playbook execution log

### DIFF
--- a/internal/team/broker_apps_starter_routine.go
+++ b/internal/team/broker_apps_starter_routine.go
@@ -200,6 +200,49 @@ func (b *Broker) livePlaybookPrompt(appID string) string {
 	return extractPlaybookRule(string(data))
 }
 
+// recordOperatorRoutineExecution appends one run of an operator routine to its
+// playbook's execution log (team/playbooks/<slug>.executions.jsonl). This closes
+// the read -> execute -> record loop the compiled skill advertises: before this,
+// the log was ALWAYS empty in the operator flow (ExecutionLog.Append was only
+// reachable via the office-only playbook_execution_record tool), so the playbook
+// never grew a run history worth reading (2026-08-17 wiki audit). Best-effort:
+// a missing app, playbook, or log is a no-op, never a failed fire.
+func (b *Broker) recordOperatorRoutineExecution(appID string, outcome PlaybookOutcome, summary string) {
+	appID = strings.TrimSpace(appID)
+	if appID == "" {
+		return
+	}
+	log := b.PlaybookExecutionLog()
+	if log == nil {
+		return
+	}
+	app, _, err := b.appStore().Get(appID)
+	if err != nil {
+		return
+	}
+	slug := strings.TrimSpace(app.Slug)
+	if slug == "" {
+		slug = appID
+	}
+	// Only record for an app that actually has a playbook — otherwise the log
+	// would accrete for apps the operator never described a rule for.
+	if b.WikiWorker() == nil || b.WikiWorker().Repo() == nil {
+		return
+	}
+	path := filepath.Join(b.WikiWorker().Repo().Root(), "team", "playbooks", slug+".md")
+	if _, statErr := os.Stat(path); statErr != nil {
+		return
+	}
+	summary = strings.TrimSpace(summary)
+	if summary == "" {
+		summary = "Routine fired."
+	}
+	if _, err := log.Append(context.Background(), slug, outcome, summary, "", appBuilderSlug); err != nil {
+		log2 := err
+		_ = log2 // Append already logs; keep the fire clean.
+	}
+}
+
 // extractPlaybookRule pulls the operator's rule out of a playbook page: the
 // blockquote body the page is built around. Editing WITHIN that blockquote (the
 // way the page invites) is picked up; a free rewrite that drops the blockquote

--- a/internal/team/broker_apps_starter_routine_test.go
+++ b/internal/team/broker_apps_starter_routine_test.go
@@ -346,3 +346,47 @@ func TestLivePlaybookPromptRoundTrip(t *testing.T) {
 		t.Fatalf("edited playbook did not change the live prompt, got %q", got)
 	}
 }
+
+func TestRecordOperatorRoutineExecution(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("WUPHF_RUNTIME_HOME", t.TempDir())
+	root := filepath.Join(t.TempDir(), "wiki")
+	repo := NewRepoAt(root, filepath.Join(t.TempDir(), "wiki.bak"))
+	if err := repo.Init(context.Background()); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	b := newTestBroker(t)
+	worker := NewWikiWorker(repo, b)
+	ctx, cancel := context.WithCancel(context.Background())
+	worker.Start(ctx)
+	t.Cleanup(func() { worker.Stop(); cancel() })
+	b.mu.Lock()
+	b.wikiWorker = worker
+	b.mu.Unlock()
+	b.SetPlaybookExecutionLog(NewExecutionLog(worker))
+
+	app := CustomApp{ID: "app_00000000000000ce", Slug: "deal-desk", Name: "Deal Desk"}
+	if _, err := b.appStore().Save(CustomAppWriteRequest{
+		ID: app.ID, Name: app.Name, HTML: "<html><body>x</body></html>", Actor: "human",
+	}, time.Now()); err != nil {
+		t.Skipf("app save unavailable: %v", err)
+	}
+	// No playbook yet -> recording is a no-op.
+	b.recordOperatorRoutineExecution(app.ID, PlaybookOutcomeSuccess, "should not record")
+	if execs, _ := b.PlaybookExecutionLog().List("deal-desk"); len(execs) != 0 {
+		t.Fatalf("recorded an execution with no playbook: %d", len(execs))
+	}
+	// Mint the playbook, then a fire records a real execution.
+	b.mintOperatorPlaybookForFirstBuild(app, "Chase renewals inside 90 days.")
+	b.recordOperatorRoutineExecution(app.ID, PlaybookOutcomeSuccess, "Chased 3 renewals; drafted 3 emails.")
+	execs, err := b.PlaybookExecutionLog().List("deal-desk")
+	if err != nil {
+		t.Fatalf("list executions: %v", err)
+	}
+	if len(execs) != 1 || execs[0].Outcome != PlaybookOutcomeSuccess {
+		t.Fatalf("expected 1 success execution, got %+v", execs)
+	}
+	if !strings.Contains(execs[0].Summary, "Chased 3 renewals") {
+		t.Fatalf("execution summary not recorded: %q", execs[0].Summary)
+	}
+}

--- a/internal/team/scheduler.go
+++ b/internal/team/scheduler.go
@@ -54,6 +54,9 @@ type schedulerBroker interface {
 	// livePlaybookPrompt returns the operator's current playbook rule for an
 	// app id, or "" to fall back to the frozen routine payload.
 	livePlaybookPrompt(appID string) string
+	// recordOperatorRoutineExecution appends one routine run to the app's
+	// playbook execution log; no-op when there is no playbook.
+	recordOperatorRoutineExecution(appID string, outcome PlaybookOutcome, summary string)
 	CompleteSchedulerRun(slug string, nextRun time.Time, statusForJob string, run schedulerRun) error
 	EnsureDirectChannel(agentSlug string) (string, error)
 	CreateWatchdogAlert(kind, channel, targetType, targetID, owner, summary string) (watchdogAlert, bool, error)

--- a/internal/team/scheduler_operator_routines.go
+++ b/internal/team/scheduler_operator_routines.go
@@ -172,6 +172,26 @@ func (w *watchdogScheduler) processOperatorRoutineJob(job schedulerJob) {
 			run.OutputSummary = res.Digest
 			run.Events = append(events, "Completed", "Session "+res.SessionID)
 		}
+		// Append this run to the app's playbook execution log so the wiki grows a
+		// real, readable run history (the compiled skill advertises this loop).
+		var outcome PlaybookOutcome
+		switch run.Status {
+		case "ok":
+			// A paused-for-approval run HAPPENED but did not complete its send.
+			if strings.HasPrefix(run.OutputSummary, "Paused for approval") {
+				outcome = PlaybookOutcomePartial
+			} else {
+				outcome = PlaybookOutcomeSuccess
+			}
+		default:
+			outcome = PlaybookOutcomeAborted
+		}
+		execSummary := strings.TrimSpace(run.OutputSummary)
+		if execSummary == "" {
+			execSummary = strings.TrimSpace(run.Message)
+		}
+		w.broker.recordOperatorRoutineExecution(strings.TrimSpace(job.TargetID), outcome, execSummary)
+
 		// Status "scheduled" (not "done") keeps the cron alive — same contract
 		// as processAgentJob.
 		_ = w.broker.CompleteSchedulerRun(job.Slug, nextRun, "scheduled", run)

--- a/internal/team/scheduler_test.go
+++ b/internal/team/scheduler_test.go
@@ -540,7 +540,8 @@ func (b *schedulerFixtureBroker) UpdateSchedulerJobState(slug string, _ time.Tim
 
 // livePlaybookPrompt: the fixture has no wiki, so it always falls back to the
 // frozen payload (the pre-live-playbook behavior these scheduler tests assert).
-func (b *schedulerFixtureBroker) livePlaybookPrompt(_ string) string { return "" }
+func (b *schedulerFixtureBroker) livePlaybookPrompt(_ string) string                             { return "" }
+func (b *schedulerFixtureBroker) recordOperatorRoutineExecution(string, PlaybookOutcome, string) {}
 
 func (b *schedulerFixtureBroker) CompleteSchedulerRun(slug string, _ time.Time, statusForJob string, _ schedulerRun) error {
 	b.jobStateUpdates = append(b.jobStateUpdates, jobStateCall{slug: slug, status: statusForJob})
@@ -602,8 +603,9 @@ func (b *recordingLedgerBroker) FindTask(string, string) (teamTask, bool) { retu
 func (b *recordingLedgerBroker) FindRequest(string, string) (humanInterview, bool) {
 	return humanInterview{}, false
 }
-func (b *recordingLedgerBroker) UpdateSchedulerJobState(string, time.Time, string) error { return nil }
-func (b *recordingLedgerBroker) livePlaybookPrompt(string) string                        { return "" }
+func (b *recordingLedgerBroker) UpdateSchedulerJobState(string, time.Time, string) error        { return nil }
+func (b *recordingLedgerBroker) livePlaybookPrompt(string) string                               { return "" }
+func (b *recordingLedgerBroker) recordOperatorRoutineExecution(string, PlaybookOutcome, string) {}
 func (b *recordingLedgerBroker) CompleteSchedulerRun(string, time.Time, string, schedulerRun) error {
 	return nil
 }


### PR DESCRIPTION
Pushes the **wiki** axis toward 8. The playbook now has a live rule (#1203); this gives it a growing run history.

The compiled skill advertises a read → execute → record loop, but the execution log (`team/playbooks/<slug>.executions.jsonl`) was **always empty** in the operator flow — `ExecutionLog.Append` was only reachable via an office-only tool, so the playbook never accreted a run trail.

- `recordOperatorRoutineExecution` maps the routine's app id → playbook slug and appends one execution per fire from the scheduler completion path: **success**, **partial** (paused at the send-gate), or **aborted** (error).
- Best-effort and gated on the app actually having a playbook, so it never accretes noise or fails a fire.

Now the wiki grows a real, readable run history the operator and agents can consult.

## Test plan
- [x] `go test ./internal/team` — new `TestRecordOperatorRoutineExecution` (no-op without a playbook; records a success with the summary once minted).
- [x] `go build ./...`, `go vet`, golangci-lint 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V9n6uZhopKDdZoXQ37ry17