### PR TITLE
fix(data-tab): table rendered as flexbox not a grid (class collision)

### DIFF
--- a/web/src/operator/surfaces/AppDataTab.tsx
+++ b/web/src/operator/surfaces/AppDataTab.tsx
@@ -586,7 +586,7 @@ function ModelTableView({ table }: { table: ModelTable }) {
                   return (
                     <Fragment key={`row-${start + i}`}>
                       <tr
-                        className={`opr-data-row${open ? " is-open" : ""}`}
+                        className={`opr-dt-row${open ? " is-open" : ""}`}
                         onClick={() => setOpenRow(open ? null : row)}
                       >
                         {table.columns.map((c) => (

--- a/web/src/styles/operator-shell.css
+++ b/web/src/styles/operator-shell.css
@@ -5118,13 +5118,13 @@
   padding: 1px 8px;
   white-space: nowrap;
 }
-.opr-data-row {
+.opr-dt-row {
   cursor: pointer;
 }
-.opr-data-row:hover td {
+.opr-dt-row:hover td {
   background: var(--t-tint-accent);
 }
-.opr-data-row.is-open td {
+.opr-dt-row.is-open td {
   background: var(--t-tint-2);
 }
 .opr-data-detail-row td {
@@ -5220,10 +5220,13 @@
   padding: 0;
 }
 .opr-data-sort-btn {
+  /* Sizes to its own content (name + type + caret) so it never forces the
+     column wider than the body cells — a width:100% here desynced the header
+     from the body in the auto table-layout (2026-08-18). */
   display: inline-flex;
   align-items: baseline;
   gap: 6px;
-  width: 100%;
+  max-width: 100%;
   background: none;
   border: 0;
   cursor: pointer;
@@ -5231,6 +5234,7 @@
   padding: 8px 10px;
   color: inherit;
   font: inherit;
+  white-space: nowrap;
 }
 .opr-data-sort-btn:hover {
   background: var(--t-tint-accent);
@@ -5240,7 +5244,7 @@
   outline-offset: -2px;
 }
 .opr-data-sort-caret {
-  margin-left: auto;
+  margin-left: 4px;
   font-size: 9px;
   color: var(--t-faint);
 }


### PR DESCRIPTION
A user hit this live: the Data tab table is unreadable with real multi-column data — headers and body cells don't line up.

**Root cause (two bugs):**
1. **Class collision** — the table `<tr>` used `opr-data-row`, which is *also* a `display:flex` key-value row in another component (operator-shell.css:4020). The tbody rows inherited that flex, so the header laid out as table columns (1695px wide) while the body packed left as flexbox (579px) — they never aligned. Renamed the table row to `opr-dt-row`.
2. **width:100% sort button** — forced the first column to grab all the slack in auto table-layout. Sizes to content now.

**Verified live:** header row width == body row width (1215px == 1215px), `tr` is `table-row`, columns align, dates and empty cells render cleanly.

Note: this was a pre-existing collision the Data-tab work inherited — my earlier data-tab '8' was overstated while the table was visually broken with real data.

## Test plan
- [x] AppDataTab.test.tsx 17 pass (text-based, unaffected by the rename); biome clean; verified live on a fresh workspace with 9-column data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V9n6uZhopKDdZoXQ37ry17