### PR TITLE
feat(tools): authored tools produce real, durable output end to end

### DIFF
--- a/agent/src/capabilities.test.ts
+++ b/agent/src/capabilities.test.ts
@@ -117,6 +117,21 @@ test("real nex.ai.summarize returns the model's text", async () => {
 	expect(await cap(tree, "nex.ai.summarize")([1, 2, 3])).toBe("6 deals moved; Globex leads.");
 });
 
+test("nex.ai.summarize feeds the FULL input to the model, not a 57-char preview", async () => {
+	let captured = "";
+	const capturing = (async (_m: unknown, ctx: { messages: { content: unknown }[] }) => {
+		captured = String(ctx.messages?.[0]?.content ?? "");
+		return { content: [{ type: "text", text: "ok" }] };
+	}) as unknown as CompleteFn;
+	// Meaningful content sits well past char 57; preview() used to cut everything
+	// after ~57 chars, so the model saw its own input "cut off" and refused.
+	const items = Array.from({ length: 12 }, (_, i) => `incident-${i}: Falcon Logistics outage breached SLA`);
+	const tree = buildCapabilities({ aiModel: MODEL, complete: capturing });
+	await cap(tree, "nex.ai.summarize")(items);
+	expect(captured.length).toBeGreaterThan(200);
+	expect(captured).toContain("incident-11");
+});
+
 // --- real integrations.call (stubbed broker) ------------------------------------
 
 const BROKER: CapabilityConfig = { brokerUrl: "http://broker.test", brokerToken: "tok" };

--- a/agent/src/capabilities.ts
+++ b/agent/src/capabilities.ts
@@ -97,6 +97,23 @@ function preview(v: unknown): string {
 	return s.length > 60 ? `${s.slice(0, 57)}…` : s;
 }
 
+/** Serialize a value as MODEL INPUT — the full content up to `max` chars, not
+ * the 60-char label preview() produces. preview() is for action tracing; feeding
+ * it to nex.ai.* was the reason summaries read "your data got cut off" — the
+ * model only ever saw the first 57 characters of its own input. */
+function modelInput(v: unknown, max = 6000): string {
+	let s: string;
+	if (typeof v === "string") s = v;
+	else {
+		try {
+			s = v === undefined ? "" : JSON.stringify(v, null, 1);
+		} catch {
+			s = String(v);
+		}
+	}
+	return s.length > max ? `${s.slice(0, max)}… (input truncated)` : s;
+}
+
 /** Deterministic hash of the subject -> 55..95 (a plausible fit score). */
 function hashScore(subject: unknown): number {
 	const s = typeof subject === "string" ? subject : preview(subject);
@@ -139,6 +156,12 @@ export function simulatedCapabilities(): CapabilityTree {
 			run: (input: unknown) => simRun(input),
 			send: (target: unknown) => `Sent to ${labelOf(target)} (simulated).`,
 			browser: (goal: unknown) => `Would drive the browser: ${labelOf(goal)} (browser engine not configured).`,
+			// The reference "now" as an ISO string. Capabilities execute HOST-side
+			// (in the sidecar, which has a reliable clock) — only the sandboxed
+			// worker's own Date.now() is unreliable. So a tool that needs the current
+			// time (SLA windows, "days since") calls `await nex.now()` instead of
+			// Date.now(); this is the ONE trustworthy clock inside a tool.
+			now: () => new Date().toISOString(),
 		},
 		// Domain-neutral store surface: an authored tool reads and writes the
 		// app's OWN records, whatever the domain (deals, tickets, candidates,
@@ -192,7 +215,7 @@ function realAI(cfg: CapabilityConfig): CapabilityTree {
 				const out = await aiComplete(
 					cfg,
 					"You score business subjects 0-100. Output ONLY an integer, nothing else.",
-					`Rubric: ${rubric}\nSubject: ${preview(subject)}\nScore 0-100:`,
+					`Rubric: ${rubric}\nSubject: ${modelInput(subject, 4000)}\nScore 0-100:`,
 				);
 				const n = Number.parseInt(out.replace(/[^0-9]/g, " ").trim().split(/\s+/)[0] ?? "", 10);
 				if (Number.isNaN(n)) throw new Error("non-numeric score");
@@ -207,7 +230,7 @@ function realAI(cfg: CapabilityConfig): CapabilityTree {
 				return await aiComplete(
 					cfg,
 					`You summarize data for a busy operator. Style: ${style}. Output the summary text only.`,
-					preview(items).slice(0, 4000),
+					modelInput(items),
 				);
 			} catch {
 				return simSummarize(items);
@@ -219,7 +242,7 @@ function realAI(cfg: CapabilityConfig): CapabilityTree {
 				return await aiComplete(
 					cfg,
 					`You write a ${labelOf(kind)} for a busy operator. Tone: ${labelOf(o.tone ?? "warm, brief")}. Output the text only.`,
-					`Context: ${preview(o.context ?? "none")}`,
+					`Context: ${modelInput(o.context ?? "none")}`,
 				);
 			} catch {
 				return `Drafted ${labelOf(kind)} — warm, brief, ready to review (simulated).`;
@@ -338,6 +361,35 @@ function realData(cfg: CapabilityConfig): CapabilityTree {
 			return `Saved to ${String(collection)}.`;
 		},
 	};
+}
+
+// fetchAppSchema GETs the app's real table schema (names + columns) from the
+// broker so the tool author can steer an authored tool onto the SAME tables the
+// app already uses. Returns a compact one-line-per-table string, or "" when
+// there is no broker/app or the app has no tables yet. Best-effort: never throws.
+export async function fetchAppSchema(cfg: CapabilityConfig): Promise<string> {
+	if (!cfg.brokerUrl || !cfg.brokerToken || !cfg.appId) return "";
+	const base = cfg.brokerUrl.replace(/\/$/, "");
+	const fetchFn = cfg.fetch ?? fetch;
+	try {
+		const res = await fetchFn(`${base}/apps/${encodeURIComponent(cfg.appId)}/db`, {
+			headers: { authorization: `Bearer ${cfg.brokerToken}` },
+		});
+		if (!res.ok) return "";
+		const body = (await res.json()) as { tables?: { name?: string; columns?: { name?: string }[] }[] };
+		const tables = Array.isArray(body.tables) ? body.tables : [];
+		const lines = tables
+			// Meta is app-owned control state (the derive marker), not a data table
+			// a tool should read — leave it out of the author's schema view.
+			.filter((t) => (t.name ?? "").trim() && (t.name ?? "").toLowerCase() !== "meta")
+			.map((t) => {
+				const cols = Array.isArray(t.columns) ? t.columns.map((c) => (c.name ?? "").trim()).filter(Boolean) : [];
+				return `- ${t.name}(${cols.join(", ")})`;
+			});
+		return lines.join("\n");
+	} catch {
+		return "";
+	}
 }
 
 function realBrowser(cfg: CapabilityConfig): CapabilityFn {

--- a/agent/src/routineRunner.ts
+++ b/agent/src/routineRunner.ts
@@ -16,6 +16,7 @@
 // as an "md" artifact (<kebab-name>-run-<n>.md).
 
 import { buildCapabilities, capabilityConfigFromEnv } from "./capabilities.js";
+import { runtimeAICapabilityConfig } from "./serviceAuthor.js";
 import type { PiSessions } from "./sessions.js";
 import type { AgentStore } from "./store.js";
 import { type CapabilityTree, runTool, type ToolRunResult } from "./toolRuntime.js";
@@ -111,7 +112,7 @@ export async function runRoutine(agent: string, routine: RoutineRunRequest, deps
 	if (tool) {
 		const execute = deps.execute ?? runTool;
 		// Pass the app id so a fired routine's tool reads/writes THIS app's store.
-		const capabilities = deps.capabilities ?? buildCapabilities({ ...capabilityConfigFromEnv(), appId: agent });
+		const capabilities = deps.capabilities ?? buildCapabilities({ ...capabilityConfigFromEnv(), ...runtimeAICapabilityConfig(), appId: agent });
 		const timeoutMs = Number(process.env.TOOL_CALL_TIMEOUT_MS) || undefined;
 		// Give the tool the routine's prompt as `input`. A synthesized fallback tool
 		// takes a single `input` param (tools.ts authorTool) — without this it ran on

--- a/agent/src/service.ts
+++ b/agent/src/service.ts
@@ -16,14 +16,14 @@
 
 import { timingSafeEqual } from "node:crypto";
 import { streamWorkflow } from "./buildAgent.js";
-import { buildCapabilities, capabilityConfigFromEnv } from "./capabilities.js";
+import { buildCapabilities, capabilityConfigFromEnv, fetchAppSchema } from "./capabilities.js";
 import { runWorkflow } from "./executor.js";
 import { providersPayload } from "./providers.js";
 import { runRoutine } from "./routineRunner.js";
 import { PiSessions } from "./sessions.js";
 import { AgentStore, defaultDataDir, sanitizeAgentId } from "./store.js";
 import { runTool } from "./toolRuntime.js";
-import { resolveToolAuthoring } from "./serviceAuthor.js";
+import { resolveToolAuthoring, runtimeAICapabilityConfig } from "./serviceAuthor.js";
 import { buildTool } from "./tools.js";
 import { type BuildRequest, type RunRequest, SCHEMA_VERSION, type ToolBuildRequest, type ToolCallRequest, type WorkflowSpec } from "./wire.js";
 
@@ -211,7 +211,10 @@ export function createServer(opts: ServerOptions = {}) {
 				const app = typeof body.app === "string" ? body.app.trim() : "";
 				if (app && !validAgentId(app)) return json({ error: "invalid tool build request: unusable app id" }, 400);
 				const authoring = resolveAuthoring();
-				const outcome = await buildTool(body.message, { ...(authoring ?? {}), tryModel: authoring != null, signal: req.signal });
+				// Steer the authored tool onto the app's REAL tables: fetch its
+				// schema so data.* calls use the names the app already wrote.
+				const buildSchema = app ? await fetchAppSchema({ ...capabilityConfigFromEnv(), appId: app }) : "";
+				const outcome = await buildTool(body.message, { ...(authoring ?? {}), tryModel: authoring != null, signal: req.signal, appSchema: buildSchema });
 				console.log(`tools/build authored_by=${outcome.authored_by} via=${authoring?.via ?? "none"} app=${app || "-"}`);
 				// `app` set -> PERSIST the authored tool under that agent (re-authoring a
 				// same-named tool bumps version); the response tool carries `version`.
@@ -279,7 +282,7 @@ export function createServer(opts: ServerOptions = {}) {
 					await runTool({ ...tool, inputs: rawInputs === undefined ? [] : rawInputs }, body.args ?? {}, {
 						approved: body.approved === true,
 						// Pass the app id so data.* binds to THIS app's real store.
-						capabilities: buildCapabilities({ ...capabilityConfigFromEnv(), appId: agent }),
+						capabilities: buildCapabilities({ ...capabilityConfigFromEnv(), ...runtimeAICapabilityConfig(), appId: agent }),
 						timeoutMs,
 					}),
 				);
@@ -322,13 +325,16 @@ export function createServer(opts: ServerOptions = {}) {
 				// Routines author through the same per-host resolution as /tools/build,
 				// so a machine with a real model authors real tools on routine fires too.
 				const routineAuthoring = resolveAuthoring();
+				// A routine that authors a tool on the fly must also target the app's
+				// real tables — fetch the schema once and pass it to the author.
+				const routineSchema = await fetchAppSchema({ ...capabilityConfigFromEnv(), appId: agent });
 				const result = await runRoutine(
 					agent,
 					{ slug: body.slug.trim(), name: body.name.trim(), prompt: body.prompt },
 					{
 						store,
 						sessions,
-						author: (p) => buildTool(p, { ...(routineAuthoring ?? {}), tryModel: routineAuthoring != null }),
+						author: (p) => buildTool(p, { ...(routineAuthoring ?? {}), tryModel: routineAuthoring != null, appSchema: routineSchema }),
 					},
 				);
 				return json({ status: result.status, digest: result.outcome, session_id: result.session.id });

--- a/agent/src/serviceAuthor.test.ts
+++ b/agent/src/serviceAuthor.test.ts
@@ -4,7 +4,7 @@
 
 import { expect, test } from "bun:test";
 import type { Provider } from "./providers.js";
-import { resolveToolAuthoring } from "./serviceAuthor.js";
+import { resolveToolAuthoring, runtimeAICapabilityConfig } from "./serviceAuthor.js";
 
 const none: Provider[] = [
 	{ id: "anthropic", label: "Anthropic", available: false, via: "none" },
@@ -35,4 +35,24 @@ test("ANTHROPIC_API_KEY outranks the CLI; ollama is the last resort; none -> stu
 	expect(resolveToolAuthoring({}, withProviders({ anthropic: "api_key" }))?.via).toBe("api_key");
 	expect(resolveToolAuthoring({}, withProviders({ ollama: "local" }))?.via).toBe("ollama");
 	expect(resolveToolAuthoring({}, () => none)).toBeUndefined();
+});
+
+// runtimeAICapabilityConfig reuses the authoring resolver so runtime nex.ai.*
+// runs on the SAME engine that authored the tool — the fix for a subscription
+// operator whose authored tool otherwise emits "nothing actually ran" stubs.
+test("runtimeAICapabilityConfig: subscription CLI -> real model + complete fn", () => {
+	const cfg = runtimeAICapabilityConfig({}, withProviders({ anthropic: "subscription_cli" }));
+	expect(cfg.aiModel?.provider).toBe("anthropic");
+	expect(typeof cfg.complete).toBe("function");
+});
+
+test("runtimeAICapabilityConfig: nothing available -> {} (nex.ai.* stays simulated)", () => {
+	const cfg = runtimeAICapabilityConfig({}, () => none);
+	expect(cfg.aiModel).toBeUndefined();
+	expect(cfg.complete).toBeUndefined();
+});
+
+test("runtimeAICapabilityConfig: TOOL_AUTHOR_MODEL=1 resolves the core model", () => {
+	const cfg = runtimeAICapabilityConfig({ TOOL_AUTHOR_MODEL: "1" }, withProviders({}));
+	expect(cfg.aiModel).toBeDefined();
 });

--- a/agent/src/serviceAuthor.ts
+++ b/agent/src/serviceAuthor.ts
@@ -19,7 +19,7 @@
 // never eats a model timeout — the original reason authoring was opt-in.
 
 import { getModel, type Model } from "@mariozechner/pi-ai";
-import { ollamaModel } from "./model.js";
+import { ollamaModel, resolveModel } from "./model.js";
 import { detectProviders } from "./providers.js";
 import type { ToolAuthorOptions } from "./tools.js";
 
@@ -125,4 +125,27 @@ export function resolveToolAuthoring(
 		return { via: "ollama", model: ollamaModel() };
 	}
 	return undefined;
+}
+
+
+/**
+ * Resolve the engine for RUNTIME `nex.ai.*` capabilities (summarize/score/write
+ * executed inside an authored tool), reusing the SAME resolver that authored the
+ * tool. Without this, a subscription-login operator (`claude` CLI on PATH, no env
+ * key) authors a real tool that then emits the "nothing actually ran" stub at
+ * execution, because the old runtime gate (TOOL_RUNTIME_MODEL=1 -> Ollama only)
+ * never sees the subscription path. Returns {} when no engine is available, so
+ * nex.ai.* stays honestly simulated rather than throwing.
+ */
+export function runtimeAICapabilityConfig(
+	env: Record<string, string | undefined> = process.env,
+	providers = detectProviders,
+): { aiModel?: Model<string>; complete?: ToolAuthorOptions["complete"] } {
+	const resolved = resolveToolAuthoring(env, providers);
+	if (!resolved) return {};
+	// env_override (TOOL_AUTHOR_MODEL=1) carries no model; resolve the core
+	// Ollama/HARNESS_PROVIDER model the same way authorToolWithModel would.
+	const aiModel = resolved.model ?? (resolved.via === "env_override" ? resolveModel() : undefined);
+	if (!aiModel) return {};
+	return { aiModel, complete: resolved.complete };
 }

--- a/agent/src/toolRuntime.test.ts
+++ b/agent/src/toolRuntime.test.ts
@@ -224,14 +224,26 @@ async function* fakeBuild() {
 const APP = "app1";
 let server: ReturnType<typeof createServer>;
 let base: string;
+let priorAuthorModel: string | undefined;
 beforeAll(() => {
+	// These HTTP tests exercise the /tools/call plumbing against the SIMULATED
+	// runtime, not a live model. Pin authoring off so runtimeAICapabilityConfig
+	// does not resolve an ambient provider (a CI runner with ANTHROPIC_API_KEY
+	// would otherwise make nex.ai.* fire a real, slow network call and this test
+	// would flake on a socket timeout). Restored in afterAll.
+	priorAuthorModel = process.env.TOOL_AUTHOR_MODEL;
+	process.env.TOOL_AUTHOR_MODEL = "0";
 	const store = new AgentStore(mkdtempSync(join(tmpdir(), "wuphf-toolcall-")));
 	store.upsertTool(APP, READ_TOOL);
 	store.upsertTool(APP, GATED_TOOL);
 	server = createServer({ port: 0, buildStream: fakeBuild, store });
 	base = server.url.toString().replace(/\/$/, "");
 });
-afterAll(() => server.stop(true));
+afterAll(() => {
+	if (priorAuthorModel === undefined) delete process.env.TOOL_AUTHOR_MODEL;
+	else process.env.TOOL_AUTHOR_MODEL = priorAuthorModel;
+	server.stop(true);
+});
 
 function post(body: unknown): Promise<Response> {
 	return fetch(`${base}/tools/call`, {

--- a/agent/src/toolRuntime.ts
+++ b/agent/src/toolRuntime.ts
@@ -46,7 +46,16 @@ export type ToolRunResult =
 	| { status: "needs_approval"; gate: ToolCallGate; actions: string[] }
 	| { status: "error"; detail: string; actions: string[] };
 
-const DEFAULT_TIMEOUT_MS = 5000;
+// Outer hard-kill for a whole tool run. It must exceed the time a tool spends
+// AWAITING its capabilities, not just its CPU work: a tool that calls nex.ai.*
+// (each capability call independently bounded at DEFAULT_CAP_TIMEOUT_MS = 60s)
+// can legitimately spend tens of seconds waiting on a real model. The old 5s
+// default silently killed every AI-using tool at 5s the moment runtime nex.ai.*
+// became real (2026-08-18) — it was only ever survivable while nex.ai.* was the
+// instant simulation. 120s covers a couple of sequential real model calls; hosts
+// running heavier tools raise it via TOOL_CALL_TIMEOUT_MS. The runaway-sync-loop
+// guard still fires — just at 120s on an isolated worker thread, not 5s.
+const DEFAULT_TIMEOUT_MS = 120_000;
 
 // Capabilities that mutate the outside world (or seize the operator's browser)
 // halt for the approval card unless the run is approved. The allow-list lives

--- a/agent/src/toolSandboxWorker.ts
+++ b/agent/src/toolSandboxWorker.ts
@@ -54,6 +54,23 @@ function plain(v: unknown): unknown {
 	}
 }
 
+/** Serialize a tool's FINAL return value for the operator. Unlike preview()
+ * (a 60-char label for action tracing), this preserves the whole output — an
+ * authored tool that returns a structured summary object must reach the
+ * execution log intact, not clipped to 57 chars. Bounded only to keep a
+ * pathological payload from bloating the log / postMessage. */
+function serializeResult(v: unknown): string {
+	if (typeof v === "string") return v;
+	let s: string;
+	try {
+		s = v === undefined ? "" : JSON.stringify(v);
+	} catch {
+		s = String(v);
+	}
+	const MAX = 200_000;
+	return s.length > MAX ? `${s.slice(0, MAX)}… (result truncated)` : s;
+}
+
 /** Rebuild the capability tree from dotted paths as RPC proxies to the host. */
 function buildProxyTree(capPaths: string[]): Record<string, unknown> {
 	const root: Record<string, unknown> = {};
@@ -112,7 +129,7 @@ self.onmessage = (ev: MessageEvent) => {
 				...msg.argValues,
 				...msg.shadowedGlobals.map(() => undefined),
 			);
-			postMessage({ t: "done", result: typeof value === "string" ? value : preview(value) });
+			postMessage({ t: "done", result: serializeResult(value) });
 		} catch (e) {
 			postMessage({ t: "err", detail: e instanceof Error ? e.message : String(e) });
 		}

--- a/agent/src/tools.ts
+++ b/agent/src/tools.ts
@@ -211,6 +211,7 @@ The code runs against these capabilities (use them; do NOT invent others — a c
 - data.list(collection, { filter, since }) -> array of the app's OWN records (whatever the app persists: deals, tickets, candidates, products). Returns [] when nothing is stored yet.
 - data.get(collection, id) -> one record by id, or null if absent
 - data.upsert(collection, record) -> saves a record to the app's store (confirmation string)
+- nex.now() -> the current time as an ISO string (the ONE reliable clock — use this for "now", SLA windows, "hours since", never Date.now())
 - nex.ai.score(subject, { rubric }) -> number 0-100
 - nex.ai.summarize(items, { style }) -> string
 - nex.ai.write(kind, { context, tone }) -> string
@@ -223,7 +224,7 @@ The tool operates on the app's OWN records via data.*: read what the app persist
 
 Runtime facts your code must respect:
 - Every input parameter arrives as a STRING (the chat binds arguments as text). Parse numbers with Number(...) and guard NaN; JSON.parse only when the operator is told to paste JSON.
-- There is no reliable wall clock in the sandbox — compute "days since" from fields the data provides, never from Date.now().
+- Date.now() inside the tool body is unreliable — get the current time from await nex.now() (an ISO string) and compute "hours/days since" from the record's own timestamp fields against that.
 - nex.ai.* return plain strings/numbers; do not JSON.parse them.
 - data.list returns records whose fields are whatever the app stored; read fields defensively (a field may be absent) and never assume a fixed schema.
 
@@ -248,6 +249,19 @@ export interface ToolAuthorOptions {
 	timeoutMs?: number;
 	/** Override the pi-ai completion call in tests so they never hit a live model. */
 	complete?: typeof complete;
+	/** A compact description of the app's EXISTING data tables (name + columns),
+	 * injected into the prompt so an authored tool reads/writes the SAME tables
+	 * the app already uses via data.* instead of inventing its own names (which
+	 * left the tool operating on a phantom, empty store — 2026-08-18 loop audit). */
+	appSchema?: string;
+}
+
+/** Build the "your app's tables" block for the prompt from a fetched schema
+ * string, or "" when there is none (a fresh app with no tables yet). */
+function appSchemaBlock(schema: string | undefined): string {
+	const s = (schema ?? "").trim();
+	if (!s) return "";
+	return `\n\nTHIS APP ALREADY HAS THESE TABLES — use these EXACT table and column names in every data.* call; do NOT invent new table names:\n${s}\nA tool that queries a table this app does not have will read an empty store and produce nothing useful.`;
 }
 
 /** Coerce model-emitted inputs — strings or {name} objects — into ToolInputs;
@@ -285,7 +299,7 @@ export async function authorToolWithModel(message: string, opts: ToolAuthorOptio
 	const completeFn = opts.complete ?? complete;
 	const timeoutMs = opts.timeoutMs ?? DEFAULT_AUTHOR_TIMEOUT_MS;
 	const ctx: Context = {
-		systemPrompt: TOOL_SCHEMA_PROMPT,
+		systemPrompt: TOOL_SCHEMA_PROMPT + appSchemaBlock(opts.appSchema),
 		messages: [{ role: "user", content: message.trim(), timestamp: Date.now() }],
 	};
 

--- a/internal/team/broker_apps.go
+++ b/internal/team/broker_apps.go
@@ -271,6 +271,15 @@ func (b *Broker) handleAppDB(w http.ResponseWriter, r *http.Request, id string) 
 			writeAppError(w, opErr)
 			return
 		}
+		// Data changed -> drop the stale wiki cache so the Knowledge tab
+		// re-synthesizes against the new rows on next view (2026-08-18
+		// output-quality pass). Best-effort: a failed invalidate must not fail
+		// the write the operator just made.
+		if op == "define" || op == "upsert" || op == "clear" {
+			if invErr := store.InvalidateAppKnowledge(id); invErr != nil {
+				fmt.Fprintf(os.Stderr, "broker: app knowledge invalidate failed: %v\n", invErr)
+			}
+		}
 		writeJSON(w, http.StatusOK, map[string]any{"table": table})
 	default:
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)

--- a/internal/team/broker_apps_knowledge.go
+++ b/internal/team/broker_apps_knowledge.go
@@ -1012,3 +1012,23 @@ func (s *customAppStore) WriteAppKnowledge(id string, pages []appKnowledgePage) 
 	}
 	return nil
 }
+
+// InvalidateAppKnowledge drops the per-app knowledge cache so the NEXT
+// GET /apps/{id}/knowledge re-synthesizes against current data. Called when the
+// app's data changes (a db define/upsert/clear): otherwise the file cache serves
+// a synthesis frozen at first view — the reason a freshly-seeded app showed an
+// accurate data tab beside a wiki still claiming "no tickets yet" (2026-08-18
+// output-quality pass). Missing cache is not an error (nothing to invalidate).
+// NOTE: for gbrain-backed workspaces pages live in the brain, not this file;
+// data-driven staleness there needs a brain-side stamp and is not handled here.
+func (s *customAppStore) InvalidateAppKnowledge(id string) error {
+	if err := validateCustomAppID(id); err != nil {
+		return err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if err := os.Remove(filepath.Join(s.appDir(id), customAppKnowledgeFile)); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("app knowledge: invalidate: %w", err)
+	}
+	return nil
+}

--- a/internal/team/custom_app_db.go
+++ b/internal/team/custom_app_db.go
@@ -90,6 +90,71 @@ func normalizeAppDBColumns(cols []AppDBColumn) []AppDBColumn {
 	return out
 }
 
+// inferAppDBColumnType maps one JSON-decoded value to an app-db column type.
+// Numbers are float64 after a JSON round-trip; arrays are []any; everything else
+// (including ISO date strings, which are indistinguishable from text here)
+// renders and synthesizes fine as "string".
+func inferAppDBColumnType(v any) string {
+	switch v.(type) {
+	case float64, float32, int, int32, int64:
+		return "number"
+	case []any, []string:
+		return "string[]"
+	default:
+		return "string"
+	}
+}
+
+// inferAppDBColumns derives a column set from sample rows for a table an authored
+// tool upserts into WITHOUT a prior define — the "just works" path so an agent
+// can CREATE its own data (a Briefings log, a daily digest) instead of failing
+// because the schema was never declared. Column order is deterministic: "id"
+// first when present, then the remaining keys alphabetically. A column's type is
+// the type of its first non-nil value across the rows, defaulting to "string".
+func inferAppDBColumns(rows []map[string]any) []AppDBColumn {
+	inferred := map[string]string{}
+	var order []string
+	for _, row := range rows {
+		for name := range row {
+			n := strings.TrimSpace(name)
+			if n == "" {
+				continue
+			}
+			if _, seen := inferred[n]; !seen {
+				order = append(order, n)
+				inferred[n] = ""
+			}
+		}
+		for name, v := range row {
+			n := strings.TrimSpace(name)
+			if n == "" || v == nil {
+				continue
+			}
+			if inferred[n] == "" {
+				inferred[n] = inferAppDBColumnType(v)
+			}
+		}
+	}
+	sort.SliceStable(order, func(i, j int) bool {
+		if order[i] == "id" {
+			return order[j] != "id"
+		}
+		if order[j] == "id" {
+			return false
+		}
+		return order[i] < order[j]
+	})
+	cols := make([]AppDBColumn, 0, len(order))
+	for _, n := range order {
+		typ := inferred[n]
+		if typ == "" {
+			typ = "string"
+		}
+		cols = append(cols, AppDBColumn{Name: n, Type: typ})
+	}
+	return normalizeAppDBColumns(cols)
+}
+
 func validateAppDBTableName(table string) (string, error) {
 	table = strings.TrimSpace(table)
 	if table == "" {
@@ -248,9 +313,22 @@ func (s *customAppStore) UpsertAppDBRows(id, table string, rows []map[string]any
 	if err != nil {
 		return AppDBTable{}, err
 	}
+	table = resolveTableBodyName(db, table)
 	body, ok := db.Tables[table]
 	if !ok {
-		return AppDBTable{}, newCustomAppCallerError("app db: table %q is not defined", table)
+		// Auto-define from the incoming rows so an authored tool can CREATE a new
+		// table (a Briefings log, a digest) without a separate define step — the
+		// "save this" the operator described just works, instead of a 400 the
+		// agent has no capability to recover from (2026-08-18 output-quality pass).
+		if len(db.Tables) >= appDBTableLimit {
+			return AppDBTable{}, newCustomAppCallerError("app db: too many tables (max %d)", appDBTableLimit)
+		}
+		cols := inferAppDBColumns(rows)
+		if len(cols) == 0 {
+			return AppDBTable{}, newCustomAppCallerError("app db: table %q is not defined and no columns could be inferred from the rows", table)
+		}
+		body = appDBTableBody{Columns: cols, Rows: []map[string]any{}}
+		db.Tables[table] = body
 	}
 	if body.Rows == nil {
 		body.Rows = []map[string]any{}
@@ -300,6 +378,24 @@ func (s *customAppStore) UpsertAppDBRows(id, table string, rows []map[string]any
 	return tableToOut(table, body), nil
 }
 
+// resolveTableBodyName returns the stored table name matching `want`
+// case-insensitively, or `want` unchanged when no such table exists (so a
+// genuine "not defined" error still fires). The app UI and an authored tool are
+// written by different model calls that do not reliably agree on casing
+// ("Incidents" vs "incidents"), so reads/writes tolerate it (2026-08-18 loop
+// audit — a tool queried a lowercase name and silently found zero rows).
+func resolveTableBodyName(db appDB, want string) string {
+	if _, ok := db.Tables[want]; ok {
+		return want
+	}
+	for name := range db.Tables {
+		if strings.EqualFold(name, want) {
+			return name
+		}
+	}
+	return want
+}
+
 // QueryAppDBTable returns a single table by name.
 func (s *customAppStore) QueryAppDBTable(id, table string) (AppDBTable, error) {
 	if err := validateCustomAppID(id); err != nil {
@@ -318,6 +414,7 @@ func (s *customAppStore) QueryAppDBTable(id, table string) (AppDBTable, error) {
 	if err != nil {
 		return AppDBTable{}, err
 	}
+	table = resolveTableBodyName(db, table)
 	body, ok := db.Tables[table]
 	if !ok {
 		return AppDBTable{}, newCustomAppCallerError("app db: table %q is not defined", table)
@@ -343,6 +440,7 @@ func (s *customAppStore) ClearAppDBTable(id, table string) (AppDBTable, error) {
 	if err != nil {
 		return AppDBTable{}, err
 	}
+	table = resolveTableBodyName(db, table)
 	body, ok := db.Tables[table]
 	if !ok {
 		return AppDBTable{}, newCustomAppCallerError("app db: table %q is not defined", table)

--- a/internal/team/custom_app_db_test.go
+++ b/internal/team/custom_app_db_test.go
@@ -35,9 +35,13 @@ func TestAppDBDefineUpsertQueryRoundTrip(t *testing.T) {
 		t.Fatalf("want 0 tables on fresh app, got %d", len(tables))
 	}
 
-	// Upsert before define is a caller error (table must exist first).
-	if _, err := store.UpsertAppDBRows(id, "Emails", []map[string]any{{"id": "1"}}, "id"); err == nil {
-		t.Fatalf("upsert before define: want error, got nil")
+	// Upsert to an UNDEFINED table auto-defines it from the row shape (the
+	// "just works" path so an authored tool can create its own data). Use a
+	// throwaway table so the "Emails" flow below stays a clean define-first case.
+	if auto, err := store.UpsertAppDBRows(id, "AutoTbl", []map[string]any{{"id": "1", "n": 5}}, "id"); err != nil {
+		t.Fatalf("upsert auto-define: want success, got error %v", err)
+	} else if len(auto.Columns) != 2 || len(auto.Rows) != 1 {
+		t.Fatalf("auto-define shape = %d cols / %d rows, want 2/1", len(auto.Columns), len(auto.Rows))
 	}
 
 	// Define with a bad/empty type normalizes to string; a duplicate column dedups.
@@ -197,5 +201,113 @@ func TestAppDBUnknownAppIsCallerError(t *testing.T) {
 	}
 	if _, err := store.DefineAppDBTable(ghost, "T", []AppDBColumn{{Name: "c"}}); err == nil || !isCustomAppCallerError(err) {
 		t.Fatalf("Define on ghost app: want caller error, got %v", err)
+	}
+}
+
+func TestAppDBTableLookupIsCaseInsensitive(t *testing.T) {
+	dir := t.TempDir()
+	store, id := newTestAppWithDB(t, dir)
+	if _, err := store.DefineAppDBTable(id, "Incidents", []AppDBColumn{{Name: "id", Type: "string"}}); err != nil {
+		t.Fatalf("define: %v", err)
+	}
+	if _, err := store.UpsertAppDBRows(id, "Incidents", []map[string]any{{"id": "INC-1"}}, "id"); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	// A tool authored with a different case ("incidents") must still find the
+	// rows the app wrote to "Incidents" — the app UI and the tool are separate
+	// model calls that do not reliably agree on casing.
+	q, err := store.QueryAppDBTable(id, "incidents")
+	if err != nil {
+		t.Fatalf("case-insensitive query: %v", err)
+	}
+	if len(q.Rows) != 1 {
+		t.Fatalf("want 1 row via lowercase name, got %d", len(q.Rows))
+	}
+	// Upsert with a different case must land in the SAME table, not create a
+	// second one.
+	if _, err := store.UpsertAppDBRows(id, "INCIDENTS", []map[string]any{{"id": "INC-2"}}, "id"); err != nil {
+		t.Fatalf("case-insensitive upsert: %v", err)
+	}
+	tables, _ := store.AppDBTables(id)
+	if len(tables) != 1 {
+		t.Fatalf("case variants created %d tables, want 1", len(tables))
+	}
+	if q2, _ := store.QueryAppDBTable(id, "Incidents"); len(q2.Rows) != 2 {
+		t.Fatalf("want 2 rows after case-variant upsert, got %d", len(q2.Rows))
+	}
+}
+
+func TestInferAppDBColumns(t *testing.T) {
+	// Types come from the first non-nil value; "id" sorts first, the rest
+	// alphabetically. A JSON round-trip makes numbers float64 and arrays []any.
+	rows := []map[string]any{
+		{"summary": "text", "id": "b1", "breachCount": float64(3), "customers": []any{"A", "B"}},
+		{"id": "b2", "summary": "more"},
+	}
+	cols := inferAppDBColumns(rows)
+	if len(cols) != 4 {
+		t.Fatalf("want 4 columns, got %d (%v)", len(cols), cols)
+	}
+	if cols[0].Name != "id" {
+		t.Fatalf("id must sort first, got %q", cols[0].Name)
+	}
+	byName := map[string]string{}
+	for _, c := range cols {
+		byName[c.Name] = c.Type
+	}
+	if byName["breachCount"] != "number" {
+		t.Fatalf("breachCount type = %q, want number", byName["breachCount"])
+	}
+	if byName["customers"] != "string[]" {
+		t.Fatalf("customers type = %q, want string[]", byName["customers"])
+	}
+	if byName["summary"] != "string" {
+		t.Fatalf("summary type = %q, want string", byName["summary"])
+	}
+}
+
+func TestUpsertAutoDefinesMissingTable(t *testing.T) {
+	store, id := newTestAppWithDB(t, t.TempDir())
+	// An authored tool writes to a table that was never defined; the store
+	// creates it from the row instead of erroring, so the write just lands.
+	tbl, err := store.UpsertAppDBRows(id, "Briefings", []map[string]any{
+		{"id": "b1", "breachCount": float64(2), "summary": "two breaches"},
+	}, "id")
+	if err != nil {
+		t.Fatalf("auto-define upsert: %v", err)
+	}
+	if len(tbl.Rows) != 1 {
+		t.Fatalf("want 1 row, got %d", len(tbl.Rows))
+	}
+	if got := appDBKeyValue(tbl.Rows[0]["breachCount"]); got != "2" {
+		t.Fatalf("breachCount = %v, want 2", tbl.Rows[0]["breachCount"])
+	}
+	// The inferred schema persists and is queryable by later calls.
+	q, err := store.QueryAppDBTable(id, "Briefings")
+	if err != nil {
+		t.Fatalf("query auto-defined table: %v", err)
+	}
+	if len(q.Columns) != 3 {
+		t.Fatalf("want 3 inferred columns, got %d (%v)", len(q.Columns), q.Columns)
+	}
+}
+
+func TestInvalidateAppKnowledgeDropsCache(t *testing.T) {
+	store, id := newTestAppWithDB(t, t.TempDir())
+	if err := store.WriteAppKnowledge(id, []appKnowledgePage{{ID: "p1", Title: "Guide"}}); err != nil {
+		t.Fatalf("WriteAppKnowledge: %v", err)
+	}
+	if _, ok, err := store.ReadAppKnowledge(id); err != nil || !ok {
+		t.Fatalf("cache should exist before invalidate: ok=%v err=%v", ok, err)
+	}
+	if err := store.InvalidateAppKnowledge(id); err != nil {
+		t.Fatalf("InvalidateAppKnowledge: %v", err)
+	}
+	if _, ok, err := store.ReadAppKnowledge(id); err != nil || ok {
+		t.Fatalf("cache should be gone after invalidate: ok=%v err=%v", ok, err)
+	}
+	// Invalidating an already-absent cache is not an error.
+	if err := store.InvalidateAppKnowledge(id); err != nil {
+		t.Fatalf("second invalidate should be a no-op, got %v", err)
 	}
 }


### PR DESCRIPTION
## What

Make a taught tool produce real work when it runs: data read from the app's own store, a real summary written by a real model, and durable rows + wiki pages that accrete as the agent works. Working the Incident Agent and a second Renewals Desk agent on a fresh workspace surfaced a chain of gaps that each quietly defeated that promise.

## The chain of fixes

1. **Author against real tables** — `fetchAppSchema` injects the app's actual table/column names into the tool-author prompt, so an authored tool targets `Incidents(customer, severity, opened_at, …)` instead of a phantom `records`/`title` shape it reads 0 rows from.
2. **One reliable clock** — `nex.now()` returns host-side time as an ISO string; sandboxed `Date.now()` is unreliable, and SLA/"hours since" tools need a real now.
3. **Case-insensitive table lookup** — `data.list("incidents")` resolves the app's `Incidents` table instead of silently reading nothing.
4. **Runtime `nex.ai.*` uses the same engine that authored the tool** (`runtimeAICapabilityConfig` reuses `resolveToolAuthoring`). Before, a subscription-login operator authored a real tool that then emitted "nothing actually ran" stubs at execution, because runtime AI was Ollama/BYOK-only.
5. **Full model input** — `nex.ai.*` fed the model a 60-char `preview()` of its own input, so summaries read "your data got cut off". `modelInput()` sends the full content.
6. **Full tool result** — the sandbox worker truncated a structured return to 57 chars before it reached the operator. `serializeResult()` preserves the whole output (200KB cap).
7. **Realistic run budget** — the tool-run hard-kill defaulted to 5s, which silently killed every AI-using tool the moment runtime `nex.ai.*` became real. Raised to 120s; each capability call is still independently bounded at 60s; hosts override via `TOOL_CALL_TIMEOUT_MS`.
8. **Agents can create data** — upsert to an undefined table auto-defines it from the row shape (`inferAppDBColumns`), so a tool that saves a Briefings log just works instead of 400ing.
9. **Wiki accretes** — a data change (define/upsert/clear) invalidates the per-app knowledge cache, so the Knowledge tab re-synthesizes against current rows instead of serving a synthesis frozen at first view.

## Verified live on a fresh workspace

- **Incident Agent** reads its incidents, computes the real SLA breaches against `nex.now()`, writes a per-owner briefing plus a durable `Briefings` row, and the wiki re-synthesizes to reflect it.
- **Renewals Desk** (second agent, different domain) flags at-risk accounts with ARR at stake — same pipeline, no incident-specific code.

## Tests

- Go: `inferAppDBColumns`, auto-define-on-upsert, knowledge-cache invalidation, case-insensitive table lookup.
- TS: `runtimeAICapabilityConfig` resolution, full-model-input regression. The `/tools/call` HTTP tests pin `TOOL_AUTHOR_MODEL=0` so they stay hermetic now that runtime AI resolves from ambient providers.
- Full `internal/team` suite green (147s); full agent `bun test` green (124 pass).

No `web/` files changed, so no screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V9n6uZhopKDdZoXQ37ry17