### PR TITLE
ci(release): make goreleaser re-runnable at an already-released tag

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -85,3 +85,17 @@ release:
     # identifier, and stay.)
     owner: najmuzzaman-mohammad
     name: gawkbot
+
+  # Re-running Release at an already-released tag must work.
+  #
+  # The npm publish step lives in the same job, AFTER goreleaser. So any tag
+  # where goreleaser succeeded and npm failed — which is every tag from
+  # v0.236.0 to v0.237.1 — can only be repaired by re-running the workflow at
+  # that tag. Without this, that re-run dies before it gets near npm:
+  # goreleaser re-uploads the assets it already attached and GitHub answers
+  # 422 already_exists, so "Publish to npm" is skipped and the tag stays
+  # unpublishable forever.
+  #
+  # replace_existing_artifacts makes the upload idempotent: same bytes, same
+  # names, overwritten rather than rejected.
+  replace_existing_artifacts: true


### PR DESCRIPTION
Follow-up to #1229 / #1230.

You re-ran `release.yml --ref v0.237.1`. It failed *earlier* than before — before npm was even reached:

```
upload failed ... 422 Validation Failed
[{Resource:ReleaseAsset Field:name Code:already_exists}]
⨯ release failed after 5m0s
```

goreleaser tried to re-upload the assets the earlier successful run already attached to the v0.237.1 release. GitHub rejects duplicate asset names, goreleaser aborts, and **`Publish to npm` is skipped.**

This matters beyond one tag: the npm step lives in the same job *after* goreleaser, so **any tag where goreleaser succeeded and npm failed can only be repaired by re-running at that tag — and that re-run always dies here.** Every tag from v0.236.0 to v0.237.1 is in exactly that state. A tag that half-published was permanently stuck half-published.

`replace_existing_artifacts: true` makes the upload idempotent: same bytes, same names, overwritten rather than rejected.

## Ordering caveat

This **cannot rescue v0.237.1**. `--ref v0.237.1` reads `.goreleaser.yml` from the tag, which predates this commit — the same reason #1229's Node fix couldn't rescue v0.237.0. It takes effect from the next tag onward, which is why this merge carries `[release]`: cutting **v0.237.2** gets a clean release (fresh tag, no asset conflict) and then reaches `npm publish`.

That publish is also the test of whether the trusted publisher attach landed. If it did, npm finally moves off 0.236.2. If it didn't, we'll get the same `404 … you do not have permission` and B8 stays open — either way we'll know from one run instead of guessing.