### PR TITLE
fix(team): a stale interview no longer makes a bot unreachable

### DIFF
--- a/internal/team/broker_requests_interviews.go
+++ b/internal/team/broker_requests_interviews.go
@@ -362,12 +362,44 @@ func firstBlockingRequestInChannel(requests []humanInterview, channel string) *h
 // office-wide drop (v3 [19:23:59]: one unanswered interview silenced every
 // bot, including a librarian directly @-mentioned in another channel).
 func (b *Broker) BotAwaitingInterviewAnswer(slug string) bool {
-	slug = strings.ToLower(strings.TrimSpace(slug))
-	if b == nil || slug == "" {
+	if b == nil {
 		return false
 	}
 	b.mu.Lock()
 	defer b.mu.Unlock()
+	return b.BotAwaitingInterviewAnswerLocked(slug)
+}
+
+// PendingInterviewTaskIDs returns the task ids of slug's active human
+// interviews ("" for an interview not tied to a task). Used with the live
+// lane state to tell a parked turn from a stale row.
+func (b *Broker) PendingInterviewTaskIDs(slug string) []string {
+	slug = strings.ToLower(strings.TrimSpace(slug))
+	if b == nil || slug == "" {
+		return nil
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	var ids []string
+	for _, req := range b.requests {
+		if !requestIsHumanInterview(req) || !requestIsActive(req) {
+			continue
+		}
+		if strings.ToLower(strings.TrimSpace(req.From)) != slug {
+			continue
+		}
+		ids = append(ids, strings.TrimSpace(req.IssueID))
+	}
+	return ids
+}
+
+// BotAwaitingInterviewAnswerLocked is BotAwaitingInterviewAnswer for
+// callers already holding b.mu.
+func (b *Broker) BotAwaitingInterviewAnswerLocked(slug string) bool {
+	slug = strings.ToLower(strings.TrimSpace(slug))
+	if b == nil || slug == "" {
+		return false
+	}
 	for _, req := range b.requests {
 		if !requestIsHumanInterview(req) || !requestIsActive(req) {
 			continue
@@ -418,6 +450,11 @@ func (b *Broker) cancelRequestLocked(req *humanInterview, actor, reason string) 
 	b.pendingInterview = firstBlockingRequest(b.requests)
 }
 
+// Every matching interview is cancelled, not just the first. A bot that
+// re-asked three times left three stacked cards in the human's DM; each
+// human message retired one, the last stayed pending, and
+// BotAwaitingInterviewAnswer kept dropping that bot's wakes — the office
+// looked dead (prod, 2026-09-07).
 func (b *Broker) cancelActiveHumanInterviewsLocked(actor, reason, channel, replyTo string) int {
 	count := 0
 	// An empty channel means NO FILTER — cancel across every channel.
@@ -442,7 +479,6 @@ func (b *Broker) cancelActiveHumanInterviewsLocked(actor, reason, channel, reply
 		}
 		b.cancelRequestLocked(&b.requests[i], actor, reason)
 		count++
-		break
 	}
 	return count
 }

--- a/internal/team/broker_requests_interviews_test.go
+++ b/internal/team/broker_requests_interviews_test.go
@@ -1364,3 +1364,34 @@ func TestGetRequestsFilterByID(t *testing.T) {
 		t.Fatalf("id filter widened visibility for an unauthorized viewer: %+v", got)
 	}
 }
+
+// TestCancelActiveHumanInterviewsLocked_RetiresEveryStackedAsk: a bot that
+// re-asked three times left three cards in the human's DM. One human
+// message must retire all of them; retiring one per message left the last
+// one pending and BotAwaitingInterviewAnswer kept dropping the bot's wakes
+// (prod, 2026-09-07).
+func TestCancelActiveHumanInterviewsLocked_RetiresEveryStackedAsk(t *testing.T) {
+	b := newTestBroker(t)
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.requests = []humanInterview{
+		{ID: "r1", Kind: "interview", Status: "pending", From: "cos", Channel: "cos__human", ReplyTo: "msg-5", Question: "q1"},
+		{ID: "r2", Kind: "interview", Status: "pending", From: "cos", Channel: "cos__human", ReplyTo: "msg-5", Question: "q2"},
+		{ID: "r3", Kind: "interview", Status: "pending", From: "cos", Channel: "cos__human", ReplyTo: "msg-5", Question: "q3"},
+		{ID: "r4", Kind: "interview", Status: "pending", From: "pm", Channel: "human__pm", Question: "elsewhere"},
+	}
+	if got := b.cancelActiveHumanInterviewsLocked("human", "Human sent a new message", "cos__human", ""); got != 3 {
+		t.Fatalf("expected all 3 stacked asks cancelled, got %d", got)
+	}
+	for _, r := range b.requests[:3] {
+		if requestIsActive(r) {
+			t.Fatalf("%s still active after the human moved on", r.ID)
+		}
+	}
+	if !requestIsActive(b.requests[3]) {
+		t.Fatalf("an interview in another channel must not be touched")
+	}
+	if b.BotAwaitingInterviewAnswerLocked("cos") {
+		t.Fatalf("cos must no longer count as awaiting an answer")
+	}
+}

--- a/internal/team/headless_claude_test.go
+++ b/internal/team/headless_claude_test.go
@@ -381,3 +381,51 @@ func TestWithAppAskPreface(t *testing.T) {
 		t.Fatalf("non-app message must pass through unchanged")
 	}
 }
+
+// TestTurnParkedOnInterview_RequiresALiveTurn: a pending interview row
+// alone must not hold a bot's wakes. After a restart the row survives but
+// the polling turn is gone; holding on the row made the Chief of Staff
+// unreachable until someone found the stale card (prod, 2026-09-07).
+func TestTurnParkedOnInterview_RequiresALiveTurn(t *testing.T) {
+	b := newTestBroker(t)
+	l := minimalLauncher(false)
+	l.broker = b
+
+	b.mu.Lock()
+	b.requests = []humanInterview{{ID: "r1", Kind: "interview", Status: "pending", From: "pm", Channel: "human__pm", Question: "q"}}
+	b.mu.Unlock()
+	if !b.BotAwaitingInterviewAnswer("pm") {
+		t.Fatalf("precondition: pm has a pending interview")
+	}
+	if l.turnParkedOnInterview(notificationTarget{Slug: "pm"}) {
+		t.Fatalf("no live turn: the wake must go through so the bot can re-read the chat")
+	}
+
+	lane := headlessLane{slug: "pm"}
+	l.headless.mu.Lock()
+	l.headless.active[lane] = &headlessCodexActiveTurn{}
+	l.headless.mu.Unlock()
+	if !l.turnParkedOnInterview(notificationTarget{Slug: "pm"}) {
+		t.Fatalf("live turn parked in the answer poll (interview without a task): the wake must be held")
+	}
+
+	// An interview tied to a task holds only while THAT task's turn is live.
+	b.mu.Lock()
+	b.requests[0].IssueID = "task-9"
+	b.mu.Unlock()
+	l.headless.mu.Lock()
+	l.headless.active[lane] = &headlessCodexActiveTurn{Turn: headlessCodexTurn{TaskID: "task-1"}}
+	l.headless.mu.Unlock()
+	if l.turnParkedOnInterview(notificationTarget{Slug: "pm"}) {
+		t.Fatalf("a live turn on an unrelated task is real work, not a parked poll")
+	}
+	l.headless.mu.Lock()
+	l.headless.active[lane] = &headlessCodexActiveTurn{Turn: headlessCodexTurn{TaskID: "task-9"}}
+	l.headless.mu.Unlock()
+	if !l.turnParkedOnInterview(notificationTarget{Slug: "pm"}) {
+		t.Fatalf("the interview's own task turn is the parked one: hold")
+	}
+	if l.turnParkedOnInterview(notificationTarget{Slug: "eng"}) {
+		t.Fatalf("another bot with no interview must never be held")
+	}
+}

--- a/internal/team/lead_slug_migration.go
+++ b/internal/team/lead_slug_migration.go
@@ -26,6 +26,10 @@ var legacyLeadSlugPatterns = []*regexp.Regexp{
 	regexp.MustCompile(`(^|[^A-Za-z0-9_-])ceo($|[^A-Za-z0-9_-])`),
 	regexp.MustCompile(`(^|[^A-Za-z0-9_-])ceo(__)`),
 	regexp.MustCompile(`(__)ceo($|[^A-Za-z0-9_-])`),
+	// Scheduler job keys encode the DM channel with "--" instead of "__"
+	// ("task-follow-up:ceo--human:task-skill-31").
+	regexp.MustCompile(`(:)ceo(--)`),
+	regexp.MustCompile(`(--)ceo(:|$)`),
 }
 
 // migrateLegacyLeadSlug rewrites every legacy lead slug in s to LeadSlug.

--- a/internal/team/lead_slug_migration_test.go
+++ b/internal/team/lead_slug_migration_test.go
@@ -20,6 +20,8 @@ func TestMigrateLegacyLeadSlug(t *testing.T) {
 		`"ceoMessagePayload"`:      `"ceoMessagePayload"`,
 		`"CEO"`:                    `"CEO"`,
 		`"the ceo's office"`:       `"the cos's office"`,
+		`"task-follow-up:ceo--human:task-skill-31"`:                   `"task-follow-up:cos--human:task-skill-31"`,
+		`"task-follow-up:human--ceo:task-1"`:                          `"task-follow-up:human--cos:task-1"`,
 		`{"from":"ceo","channel":"ceo__human","tagged":["ceo","pm"]}`: `{"from":"cos","channel":"cos__human","tagged":["cos","pm"]}`,
 	}
 	for in, want := range cases {

--- a/internal/team/notifier_delivery.go
+++ b/internal/team/notifier_delivery.go
@@ -172,7 +172,7 @@ func (l *Launcher) sendTaskUpdate(target notificationTarget, action officeAction
 	// once the answer lands. Suppress only this bot; every other bot
 	// keeps working (the old office-wide drop wedged the whole office
 	// behind one buried card, [19:23:59]).
-	if l.broker != nil && l.broker.BotAwaitingInterviewAnswer(target.Slug) {
+	if l.turnParkedOnInterview(target) {
 		return
 	}
 	// The channel this bot is told to reply in. A task with no channel used
@@ -273,7 +273,7 @@ func (l *Launcher) sendChannelUpdate(target notificationTarget, msg channelMessa
 	// Scoped interview gate — same contract as sendTaskUpdate: suppress
 	// new turns ONLY for the bot whose own interview is pending (its
 	// turn is parked in the answer poll); everyone else keeps working.
-	if l.broker != nil && l.broker.BotAwaitingInterviewAnswer(target.Slug) {
+	if l.turnParkedOnInterview(target) {
 		return
 	}
 	// Same as sendTaskUpdate: this value is interpolated straight into the
@@ -392,4 +392,61 @@ func (l *Launcher) slackChannelConventionNote(channel string) string {
 		"(3) You are part of ONE coordinating presence (the team bot). Never introduce yourself by an internal role name like Chief of Staff or planner; speak as the team. " +
 		"(4) If a message needs no action from you, post NOTHING. Never post acknowledgement-only replies (\"noted\", \"acknowledged\", \"no action needed\") — real people read this channel, and repeating the same status is spam. Summarize once when the situation changes, not once per incoming message. " +
 		"(5) Every task lives in its OWN Slack thread (the team opens one automatically, rooted on the task card). Do all of a task's work inside that thread — never start parallel top-level messages for the same task. To quote or reference another message, paste its Slack message link; Slack renders the link as a quoted reply."
+}
+
+// turnParkedOnInterview reports whether a wake for slug must be held
+// because the bot's CURRENT turn is parked in the /interview/answer poll.
+//
+// A pending interview row alone is not enough: after a broker restart the
+// row survives but the turn that was polling for the answer is gone, and
+// holding wakes on the row alone made the bot unreachable — every human
+// message was dropped until someone found and answered the stale card
+// (prod, 2026-09-07). The gate therefore also requires a live headless
+// turn for the bot. A target that would be delivered to a live tmux pane
+// cannot be inspected the same way and keeps the conservative row-only
+// rule; the routing question is asked exactly the way delivery asks it.
+func (l *Launcher) turnParkedOnInterview(target notificationTarget) bool {
+	slug := strings.TrimSpace(target.Slug)
+	if l == nil || l.broker == nil || slug == "" || !l.broker.BotAwaitingInterviewAnswer(slug) {
+		return false
+	}
+	if !l.targeter().ShouldUseHeadlessForTarget(target) {
+		return true
+	}
+	return l.headlessTurnParkedFor(slug, l.broker.PendingInterviewTaskIDs(slug))
+}
+
+// headlessTurnParkedFor reports whether slug has a live headless turn that
+// is the one waiting on an interview: a turn on the same task as a pending
+// interview, or — for an interview with no task — any live turn. A live
+// turn on an unrelated task is real work, not a parked poll, and must not
+// hold the bot's wakes.
+func (l *Launcher) headlessTurnParkedFor(slug string, interviewTaskIDs []string) bool {
+	slug = strings.TrimSpace(slug)
+	if l == nil || slug == "" {
+		return false
+	}
+	anyTask := false
+	want := make(map[string]struct{}, len(interviewTaskIDs))
+	for _, id := range interviewTaskIDs {
+		if id == "" {
+			anyTask = true
+			continue
+		}
+		want[id] = struct{}{}
+	}
+	l.headless.mu.Lock()
+	defer l.headless.mu.Unlock()
+	for lane, active := range l.headless.active {
+		if active == nil || lane.slug != slug {
+			continue
+		}
+		if anyTask {
+			return true
+		}
+		if _, ok := want[strings.TrimSpace(active.Turn.TaskID)]; ok {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/team/office_eval_jobs_utterance.go
+++ b/internal/team/office_eval_jobs_utterance.go
@@ -323,6 +323,15 @@ func evalJobUtteranceRouting(fx *officeEvalFixture, r *OfficeEvalReport) error {
 	}
 	fx.broker.mu.Unlock()
 	taskA2 := fx.broker.TaskByID(taskA.ID)
+	// The asking bot's turn is parked in the /interview/answer poll — model
+	// that live turn on its lane. The gate keys on the live turn, not on the
+	// pending row alone: after a restart the row survives but the polling
+	// turn is gone, and holding on the row made the bot unreachable
+	// (prod, 2026-09-07).
+	engLane := headlessLane{slug: "eng"}
+	fx.launcher.headless.mu.Lock()
+	fx.launcher.headless.active[engLane] = &headlessCodexActiveTurn{Turn: headlessCodexTurn{TaskID: taskA.ID}}
+	fx.launcher.headless.mu.Unlock()
 	fx.launcher.sendTaskUpdate(notificationTarget{Slug: "eng"}, officeActionLog{
 		Kind: "task_updated", Actor: "human", Channel: taskA2.Channel, RelatedID: taskA2.ID,
 	}, *taskA2, "Continue work.")
@@ -336,13 +345,17 @@ func evalJobUtteranceRouting(fx *officeEvalFixture, r *OfficeEvalReport) error {
 		parked == "", fmt.Sprintf("dispatched=%q", parked), "")
 
 	// …and resumes once the human answers (exact FE payload:
-	// web/src/api/client.ts answerRequest).
+	// web/src/api/client.ts answerRequest). The answer releases the parked
+	// turn, so its lane is free again when the next wake arrives.
 	ansStatus, ansBody, err := client.postJSON("/requests/answer", map[string]any{
 		"id": ivdParsed.ID, "choice_id": "answer_directly", "custom_text": "CSV, one row per account.",
 	})
 	if err != nil {
 		return err
 	}
+	fx.launcher.headless.mu.Lock()
+	delete(fx.launcher.headless.active, engLane)
+	fx.launcher.headless.mu.Unlock()
 	fx.launcher.sendTaskUpdate(notificationTarget{Slug: "eng"}, officeActionLog{
 		Kind: "task_updated", Actor: "human", Channel: taskA2.Channel, RelatedID: taskA2.ID,
 	}, *taskA2, "Continue work.")
@@ -352,6 +365,61 @@ func evalJobUtteranceRouting(fx *officeEvalFixture, r *OfficeEvalReport) error {
 		resumed = wake[0]
 	case <-time.After(utteranceWakeTimeout):
 	}
+	// After a restart the pending row is still there but no turn is parked:
+	// the wake must flow so the bot can re-read the chat and re-ask. Holding
+	// on the row alone made the Chief of Staff unreachable until someone
+	// found the stale card (prod, 2026-09-07). Fresh task + fresh interview
+	// so no earlier dispatch for taskA can dedupe this one.
+	taskR, err := createTask("Reconcile the partner list (utterance d, restart)", "eng")
+	if err != nil {
+		return err
+	}
+	if _, _, err := client.postJSON("/requests", map[string]any{
+		"kind": "interview", "from": "eng", "channel": fx.broker.TaskByID(taskR.ID).Channel,
+		"issue_id": taskR.ID, "title": "Which list?", "question": "Which partner list is canonical?",
+	}); err != nil {
+		return err
+	}
+	if !fx.broker.BotAwaitingInterviewAnswer("eng") {
+		return fmt.Errorf("restart probe: eng should have a pending interview")
+	}
+	// Raising the interview parks the task; force Running so the only gate
+	// under test is the interview one.
+	fx.broker.mu.Lock()
+	if t := fx.broker.taskByIDLocked(taskR.ID); t != nil {
+		t.LifecycleState = LifecycleStateRunning
+		t.status = "in_progress"
+	}
+	fx.broker.mu.Unlock()
+	rSnapshot := fx.broker.TaskByID(taskR.ID)
+	// Let the previous lane finish winding down so the only live-state under
+	// test is "no parked turn" — the shape a restarted office is in.
+	for i := 0; i < 40; i++ {
+		fx.launcher.headless.mu.Lock()
+		live := 0
+		for lane, a := range fx.launcher.headless.active {
+			if lane.slug == "eng" && a != nil {
+				live++
+			}
+		}
+		fx.launcher.headless.mu.Unlock()
+		if live == 0 {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	fx.launcher.sendTaskUpdate(notificationTarget{Slug: "eng"}, officeActionLog{
+		Kind: "task_updated", Actor: "human", Channel: rSnapshot.Channel, RelatedID: taskR.ID,
+	}, *rSnapshot, "Continue work.")
+	afterRestart := ""
+	select {
+	case wake := <-woke:
+		afterRestart = wake[0]
+	case <-time.After(utteranceWakeTimeout):
+	}
+	r.add(job, "a pending interview with no live turn (post-restart) does not park the bot",
+		afterRestart == "eng", fmt.Sprintf("dispatched=%q", afterRestart), "")
+
 	fx.launcher.stopHeadlessWorkers()
 	r.add(job, "answering the interview resumes the asking bot's lane",
 		ansStatus == http.StatusOK && resumed == "eng",

--- a/internal/team/slug_normalisation_test.go
+++ b/internal/team/slug_normalisation_test.go
@@ -183,12 +183,10 @@ func TestEmptyFilterMeansNoFilter(t *testing.T) {
 		}
 	})
 
-	// cancelActiveHumanInterviewsLocked breaks after the first match by design,
-	// so the count is always 0 or 1. The behavioural difference the fix makes
-	// is therefore about REACH, not volume: with no channel given it must be
-	// able to reach an interview that lives outside #general. Before the fix
-	// the empty channel normalised to "general" and nothing outside that room
-	// was ever a candidate.
+	// The behavioural difference the fix makes is about REACH: with no
+	// channel given it must be able to reach an interview that lives outside
+	// #general. Before the fix the empty channel normalised to "general" and
+	// nothing outside that room was ever a candidate.
 	t.Run("cancelling with no channel reaches an interview outside #general", func(t *testing.T) {
 		b := newTestBroker(t)
 		b.mu.Lock()


### PR DESCRIPTION
## Summary
**Prod, 2026-09-07: no bot responded.** Reproduced on a copy of the prod home and fixed.

The Chief of Staff had three stacked interviews in its DM, all anchored to one message from September 3. Each human message cancelled only **one** of them (`cancelActiveHumanInterviewsLocked` broke after the first match), so one stayed pending forever, and `BotAwaitingInterviewAnswer` dropped every wake for that bot. After a restart there was no parked turn to answer into, so the human's messages went nowhere. Every message since 09-03 in that DM was silently discarded.

- `cancelActiveHumanInterviewsLocked` retires every matching interview in the thread.
- The wake gate in `sendChannelUpdate` / `sendTaskUpdate` holds only while the bot has a **live** headless turn on the interview's own task (or any live turn for an interview with no task). A pending row alone, as after a restart, lets the wake through so the bot re-reads the chat.
- Pane-backed targets keep the conservative row-only rule.
- Lead-slug migration also rewrites scheduler keys that encode DMs with `--`.
- Office eval: the parked turn is modelled on the lane, plus a post-restart probe (pending row, no live turn → wake flows).

## Verification
- On a copy of the real prod home (`~/.wuphf`), booted with the v0.238.0 release binary: message to the Chief of Staff → **no turn, no reply for 3 minutes** (matches prod).
- Same home, this branch: "are you there?" → "Yes, here — ready." in 8 s; "what is 2+2?" → "4." in 10 s. Both posted into `#cos__human`.
- `go test ./internal/team/ ./internal/teammcp/` green; `golangci-lint` 0 issues.

## Why prod could not have had this fix yet
Prod runs `npx gawkbot@latest`, which still resolves to 0.236.2 because npm publishing is blocked (B8). This ships as a GitHub release; the founder runs the release binary, or attaches the trusted publisher so `npx` picks it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V9n6uZhopKDdZoXQ37ry17
